### PR TITLE
feat(shaka): add typos spell check to preflight

### DIFF
--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -46,6 +46,7 @@
           cue
           nixfmt-rfc-style
           nil
+          typos
         ];
     in
     {

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -33,6 +33,15 @@ const CHECKS: &[Check] = &[
         paths: &["tools/shaka/**", "*/*/project.cue", "*/*/justfile"],
         run: shaka_project_generate_justfiles_check,
     },
+    Check {
+        // Whole-repo scan: typos is fast enough that scoping by
+        // changed paths isn't worth the complexity, and a fresh
+        // entry in typos.toml that suppresses an old false positive
+        // should still fire on every PR until cleaned up.
+        name: "typos",
+        paths: &[],
+        run: typos_check,
+    },
 ];
 
 pub fn run(keep_going: bool, since: Option<String>) {
@@ -257,6 +266,10 @@ fn shaka_project_schema_check() -> CheckResult {
 
 fn shaka_project_generate_justfiles_check() -> CheckResult {
     spawn_self(&["project", "generate-justfiles", "--check"])
+}
+
+fn typos_check() -> CheckResult {
+    run_command(&mut Command::new("typos"))
 }
 
 fn spawn_self(args: &[&str]) -> CheckResult {

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,12 @@
+[files]
+extend-exclude = [
+  "**/target/",
+  "**/result/",
+  "*.lock",
+  "**/*.lock",
+]
+
+[default.extend-words]
+# Add false-positive overrides as they're discovered. Keep entries
+# justified with a brief comment so future readers know why each one is
+# pinned.


### PR DESCRIPTION
Wires `crate-ci/typos` into preflight as a whole-repo check. typos
runs on the entire tree rather than scoped to changed paths because
the scan is sub-second and a fresh entry in `typos.toml` should fire
on every PR until the latent typos it allowlists are cleaned up —
scoping by changed files would mask that.

Plumbed via `workflowPackages` in `kolohelios-nix` so every project's
devShell gets `typos` for local `--write-changes` cleanup, and shaka's
preflight context (which consumes `workflowPackages`) inherits it
automatically.

Initial `typos.toml` excludes `target/`, `result/`, and `*.lock` files
and leaves `extend-words` empty; allowlist grows as false positives
are discovered.

Closes #50.