### PR TITLE
feat(shaka): add ci gate command and gate job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -124,3 +124,21 @@ jobs:
           path: result/nixos.img
           retention-days: 7
           compression-level: 6
+
+  # ── Required status check ─────────────────────────────────────
+  # Branch protection requires only this job. It runs unconditionally
+  # and asserts every upstream job finished as success or skipped, so
+  # path-filtered jobs can still skip without blocking merge. Every
+  # new CI job must add itself to `gate.needs`.
+  gate:
+    name: Gate
+    needs: [changes, validate, build-shaka, build-image]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - run: nix run ./tools/shaka -- ci gate --needs '${{ toJson(needs) }}'

--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -1,0 +1,140 @@
+use clap::Subcommand;
+use serde_json::Value;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Subcommand)]
+pub enum CiCommand {
+    /// Assert every upstream job in a workflow's needs context succeeded or was skipped
+    Gate {
+        /// JSON object from `${{ toJson(needs) }}` in the workflow file
+        #[arg(long)]
+        needs: String,
+    },
+}
+
+pub fn run(cmd: CiCommand) {
+    match cmd {
+        CiCommand::Gate { needs } => match gate(&needs) {
+            Ok(()) => {}
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                std::process::exit(1);
+            }
+        },
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum JobOutcome {
+    Pass,
+    Skip,
+    Block,
+}
+
+fn classify(result: &str) -> JobOutcome {
+    match result {
+        "success" => JobOutcome::Pass,
+        "skipped" => JobOutcome::Skip,
+        _ => JobOutcome::Block,
+    }
+}
+
+fn gate(needs_json: &str) -> Result<(), String> {
+    let parsed: Value =
+        serde_json::from_str(needs_json).map_err(|e| format!("could not parse --needs as JSON: {e}"))?;
+
+    let jobs = parsed
+        .as_object()
+        .ok_or_else(|| "--needs must be a JSON object".to_string())?;
+
+    if jobs.is_empty() {
+        return Err("--needs object is empty (no upstream jobs)".to_string());
+    }
+
+    let mut blocking: Vec<(String, String)> = Vec::new();
+
+    println!("{BOLD}Gate: checking upstream jobs{RESET}");
+    for (name, job) in jobs {
+        let result = job
+            .get("result")
+            .and_then(|r| r.as_str())
+            .unwrap_or("missing");
+        let outcome = classify(result);
+        let (label, color) = match outcome {
+            JobOutcome::Pass => ("PASS", GREEN),
+            JobOutcome::Skip => ("SKIP", YELLOW),
+            JobOutcome::Block => ("FAIL", RED),
+        };
+        println!("  {color}{BOLD}[{label}]{RESET} {name}: {result}");
+        if outcome == JobOutcome::Block {
+            blocking.push((name.clone(), result.to_string()));
+        }
+    }
+
+    println!();
+    if blocking.is_empty() {
+        println!("{GREEN}{BOLD}Gate passed{RESET} ({} job(s))", jobs.len());
+        Ok(())
+    } else {
+        eprintln!(
+            "{RED}{BOLD}Gate failed{RESET}: {} of {} job(s) blocking",
+            blocking.len(),
+            jobs.len()
+        );
+        for (name, result) in &blocking {
+            eprintln!("  - {name}: {result}");
+        }
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_success_passes() {
+        assert_eq!(classify("success"), JobOutcome::Pass);
+    }
+
+    #[test]
+    fn classify_skipped_passes() {
+        assert_eq!(classify("skipped"), JobOutcome::Skip);
+    }
+
+    #[test]
+    fn classify_failure_blocks() {
+        assert_eq!(classify("failure"), JobOutcome::Block);
+    }
+
+    #[test]
+    fn classify_cancelled_blocks() {
+        assert_eq!(classify("cancelled"), JobOutcome::Block);
+    }
+
+    #[test]
+    fn classify_missing_or_unknown_blocks() {
+        assert_eq!(classify("missing"), JobOutcome::Block);
+        assert_eq!(classify(""), JobOutcome::Block);
+    }
+
+    #[test]
+    fn gate_rejects_invalid_json() {
+        assert!(gate("not json").is_err());
+    }
+
+    #[test]
+    fn gate_rejects_non_object() {
+        assert!(gate("[]").is_err());
+    }
+
+    #[test]
+    fn gate_rejects_empty_object() {
+        assert!(gate("{}").is_err());
+    }
+}

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+mod ci;
 mod commit;
 mod generate;
 mod gh;
@@ -19,6 +20,11 @@ struct Cli {
 enum Commands {
     /// Build the project
     Build,
+    /// CI orchestration helpers (gate, etc.)
+    Ci {
+        #[command(subcommand)]
+        command: ci::CiCommand,
+    },
     /// Commit message tooling (lint, etc.)
     Commit {
         #[command(subcommand)]
@@ -55,6 +61,7 @@ fn main() {
         Commands::Build => {
             println!("build");
         }
+        Commands::Ci { command } => ci::run(command),
         Commands::Commit { command } => commit::run(command),
         Commands::Generate { check } => generate::run(check),
         Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -277,7 +277,7 @@ fn fix_branch_protection(repo: &str, checks: &[Check]) {
     let body = json!({
         "required_status_checks": {
             "strict": false,
-            "contexts": ["Validate"]
+            "contexts": ["Gate"]
         },
         "enforce_admins": true,
         "required_pull_request_reviews": null,


### PR DESCRIPTION
Replaces the single required `Validate` status check with a `Gate` job that
depends on every CI job, runs `if: always()`, and asserts each upstream
finished as `success` or `skipped`. Lets path-filtered builds skip without
blocking merge while still gating on their results when they do run.

Assertion lives in `shaka ci gate` so it's testable and versioned with CI
tooling. `repo audit --fix` now writes `["Gate"]` as the required context;
needs a one-shot `shaka repo audit --fix` after merge to flip the live
branch protection.

Closes #62