### PR TITLE
feat(shaka): add coverage subcommand and project.cue schema

### DIFF
--- a/tools/shaka/bin/shaka
+++ b/tools/shaka/bin/shaka
@@ -5,16 +5,20 @@
 # doesn't ship the rust toolchain — cargo lives only in tools/shaka/flake.nix.
 # Cargo's incremental check is fast enough that running this on every call is
 # effectively free when nothing has changed.
+#
+# Preserves the caller's cwd (commands like `shaka validate` and `shaka
+# coverage` discover projects relative to cwd, expecting the repo root).
+# When invoked outside the dev shell, re-enters via `nix develop` so cargo is
+# on PATH for both the build step and shaka's runtime tool spawning
+# (e.g. `shaka coverage` invokes `cargo llvm-cov`).
 
 set -euo pipefail
 
 shaka_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$shaka_dir"
 
-if command -v cargo >/dev/null 2>&1; then
-    cargo build --quiet
-else
-    nix develop --command cargo build --quiet
+if ! command -v cargo >/dev/null 2>&1; then
+    exec nix develop "$shaka_dir" --command bash "${BASH_SOURCE[0]}" "$@"
 fi
 
+cargo build --quiet --manifest-path "$shaka_dir/Cargo.toml"
 exec "$shaka_dir/target/debug/shaka" "$@"

--- a/tools/shaka/flake.lock
+++ b/tools/shaka/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
-        "revCount": 911413,
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "revCount": 911667,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.911413%2Brev-10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac/019db652-230b-7233-9071-3ee327cef119/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.911667%2Brev-a4bf06618f0b5ee50f14ed8f0da77d34ecc19160/019dcae8-75b0-71d1-abd5-feab9658f0fa/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -16,7 +16,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777346187,
+        "narHash": "sha256-oVxyGjpiIsrXhWTJVUOs38fZQkLjd0nZGOY9K7Kfot8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "146e7bf7569b8288f24d41d806b9f584f7cfd5b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -1,7 +1,13 @@
 {
   description = "shaka — build tooling for kolohelios";
 
-  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
   outputs =
     { self, ... }@inputs:
@@ -23,9 +29,20 @@
             pkgs = import inputs.nixpkgs {
               inherit system;
               config.allowUnfree = true;
+              overlays = [ inputs.rust-overlay.overlays.default ];
             };
           }
         );
+
+      rustToolchain =
+        pkgs:
+        pkgs.rust-bin.nightly.latest.default.override {
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+            "llvm-tools-preview"
+          ];
+        };
     in
     {
       packages = forEachSupportedSystem ({ pkgs, ... }: {
@@ -48,12 +65,8 @@
         { pkgs, system }:
         {
           default = pkgs.mkShell {
-            packages = with pkgs; [
-              cargo
-              rustc
-              rust-analyzer
-              clippy
-              rustfmt
+            packages = [
+              (rustToolchain pkgs)
               self.formatter.${system}
             ];
           };

--- a/tools/shaka/schema/project.cue
+++ b/tools/shaka/schema/project.cue
@@ -3,4 +3,14 @@ package project
 #Project: {
 	name: string & =~"^[a-z][a-z0-9-]*$"
 	kind: "rust" | "infra"
+	coverage?: {
+		line?: {
+			warn: number & >=0 & <=100
+			fail: number & >=0 & <=100
+		}
+		branch?: {
+			warn: number & >=0 & <=100
+			fail: number & >=0 & <=100
+		}
+	}
 }

--- a/tools/shaka/src/coverage.rs
+++ b/tools/shaka/src/coverage.rs
@@ -1,0 +1,253 @@
+use crate::validate::{discover, write_schema};
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Deserialize)]
+struct ProjectMeta {
+    name: String,
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct LlvmCovExport {
+    data: Vec<LlvmCovRun>,
+}
+
+#[derive(Deserialize)]
+struct LlvmCovRun {
+    totals: LlvmCovTotals,
+}
+
+#[derive(Deserialize)]
+struct LlvmCovTotals {
+    lines: LlvmCovMetric,
+    branches: LlvmCovMetric,
+}
+
+#[derive(Deserialize)]
+struct LlvmCovMetric {
+    count: u64,
+    percent: f64,
+}
+
+struct CoverageMetrics {
+    line_percent: f64,
+    branch_percent: Option<f64>,
+}
+
+pub fn run(project_filter: Option<String>) {
+    let schema_path = match write_schema() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} could not write schema: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let projects = discover(Path::new("."));
+    let mut rust_projects = Vec::new();
+    let mut filter_failed = false;
+
+    for project_dir in projects {
+        match read_project_meta(&schema_path, &project_dir) {
+            Ok(meta) if meta.kind == "rust" => {
+                if project_filter
+                    .as_deref()
+                    .map_or(true, |f| f == meta.name.as_str())
+                {
+                    rust_projects.push((project_dir, meta));
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!(
+                    "{YELLOW}{BOLD}warn:{RESET} could not read {}: {DIM}{e}{RESET}",
+                    project_dir.display()
+                );
+            }
+        }
+    }
+
+    if rust_projects.is_empty() {
+        if let Some(name) = project_filter.as_deref() {
+            eprintln!("{RED}{BOLD}error:{RESET} no rust project named {name}");
+            filter_failed = true;
+        } else {
+            println!("{YELLOW}no rust projects found{RESET}");
+        }
+        if filter_failed {
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    println!(
+        "{BOLD}coverage:{RESET} {} rust project{}",
+        rust_projects.len(),
+        if rust_projects.len() == 1 { "" } else { "s" }
+    );
+
+    let mut summaries = Vec::new();
+    let mut errors = 0;
+    for (project_dir, meta) in &rust_projects {
+        match run_coverage(project_dir) {
+            Ok(metrics) => {
+                let branch_str = metrics
+                    .branch_percent
+                    .map(|b| format!(", branch {b:.1}%"))
+                    .unwrap_or_default();
+                println!(
+                    "  {GREEN}{BOLD}ok{RESET}    {} ({DIM}line {:.1}%{branch_str}{RESET})",
+                    meta.name, metrics.line_percent,
+                );
+                summaries.push((meta.name.clone(), metrics));
+            }
+            Err(e) => {
+                eprintln!(
+                    "  {RED}{BOLD}ERROR{RESET} {} ({DIM}{e}{RESET})",
+                    meta.name
+                );
+                errors += 1;
+            }
+        }
+    }
+
+    if !summaries.is_empty() {
+        println!();
+        let line_avg = summaries.iter().map(|(_, m)| m.line_percent).sum::<f64>()
+            / summaries.len() as f64;
+        let branch_avg: Vec<f64> =
+            summaries.iter().filter_map(|(_, m)| m.branch_percent).collect();
+        let branch_str = if branch_avg.is_empty() {
+            String::new()
+        } else {
+            let avg = branch_avg.iter().sum::<f64>() / branch_avg.len() as f64;
+            format!(", branch {avg:.1}% across {}", branch_avg.len())
+        };
+        println!(
+            "{BOLD}coverage avg:{RESET} line {line_avg:.1}% across {}{branch_str}",
+            summaries.len()
+        );
+    }
+
+    if errors > 0 {
+        std::process::exit(1);
+    }
+}
+
+fn read_project_meta(
+    schema_path: &Path,
+    project_dir: &Path,
+) -> Result<ProjectMeta, String> {
+    let project_file = project_dir.join("project.cue");
+    if !project_file.exists() {
+        return Err("no project.cue".to_string());
+    }
+    let out = Command::new("cue")
+        .arg("export")
+        .arg("--out")
+        .arg("json")
+        .arg(schema_path)
+        .arg(&project_file)
+        .output()
+        .map_err(|e| format!("failed to spawn cue: {e}"))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+    serde_json::from_slice(&out.stdout)
+        .map_err(|e| format!("could not parse cue output: {e}"))
+}
+
+fn run_coverage(project_dir: &Path) -> Result<CoverageMetrics, String> {
+    let manifest = absolute(project_dir).join("Cargo.toml");
+    if !manifest.exists() {
+        return Err(format!("missing {}", manifest.display()));
+    }
+
+    let out = Command::new("cargo")
+        .arg("llvm-cov")
+        .arg("--json")
+        .arg("--summary-only")
+        .arg("--branch")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .output()
+        .map_err(|e| format!("failed to spawn cargo llvm-cov: {e}"))?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        let last = stderr.lines().last().unwrap_or(&stderr).to_string();
+        return Err(format!("cargo llvm-cov failed: {last}"));
+    }
+
+    parse_llvm_cov_json(&out.stdout)
+}
+
+fn absolute(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    }
+}
+
+fn parse_llvm_cov_json(json: &[u8]) -> Result<CoverageMetrics, String> {
+    let export: LlvmCovExport = serde_json::from_slice(json)
+        .map_err(|e| format!("could not parse cargo llvm-cov json: {e}"))?;
+    let totals = &export
+        .data
+        .first()
+        .ok_or_else(|| "cargo llvm-cov json had no data entries".to_string())?
+        .totals;
+    Ok(CoverageMetrics {
+        line_percent: totals.lines.percent,
+        branch_percent: if totals.branches.count > 0 {
+            Some(totals.branches.percent)
+        } else {
+            None
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_export() {
+        let json = br#"{"data":[{"totals":{"lines":{"count":100,"percent":80.5},"branches":{"count":0,"percent":0.0}}}]}"#;
+        let m = parse_llvm_cov_json(json).unwrap();
+        assert!((m.line_percent - 80.5).abs() < 0.001);
+        assert_eq!(m.branch_percent, None);
+    }
+
+    #[test]
+    fn parse_with_branches() {
+        let json = br#"{"data":[{"totals":{"lines":{"count":1890,"percent":32.0},"branches":{"count":102,"percent":71.5}}}]}"#;
+        let m = parse_llvm_cov_json(json).unwrap();
+        assert!((m.line_percent - 32.0).abs() < 0.001);
+        assert!(matches!(m.branch_percent, Some(p) if (p - 71.5).abs() < 0.001));
+    }
+
+    #[test]
+    fn parse_empty_data_is_error() {
+        let json = br#"{"data":[]}"#;
+        assert!(parse_llvm_cov_json(json).is_err());
+    }
+
+    #[test]
+    fn parse_invalid_json_is_error() {
+        let json = b"not json";
+        assert!(parse_llvm_cov_json(json).is_err());
+    }
+}

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod ci;
 mod commit;
+mod coverage;
 mod generate;
 mod gh;
 mod jj;
@@ -29,6 +30,12 @@ enum Commands {
     Commit {
         #[command(subcommand)]
         command: commit::CommitCommand,
+    },
+    /// Run cargo llvm-cov on each rust project and report coverage
+    Coverage {
+        /// Limit to a single project by name
+        #[arg(long)]
+        project: Option<String>,
     },
     /// Generate justfiles from each project.cue (root + per-project)
     Generate {
@@ -63,6 +70,7 @@ fn main() {
         }
         Commands::Ci { command } => ci::run(command),
         Commands::Commit { command } => commit::run(command),
+        Commands::Coverage { project } => coverage::run(project),
         Commands::Generate { check } => generate::run(check),
         Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
         Commands::Repo { command } => repo::run(command),

--- a/tools/shaka/src/validate.rs
+++ b/tools/shaka/src/validate.rs
@@ -9,7 +9,7 @@ const DIM: &str = "\x1b[2m";
 const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
 
-const SCHEMA: &str = include_str!("../schema/project.cue");
+pub const SCHEMA: &str = include_str!("../schema/project.cue");
 const SLOTS: &[&str] = &["apps", "infra", "packages", "services", "tools"];
 
 enum ProjectResult {
@@ -70,7 +70,7 @@ pub fn run() {
     println!("{GREEN}{BOLD}validate passed{RESET}");
 }
 
-fn discover(root: &Path) -> Vec<PathBuf> {
+pub fn discover(root: &Path) -> Vec<PathBuf> {
     let mut projects = Vec::new();
     for slot in SLOTS {
         let slot_dir = root.join(slot);
@@ -112,7 +112,7 @@ fn validate_project(schema_path: &Path, project_dir: &Path) -> ProjectResult {
     }
 }
 
-fn write_schema() -> std::io::Result<PathBuf> {
+pub fn write_schema() -> std::io::Result<PathBuf> {
     let path = std::env::temp_dir().join("shaka-project-schema.cue");
     let mut f = std::fs::File::create(&path)?;
     f.write_all(SCHEMA.as_bytes())?;


### PR DESCRIPTION
Add 'shaka coverage [--project <name>]' that runs cargo llvm-cov on each
rust project discovered in the monorepo and reports per-project line and
branch coverage with a roll-up. Slice 1 of #45 — measurement only, no
threshold gating yet (slice 2).

Schema additions:
- Optional 'coverage' block on #Project with line/branch warn/fail
  thresholds (validated as 0..=100). Read but not enforced in this slice.

Toolchain:
- Switch tools/shaka/flake.nix to oxalica/rust-overlay with the nightly
  toolchain (extensions: rust-src, rust-analyzer, llvm-tools-preview).
  cargo-llvm-cov is broken in nixpkgs on darwin (rust profiler runtime
  disabled); the overlay supplies a profiler-enabled toolchain. Branch
  coverage requires nightly.
- cargo-llvm-cov itself is not on nixpkgs/darwin either; install via
  'cargo install cargo-llvm-cov' once.

Closes #85.