### PR TITLE
feat(shaka): add validate command and CUE project schema

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,9 @@
               nixfmt-rfc-style
               nil # Nix LSP
 
+              # Schema / config
+              cue
+
               # Infra
               opentofu
               linode-cli

--- a/infra/devbox/project.cue
+++ b/infra/devbox/project.cue
@@ -1,0 +1,5 @@
+package project
+
+#Project & {
+	name: "devbox"
+}

--- a/tools/shaka/Cargo.lock
+++ b/tools/shaka/Cargo.lock
@@ -53,6 +53,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,10 +117,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -117,16 +209,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -145,6 +277,31 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -196,6 +353,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -216,16 +374,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -240,6 +469,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/tools/shaka/Cargo.toml
+++ b/tools/shaka/Cargo.toml
@@ -11,3 +11,6 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/tools/shaka/project.cue
+++ b/tools/shaka/project.cue
@@ -1,0 +1,5 @@
+package project
+
+#Project & {
+	name: "shaka"
+}

--- a/tools/shaka/schema/project.cue
+++ b/tools/shaka/schema/project.cue
@@ -1,0 +1,5 @@
+package project
+
+#Project: {
+	name: string & =~"^[a-z][a-z0-9-]*$"
+}

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 mod gh;
 mod preflight;
 mod repo;
+mod validate;
 
 #[derive(Parser)]
 #[command(name = "shaka", about = "Build tooling for kolohelios")]
@@ -26,6 +27,8 @@ enum Commands {
         #[command(subcommand)]
         command: repo::RepoCommand,
     },
+    /// Validate every project's project.cue against the shared schema
+    Validate,
 }
 
 fn main() {
@@ -37,5 +40,6 @@ fn main() {
         }
         Commands::Preflight { keep_going } => preflight::run(keep_going),
         Commands::Repo { command } => repo::run(command),
+        Commands::Validate => validate::run(),
     }
 }

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -19,6 +19,7 @@ struct Check {
 
 const CHECKS: &[Check] = &[
     Check { name: "nix flake check", run: nix_flake_check },
+    Check { name: "shaka validate", run: shaka_validate },
     Check { name: "tofu validate (infra/devbox/terraform)", run: tofu_validate },
     Check { name: "tofu plan (infra/devbox/terraform)", run: tofu_plan },
 ];
@@ -78,6 +79,19 @@ pub fn run(keep_going: bool) {
 
 fn nix_flake_check() -> CheckResult {
     run_command(Command::new("nix").args(["flake", "check", "--all-systems"]))
+}
+
+fn shaka_validate() -> CheckResult {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            return CheckResult::Fail {
+                detail: format!("could not locate shaka binary: {e}"),
+                output: None,
+            };
+        }
+    };
+    run_command(Command::new(exe).arg("validate"))
 }
 
 fn tofu_validate() -> CheckResult {

--- a/tools/shaka/src/validate.rs
+++ b/tools/shaka/src/validate.rs
@@ -1,0 +1,232 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+const SCHEMA: &str = include_str!("../schema/project.cue");
+const SLOTS: &[&str] = &["apps", "infra", "packages", "services", "tools"];
+
+enum ProjectResult {
+    Pass,
+    MissingFile,
+    Failed(String),
+    Error(String),
+}
+
+pub fn run() {
+    let schema_path = match write_schema() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} could not write schema: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let projects = discover(Path::new("."));
+    if projects.is_empty() {
+        println!("{YELLOW}no projects found in slots {:?}{RESET}", SLOTS);
+        return;
+    }
+
+    println!("{BOLD}validate:{RESET} {} projects", projects.len());
+
+    let mut failures = 0;
+    for project in &projects {
+        let display = project.display();
+        match validate_project(&schema_path, project) {
+            ProjectResult::Pass => println!("  {GREEN}{BOLD}ok{RESET}    {display}"),
+            ProjectResult::MissingFile => {
+                println!("  {RED}{BOLD}FAIL{RESET}  {display} ({DIM}missing project.cue{RESET})");
+                failures += 1;
+            }
+            ProjectResult::Failed(msg) => {
+                println!("  {RED}{BOLD}FAIL{RESET}  {display}");
+                for line in msg.lines() {
+                    println!("    {DIM}{line}{RESET}");
+                }
+                failures += 1;
+            }
+            ProjectResult::Error(msg) => {
+                println!("  {RED}{BOLD}ERROR{RESET} {display} ({DIM}{msg}{RESET})");
+                failures += 1;
+            }
+        }
+    }
+
+    println!();
+    if failures > 0 {
+        eprintln!(
+            "{RED}{BOLD}validate failed{RESET} ({failures} of {} projects)",
+            projects.len()
+        );
+        std::process::exit(1);
+    }
+    println!("{GREEN}{BOLD}validate passed{RESET}");
+}
+
+fn discover(root: &Path) -> Vec<PathBuf> {
+    let mut projects = Vec::new();
+    for slot in SLOTS {
+        let slot_dir = root.join(slot);
+        let entries = match std::fs::read_dir(&slot_dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                projects.push(path);
+            }
+        }
+    }
+    projects.sort();
+    projects
+}
+
+fn validate_project(schema_path: &Path, project_dir: &Path) -> ProjectResult {
+    let project_file = project_dir.join("project.cue");
+    if !project_file.exists() {
+        return ProjectResult::MissingFile;
+    }
+
+    match Command::new("cue")
+        .arg("vet")
+        .arg(schema_path)
+        .arg(&project_file)
+        .output()
+    {
+        Ok(out) if out.status.success() => ProjectResult::Pass,
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let combined = if stderr.is_empty() { stdout } else { stderr };
+            ProjectResult::Failed(combined)
+        }
+        Err(e) => ProjectResult::Error(format!("failed to spawn cue: {e}")),
+    }
+}
+
+fn write_schema() -> std::io::Result<PathBuf> {
+    let path = std::env::temp_dir().join("shaka-project-schema.cue");
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(SCHEMA.as_bytes())?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn mkdir(root: &Path, rel: &str) {
+        fs::create_dir_all(root.join(rel)).unwrap();
+    }
+
+    fn touch(root: &Path, rel: &str) {
+        let path = root.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::File::create(path).unwrap();
+    }
+
+    #[test]
+    fn discover_finds_direct_children_of_each_slot() {
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "tools/shaka");
+        mkdir(tmp.path(), "infra/devbox");
+        mkdir(tmp.path(), "apps/foo");
+
+        let projects = discover(tmp.path());
+
+        assert_eq!(projects.len(), 3);
+        assert!(projects.iter().any(|p| p.ends_with("apps/foo")));
+        assert!(projects.iter().any(|p| p.ends_with("infra/devbox")));
+        assert!(projects.iter().any(|p| p.ends_with("tools/shaka")));
+    }
+
+    #[test]
+    fn discover_returns_empty_for_empty_root() {
+        let tmp = TempDir::new().unwrap();
+        assert!(discover(tmp.path()).is_empty());
+    }
+
+    #[test]
+    fn discover_skips_missing_slot_dirs() {
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "tools/shaka");
+
+        let projects = discover(tmp.path());
+
+        assert_eq!(projects.len(), 1);
+        assert!(projects[0].ends_with("tools/shaka"));
+    }
+
+    #[test]
+    fn discover_ignores_non_slot_directories() {
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "projects/legacy");
+        mkdir(tmp.path(), ".git/refs");
+        mkdir(tmp.path(), "docs/intro");
+        mkdir(tmp.path(), "tools/shaka");
+
+        let projects = discover(tmp.path());
+
+        assert_eq!(projects.len(), 1);
+        assert!(projects[0].ends_with("tools/shaka"));
+    }
+
+    #[test]
+    fn discover_ignores_files_inside_slots() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "apps/.gitkeep");
+        touch(tmp.path(), "tools/README.md");
+        mkdir(tmp.path(), "tools/shaka");
+
+        let projects = discover(tmp.path());
+
+        assert_eq!(projects.len(), 1);
+        assert!(projects[0].ends_with("tools/shaka"));
+    }
+
+    #[test]
+    fn discover_does_not_recurse_into_projects() {
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "tools/shaka/src/subdir");
+        mkdir(tmp.path(), "tools/shaka/schema");
+
+        let projects = discover(tmp.path());
+
+        assert_eq!(projects.len(), 1);
+        assert!(projects[0].ends_with("tools/shaka"));
+    }
+
+    #[test]
+    fn discover_returns_sorted_paths() {
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "tools/zeta");
+        mkdir(tmp.path(), "apps/alpha");
+        mkdir(tmp.path(), "infra/middle");
+
+        let projects = discover(tmp.path());
+
+        let names: Vec<String> =
+            projects.iter().map(|p| p.display().to_string()).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn validate_project_reports_missing_project_file() {
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "apps/foo");
+        let result = validate_project(Path::new("/nonexistent-schema.cue"), &tmp.path().join("apps/foo"));
+        assert!(matches!(result, ProjectResult::MissingFile));
+    }
+}


### PR DESCRIPTION
Adds `shaka validate`, which discovers projects in the fixed slot list (`apps/`, `infra/`, `packages/`, `services/`, `tools/`) and validates each one against a CUE schema. Every direct child of a slot must have a `project.cue`; missing files and constraint violations are both failures. The schema is embedded in the binary and currently requires only `name: string & =~"^[a-z][a-z0-9-]*$"` — it will grow as ownership, dependency, and CI metadata are added.

Wires `shaka validate` into `shaka preflight` (and therefore CI) by spawning the same shaka binary as a subprocess, so any project added without metadata blocks merge. Adds `project.cue` files for the two existing projects (`tools/shaka`, `infra/devbox`). `cue` is added to the root devShell so shaka can spawn it from the same environment CI uses.

Closes #16