### PR TITLE
fix(shaka): repo send reuses existing bookmark on @

### DIFF
--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -1,6 +1,6 @@
 use crate::gh;
 use crate::jj;
-use crate::repo::send::split_message;
+use crate::repo::send::{resolve_bookmark, split_message};
 
 const GREEN: &str = "\x1b[32m";
 const RED: &str = "\x1b[31m";
@@ -8,17 +8,6 @@ const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
 
 pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
-    let bookmark = match bookmark_arg {
-        Some(b) => b,
-        None => match resolve_bookmark() {
-            Ok(b) => b,
-            Err(msg) => {
-                eprintln!("{RED}{BOLD}error:{RESET} {msg}");
-                std::process::exit(1);
-            }
-        },
-    };
-
     let description = match jj::current_description() {
         Ok(d) => d,
         Err(e) => {
@@ -33,6 +22,18 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
         );
         std::process::exit(1);
     }
+
+    let bookmark = match bookmark_arg {
+        Some(b) => b,
+        None => match resolve_bookmark(trimmed) {
+            Ok(b) => b,
+            Err(msg) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {msg}");
+                std::process::exit(1);
+            }
+        },
+    };
+
     let (title, body) = split_message(trimmed);
 
     if dry_run {
@@ -76,21 +77,4 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
             std::process::exit(1);
         }
     }
-}
-
-fn resolve_bookmark() -> Result<String, String> {
-    let bookmarks = jj::current_bookmarks().map_err(|e| e.to_string())?;
-    if bookmarks.len() == 1 {
-        return Ok(bookmarks.into_iter().next().unwrap());
-    }
-    if bookmarks.is_empty() {
-        let desc = jj::current_description().map_err(|e| e.to_string())?;
-        return jj::derive_bookmark(desc.trim()).ok_or_else(|| {
-            "no bookmark on current change and could not derive one — pass --bookmark".to_string()
-        });
-    }
-    Err(format!(
-        "multiple bookmarks on current change ({}); pass --bookmark to disambiguate",
-        bookmarks.join(", ")
-    ))
 }

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -24,14 +24,15 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         std::process::exit(1);
     }
 
-    let bookmark = match bookmark_arg.or_else(|| jj::derive_bookmark(trimmed)) {
+    let bookmark = match bookmark_arg {
         Some(b) => b,
-        None => {
-            eprintln!(
-                "{RED}{BOLD}error:{RESET} could not derive bookmark from description; pass --bookmark"
-            );
-            std::process::exit(1);
-        }
+        None => match resolve_bookmark(trimmed) {
+            Ok(b) => b,
+            Err(msg) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {msg}");
+                std::process::exit(1);
+            }
+        },
     };
 
     let (title, body) = split_message(trimmed);
@@ -83,6 +84,31 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         Err(e) => {
             eprintln!("{YELLOW}{BOLD}warn:{RESET} could not check existing PRs: {e}");
             std::process::exit(1);
+        }
+    }
+}
+
+/// Pick the bookmark for the current change.
+///
+/// Prefers a bookmark already on `@` (set by `/start` or the user). If `@`
+/// has no bookmark, derives one from the description. If `@` has multiple
+/// bookmarks, warns and falls back to deriving — pass `--bookmark` to pick
+/// one explicitly.
+pub fn resolve_bookmark(description: &str) -> Result<String, String> {
+    let bookmarks = jj::current_bookmarks().map_err(|e| e.to_string())?;
+    match bookmarks.len() {
+        1 => Ok(bookmarks.into_iter().next().unwrap()),
+        0 => jj::derive_bookmark(description).ok_or_else(|| {
+            "could not derive bookmark from description; pass --bookmark".to_string()
+        }),
+        _ => {
+            eprintln!(
+                "{YELLOW}{BOLD}warn:{RESET} multiple bookmarks on @ ({}); deriving from description — pass --bookmark to override",
+                bookmarks.join(", ")
+            );
+            jj::derive_bookmark(description).ok_or_else(|| {
+                "could not derive bookmark from description; pass --bookmark".to_string()
+            })
         }
     }
 }


### PR DESCRIPTION
repo send always derived a bookmark name from the commit description and
ran 'jj bookmark set', minting a second bookmark on @ even when /start had
already created one. The PR ended up on the derived name, leaving the
intentional bookmark behind as junk to clean up.

Lift resolve_bookmark out of repo/pr.rs into repo/send.rs so both commands
share one resolution path: prefer a bookmark already on @, fall back to
deriving from the description when none exists, and warn + derive when
multiple exist (pass --bookmark to pick deterministically).

Closes #80.