### PR TITLE
refactor(flake): consume kolohelios-nix in root and shaka flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,13 +1,27 @@
 {
   "nodes": {
+    "kolohelios-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "path": "./nix/kolohelios-nix",
+        "type": "path"
+      },
+      "original": {
+        "path": "./nix/kolohelios-nix",
+        "type": "path"
+      },
+      "parent": []
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
-        "revCount": 911413,
+        "lastModified": 1777077449,
+        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
+        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
+        "revCount": 911667,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.911413%2Brev-10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac/019db652-230b-7233-9071-3ee327cef119/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.911667%2Brev-a4bf06618f0b5ee50f14ed8f0da77d34ecc19160/019dcae8-75b0-71d1-abd5-feab9658f0fa/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -16,7 +30,11 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "kolohelios-nix": "kolohelios-nix",
+        "nixpkgs": [
+          "kolohelios-nix",
+          "nixpkgs"
+        ]
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,35 +2,18 @@
   description = "kolohelios — monorepo";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
+    kolohelios-nix.url = "path:./nix/kolohelios-nix";
+    nixpkgs.follows = "kolohelios-nix/nixpkgs";
   };
 
   outputs =
-    { self, nixpkgs, ... }:
+    { self, kolohelios-nix, nixpkgs, ... }:
     let
+      inherit (kolohelios-nix.lib) forEachSupportedSystem workflowPackages;
+
       lib = nixpkgs.lib;
 
-      # Systems we build devShells for (image is x86_64-linux only)
-      shellSystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
-
-      forEachSystem =
-        f:
-        lib.genAttrs shellSystems (
-          system:
-          f {
-            inherit system;
-            pkgs = import nixpkgs {
-              inherit system;
-              config.allowUnfree = true;
-            };
-          }
-        );
-
-      # NixOS pkgs — always x86_64-linux for the devbox
+      # NixOS pkgs — always x86_64-linux for the devbox.
       nixosPkgs = import nixpkgs {
         system = "x86_64-linux";
         config.allowUnfree = true;
@@ -60,29 +43,20 @@
         imageCfg.config.system.build.linodeImage;
 
       # ── Dev shells ──────────────────────────────────────────────
-      devShells = forEachSystem (
-        { pkgs, system }:
+      # Cross-cutting workflow tools come from kolohelios-nix; this shell
+      # adds infra-specific tools (opentofu, linode-cli) for working at the
+      # repo root.
+      devShells = forEachSupportedSystem (
+        { pkgs, ... }:
         {
           default = pkgs.mkShell {
             name = "kolohelios";
-            packages = with pkgs; [
-              # Nix tooling
-              nixfmt-rfc-style
-              nil # Nix LSP
-
-              # Schema / config
-              cue
-
-              # Infra
-              opentofu
-              linode-cli
-
-              # General
-              git
-              jujutsu
-              jq
-              just
-            ];
+            packages =
+              (workflowPackages pkgs)
+              ++ (with pkgs; [
+                opentofu
+                linode-cli
+              ]);
           };
         }
       );
@@ -90,14 +64,13 @@
       # ── Checks ──────────────────────────────────────────────────
       checks.x86_64-linux = {
         # Verify the NixOS configuration evaluates cleanly
-        devbox-eval =
-          nixosPkgs.runCommand "devbox-eval-check" { } ''
-            # If we got here, the NixOS config evaluated successfully
-            echo "nixosConfigurations.devbox evaluates" > $out
-          '';
+        devbox-eval = nixosPkgs.runCommand "devbox-eval-check" { } ''
+          # If we got here, the NixOS config evaluated successfully
+          echo "nixosConfigurations.devbox evaluates" > $out
+        '';
       };
 
       # ── Formatter ───────────────────────────────────────────────
-      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixfmt-rfc-style);
+      formatter = kolohelios-nix.formatter;
     };
 }

--- a/tools/shaka/flake.lock
+++ b/tools/shaka/flake.lock
@@ -1,5 +1,19 @@
 {
   "nodes": {
+    "kolohelios-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "path": "../../nix/kolohelios-nix",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../nix/kolohelios-nix",
+        "type": "path"
+      },
+      "parent": []
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777077449,
@@ -16,7 +30,11 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "kolohelios-nix": "kolohelios-nix",
+        "nixpkgs": [
+          "kolohelios-nix",
+          "nixpkgs"
+        ],
         "rust-overlay": "rust-overlay"
       }
     },
@@ -27,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777346187,
-        "narHash": "sha256-oVxyGjpiIsrXhWTJVUOs38fZQkLjd0nZGOY9K7Kfot8=",
+        "lastModified": 1777432579,
+        "narHash": "sha256-Ce11TStDsqCge2vAAfLKe2+4lDI5cSX5ZYZOuKJBKKQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "146e7bf7569b8288f24d41d806b9f584f7cfd5b5",
+        "rev": "3ecb5e6ab380ced3272ef7fcfe398bffbcc0f152",
         "type": "github"
       },
       "original": {

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -2,7 +2,8 @@
   description = "shaka — build tooling for kolohelios";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
+    kolohelios-nix.url = "path:../../nix/kolohelios-nix";
+    nixpkgs.follows = "kolohelios-nix/nixpkgs";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -10,26 +11,20 @@
   };
 
   outputs =
-    { self, ... }@inputs:
+    { self, kolohelios-nix, nixpkgs, rust-overlay, ... }:
     let
-      inherit (inputs.nixpkgs) lib;
-
-      supportedSystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
+      inherit (kolohelios-nix.lib) supportedSystems workflowPackages;
 
       forEachSupportedSystem =
         f:
-        lib.genAttrs supportedSystems (
+        nixpkgs.lib.genAttrs supportedSystems (
           system:
           f {
             inherit system;
-            pkgs = import inputs.nixpkgs {
+            pkgs = import nixpkgs {
               inherit system;
               config.allowUnfree = true;
-              overlays = [ inputs.rust-overlay.overlays.default ];
+              overlays = [ rust-overlay.overlays.default ];
             };
           }
         );
@@ -67,18 +62,21 @@
       });
 
       devShells = forEachSupportedSystem (
-        { pkgs, system }:
+        { pkgs, ... }:
         {
           default = pkgs.mkShell {
-            packages = [
-              (rustToolchain pkgs)
-              pkgs.jq
-              self.formatter.${system}
-            ];
+            packages =
+              [ (rustToolchain pkgs) ]
+              ++ (workflowPackages pkgs)
+              # cargo-llvm-cov is needed by `just coverage`. Nixpkgs marks
+              # it broken on darwin (rust profiler runtime not in nixpkgs's
+              # darwin rustc); developers on darwin install it via
+              # `cargo install cargo-llvm-cov`.
+              ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
           };
         }
       );
 
-      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt);
+      formatter = kolohelios-nix.formatter;
     };
 }


### PR DESCRIPTION
Both root flake.nix and tools/shaka/flake.nix now take kolohelios-nix as
a 'path:' input and use its lib helpers (forEachSupportedSystem,
workflowPackages, formatter). Both pin nixpkgs by 'follows = kolohelios-
nix/nixpkgs' so the repo has a single nixpkgs revision.

Effect: closures share between flakes. CI's nix runs no longer pull
duplicate nixpkgs/cue/jj/just/jq/nixfmt closures per flake — addresses
the disk-pressure failures in the previous dissolve-root-flake attempt
(#107, closed and being restructured).

Boilerplate dropped:
- forEachSystem helper (~12 lines × 2 flakes)
- supportedSystems list (~4 lines × 2 flakes)
- nixpkgs input declarations (~3 lines × 2 flakes)
- workflow tool list inline in devShells (~10 lines)
- formatter output (1 line × 2 flakes — re-exported from
  kolohelios-nix.formatter)

Shaka's flake re-implements forEachSupportedSystem locally because rust-
overlay needs to be applied via overlays = [...]; on import, which
kolohelios-nix's helper doesn't expose. Still uses kolohelios-nix's
supportedSystems and workflowPackages.

Part of the #107 restructure into three smaller PRs:
1. (this) consumer migration to kolohelios-nix
2. per-project preflight (resurrects #106)
3. dissolve root flake (revised #107)