### PR TITLE
ci: run commit lint before preflight to fail fast

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,16 +95,16 @@ jobs:
             ~/.cargo/git/
           key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
           restore-keys: cargo-${{ runner.os }}-
-      - name: shaka preflight
-        run: |
-          nix develop ./tools/shaka --command tools/shaka/bin/shaka preflight \
-            --since "${{ needs.changes.outputs.base_ref }}"
       - name: shaka commit lint
         if: github.event_name == 'pull_request'
         run: |
           nix develop ./tools/shaka --command jj git init --colocate
           nix develop ./tools/shaka --command tools/shaka/bin/shaka commit lint \
             -r '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}'
+      - name: shaka preflight
+        run: |
+          nix develop ./tools/shaka --command tools/shaka/bin/shaka preflight \
+            --since "${{ needs.changes.outputs.base_ref }}"
 
   # ── Build jobs (run after validation, only when inputs change) ─
   build-shaka:


### PR DESCRIPTION
Commit-lint is cheap (parse messages) and blocking; preflight is
minutes of nix evaluation, tofu plan, etc. Running commit-lint first
lets GitHub Actions short-circuit on malformed commits in seconds
instead of waiting for the full preflight to grind through.

Mirrors the ordering /ship already uses locally.

Closes #84