### PR TITLE
feat(shaka): add Rust CLI boilerplate with clap and Nix build

### DIFF
--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -37,6 +37,13 @@
         };
       });
 
+      apps = forEachSupportedSystem ({ system, ... }: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/shaka";
+        };
+      });
+
       devShells = forEachSupportedSystem (
         { pkgs, system }:
         {


### PR DESCRIPTION
Adds initial Rust CLI scaffolding for the `shaka` build tool using `clap` with derive macros. Includes a `Cargo.toml`, `Cargo.lock`, and a `build` subcommand stub, along with updates to `flake.nix` to wire up the Nix build.