### PR TITLE
chore(shaka): add wrapper that rebuilds shaka if stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,21 @@ The single CI gate is `shaka preflight`. If you add a check that should run in
 CI, add it to `CHECKS` in `tools/shaka/src/preflight.rs` with appropriate path
 scopes — do **not** add a new GitHub Actions job.
 
+### Running `shaka`
+
+`shaka` is **not** on `$PATH` globally, and the root `nix develop` does
+**not** ship the rust toolchain (cargo lives only in `tools/shaka/flake.nix`).
+Always invoke shaka via the wrapper script:
+
+```
+tools/shaka/bin/shaka <subcommand>
+```
+
+It runs an incremental `cargo build` (free when no source has changed) and
+exec's the resulting debug binary, so it works from any cwd, in or out of the
+dev shell, and never leaves you on a stale binary. Don't reach for `cargo
+run` or `nix run ./tools/shaka` — the wrapper subsumes both.
+
 ## Version control
 
 - **Jujutsu (`jj`)** for all VCS operations — never `git` for working-copy

--- a/tools/shaka/bin/shaka
+++ b/tools/shaka/bin/shaka
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Invoke the shaka CLI, rebuilding incrementally if any source has changed.
+#
+# Exists because shaka isn't on $PATH globally and the root `nix develop`
+# doesn't ship the rust toolchain — cargo lives only in tools/shaka/flake.nix.
+# Cargo's incremental check is fast enough that running this on every call is
+# effectively free when nothing has changed.
+
+set -euo pipefail
+
+shaka_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$shaka_dir"
+
+if command -v cargo >/dev/null 2>&1; then
+    cargo build --quiet
+else
+    nix develop --command cargo build --quiet
+fi
+
+exec "$shaka_dir/target/debug/shaka" "$@"


### PR DESCRIPTION
`shaka` isn't on `$PATH` globally and the root `nix develop` doesn't ship the rust toolchain — cargo lives only in `tools/shaka/flake.nix` — which leaves agents and casual contributors choosing between three different invocation patterns (direct binary, `cargo run`, `nix run`), each with different speeds and pitfalls. Adds a single canonical entry point at `tools/shaka/bin/shaka` that runs an incremental `cargo build` (free when no source has changed, falling back to `nix develop --command` when invoked outside the dev shell) and execs the freshly-built debug binary. CLAUDE.md now points readers at the wrapper as the only documented invocation.