### PR TITLE
ci: cache cargo target/ between validate runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,6 +84,17 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      # Skip cargo dependency rebuilds when Cargo.lock is unchanged. Only
+      # covers the host-side `cargo` invocations from `just validate`; the
+      # `nix flake check` path runs in a sandbox actions/cache can't reach.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            tools/shaka/target/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+          key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
       - name: shaka preflight
         run: |
           nix develop ./tools/shaka --command tools/shaka/bin/shaka preflight \


### PR DESCRIPTION
Persists `tools/shaka/target/` and `~/.cargo/{registry,git}/` across
runs keyed on `Cargo.lock`. Without it, every fresh runner rebuilds
clap/serde/etc. from source before `cargo test`/`clippy`/`llvm-cov`
can run, costing ~5min per validate even when only shaka source
changed. `restore-keys` falls back to the latest partial match so
dependency-bump runs still see incremental builds rather than
from-scratch.

Scoped to the host-side cargo invocations from `just validate`; the
`nix flake check ./tools/shaka` path runs in a buildRustPackage
sandbox actions/cache can't reach, and FlakeHub cache covers nix
store paths.

Closes #133.