### PR TITLE
fix(flake): drop direnv and nix-direnv from devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,8 +69,6 @@
               # Nix tooling
               nixfmt-rfc-style
               nil # Nix LSP
-              direnv
-              nix-direnv
 
               # Infra
               opentofu


### PR DESCRIPTION
Removes `direnv` and `nix-direnv` from the project devShell. They are host-level tools (managed by nix-darwin) and creating a chicken-and-egg load: `direnv` has to be on PATH already to load the flake that provides it. The Nix package set was also rebuilding `direnv 2.37.1` from source — its fish test phase gets killed (signal 9), causing `direnv reload` to fail in this repo.