### PR TITLE
ci: drop free-disk-space cleanup from validate job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,18 +68,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      # GitHub-hosted runners ship with ~14 GB free, which fills up under
-      # multi-flake nix workloads (kolohelios-nix + shaka + devbox closures
-      # + per-project nix-develop entries from preflight). Aggressive
-      # cleanup of unused preinstalled tooling frees ~30 GB.
-      - uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true


### PR DESCRIPTION
The 60-90s `jlumbroso/free-disk-space` step was added preemptively to make room for nix workloads, on the theory that ubuntu-latest's ~14 GB free wouldn't fit our closures. Test the assumption by removing it: if preflight runs without filling the disk, the cleanup is dead weight.

If disk pressure returns, we can either reintroduce a targeted cleanup or revisit a container-based runner (the alpine `nixos/nix` image trips GitHub Actions' glibc-only injected node, so a container migration needs a glibc-based base — separate change).

Closes #131