### PR TITLE
chore(claude): allowlist common read-only commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo build *)",
+      "Bash(jj log *)",
+      "Bash(cue vet *)",
+      "Bash(jj diff *)",
+      "Bash(cue export *)",
+      "Bash(nix build *)",
+      "Bash(jj st *)",
+      "Bash(jj op log *)",
+      "Bash(shaka *)",
+      "Bash(tools/shaka/bin/shaka *)"
+    ]
+  }
+}


### PR DESCRIPTION
Add `.claude/settings.json` with prefix patterns for read-only commands
that show up frequently in transcripts (cargo build, jj log/diff/st,
cue vet/export, nix build) plus the shaka wrapper. Reduces permission
prompts during agent-assisted work; safety for shaka stays in the CLI
itself.