### PR TITLE
build: set FlakeHub visibility to private

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,3 +19,4 @@ jobs:
         with:
           directory: tools/shaka
           name: kolohelios/shaka
+          visibility: private


### PR DESCRIPTION
Adds required `visibility: private` to the `flakehub-push` step, fixing the non-zero exit code error caused by the missing `--visibility` flag.