### PR TITLE
feat(shaka): add preflight command for CI/local parity

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   # ── Single gate for branch protection ─────────────────────────
-  # All validation checks go here. This is the only required status
-  # check on main. Shaka will extend this with `shaka repo audit` etc.
+  # `shaka preflight` runs every validation check in one place. CI and
+  # local dev invoke the same command so they cannot drift apart.
   validate:
     name: Validate
     runs-on: ubuntu-latest
@@ -22,25 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/determinate-nix-action@main
-
-      # Nix
-      - name: Nix flake check
-        run: nix flake check --all-systems
-
-      # Terraform
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "~> 1.9"
-
-      - name: Terraform validate
-        working-directory: infra/devbox/terraform
-        run: |
-          terraform init
-          terraform validate
-
-      - name: Terraform plan
-        working-directory: infra/devbox/terraform
-        run: terraform plan
+      - name: shaka preflight
+        run: nix develop --command nix run ./tools/shaka -- preflight
 
   # ── Build jobs (run after validation) ─────────────────────────
   build-shaka:

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 mod gh;
+mod preflight;
 mod repo;
 
 #[derive(Parser)]
@@ -14,6 +15,12 @@ struct Cli {
 enum Commands {
     /// Build the project
     Build,
+    /// Run every validation check CI runs (nix flake check, tofu validate, tofu plan)
+    Preflight {
+        /// Continue running checks after a failure and report all at the end
+        #[arg(long)]
+        keep_going: bool,
+    },
     /// Repository management
     Repo {
         #[command(subcommand)]
@@ -28,6 +35,7 @@ fn main() {
         Commands::Build => {
             println!("build");
         }
+        Commands::Preflight { keep_going } => preflight::run(keep_going),
         Commands::Repo { command } => repo::run(command),
     }
 }

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -1,0 +1,164 @@
+use std::io::Write;
+use std::process::{Command, Output};
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+enum CheckResult {
+    Pass,
+    Fail { detail: String, output: Option<Output> },
+}
+
+struct Check {
+    name: &'static str,
+    run: fn() -> CheckResult,
+}
+
+const CHECKS: &[Check] = &[
+    Check { name: "nix flake check", run: nix_flake_check },
+    Check { name: "tofu validate (infra/devbox/terraform)", run: tofu_validate },
+    Check { name: "tofu plan (infra/devbox/terraform)", run: tofu_plan },
+];
+
+pub fn run(keep_going: bool) {
+    let total = CHECKS.len();
+    let mut passed = 0usize;
+    let mut failures: Vec<(&'static str, CheckResult)> = Vec::new();
+
+    println!("{BOLD}preflight:{RESET} running {total} checks");
+
+    for (i, check) in CHECKS.iter().enumerate() {
+        let label = format!("[{}/{}] {}", i + 1, total, check.name);
+        print!("  {label} ... ");
+        std::io::stdout().flush().ok();
+
+        let result = (check.run)();
+        match &result {
+            CheckResult::Pass => {
+                println!("{GREEN}{BOLD}ok{RESET}");
+                passed += 1;
+            }
+            CheckResult::Fail { detail, .. } => {
+                println!("{RED}{BOLD}FAIL{RESET}");
+                if !detail.is_empty() {
+                    println!("    {DIM}{detail}{RESET}");
+                }
+                failures.push((check.name, result));
+                if !keep_going {
+                    break;
+                }
+            }
+        }
+    }
+
+    println!();
+    if failures.is_empty() {
+        println!("{GREEN}{BOLD}preflight passed{RESET} ({passed}/{total})");
+        return;
+    }
+
+    for (name, result) in &failures {
+        if let CheckResult::Fail { output: Some(out), .. } = result {
+            println!("{BOLD}── {name} ──{RESET}");
+            std::io::stdout().write_all(&out.stdout).ok();
+            std::io::stderr().write_all(&out.stderr).ok();
+            println!();
+        }
+    }
+
+    eprintln!(
+        "{RED}{BOLD}preflight failed{RESET} ({passed} passed, {} failed of {total})",
+        failures.len()
+    );
+    std::process::exit(1);
+}
+
+fn nix_flake_check() -> CheckResult {
+    run_command(Command::new("nix").args(["flake", "check", "--all-systems"]))
+}
+
+fn tofu_validate() -> CheckResult {
+    let init = Command::new("tofu")
+        .args(["init", "-backend=false", "-input=false"])
+        .current_dir("infra/devbox/terraform")
+        .output();
+    match init {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => {
+            return CheckResult::Fail {
+                detail: "tofu init failed".into(),
+                output: Some(out),
+            };
+        }
+        Err(e) => {
+            return CheckResult::Fail {
+                detail: format!("failed to spawn tofu: {e}"),
+                output: None,
+            };
+        }
+    }
+
+    run_command(
+        Command::new("tofu")
+            .arg("validate")
+            .current_dir("infra/devbox/terraform"),
+    )
+}
+
+fn tofu_plan() -> CheckResult {
+    let required = ["TF_VAR_linode_token", "TF_VAR_root_pass", "TF_VAR_image_id"];
+    let missing: Vec<&str> = required
+        .iter()
+        .copied()
+        .filter(|var| std::env::var(var).is_err())
+        .collect();
+    if !missing.is_empty() {
+        return CheckResult::Fail {
+            detail: format!("missing required env vars: {}", missing.join(", ")),
+            output: None,
+        };
+    }
+
+    let init = Command::new("tofu")
+        .args(["init", "-input=false"])
+        .current_dir("infra/devbox/terraform")
+        .output();
+    match init {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => {
+            return CheckResult::Fail {
+                detail: "tofu init failed".into(),
+                output: Some(out),
+            };
+        }
+        Err(e) => {
+            return CheckResult::Fail {
+                detail: format!("failed to spawn tofu: {e}"),
+                output: None,
+            };
+        }
+    }
+
+    run_command(
+        Command::new("tofu")
+            .arg("plan")
+            .current_dir("infra/devbox/terraform"),
+    )
+}
+
+fn run_command(cmd: &mut Command) -> CheckResult {
+    match cmd.output() {
+        Ok(out) if out.status.success() => CheckResult::Pass,
+        Ok(out) => CheckResult::Fail {
+            detail: format!("exit code {}", out.status.code().unwrap_or(-1)),
+            output: Some(out),
+        },
+        Err(e) => CheckResult::Fail {
+            detail: format!("failed to spawn: {e}"),
+            output: None,
+        },
+    }
+}


### PR DESCRIPTION
Adds `shaka preflight`, a single command that runs every validation check CI runs: `nix flake check --all-systems`, `tofu validate` and `tofu plan` against `infra/devbox/terraform`. CI's `validate` job now invokes this command instead of running each check itself, so the two cannot drift apart. The terraform tooling is unified on opentofu (the devShell already used it; setup-terraform is dropped). `tofu plan` requires `TF_VAR_linode_token`, `TF_VAR_root_pass`, and `TF_VAR_image_id` to be set and fails if any are missing — locally these come from 1Password, in CI from repo secrets.

Closes #19