### PR TITLE
feat(shaka): add jj workflow and PR commands

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -129,6 +129,39 @@ fn api_write(method: &str, endpoint: &str, body: &Value) -> Result<Value, GhErro
     })
 }
 
+/// Find the URL of an open PR whose head branch matches `head`. Returns `None`
+/// if no PR exists. `repo` is in `owner/repo` form.
+pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<String>, GhError> {
+    let owner = repo.split('/').next().unwrap_or("");
+    let endpoint = format!("/repos/{repo}/pulls?head={owner}:{head}&state=open");
+    let result = api_get(&endpoint)?;
+    if let Some(arr) = result.as_array() {
+        if let Some(first) = arr.first() {
+            if let Some(url) = first["html_url"].as_str() {
+                return Ok(Some(url.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Run `gh pr create` and return the PR URL.
+pub fn pr_create(title: &str, body: &str, head: &str) -> Result<String, GhError> {
+    let output = Command::new("gh")
+        .args([
+            "pr", "create", "--title", title, "--body", body, "--head", head,
+        ])
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GhError {
+            message: format!("gh pr create: {}", stderr.trim()),
+        });
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(url)
+}
+
 /// Detect owner/repo from the git remote origin URL.
 pub fn detect_repo() -> Result<String, GhError> {
     let output = Command::new("git")

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -1,0 +1,200 @@
+use std::fmt;
+use std::process::Command;
+
+#[derive(Debug)]
+pub struct JjError {
+    pub message: String,
+}
+
+impl fmt::Display for JjError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl From<std::io::Error> for JjError {
+    fn from(e: std::io::Error) -> Self {
+        JjError {
+            message: format!("failed to run jj: {e}"),
+        }
+    }
+}
+
+/// Run `jj` with the given args, returning stdout on success.
+pub fn run(args: &[&str]) -> Result<String, JjError> {
+    let output = Command::new("jj").args(args).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(JjError {
+            message: format!("jj {}: {}", args.join(" "), stderr.trim()),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Run `jj` and stream stdout/stderr to the parent's stdio.
+pub fn run_streaming(args: &[&str]) -> Result<(), JjError> {
+    let status = Command::new("jj").args(args).status()?;
+    if !status.success() {
+        return Err(JjError {
+            message: format!("jj {} exited with status {status}", args.join(" ")),
+        });
+    }
+    Ok(())
+}
+
+pub fn fetch() -> Result<(), JjError> {
+    run_streaming(&["git", "fetch"])
+}
+
+pub fn rebase_onto(dest: &str) -> Result<(), JjError> {
+    run_streaming(&["rebase", "-d", dest])
+}
+
+/// Description of the current change (`@`).
+pub fn current_description() -> Result<String, JjError> {
+    run(&["log", "-r", "@", "-T", "description", "--no-graph"])
+}
+
+/// Local bookmarks pointing at `@`.
+pub fn current_bookmarks() -> Result<Vec<String>, JjError> {
+    let out = run(&[
+        "log",
+        "-r",
+        "@",
+        "-T",
+        r#"bookmarks.map(|b| b.name()).join("\n")"#,
+        "--no-graph",
+    ])?;
+    Ok(out
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect())
+}
+
+/// Move (or create) a bookmark to point at `@`.
+pub fn set_bookmark(name: &str) -> Result<(), JjError> {
+    run_streaming(&["bookmark", "set", name, "-r", "@"])
+}
+
+pub fn push_bookmark(name: &str) -> Result<(), JjError> {
+    run_streaming(&["git", "push", "--allow-new", "--bookmark", name])
+}
+
+/// Best-effort slugify of a string into a bookmark-safe segment.
+pub fn slugify(s: &str, max_len: usize) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for c in s.to_lowercase().chars() {
+        if out.len() >= max_len {
+            break;
+        }
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+            last_dash = false;
+        } else if !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    out.trim_end_matches('-').to_string()
+}
+
+/// Derive a bookmark name from a Conventional-Commits-style description.
+///
+/// `feat(shaka): add commit lint` → `feat/shaka-add-commit-lint`
+/// `fix: typo in readme` → `fix/typo-in-readme`
+/// `arbitrary text` → `change/arbitrary-text`
+pub fn derive_bookmark(description: &str) -> Option<String> {
+    const MAX_LEN: usize = 60;
+    let first_line = description.lines().next()?.trim();
+    if first_line.is_empty() {
+        return None;
+    }
+
+    let (prefix, subject) = match first_line.find(": ") {
+        Some(colon) => {
+            let header = &first_line[..colon];
+            let subject = first_line[colon + 2..].trim();
+            let (typ, scope) = match (header.find('('), header.rfind(')')) {
+                (Some(open), Some(close)) if close > open => {
+                    (&header[..open], Some(&header[open + 1..close]))
+                }
+                _ => (header, None),
+            };
+            let typ = typ.trim();
+            let prefix = match scope {
+                Some(s) if !s.trim().is_empty() => format!("{}/{}", typ, s.trim()),
+                _ => format!("{typ}/"),
+            };
+            (prefix, subject)
+        }
+        None => ("change/".to_string(), first_line),
+    };
+
+    let remaining = MAX_LEN.saturating_sub(prefix.len());
+    let slug = slugify(subject, remaining.max(8));
+    if slug.is_empty() {
+        return None;
+    }
+
+    let bookmark = if prefix.ends_with('/') {
+        format!("{prefix}{slug}")
+    } else {
+        format!("{prefix}-{slug}")
+    };
+    Some(bookmark)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(slugify("Add Commit Lint", 50), "add-commit-lint");
+    }
+
+    #[test]
+    fn slugify_collapses_punct() {
+        assert_eq!(slugify("foo!! bar...baz", 50), "foo-bar-baz");
+    }
+
+    #[test]
+    fn slugify_truncates_and_trims_dash() {
+        assert_eq!(slugify("hello world there", 8), "hello-wo");
+        assert_eq!(slugify("hello world there", 6), "hello");
+    }
+
+    #[test]
+    fn derive_with_scope() {
+        assert_eq!(
+            derive_bookmark("feat(shaka): add commit lint").as_deref(),
+            Some("feat/shaka-add-commit-lint"),
+        );
+    }
+
+    #[test]
+    fn derive_without_scope() {
+        assert_eq!(
+            derive_bookmark("fix: typo in readme").as_deref(),
+            Some("fix/typo-in-readme"),
+        );
+    }
+
+    #[test]
+    fn derive_non_conventional() {
+        assert_eq!(
+            derive_bookmark("arbitrary text here").as_deref(),
+            Some("change/arbitrary-text-here"),
+        );
+    }
+
+    #[test]
+    fn derive_empty_returns_none() {
+        assert!(derive_bookmark("").is_none());
+        assert!(derive_bookmark("   \n").is_none());
+    }
+}

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 mod commit;
 mod generate;
 mod gh;
+mod jj;
 mod preflight;
 mod repo;
 mod validate;

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -1,4 +1,7 @@
 mod audit;
+mod pr;
+pub mod send;
+mod sync;
 
 use clap::Subcommand;
 
@@ -14,10 +17,47 @@ pub enum RepoCommand {
         #[arg(long)]
         fix: bool,
     },
+    /// Fetch from origin and rebase the current change onto main@origin
+    Sync {
+        /// Print the commands that would run without executing them
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Set a bookmark on the current change, push it, and open a PR
+    Send {
+        /// Bookmark name (auto-derived from the change description if omitted)
+        #[arg(long)]
+        bookmark: Option<String>,
+
+        /// Push only — do not create a PR even if one is missing
+        #[arg(long)]
+        no_pr: bool,
+
+        /// Print the commands that would run without executing them
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Ensure a GitHub PR exists for the current change (push, then create if needed)
+    Pr {
+        /// Bookmark name (auto-detected from the current change if omitted)
+        #[arg(long)]
+        bookmark: Option<String>,
+
+        /// Print the commands that would run without executing them
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 pub fn run(cmd: RepoCommand) {
     match cmd {
         RepoCommand::Audit { repo, fix } => audit::run(repo, fix),
+        RepoCommand::Sync { dry_run } => sync::run(dry_run),
+        RepoCommand::Send {
+            bookmark,
+            no_pr,
+            dry_run,
+        } => send::run(bookmark, no_pr, dry_run),
+        RepoCommand::Pr { bookmark, dry_run } => pr::run(bookmark, dry_run),
     }
 }

--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -1,0 +1,96 @@
+use crate::gh;
+use crate::jj;
+use crate::repo::send::split_message;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
+    let bookmark = match bookmark_arg {
+        Some(b) => b,
+        None => match resolve_bookmark() {
+            Ok(b) => b,
+            Err(msg) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {msg}");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    let description = match jj::current_description() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    let trimmed = description.trim();
+    if trimmed.is_empty() {
+        eprintln!(
+            "{RED}{BOLD}error:{RESET} current change has no description — run `jj describe` first"
+        );
+        std::process::exit(1);
+    }
+    let (title, body) = split_message(trimmed);
+
+    if dry_run {
+        println!("would run: jj bookmark set {bookmark} -r @");
+        println!("would run: jj git push --allow-new --bookmark {bookmark}");
+        println!("would ensure PR exists for head {bookmark}");
+        return;
+    }
+
+    println!("{BOLD}setting bookmark {bookmark}{RESET}");
+    if let Err(e) = jj::set_bookmark(&bookmark) {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    println!("{BOLD}pushing {bookmark}{RESET}");
+    if let Err(e) = jj::push_bookmark(&bookmark) {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    let repo = match gh::detect_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    match gh::pr_for_head(&repo, &bookmark) {
+        Ok(Some(url)) => println!("{GREEN}{BOLD}pushed{RESET} (PR: {url})"),
+        Ok(None) => match gh::pr_create(title, body, &bookmark) {
+            Ok(url) => println!("{GREEN}{BOLD}created{RESET} ({url})"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");
+                std::process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn resolve_bookmark() -> Result<String, String> {
+    let bookmarks = jj::current_bookmarks().map_err(|e| e.to_string())?;
+    if bookmarks.len() == 1 {
+        return Ok(bookmarks.into_iter().next().unwrap());
+    }
+    if bookmarks.is_empty() {
+        let desc = jj::current_description().map_err(|e| e.to_string())?;
+        return jj::derive_bookmark(desc.trim()).ok_or_else(|| {
+            "no bookmark on current change and could not derive one — pass --bookmark".to_string()
+        });
+    }
+    Err(format!(
+        "multiple bookmarks on current change ({}); pass --bookmark to disambiguate",
+        bookmarks.join(", ")
+    ))
+}

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -1,0 +1,116 @@
+use crate::gh;
+use crate::jj;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
+    let description = match jj::current_description() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let trimmed = description.trim();
+    if trimmed.is_empty() {
+        eprintln!(
+            "{RED}{BOLD}error:{RESET} current change has no description — run `jj describe` first"
+        );
+        std::process::exit(1);
+    }
+
+    let bookmark = match bookmark_arg.or_else(|| jj::derive_bookmark(trimmed)) {
+        Some(b) => b,
+        None => {
+            eprintln!(
+                "{RED}{BOLD}error:{RESET} could not derive bookmark from description; pass --bookmark"
+            );
+            std::process::exit(1);
+        }
+    };
+
+    let (title, body) = split_message(trimmed);
+
+    if dry_run {
+        println!("would run: jj bookmark set {bookmark} -r @");
+        println!("would run: jj git push --allow-new --bookmark {bookmark}");
+        if !no_pr {
+            println!("would run: gh pr create --title {title:?} --head {bookmark}");
+        }
+        return;
+    }
+
+    println!("{BOLD}setting bookmark {bookmark}{RESET}");
+    if let Err(e) = jj::set_bookmark(&bookmark) {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    println!("{BOLD}pushing {bookmark}{RESET}");
+    if let Err(e) = jj::push_bookmark(&bookmark) {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    if no_pr {
+        println!("{GREEN}{BOLD}pushed{RESET}");
+        return;
+    }
+
+    let repo = match gh::detect_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{YELLOW}{BOLD}warn:{RESET} could not detect repo: {e}");
+            println!("{GREEN}{BOLD}pushed{RESET} (skipping PR)");
+            return;
+        }
+    };
+
+    match gh::pr_for_head(&repo, &bookmark) {
+        Ok(Some(url)) => println!("{GREEN}{BOLD}pushed{RESET} (PR exists: {url})"),
+        Ok(None) => match gh::pr_create(title, body, &bookmark) {
+            Ok(url) => println!("{GREEN}{BOLD}sent{RESET} ({url})"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");
+                std::process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("{YELLOW}{BOLD}warn:{RESET} could not check existing PRs: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Split a commit message into a PR title (first line) and body (the rest,
+/// with leading blank lines stripped).
+pub fn split_message(message: &str) -> (&str, &str) {
+    match message.split_once('\n') {
+        Some((title, rest)) => (title.trim(), rest.trim_start_matches('\n').trim_end()),
+        None => (message.trim(), ""),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_message;
+
+    #[test]
+    fn split_title_only() {
+        assert_eq!(split_message("feat: thing"), ("feat: thing", ""));
+    }
+
+    #[test]
+    fn split_title_and_body() {
+        let msg = "feat: thing\n\nlonger explanation\nspans lines\n";
+        assert_eq!(
+            split_message(msg),
+            ("feat: thing", "longer explanation\nspans lines"),
+        );
+    }
+}

--- a/tools/shaka/src/repo/sync.rs
+++ b/tools/shaka/src/repo/sync.rs
@@ -1,0 +1,28 @@
+use crate::jj;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+pub fn run(dry_run: bool) {
+    if dry_run {
+        println!("would run: jj git fetch");
+        println!("would run: jj rebase -d main@origin");
+        return;
+    }
+
+    println!("{BOLD}fetching from origin{RESET}");
+    if let Err(e) = jj::fetch() {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    println!("{BOLD}rebasing onto main@origin{RESET}");
+    if let Err(e) = jj::rebase_onto("main@origin") {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    println!("{GREEN}{BOLD}synced{RESET}");
+}


### PR DESCRIPTION
Wrap common jj + GitHub workflows into single commands so Claude Code (and
humans) can drive the loop without orchestrating jj/gh by hand. Adds
`shaka repo sync` (fetch + rebase onto main@origin), `shaka repo send`
(derive bookmark, push, open PR), and `shaka repo pr` (ensure a PR exists
for the current change). Each supports --dry-run; bookmark names are
derived from the Conventional Commit header.