### PR TITLE
docs(nix-lib): document consumer pattern in flake.nix header

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,12 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Manual trigger from the Actions UI. Useful for forcing publish jobs
+  # (build-shaka, build-nix-lib, build-image) to run when path filters
+  # would otherwise skip them — e.g. bootstrapping FlakeHub publishing
+  # after adding a new project, or republishing without a real code
+  # change.
+  workflow_dispatch:
 
 jobs:
   # ── Detect changed paths ──────────────────────────────────────
@@ -85,7 +91,7 @@ jobs:
   build-shaka:
     name: Build shaka
     needs: [validate, changes]
-    if: needs.changes.outputs.shaka == 'true'
+    if: needs.changes.outputs.shaka == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -98,7 +104,7 @@ jobs:
           flakehub: true
       - run: nix build ./tools/shaka
       - uses: DeterminateSystems/flakehub-push@main
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           directory: tools/shaka
           name: kolohelios/shaka
@@ -108,7 +114,7 @@ jobs:
   build-nix-lib:
     name: Build kolohelios-nix
     needs: [validate, changes]
-    if: needs.changes.outputs.nix-lib == 'true'
+    if: needs.changes.outputs.nix-lib == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -124,7 +130,7 @@ jobs:
       # then uploads.
       - run: nix flake check ./nix/kolohelios-nix
       - uses: DeterminateSystems/flakehub-push@main
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           directory: nix/kolohelios-nix
           name: kolohelios/kolohelios-nix
@@ -134,7 +140,7 @@ jobs:
   build-image:
     name: Build Linode image
     needs: [validate, changes]
-    if: needs.changes.outputs.image == 'true'
+    if: needs.changes.outputs.image == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -147,7 +153,7 @@ jobs:
           flakehub: true
       - run: nix build .#linodeImage
       - uses: actions/upload-artifact@v5
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         with:
           name: linode-image
           path: result/nixos.img

--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "kolohelios — shared nix utilities for project flakes";
 
+  # Consumed by other project flakes in this repo (tools/shaka,
+  # infra/devbox, and the root flake) for a single nixpkgs pin and a
+  # shared workflow-tool list. Consumers reference this flake via a
+  # `path:` input and `nixpkgs.follows = "kolohelios-nix/nixpkgs"` so
+  # the entire repo shares one nixpkgs revision and closures hit cache
+  # together. Published to FlakeHub by the build-nix-lib CI job; pushed
+  # closures back-fill the substituter for path-input consumers too,
+  # since derivations are content-addressed.
+
   inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
 
   outputs =


### PR DESCRIPTION
Adds a comment block at the top of nix/kolohelios-nix/flake.nix that
explains how consumer flakes integrate (path: input + follows for
nixpkgs), why (single nixpkgs pin → shared closures across the repo),
and where it gets published (FlakeHub via build-nix-lib).

Also serves as a real change inside nix/kolohelios-nix/** that triggers
the build-nix-lib job's path filter on merge — bootstrapping the first
FlakeHub publish without relying on the workflow_dispatch path.