### PR TITLE
perf(ci): scope preflight checks and build jobs to changed paths

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,11 +6,51 @@ on:
     branches: [main]
 
 jobs:
+  # ── Detect changed paths ──────────────────────────────────────
+  # Build jobs use these outputs to skip when their inputs haven't
+  # changed. The validate job always runs but passes the base ref
+  # to `shaka preflight --since` so individual checks self-skip.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      base_ref: ${{ steps.base.outputs.ref }}
+      shaka: ${{ steps.filter.outputs.shaka }}
+      image: ${{ steps.filter.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: base
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]]; then
+            BASE=$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)
+          fi
+          echo "ref=$BASE" >> "$GITHUB_OUTPUT"
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          base: ${{ steps.base.outputs.ref }}
+          filters: |
+            shaka:
+              - 'tools/shaka/**'
+              - 'flake.nix'
+              - 'flake.lock'
+            image:
+              - 'infra/devbox/nixos/**'
+              - 'flake.nix'
+              - 'flake.lock'
+
   # ── Single gate for branch protection ─────────────────────────
   # `shaka preflight` runs every validation check in one place. CI and
   # local dev invoke the same command so they cannot drift apart.
   validate:
     name: Validate
+    needs: changes
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -21,14 +61,19 @@ jobs:
       TF_VAR_image_id: ${{ vars.DEVBOX_IMAGE_ID }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: DeterminateSystems/determinate-nix-action@main
       - name: shaka preflight
-        run: nix develop --command nix run ./tools/shaka -- preflight
+        run: |
+          nix develop --command nix run ./tools/shaka -- preflight \
+            --since "${{ needs.changes.outputs.base_ref }}"
 
-  # ── Build jobs (run after validation) ─────────────────────────
+  # ── Build jobs (run after validation, only when inputs change) ─
   build-shaka:
     name: Build shaka
-    needs: validate
+    needs: [validate, changes]
+    if: needs.changes.outputs.shaka == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -47,7 +92,8 @@ jobs:
 
   build-image:
     name: Build Linode image
-    needs: validate
+    needs: [validate, changes]
+    if: needs.changes.outputs.image == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -28,6 +28,9 @@ enum Commands {
         /// Continue running checks after a failure and report all at the end
         #[arg(long)]
         keep_going: bool,
+        /// Skip checks whose path scope does not intersect changes since this git ref
+        #[arg(long, value_name = "REF")]
+        since: Option<String>,
     },
     /// Repository management
     Repo {
@@ -46,7 +49,7 @@ fn main() {
             println!("build");
         }
         Commands::Generate { check } => generate::run(check),
-        Commands::Preflight { keep_going } => preflight::run(keep_going),
+        Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
         Commands::Repo { command } => repo::run(command),
         Commands::Validate => validate::run(),
     }

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -3,6 +3,7 @@ use std::process::{Command, Output};
 
 const GREEN: &str = "\x1b[32m";
 const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
 const DIM: &str = "\x1b[2m";
 const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
@@ -14,26 +15,93 @@ enum CheckResult {
 
 struct Check {
     name: &'static str,
+    /// Glob patterns (with `*` and `**`) for paths that should trigger this check.
+    /// Empty list means "always run regardless of changed files".
+    paths: &'static [&'static str],
     run: fn() -> CheckResult,
 }
 
 const CHECKS: &[Check] = &[
-    Check { name: "nix flake check", run: nix_flake_check },
-    Check { name: "shaka validate", run: shaka_validate },
-    Check { name: "shaka generate --check", run: shaka_generate_check },
-    Check { name: "tofu validate (infra/devbox/terraform)", run: tofu_validate },
-    Check { name: "tofu plan (infra/devbox/terraform)", run: tofu_plan },
+    Check {
+        name: "nix flake check",
+        paths: &[
+            "flake.nix",
+            "flake.lock",
+            "tools/shaka/**",
+            "infra/devbox/nixos/**",
+        ],
+        run: nix_flake_check,
+    },
+    Check {
+        name: "shaka validate",
+        paths: &["tools/shaka/**", "*/*/project.cue"],
+        run: shaka_validate,
+    },
+    Check {
+        name: "shaka generate --check",
+        paths: &[
+            "tools/shaka/**",
+            "*/*/project.cue",
+            "justfile",
+            "*/*/justfile",
+        ],
+        run: shaka_generate_check,
+    },
+    Check {
+        name: "tofu validate (infra/devbox/terraform)",
+        paths: &["infra/devbox/terraform/**"],
+        run: tofu_validate,
+    },
+    Check {
+        name: "tofu plan (infra/devbox/terraform)",
+        paths: &[
+            "infra/devbox/terraform/**",
+            "infra/devbox/nixos/**",
+            "flake.nix",
+            "flake.lock",
+        ],
+        run: tofu_plan,
+    },
 ];
 
-pub fn run(keep_going: bool) {
-    let total = CHECKS.len();
+pub fn run(keep_going: bool, since: Option<String>) {
+    let changed = match since.as_deref() {
+        Some(r) => match changed_paths(r) {
+            Ok(p) => Some(p),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} could not get changed paths: {e}");
+                std::process::exit(1);
+            }
+        },
+        None => None,
+    };
+
+    let (to_run, skipped): (Vec<&Check>, Vec<&Check>) = CHECKS.iter().partition(|c| match &changed {
+        None => true,
+        Some(paths) => c.paths.is_empty() || paths.iter().any(|p| matches_any(p, c.paths)),
+    });
+
+    let total_to_run = to_run.len();
+    if let Some(_) = changed {
+        if skipped.is_empty() {
+            println!("{BOLD}preflight:{RESET} running {total_to_run} checks (no path filter applied)");
+        } else {
+            let names: Vec<&str> = skipped.iter().map(|c| c.name).collect();
+            println!(
+                "{BOLD}preflight:{RESET} running {total_to_run} of {} checks ({YELLOW}skipped:{RESET} {})",
+                CHECKS.len(),
+                names.join(", ")
+            );
+        }
+    } else {
+        println!("{BOLD}preflight:{RESET} running {total_to_run} checks");
+    }
+
     let mut passed = 0usize;
     let mut failures: Vec<(&'static str, CheckResult)> = Vec::new();
 
-    println!("{BOLD}preflight:{RESET} running {total} checks");
-
-    for (i, check) in CHECKS.iter().enumerate() {
-        let label = format!("[{}/{}] {}", i + 1, total, check.name);
+    for (i, check) in to_run.iter().enumerate() {
+        let label = format!("[{}/{}] {}", i + 1, total_to_run, check.name);
         print!("  {label} ... ");
         std::io::stdout().flush().ok();
 
@@ -58,7 +126,14 @@ pub fn run(keep_going: bool) {
 
     println!();
     if failures.is_empty() {
-        println!("{GREEN}{BOLD}preflight passed{RESET} ({passed}/{total})");
+        println!(
+            "{GREEN}{BOLD}preflight passed{RESET} ({passed}/{total_to_run}{})",
+            if !skipped.is_empty() {
+                format!(", {} skipped", skipped.len())
+            } else {
+                String::new()
+            }
+        );
         return;
     }
 
@@ -72,10 +147,63 @@ pub fn run(keep_going: bool) {
     }
 
     eprintln!(
-        "{RED}{BOLD}preflight failed{RESET} ({passed} passed, {} failed of {total})",
+        "{RED}{BOLD}preflight failed{RESET} ({passed} passed, {} failed of {total_to_run})",
         failures.len()
     );
     std::process::exit(1);
+}
+
+fn changed_paths(since: &str) -> Result<Vec<String>, String> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", since])
+        .output()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!("git diff failed: {stderr}"));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(String::from)
+        .collect())
+}
+
+fn matches_any(path: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|p| matches_pattern(path, p))
+}
+
+fn matches_pattern(path: &str, pattern: &str) -> bool {
+    let path_parts: Vec<&str> = path.split('/').collect();
+    let pat_parts: Vec<&str> = pattern.split('/').collect();
+    matches_parts(&path_parts, &pat_parts)
+}
+
+fn matches_parts(path: &[&str], pat: &[&str]) -> bool {
+    if pat.is_empty() {
+        return path.is_empty();
+    }
+    let head = pat[0];
+    if head == "**" {
+        if pat.len() == 1 {
+            return true;
+        }
+        for i in 0..=path.len() {
+            if matches_parts(&path[i..], &pat[1..]) {
+                return true;
+            }
+        }
+        return false;
+    }
+    if path.is_empty() {
+        return false;
+    }
+    let part_matches = head == "*" || head == path[0];
+    if !part_matches {
+        return false;
+    }
+    matches_parts(&path[1..], &pat[1..])
 }
 
 fn nix_flake_check() -> CheckResult {
@@ -185,5 +313,60 @@ fn run_command(cmd: &mut Command) -> CheckResult {
             detail: format!("failed to spawn: {e}"),
             output: None,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_exact_path() {
+        assert!(matches_pattern("flake.nix", "flake.nix"));
+        assert!(!matches_pattern("flake.lock", "flake.nix"));
+    }
+
+    #[test]
+    fn double_star_at_end_matches_everything_under() {
+        assert!(matches_pattern("tools/shaka/src/main.rs", "tools/shaka/**"));
+        assert!(matches_pattern("tools/shaka/Cargo.toml", "tools/shaka/**"));
+        assert!(matches_pattern("tools/shaka/a/b/c/d.rs", "tools/shaka/**"));
+    }
+
+    #[test]
+    fn double_star_does_not_cross_unrelated_prefixes() {
+        assert!(!matches_pattern("tools/other/src/main.rs", "tools/shaka/**"));
+        assert!(!matches_pattern("apps/foo/src/main.rs", "tools/shaka/**"));
+    }
+
+    #[test]
+    fn single_star_matches_one_component() {
+        assert!(matches_pattern("tools/shaka/project.cue", "*/*/project.cue"));
+        assert!(matches_pattern("apps/foo/project.cue", "*/*/project.cue"));
+        assert!(!matches_pattern("tools/shaka/src/project.cue", "*/*/project.cue"));
+        assert!(!matches_pattern("project.cue", "*/*/project.cue"));
+    }
+
+    #[test]
+    fn single_star_must_match_exactly_one_segment() {
+        assert!(!matches_pattern("tools/project.cue", "*/*/project.cue"));
+    }
+
+    #[test]
+    fn matches_any_returns_false_when_no_pattern_matches() {
+        assert!(!matches_any("README.md", &["tools/shaka/**", "infra/**"]));
+    }
+
+    #[test]
+    fn matches_any_returns_true_when_one_pattern_matches() {
+        assert!(matches_any(
+            "tools/shaka/Cargo.toml",
+            &["infra/**", "tools/shaka/**"]
+        ));
+    }
+
+    #[test]
+    fn empty_path_does_not_match_pattern_with_components() {
+        assert!(!matches_pattern("", "tools/shaka/**"));
     }
 }


### PR DESCRIPTION
Teaches `shaka preflight` to skip checks whose path scope doesn't intersect the changes since a given git ref. Each check declares globs for files that affect its outcome, e.g. `tofu plan` runs only when `infra/devbox/terraform/**` or `infra/devbox/nixos/**` changed. The CI workflow gains a `changes` job that detects the base ref (PR base or previous push) and feeds it to `shaka preflight --since`. The `build-shaka` and `build-image` jobs are now conditional on the same path filters, so unrelated PRs no longer rebuild them.

The path matcher supports `*` (one segment) and `**` (any number of trailing segments) — enough for the current scopes without pulling in a glob crate. Without `--since`, preflight runs every check (current behavior preserved). 8 unit tests cover the matcher.

Closes #13