### PR TITLE
feat(shaka): add workspace new|list|forget subcommand

### DIFF
--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -54,11 +54,16 @@
             version = "0.1.0";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
-            # Integration tests in tests/schema.rs shell out to `cue vet`
-            # against the shipped schema fixtures. Make cue available during
-            # the check phase so `nix flake check` (and CI's `shaka preflight`)
-            # can run them in the build sandbox.
-            nativeCheckInputs = [ pkgs.cue ];
+            # Integration tests shell out to external tools: tests/schema.rs
+            # uses `cue vet`; tests/workspace.rs uses `jj` (which itself
+            # invokes `git` for colocated repos). Make all three available
+            # during the check phase so `nix flake check` (and CI's `shaka
+            # preflight`) can run them in the build sandbox.
+            nativeCheckInputs = [
+              pkgs.cue
+              pkgs.jujutsu
+              pkgs.git
+            ];
           };
         }
       );

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug)]
@@ -214,6 +215,93 @@ pub fn slugify(s: &str, max_len: usize) -> String {
     out.trim_end_matches('-').to_string()
 }
 
+/// Absolute path of the repo root (the working copy of the default
+/// workspace).
+pub fn repo_root() -> Result<PathBuf, JjError> {
+    let out = run(&["workspace", "root"])?;
+    Ok(PathBuf::from(out.trim()))
+}
+
+/// Information about a single jj workspace, surfaced from `jj workspace
+/// list`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct WorkspaceInfo {
+    pub name: String,
+    pub change_id: String,
+    pub description_first_line: String,
+}
+
+/// All workspaces registered in the repo, in the order `jj` reports.
+pub fn workspaces() -> Result<Vec<WorkspaceInfo>, JjError> {
+    let out = run(&[
+        "workspace",
+        "list",
+        "-T",
+        r#"name ++ "\t" ++ target.change_id().short() ++ "\t" ++ target.description().first_line() ++ "\n""#,
+    ])?;
+    Ok(parse_workspace_list(&out))
+}
+
+fn parse_workspace_list(out: &str) -> Vec<WorkspaceInfo> {
+    let mut result = Vec::new();
+    for line in out.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(3, '\t');
+        let (Some(name), Some(change_id), Some(desc)) = (parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        result.push(WorkspaceInfo {
+            name: name.to_string(),
+            change_id: change_id.to_string(),
+            description_first_line: desc.to_string(),
+        });
+    }
+    result
+}
+
+/// Register a new workspace at `path` with the given name.
+pub fn workspace_add(name: &str, path: &Path) -> Result<(), JjError> {
+    run_streaming(&[
+        "workspace",
+        "add",
+        "--name",
+        name,
+        path.to_str().ok_or_else(|| JjError {
+            message: format!("workspace path is not valid UTF-8: {}", path.display()),
+        })?,
+    ])
+}
+
+/// De-register a workspace from the repo. Does not remove the workspace
+/// directory on disk.
+pub fn workspace_forget(name: &str) -> Result<(), JjError> {
+    run_streaming(&["workspace", "forget", name])
+}
+
+/// Count files changed by the named workspace's `@` versus its parent.
+pub fn dirty_counts_for(workspace: &str) -> Result<DirtyCounts, JjError> {
+    let revset = format!("{workspace}@");
+    let out = run(&["diff", "--summary", "-r", &revset])?;
+    Ok(parse_diff_summary(&out))
+}
+
+/// Count non-empty commits in `base..<workspace>@`.
+pub fn ahead_count_for(workspace: &str, base: &str) -> Result<usize, JjError> {
+    let revset = format!("{base}..{workspace}@ ~ empty()");
+    let out = run(&[
+        "log",
+        "-r",
+        &revset,
+        "-T",
+        r#"commit_id ++ "\n""#,
+        "--no-graph",
+    ])?;
+    Ok(out.lines().filter(|l| !l.trim().is_empty()).count())
+}
+
 /// Derive a bookmark name from a Conventional-Commits-style description.
 ///
 /// `feat(shaka): add commit lint` → `feat/shaka-add-commit-lint`
@@ -323,6 +411,27 @@ mod tests {
         assert_eq!(counts.modified, 3); // M + M + R
         assert_eq!(counts.deleted, 1);
         assert_eq!(counts.total(), 6);
+    }
+
+    #[test]
+    fn parse_workspace_list_basic() {
+        let out = "default\tqmxvvpuksqwk\tfeat: do the thing\nfoo\tabcdef012345\t\n";
+        let ws = parse_workspace_list(out);
+        assert_eq!(ws.len(), 2);
+        assert_eq!(ws[0].name, "default");
+        assert_eq!(ws[0].change_id, "qmxvvpuksqwk");
+        assert_eq!(ws[0].description_first_line, "feat: do the thing");
+        assert_eq!(ws[1].name, "foo");
+        assert_eq!(ws[1].change_id, "abcdef012345");
+        assert_eq!(ws[1].description_first_line, "");
+    }
+
+    #[test]
+    fn parse_workspace_list_skips_blank_and_malformed() {
+        let out = "\ndefault\tabc123\tdesc\nmalformed-line\n\n";
+        let ws = parse_workspace_list(out);
+        assert_eq!(ws.len(), 1);
+        assert_eq!(ws[0].name, "default");
     }
 
     #[test]

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -7,6 +7,7 @@ mod jj;
 mod preflight;
 mod project;
 mod repo;
+mod workspace;
 
 #[derive(Parser)]
 #[command(name = "shaka", about = "Build tooling for kolohelios")]
@@ -48,6 +49,11 @@ enum Commands {
         #[command(subcommand)]
         command: repo::RepoCommand,
     },
+    /// jj workspace management (sibling working copies)
+    Workspace {
+        #[command(subcommand)]
+        command: workspace::WorkspaceCommand,
+    },
 }
 
 fn main() {
@@ -62,5 +68,6 @@ fn main() {
         Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
         Commands::Project { command } => project::run(command),
         Commands::Repo { command } => repo::run(command),
+        Commands::Workspace { command } => workspace::run(command),
     }
 }

--- a/tools/shaka/src/workspace/forget.rs
+++ b/tools/shaka/src/workspace/forget.rs
@@ -1,0 +1,63 @@
+use std::fs;
+
+use super::{die, workspace_path, BOLD, GREEN, RESET};
+use crate::jj;
+
+pub fn run(name: &str, force: bool) {
+    if name == "default" {
+        die("cannot forget the default workspace");
+    }
+
+    let repo_root = match jj::repo_root() {
+        Ok(p) => p,
+        Err(e) => die(&e.to_string()),
+    };
+
+    let workspaces = match jj::workspaces() {
+        Ok(w) => w,
+        Err(e) => die(&e.to_string()),
+    };
+    if !workspaces.iter().any(|w| w.name == name) {
+        die(&format!("no such workspace: {name}"));
+    }
+
+    if !force {
+        let dirty = match jj::dirty_counts_for(name) {
+            Ok(d) => d,
+            Err(e) => die(&e.to_string()),
+        };
+        if dirty.total() > 0 {
+            die(&format!(
+                "workspace {name} has {} uncommitted file change(s); pass --force to override",
+                dirty.total()
+            ));
+        }
+        let ahead = match jj::ahead_count_for(name, "main@origin") {
+            Ok(n) => n,
+            Err(e) => die(&format!(
+                "could not check commits ahead of main@origin (pass --force to skip the safety check): {e}"
+            )),
+        };
+        if ahead > 0 {
+            die(&format!(
+                "workspace {name} has {ahead} commit(s) ahead of main@origin; pass --force to override"
+            ));
+        }
+    }
+
+    if let Err(e) = jj::workspace_forget(name) {
+        die(&e.to_string());
+    }
+
+    let path = workspace_path(&repo_root, name);
+    if path.exists() {
+        if let Err(e) = fs::remove_dir_all(&path) {
+            die(&format!(
+                "removed jj workspace but failed to remove directory {}: {e}",
+                path.display()
+            ));
+        }
+    }
+
+    println!("{GREEN}{BOLD}forgot{RESET} workspace {BOLD}{name}{RESET}");
+}

--- a/tools/shaka/src/workspace/list.rs
+++ b/tools/shaka/src/workspace/list.rs
@@ -1,0 +1,28 @@
+use super::{die, workspace_path, BOLD, DIM, RESET};
+use crate::jj;
+
+pub fn run() {
+    let repo_root = match jj::repo_root() {
+        Ok(p) => p,
+        Err(e) => die(&e.to_string()),
+    };
+    let workspaces = match jj::workspaces() {
+        Ok(w) => w,
+        Err(e) => die(&e.to_string()),
+    };
+
+    for ws in workspaces {
+        let path = if ws.name == "default" {
+            repo_root.clone()
+        } else {
+            workspace_path(&repo_root, &ws.name)
+        };
+        let desc = if ws.description_first_line.is_empty() {
+            format!("{DIM}(no description){RESET}")
+        } else {
+            ws.description_first_line.clone()
+        };
+        println!("{BOLD}{}{RESET} {DIM}{}{RESET}", ws.name, path.display());
+        println!("  {DIM}{}{RESET}  {desc}", ws.change_id);
+    }
+}

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -1,0 +1,77 @@
+mod forget;
+mod list;
+mod new;
+
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Subcommand)]
+pub enum WorkspaceCommand {
+    /// Create a new jj workspace as a sibling of the repo
+    New {
+        /// Workspace name (slug). Directory will be ../<repo-basename>-<name>
+        name: String,
+    },
+    /// List all jj workspaces in the repo
+    List,
+    /// De-register a jj workspace and remove its directory
+    Forget {
+        /// Workspace name to forget
+        name: String,
+        /// Forget even if the workspace has uncommitted or unpushed work
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+pub fn run(cmd: WorkspaceCommand) {
+    match cmd {
+        WorkspaceCommand::New { name } => new::run(&name),
+        WorkspaceCommand::List => list::run(),
+        WorkspaceCommand::Forget { name, force } => forget::run(&name, force),
+    }
+}
+
+/// Path where a workspace directory lives, by convention:
+/// `<repo-root>/../<repo-basename>-<name>`. Tying the prefix to the repo
+/// basename keeps tests hermetic (each tempdir gets its own prefix) and
+/// makes the relationship between the repo and its workspaces obvious on
+/// disk.
+pub(crate) fn workspace_path(repo_root: &Path, name: &str) -> PathBuf {
+    let basename = repo_root
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "workspace".to_string());
+    let parent = repo_root.parent().unwrap_or(repo_root);
+    parent.join(format!("{basename}-{name}"))
+}
+
+pub(crate) fn die(msg: &str) -> ! {
+    eprintln!("{RED}{BOLD}error:{RESET} {msg}");
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn workspace_path_prefixes_with_basename() {
+        let p = workspace_path(Path::new("/Users/me/code/kolohelios"), "feat-foo");
+        assert_eq!(p, Path::new("/Users/me/code/kolohelios-feat-foo"));
+    }
+
+    #[test]
+    fn workspace_path_handles_temp_style_parent() {
+        let p = workspace_path(Path::new("/tmp/abc/repo"), "i42");
+        assert_eq!(p, Path::new("/tmp/abc/repo-i42"));
+    }
+}

--- a/tools/shaka/src/workspace/new.rs
+++ b/tools/shaka/src/workspace/new.rs
@@ -1,0 +1,31 @@
+use super::{die, workspace_path, BOLD, DIM, GREEN, RESET};
+use crate::jj;
+
+pub fn run(name: &str) {
+    let repo_root = match jj::repo_root() {
+        Ok(p) => p,
+        Err(e) => die(&e.to_string()),
+    };
+
+    let path = workspace_path(&repo_root, name);
+    if path.exists() {
+        die(&format!("path already exists: {}", path.display()));
+    }
+
+    let workspaces = match jj::workspaces() {
+        Ok(w) => w,
+        Err(e) => die(&e.to_string()),
+    };
+    if workspaces.iter().any(|w| w.name == name) {
+        die(&format!("workspace already registered: {name}"));
+    }
+
+    if let Err(e) = jj::workspace_add(name, &path) {
+        die(&e.to_string());
+    }
+
+    println!(
+        "{GREEN}{BOLD}created{RESET} workspace {BOLD}{name}{RESET} at {DIM}{}{RESET}",
+        path.display()
+    );
+}

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -1,0 +1,135 @@
+//! Integration tests for `shaka workspace`.
+//!
+//! Sets up a real jj-colocated repo in a tempdir and exercises the
+//! `new|list|forget` lifecycle end-to-end via the compiled binary.
+//! `--force` is used on `forget` so the test doesn't depend on a
+//! `main@origin` revset (none exists in a freshly-init'd repo).
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const SHAKA: &str = env!("CARGO_BIN_EXE_shaka");
+
+fn jj_init_colocated(repo: &Path) {
+    Command::new("jj")
+        .args(["git", "init", "--colocate"])
+        .current_dir(repo)
+        .status()
+        .expect("failed to spawn jj")
+        .success()
+        .then_some(())
+        .expect("jj git init failed");
+}
+
+fn shaka(repo: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(SHAKA)
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("failed to spawn shaka")
+}
+
+fn assert_success(out: &std::process::Output, ctx: &str) {
+    assert!(
+        out.status.success(),
+        "{ctx}: shaka exited {:?}\nstdout: {}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn new_creates_workspace_and_directory() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let out = shaka(&repo, &["workspace", "new", "feat-foo"]);
+    assert_success(&out, "workspace new");
+
+    let workspace_path = parent.path().join("repo-feat-foo");
+    assert!(
+        workspace_path.is_dir(),
+        "expected workspace dir at {}",
+        workspace_path.display()
+    );
+    assert!(
+        workspace_path.join(".jj").is_dir(),
+        "expected .jj inside workspace dir"
+    );
+
+    let list = shaka(&repo, &["workspace", "list"]);
+    assert_success(&list, "workspace list");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(stdout.contains("default"), "list missing default: {stdout}");
+    assert!(
+        stdout.contains("feat-foo"),
+        "list missing feat-foo: {stdout}"
+    );
+}
+
+#[test]
+fn forget_removes_workspace_and_directory() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let new_out = shaka(&repo, &["workspace", "new", "scratch"]);
+    assert_success(&new_out, "workspace new");
+    let workspace_path = parent.path().join("repo-scratch");
+    assert!(workspace_path.is_dir());
+
+    let forget_out = shaka(&repo, &["workspace", "forget", "scratch", "--force"]);
+    assert_success(&forget_out, "workspace forget --force");
+
+    assert!(
+        !workspace_path.exists(),
+        "expected workspace dir to be removed: {}",
+        workspace_path.display()
+    );
+
+    let list = shaka(&repo, &["workspace", "list"]);
+    assert_success(&list, "workspace list after forget");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        !stdout.contains("scratch"),
+        "scratch still listed after forget: {stdout}"
+    );
+}
+
+#[test]
+fn new_rejects_existing_path() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let workspace_path = parent.path().join("repo-collide");
+    std::fs::create_dir(&workspace_path).unwrap();
+
+    let out = shaka(&repo, &["workspace", "new", "collide"]);
+    assert!(!out.status.success(), "expected failure on path collision");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("already exists"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn forget_refuses_default_workspace() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let out = shaka(&repo, &["workspace", "forget", "default"]);
+    assert!(!out.status.success(), "expected failure on default forget");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("default"), "unexpected stderr: {stderr}");
+}


### PR DESCRIPTION
Wires up the user-facing workspace lifecycle on top of the jj primitives.
new creates a sibling working copy at <repo-root>/../<repo-basename>-<name>
and registers it under the un-prefixed name (so jj workspace list and
shaka workspace list show identical names). list summarizes every
workspace with name, path, change id, and description. forget refuses
on uncommitted changes or commits ahead of main@origin unless --force,
then de-registers the workspace AND removes its directory (jj alone
leaves the directory on disk).

The directory prefix is derived from the repo basename rather than
hardcoded, which keeps the implementation generic and lets integration
tests run hermetically against tempdirs.

Closes #100