### PR TITLE
feat(shaka): add repo status subcommand

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -129,20 +129,31 @@ fn api_write(method: &str, endpoint: &str, body: &Value) -> Result<Value, GhErro
     })
 }
 
-/// Find the URL of an open PR whose head branch matches `head`. Returns `None`
-/// if no PR exists. `repo` is in `owner/repo` form.
-pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<String>, GhError> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrInfo {
+    pub number: u64,
+    pub url: String,
+}
+
+/// Find the open PR whose head branch matches `head`. Returns `None` if no PR
+/// exists. `repo` is in `owner/repo` form.
+pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
     let owner = repo.split('/').next().unwrap_or("");
     let endpoint = format!("/repos/{repo}/pulls?head={owner}:{head}&state=open");
     let result = api_get(&endpoint)?;
-    if let Some(arr) = result.as_array() {
-        if let Some(first) = arr.first() {
-            if let Some(url) = first["html_url"].as_str() {
-                return Ok(Some(url.to_string()));
-            }
-        }
-    }
-    Ok(None)
+    let Some(first) = result.as_array().and_then(|arr| arr.first()) else {
+        return Ok(None);
+    };
+    let number = first["number"].as_u64().ok_or_else(|| GhError {
+        message: format!("PR for head {head} missing 'number' field"),
+    })?;
+    let url = first["html_url"]
+        .as_str()
+        .ok_or_else(|| GhError {
+            message: format!("PR for head {head} missing 'html_url' field"),
+        })?
+        .to_string();
+    Ok(Some(PrInfo { number, url }))
 }
 
 /// Run `gh pr create` and return the PR URL.

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -56,22 +56,120 @@ pub fn current_description() -> Result<String, JjError> {
     run(&["log", "-r", "@", "-T", "description", "--no-graph"])
 }
 
-/// Local bookmarks pointing at `@`.
-pub fn current_bookmarks() -> Result<Vec<String>, JjError> {
+/// Resolve a single revset to its commit id. Errors if the revset matches
+/// zero or more than one revision.
+pub fn commit_id_of(revset: &str) -> Result<String, JjError> {
+    let out = run(&["log", "-r", revset, "-T", r#"commit_id ++ "\n""#, "--no-graph"])?;
+    let mut ids = out.lines().map(str::trim).filter(|l| !l.is_empty());
+    let first = ids.next().ok_or_else(|| JjError {
+        message: format!("revset {revset:?} matched no revisions"),
+    })?;
+    if ids.next().is_some() {
+        return Err(JjError {
+            message: format!("revset {revset:?} matched multiple revisions"),
+        });
+    }
+    Ok(first.to_string())
+}
+
+/// Count non-empty commits in `base..@`.
+pub fn ahead_count(base: &str) -> Result<usize, JjError> {
+    let revset = format!("{base}..@ ~ empty()");
+    let out = run(&["log", "-r", &revset, "-T", r#"commit_id ++ "\n""#, "--no-graph"])?;
+    Ok(out.lines().filter(|l| !l.trim().is_empty()).count())
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DirtyCounts {
+    pub added: usize,
+    pub modified: usize,
+    pub deleted: usize,
+}
+
+impl DirtyCounts {
+    pub fn total(&self) -> usize {
+        self.added + self.modified + self.deleted
+    }
+}
+
+/// Count files changed by `@` versus its parent.
+pub fn dirty_counts() -> Result<DirtyCounts, JjError> {
+    let out = run(&["diff", "--summary", "-r", "@"])?;
+    Ok(parse_diff_summary(&out))
+}
+
+fn parse_diff_summary(out: &str) -> DirtyCounts {
+    let mut counts = DirtyCounts::default();
+    for line in out.lines() {
+        match line.chars().next() {
+            Some('A' | 'C') => counts.added += 1,
+            Some('M' | 'R') => counts.modified += 1,
+            Some('D') => counts.deleted += 1,
+            _ => {}
+        }
+    }
+    counts
+}
+
+/// Short change id of the current change (`@`).
+pub fn current_change_id() -> Result<String, JjError> {
     let out = run(&[
         "log",
         "-r",
         "@",
         "-T",
-        r#"bookmarks.map(|b| b.name()).join("\n")"#,
+        r#"change_id.short() ++ "\n""#,
         "--no-graph",
     ])?;
-    Ok(out
-        .lines()
-        .map(|l| l.trim())
-        .filter(|l| !l.is_empty())
-        .map(String::from)
-        .collect())
+    Ok(out.trim().to_string())
+}
+
+/// Timestamp (RFC3339-ish) of the most recent `git fetch` operation, or
+/// `None` if the op log doesn't contain one within the inspected window.
+pub fn last_fetch_time() -> Result<Option<String>, JjError> {
+    let out = run(&[
+        "op",
+        "log",
+        "--no-graph",
+        "-T",
+        r#"separate(" | ", time.end().format("%+"), description.first_line()) ++ "\n""#,
+        "--limit",
+        "200",
+    ])?;
+    for line in out.lines() {
+        if let Some((ts, desc)) = line.split_once(" | ") {
+            if desc.starts_with("fetch from git remote") {
+                return Ok(Some(ts.trim().to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Local bookmarks pointing at any commit in the given revset, in revset
+/// order (jj's default: youngest first).
+pub fn bookmarks_on(revset: &str) -> Result<Vec<String>, JjError> {
+    let out = run(&[
+        "log",
+        "-r",
+        revset,
+        "-T",
+        r#"bookmarks.map(|b| b.name()).join("\n") ++ "\n""#,
+        "--no-graph",
+    ])?;
+    let mut names = Vec::new();
+    for line in out.lines() {
+        let name = line.trim();
+        if !name.is_empty() && !names.iter().any(|n: &String| n == name) {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
+}
+
+/// Local bookmarks pointing at `@`.
+pub fn current_bookmarks() -> Result<Vec<String>, JjError> {
+    bookmarks_on("@")
 }
 
 /// Move (or create) a bookmark to point at `@`.
@@ -196,5 +294,29 @@ mod tests {
     fn derive_empty_returns_none() {
         assert!(derive_bookmark("").is_none());
         assert!(derive_bookmark("   \n").is_none());
+    }
+
+    #[test]
+    fn parse_diff_summary_empty() {
+        assert_eq!(parse_diff_summary(""), DirtyCounts::default());
+    }
+
+    #[test]
+    fn parse_diff_summary_mixed() {
+        let out = "A new.rs\nM changed.rs\nM other.rs\nD gone.rs\nR moved.rs\nC copied.rs\n";
+        let counts = parse_diff_summary(out);
+        assert_eq!(counts.added, 2); // A + C
+        assert_eq!(counts.modified, 3); // M + M + R
+        assert_eq!(counts.deleted, 1);
+        assert_eq!(counts.total(), 6);
+    }
+
+    #[test]
+    fn parse_diff_summary_skips_blank_and_unknown() {
+        let out = "\nA file\n? weird\n";
+        let counts = parse_diff_summary(out);
+        assert_eq!(counts.added, 1);
+        assert_eq!(counts.modified, 0);
+        assert_eq!(counts.deleted, 0);
     }
 }

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -1,6 +1,7 @@
 mod audit;
 mod pr;
 pub mod send;
+mod status;
 mod sync;
 
 use clap::Subcommand;
@@ -47,6 +48,12 @@ pub enum RepoCommand {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Print a one-shot summary of the current working-copy state
+    Status {
+        /// Emit JSON instead of human-readable output
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub fn run(cmd: RepoCommand) {
@@ -59,5 +66,6 @@ pub fn run(cmd: RepoCommand) {
             dry_run,
         } => send::run(bookmark, no_pr, dry_run),
         RepoCommand::Pr { bookmark, dry_run } => pr::run(bookmark, dry_run),
+        RepoCommand::Status { json } => status::run(json),
     }
 }

--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -63,7 +63,7 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
     };
 
     match gh::pr_for_head(&repo, &bookmark) {
-        Ok(Some(url)) => println!("{GREEN}{BOLD}pushed{RESET} (PR: {url})"),
+        Ok(Some(pr)) => println!("{GREEN}{BOLD}pushed{RESET} (PR: {})", pr.url),
         Ok(None) => match gh::pr_create(title, body, &bookmark) {
             Ok(url) => println!("{GREEN}{BOLD}created{RESET} ({url})"),
             Err(e) => {

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -72,7 +72,7 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
     };
 
     match gh::pr_for_head(&repo, &bookmark) {
-        Ok(Some(url)) => println!("{GREEN}{BOLD}pushed{RESET} (PR exists: {url})"),
+        Ok(Some(pr)) => println!("{GREEN}{BOLD}pushed{RESET} (PR exists: {})", pr.url),
         Ok(None) => match gh::pr_create(title, body, &bookmark) {
             Ok(url) => println!("{GREEN}{BOLD}sent{RESET} ({url})"),
             Err(e) => {

--- a/tools/shaka/src/repo/status.rs
+++ b/tools/shaka/src/repo/status.rs
@@ -1,0 +1,156 @@
+use serde::Serialize;
+
+use crate::gh;
+use crate::jj;
+
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const RED: &str = "\x1b[31m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Serialize)]
+struct Status {
+    bookmarks: Vec<String>,
+    change_id: String,
+    parent: Parent,
+    dirty: Dirty,
+    ahead: usize,
+    pr: Option<Pr>,
+    last_fetch: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Parent {
+    commit_id: String,
+    is_main_origin: bool,
+}
+
+#[derive(Serialize)]
+struct Dirty {
+    added: usize,
+    modified: usize,
+    deleted: usize,
+    total: usize,
+}
+
+#[derive(Serialize)]
+struct Pr {
+    number: u64,
+    url: String,
+    bookmark: String,
+}
+
+pub fn run(json: bool) {
+    let status = match collect() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    if json {
+        match serde_json::to_string_pretty(&status) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} failed to serialize status: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        render_human(&status);
+    }
+}
+
+fn collect() -> Result<Status, String> {
+    let bookmarks = jj::bookmarks_on("main@origin..@").map_err(|e| e.to_string())?;
+    let change_id = jj::current_change_id().map_err(|e| e.to_string())?;
+    let parent_id = jj::commit_id_of("@-").map_err(|e| e.to_string())?;
+    let main_id = jj::commit_id_of("main@origin").map_err(|e| e.to_string())?;
+    let parent = Parent {
+        is_main_origin: parent_id == main_id,
+        commit_id: parent_id,
+    };
+    let counts = jj::dirty_counts().map_err(|e| e.to_string())?;
+    let dirty = Dirty {
+        added: counts.added,
+        modified: counts.modified,
+        deleted: counts.deleted,
+        total: counts.total(),
+    };
+    let ahead = jj::ahead_count("main@origin").map_err(|e| e.to_string())?;
+
+    // PR lookup is best-effort: a missing `gh`, no remote, or a transient API
+    // error shouldn't fail the whole command.
+    let pr = bookmarks
+        .first()
+        .and_then(|b| match gh::detect_repo() {
+            Ok(repo) => gh::pr_for_head(&repo, b)
+                .ok()
+                .flatten()
+                .map(|info| Pr { number: info.number, url: info.url, bookmark: b.clone() }),
+            Err(_) => None,
+        });
+
+    let last_fetch = jj::last_fetch_time().map_err(|e| e.to_string())?;
+
+    Ok(Status {
+        bookmarks,
+        change_id,
+        parent,
+        dirty,
+        ahead,
+        pr,
+        last_fetch,
+    })
+}
+
+fn render_human(s: &Status) {
+    let bookmark_label = if s.bookmarks.is_empty() {
+        format!("{DIM}none{RESET}")
+    } else {
+        s.bookmarks.join(", ")
+    };
+    println!("{BOLD}bookmark:{RESET}     {bookmark_label} {DIM}({}){RESET}", s.change_id);
+
+    let parent_short = short_id(&s.parent.commit_id);
+    let parent_label = if s.parent.is_main_origin {
+        format!("{GREEN}main@origin{RESET} {DIM}({parent_short}){RESET}")
+    } else {
+        format!("{YELLOW}{parent_short}{RESET} {DIM}(not main@origin){RESET}")
+    };
+    println!("{BOLD}parent:{RESET}       {parent_label}");
+
+    let dirty_label = if s.dirty.total == 0 {
+        format!("{DIM}clean{RESET}")
+    } else {
+        format!(
+            "{YELLOW}{}+{RESET} {YELLOW}{}~{RESET} {YELLOW}{}-{RESET}",
+            s.dirty.added, s.dirty.modified, s.dirty.deleted
+        )
+    };
+    println!("{BOLD}working copy:{RESET} {dirty_label}");
+
+    let ahead_label = match s.ahead {
+        0 => format!("{DIM}0 commits past main@origin{RESET}"),
+        1 => "1 commit past main@origin".to_string(),
+        n => format!("{n} commits past main@origin"),
+    };
+    println!("{BOLD}ahead:{RESET}        {ahead_label}");
+
+    match &s.pr {
+        Some(p) => println!("{BOLD}pr:{RESET}           #{} {DIM}{}{RESET}", p.number, p.url),
+        None => println!("{BOLD}pr:{RESET}           {DIM}none{RESET}"),
+    }
+
+    match &s.last_fetch {
+        Some(t) => println!("{BOLD}last fetch:{RESET}   {t}"),
+        None => println!("{BOLD}last fetch:{RESET}   {DIM}unknown{RESET}"),
+    }
+}
+
+fn short_id(id: &str) -> &str {
+    let n = id.len().min(12);
+    &id[..n]
+}


### PR DESCRIPTION
Picking up where things stand currently takes 3–4 commands: `jj
status`, `jj log -r 'main@origin..@'`, `jj bookmark list`, and
`gh pr list --head <branch>`. Each is cheap, but assembling the
answer ("which bookmark, what's the parent, is the working copy
dirty, how far ahead of main, is there an open PR yet") is the
actual question — both for humans and for AI agents.

Add `shaka repo status`:

  bookmark:     feat/shaka-repo-status (yvquuqtuqrwp)
  parent:       e23b58d10b38 (not main@origin)
  working copy: 1+ 1~ 0-
  ahead:        3 commits past main@origin
  pr:           none
  last fetch:   2026-04-28T08:38:25.166-07:00

Bookmarks come from `main@origin..@` rather than just `@`, so the
typical mid-stack state — bookmark on `@-`, working copy on a fresh
empty `@` — still shows the user's working bookmark instead of an
unhelpful "none". The PR lookup uses the topmost bookmark in that set
and is best-effort: a missing `gh`, no remote, or a transient API
error degrades to `pr: none` rather than failing the whole command.

Last-fetch comes from `jj op log` filtered to "fetch from git remote"
descriptions; this works in colocated and non-colocated layouts
without needing to inspect `.git/FETCH_HEAD`.

`--json` emits the same data as a stable schema for programmatic
consumers.