### PR TITLE
build: enable rolling releases for FlakeHub branch pushes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,3 +20,4 @@ jobs:
           directory: tools/shaka
           name: kolohelios/shaka
           visibility: private
+          rolling: true


### PR DESCRIPTION
Enable `rolling: true` in the flakehub-push step so that pushes to `main` publish a rolling release instead of requiring a semver tag. Without this, flakehub-push tries to parse the branch name `main` as a semver version and fails.