### PR TITLE
feat(shaka): add workspace status command

### DIFF
--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -187,6 +187,13 @@ pub fn current_bookmarks() -> Result<Vec<String>, JjError> {
     bookmarks_on("@")
 }
 
+/// Local bookmarks pointing at a named workspace's `@` (`<name>@`).
+/// For the `default` workspace, pass `"default"` — jj accepts `default@`.
+pub fn bookmarks_on_workspace(workspace: &str) -> Result<Vec<String>, JjError> {
+    let revset = format!("{workspace}@");
+    bookmarks_on(&revset)
+}
+
 /// Move (or create) a bookmark to point at `@`.
 pub fn set_bookmark(name: &str) -> Result<(), JjError> {
     run_streaming(&["bookmark", "set", name, "-r", "@"])

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -1,6 +1,7 @@
 mod forget;
 mod list;
 mod new;
+mod status;
 
 use std::path::{Path, PathBuf};
 
@@ -36,6 +37,12 @@ pub enum WorkspaceCommand {
         #[arg(long)]
         force: bool,
     },
+    /// Show status summary across all workspaces
+    Status {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub fn run(cmd: WorkspaceCommand) {
@@ -43,6 +50,7 @@ pub fn run(cmd: WorkspaceCommand) {
         WorkspaceCommand::New { name, issue } => new::run(name.as_deref(), issue),
         WorkspaceCommand::List => list::run(),
         WorkspaceCommand::Forget { name, force } => forget::run(&name, force),
+        WorkspaceCommand::Status { json } => status::run(json),
     }
 }
 

--- a/tools/shaka/src/workspace/status.rs
+++ b/tools/shaka/src/workspace/status.rs
@@ -1,0 +1,129 @@
+use serde::Serialize;
+
+use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET};
+
+const YELLOW: &str = "\x1b[33m";
+use crate::jj;
+
+#[derive(Serialize)]
+struct WorkspaceStatus {
+    name: String,
+    path: String,
+    change_id: String,
+    description: String,
+    bookmarks: Vec<String>,
+    ahead: usize,
+    dirty: bool,
+    dirty_counts: DirtyCounts,
+}
+
+#[derive(Serialize)]
+struct DirtyCounts {
+    added: usize,
+    modified: usize,
+    deleted: usize,
+    total: usize,
+}
+
+pub fn run(json: bool) {
+    let repo_root = match jj::repo_root() {
+        Ok(p) => p,
+        Err(e) => die(&e.to_string()),
+    };
+
+    let workspaces = match jj::workspaces() {
+        Ok(w) => w,
+        Err(e) => die(&e.to_string()),
+    };
+
+    let mut statuses: Vec<WorkspaceStatus> = Vec::new();
+
+    for ws in &workspaces {
+        let path = if ws.name == "default" {
+            repo_root.clone()
+        } else {
+            workspace_path(&repo_root, &ws.name)
+        };
+
+        let bookmarks = jj::bookmarks_on_workspace(&ws.name).unwrap_or_default();
+
+        let counts = jj::dirty_counts_for(&ws.name).unwrap_or_default();
+        let dirty = counts.total() > 0;
+
+        // ahead_count_for may fail if main@origin doesn't exist (fresh repo);
+        // fall back to 0 so status still renders.
+        let ahead = jj::ahead_count_for(&ws.name, "main@origin").unwrap_or(0);
+
+        statuses.push(WorkspaceStatus {
+            name: ws.name.clone(),
+            path: path.display().to_string(),
+            change_id: ws.change_id.clone(),
+            description: ws.description_first_line.clone(),
+            bookmarks,
+            ahead,
+            dirty,
+            dirty_counts: DirtyCounts {
+                added: counts.added,
+                modified: counts.modified,
+                deleted: counts.deleted,
+                total: counts.total(),
+            },
+        });
+    }
+
+    if json {
+        match serde_json::to_string_pretty(&statuses) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} failed to serialize workspace status: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        render_human(&statuses);
+    }
+}
+
+fn render_human(statuses: &[WorkspaceStatus]) {
+    for ws in statuses {
+        // Header: name + path
+        println!("{BOLD}{}{RESET}  {DIM}{}{RESET}", ws.name, ws.path);
+
+        // Current @: change id + description
+        let desc = if ws.description.is_empty() {
+            format!("{DIM}(no description){RESET}")
+        } else {
+            ws.description.clone()
+        };
+        println!("  @ {DIM}{}{RESET}  {desc}", ws.change_id);
+
+        // Bookmarks
+        let bookmark_label = if ws.bookmarks.is_empty() {
+            format!("{DIM}none{RESET}")
+        } else {
+            ws.bookmarks.join(", ")
+        };
+        println!("  {BOLD}bookmarks:{RESET}  {bookmark_label}");
+
+        // Ahead
+        let ahead_label = match ws.ahead {
+            0 => format!("{DIM}0 commits ahead of main@origin{RESET}"),
+            1 => format!("{GREEN}1 commit ahead of main@origin{RESET}"),
+            n => format!("{GREEN}{n} commits ahead of main@origin{RESET}"),
+        };
+        println!("  {BOLD}ahead:{RESET}      {ahead_label}");
+
+        // Dirty
+        let dirty_label = if !ws.dirty {
+            format!("{DIM}clean{RESET}")
+        } else {
+            format!(
+                "{YELLOW}{}+{RESET} {YELLOW}{}~{RESET} {YELLOW}{}-{RESET}",
+                ws.dirty_counts.added, ws.dirty_counts.modified, ws.dirty_counts.deleted
+            )
+        };
+        println!("  {BOLD}working copy:{RESET} {dirty_label}");
+
+        println!();
+    }
+}

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -157,6 +157,53 @@ fn new_rejects_neither_name_nor_issue() {
 }
 
 #[test]
+fn status_lists_all_workspaces() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    // Create a second workspace
+    let new_out = shaka(&repo, &["workspace", "new", "feat-bar"]);
+    assert_success(&new_out, "workspace new feat-bar");
+
+    // Human-readable output should mention both workspaces
+    let status_out = shaka(&repo, &["workspace", "status"]);
+    assert_success(&status_out, "workspace status");
+    let stdout = String::from_utf8_lossy(&status_out.stdout);
+    assert!(
+        stdout.contains("default"),
+        "status missing default: {stdout}"
+    );
+    assert!(
+        stdout.contains("feat-bar"),
+        "status missing feat-bar: {stdout}"
+    );
+
+    // --json output should be parseable JSON with both workspaces
+    let json_out = shaka(&repo, &["workspace", "status", "--json"]);
+    assert_success(&json_out, "workspace status --json");
+    let json_str = String::from_utf8_lossy(&json_out.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("workspace status --json is not valid JSON");
+    let arr = parsed.as_array().expect("expected JSON array");
+    assert!(
+        arr.len() >= 2,
+        "expected at least 2 workspaces in JSON, got {}: {json_str}",
+        arr.len()
+    );
+    let names: Vec<&str> = arr.iter().filter_map(|v| v["name"].as_str()).collect();
+    assert!(
+        names.contains(&"default"),
+        "JSON missing default workspace: {json_str}"
+    );
+    assert!(
+        names.contains(&"feat-bar"),
+        "JSON missing feat-bar workspace: {json_str}"
+    );
+}
+
+#[test]
 fn forget_refuses_default_workspace() {
     let parent = TempDir::new().expect("tempdir");
     let repo = parent.path().join("repo");


### PR DESCRIPTION
Adds `shaka workspace status`, which prints a summary row for every jj workspace registered in the repo: name, path, current `@` (change ID + description), bookmarks at `@`, how many commits ahead of `main@origin`, and whether the working copy has uncommitted changes. `--json` emits the same data as a structured array for scripting. Includes a `bookmarks_on_workspace(name)` primitive in `jj.rs` and an integration test asserting both human and JSON output cover all workspaces.

Closes #101.