### PR TITLE
ci: publish kolohelios-nix to FlakeHub on main pushes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,7 @@ jobs:
       base_ref: ${{ steps.base.outputs.ref }}
       shaka: ${{ steps.filter.outputs.shaka }}
       image: ${{ steps.filter.outputs.image }}
+      nix-lib: ${{ steps.filter.outputs.nix-lib }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -44,6 +45,8 @@ jobs:
               - 'infra/devbox/nixos/**'
               - 'flake.nix'
               - 'flake.lock'
+            nix-lib:
+              - 'nix/kolohelios-nix/**'
 
   # ── Single gate for branch protection ─────────────────────────
   # `shaka preflight` runs every validation check in one place. CI and
@@ -102,6 +105,32 @@ jobs:
           visibility: private
           rolling: true
 
+  build-nix-lib:
+    name: Build kolohelios-nix
+    needs: [validate, changes]
+    if: needs.changes.outputs.nix-lib == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      # `nix flake check` forces evaluation of the lib's outputs (lib,
+      # formatter, devShells), which seeds the closure that flakehub-push
+      # then uploads.
+      - run: nix flake check ./nix/kolohelios-nix
+      - uses: DeterminateSystems/flakehub-push@main
+        if: github.event_name == 'push'
+        with:
+          directory: nix/kolohelios-nix
+          name: kolohelios/kolohelios-nix
+          visibility: private
+          rolling: true
+
   build-image:
     name: Build Linode image
     needs: [validate, changes]
@@ -132,7 +161,7 @@ jobs:
   # new CI job must add itself to `gate.needs`.
   gate:
     name: Gate
-    needs: [changes, validate, build-shaka, build-image]
+    needs: [changes, validate, build-shaka, build-nix-lib, build-image]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Mirror the build-shaka job pattern for kolohelios-nix: a build-nix-lib
job runs after validate, gated on changes to nix/kolohelios-nix/**, and
flakehub-pushes the result on push events.

Once published, FlakeHub serves kolohelios-nix's closure as a substituter
for any flake that consumes it (root, tools/shaka, future projects). With
nixpkgs.follows = kolohelios-nix/nixpkgs across the repo, the entire
shared base hits cache instead of re-evaluating per consumer — material
help for CI disk pressure once per-project preflight (PR 2) and root
flake dissolution (PR 3) land.

Path inputs and FlakeHub URL inputs both work here: derivations are
content-addressed, so the cache hit applies regardless of how consumers
reference the lib. Path inputs stay the default for ergonomics; FlakeHub
URL inputs become a later option if explicit version semantics are
wanted.

Adds the new job to gate.needs and adds a nix-lib path filter to the
changes job, so non-nix-lib PRs skip the build-nix-lib job cleanly.

Closes #110.