### PR TITLE
fix(shaka): drop strict status checks in repo audit

### DIFF
--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -232,6 +232,12 @@ fn check_branch_protection(repo: &str) -> Vec<Check> {
             "not configured",
         ),
         bool_check(
+            "Strict status checks",
+            data["required_status_checks"]["strict"].as_bool() != Some(true),
+            "off (stale-but-mergeable allowed)",
+            "on (forces rebase before merge)",
+        ),
+        bool_check(
             "Force push",
             data["allow_force_pushes"]["enabled"].as_bool() == Some(false),
             "blocked",
@@ -256,7 +262,10 @@ fn fix_branch_protection(repo: &str, checks: &[Check]) {
             c.status == Status::Fail
                 && matches!(
                     c.name,
-                    "Required status checks" | "Force push" | "Branch deletion"
+                    "Required status checks"
+                        | "Strict status checks"
+                        | "Force push"
+                        | "Branch deletion"
                 )
         });
 
@@ -267,7 +276,7 @@ fn fix_branch_protection(repo: &str, checks: &[Check]) {
     println!("  {YELLOW}Fixing branch protection...{RESET}");
     let body = json!({
         "required_status_checks": {
-            "strict": true,
+            "strict": false,
             "contexts": ["Validate"]
         },
         "enforce_admins": true,


### PR DESCRIPTION
The audit currently enforces \`required_status_checks.strict = true\` on
\`main\`, which translates to GitHub's "Require branches to be up to date
before merging" rule. For a solo project the rebase churn isn't paying its
way — without a second concurrent contributor, semantic merge skew is
essentially unreachable.

**Changes**

- \`fix_branch_protection\` now writes \`strict: false\`.
- \`check_branch_protection\` adds a "Strict status checks" check that fails
  when the live config has \`strict: true\`. Without this, the audit would
  silently re-pass even if drift re-enabled strict.

After merge, run \`shaka repo audit --fix\` to push the new policy to GitHub.

Closes #60