### PR TITLE
perf(ci): enable FlakeHub Cache as Nix substituter and push target

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
       - name: shaka preflight
         run: |
           nix develop --command nix run ./tools/shaka -- preflight \
@@ -80,7 +83,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
       - run: nix build ./tools/shaka
       - uses: DeterminateSystems/flakehub-push@main
         if: github.event_name == 'push'
@@ -100,7 +106,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/determinate-nix-action@main
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
       - run: nix build .#linodeImage
       - uses: actions/upload-artifact@v4
         if: github.event_name == 'push'


### PR DESCRIPTION
Sets `flakehub: true` on every `DeterminateSystems/determinate-nix-action` step. The action defaults to `flakehub: false`; with the input enabled and `id-token: write` already in place, FlakeHub Cache is configured as both a substituter (pull) and a push target. Subsequent CI runs should resolve previously-built derivations (shaka, the linode image, devShell closures) from the cache instead of rebuilding from scratch via `cache.nixos.org`.

Closes #22