### PR TITLE
feat(shaka): add workspace cleanup subcommand

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -130,16 +130,26 @@ fn api_write(method: &str, endpoint: &str, body: &Value) -> Result<Value, GhErro
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrState {
+    Open,
+    Closed,
+    Merged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrInfo {
     pub number: u64,
     pub url: String,
+    pub state: PrState,
 }
 
-/// Find the open PR whose head branch matches `head`. Returns `None` if no PR
-/// exists. `repo` is in `owner/repo` form.
+/// Find the PR whose head branch matches `head`, checking all states (open,
+/// closed, merged). Returns `None` if no PR exists. `repo` is in `owner/repo`
+/// form.
 pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
     let owner = repo.split('/').next().unwrap_or("");
-    let endpoint = format!("/repos/{repo}/pulls?head={owner}:{head}&state=open");
+    // Query all states so we can detect merged PRs.
+    let endpoint = format!("/repos/{repo}/pulls?head={owner}:{head}&state=all");
     let result = api_get(&endpoint)?;
     let Some(first) = result.as_array().and_then(|arr| arr.first()) else {
         return Ok(None);
@@ -153,7 +163,19 @@ pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
             message: format!("PR for head {head} missing 'html_url' field"),
         })?
         .to_string();
-    Ok(Some(PrInfo { number, url }))
+    // A closed PR with a merge_commit_sha is merged; otherwise it's closed.
+    let state = match first["state"].as_str() {
+        Some("open") => PrState::Open,
+        Some("closed") => {
+            if first["merged_at"].is_string() {
+                PrState::Merged
+            } else {
+                PrState::Closed
+            }
+        }
+        _ => PrState::Closed,
+    };
+    Ok(Some(PrInfo { number, url, state }))
 }
 
 /// Run `gh pr create` and return the PR URL.

--- a/tools/shaka/src/workspace/cleanup.rs
+++ b/tools/shaka/src/workspace/cleanup.rs
@@ -51,14 +51,9 @@ pub fn run(dry_run: bool) {
         }
 
         let revset = format!("main@origin..{}@", ws.name);
-        let bookmarks = match jj::bookmarks_on(&revset) {
-            Ok(b) => b,
-            Err(_) => {
-                // Workspace may not have any commits ahead of main@origin, or
-                // main@origin doesn't exist in this repo. Skip it.
-                vec![]
-            }
-        };
+        // Workspace may not have any commits ahead of main@origin, or
+        // main@origin doesn't exist in this repo — treat both as no bookmarks.
+        let bookmarks = jj::bookmarks_on(&revset).unwrap_or_default();
 
         if bookmarks.is_empty() {
             continue;
@@ -76,9 +71,7 @@ pub fn run(dry_run: bool) {
                 }
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!(
-                        "{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}"
-                    );
+                    eprintln!("{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}");
                 }
             }
         }

--- a/tools/shaka/src/workspace/cleanup.rs
+++ b/tools/shaka/src/workspace/cleanup.rs
@@ -1,0 +1,127 @@
+use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET};
+use crate::{gh, jj};
+use std::fs;
+
+/// A workspace that has a merged PR and is eligible for cleanup.
+struct MergedWorkspace {
+    name: String,
+    pr_url: String,
+}
+
+/// Walk all workspaces, find ones whose bookmarks ahead of `main@origin` have
+/// a merged PR on the remote, and clean them up (or preview with --dry-run).
+///
+/// Design note: we use a bookmark-convention approach for v1. For each
+/// workspace we enumerate all bookmarks in `main@origin..<workspace>@` and
+/// query GitHub for each via `gh::pr_for_head`. If any bookmark resolves to a
+/// merged PR the workspace is a cleanup candidate.
+///
+/// Trade-off: a workspace with multiple bookmarks where only one has a merged
+/// PR will still be cleaned up. This is intentional — if the branch landed,
+/// the workspace's purpose is done. A future revision could require all
+/// bookmarks to be merged before cleaning.
+pub fn run(dry_run: bool) {
+    let repo_root = match jj::repo_root() {
+        Ok(p) => p,
+        Err(e) => die(&e.to_string()),
+    };
+
+    // Detect the GitHub repo. If there's no remote (e.g. a local-only repo or
+    // a fresh test environment), we skip the PR-state queries and report
+    // nothing to clean up — no point erroring fatally for a read-only command.
+    let repo = match gh::detect_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{DIM}warn:{RESET} could not detect GitHub repo ({e}); skipping PR checks");
+            println!("no workspaces with merged PRs found");
+            return;
+        }
+    };
+
+    let workspaces = match jj::workspaces() {
+        Ok(w) => w,
+        Err(e) => die(&e.to_string()),
+    };
+
+    let mut candidates: Vec<MergedWorkspace> = Vec::new();
+
+    for ws in &workspaces {
+        if ws.name == "default" {
+            continue;
+        }
+
+        let revset = format!("main@origin..{}@", ws.name);
+        let bookmarks = match jj::bookmarks_on(&revset) {
+            Ok(b) => b,
+            Err(_) => {
+                // Workspace may not have any commits ahead of main@origin, or
+                // main@origin doesn't exist in this repo. Skip it.
+                vec![]
+            }
+        };
+
+        if bookmarks.is_empty() {
+            continue;
+        }
+
+        for bookmark in &bookmarks {
+            match gh::pr_for_head(&repo, bookmark) {
+                Ok(Some(pr)) if pr.state == gh::PrState::Merged => {
+                    candidates.push(MergedWorkspace {
+                        name: ws.name.clone(),
+                        pr_url: pr.url.clone(),
+                    });
+                    // One merged bookmark is enough to flag this workspace.
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!(
+                        "{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}"
+                    );
+                }
+            }
+        }
+    }
+
+    if candidates.is_empty() {
+        println!("no workspaces with merged PRs found");
+        return;
+    }
+
+    for candidate in &candidates {
+        if dry_run {
+            println!(
+                "{DIM}dry-run:{RESET} would forget workspace {BOLD}{}{RESET} (merged: {})",
+                candidate.name, candidate.pr_url
+            );
+        } else {
+            let path = workspace_path(&repo_root, &candidate.name);
+
+            if let Err(e) = jj::workspace_forget(&candidate.name) {
+                eprintln!(
+                    "{RED}{BOLD}error:{RESET} failed to forget workspace {}: {e}",
+                    candidate.name
+                );
+                continue;
+            }
+
+            if path.exists() {
+                if let Err(e) = fs::remove_dir_all(&path) {
+                    eprintln!(
+                        "{RED}{BOLD}error:{RESET} removed jj workspace {} but failed to \
+                         remove directory {}: {e}",
+                        candidate.name,
+                        path.display()
+                    );
+                    continue;
+                }
+            }
+
+            println!(
+                "{GREEN}{BOLD}forgot{RESET} workspace {BOLD}{}{RESET} (merged: {})",
+                candidate.name, candidate.pr_url
+            );
+        }
+    }
+}

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -1,3 +1,4 @@
+mod cleanup;
 mod forget;
 mod list;
 mod new;
@@ -43,6 +44,12 @@ pub enum WorkspaceCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Remove workspaces whose PRs have been merged
+    Cleanup {
+        /// Preview what would be cleaned up without making any changes
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 pub fn run(cmd: WorkspaceCommand) {
@@ -51,6 +58,7 @@ pub fn run(cmd: WorkspaceCommand) {
         WorkspaceCommand::List => list::run(),
         WorkspaceCommand::Forget { name, force } => forget::run(&name, force),
         WorkspaceCommand::Status { json } => status::run(json),
+        WorkspaceCommand::Cleanup { dry_run } => cleanup::run(dry_run),
     }
 }
 

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -215,3 +215,31 @@ fn forget_refuses_default_workspace() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("default"), "unexpected stderr: {stderr}");
 }
+
+#[test]
+fn cleanup_dry_run_does_not_remove_workspace() {
+    // Verify that `cleanup --dry-run` exits successfully and leaves the
+    // workspace directory intact. We cannot exercise the merged-PR path in
+    // integration tests (that requires network + auth), but we can confirm
+    // that the command handles a repo with no git remote gracefully (warns and
+    // exits 0) and does not touch the workspace directory.
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let new_out = shaka(&repo, &["workspace", "new", "feat-bar"]);
+    assert_success(&new_out, "workspace new");
+    let workspace_path = parent.path().join("repo-feat-bar");
+    assert!(workspace_path.is_dir(), "workspace dir should exist before cleanup");
+
+    let cleanup_out = shaka(&repo, &["workspace", "cleanup", "--dry-run"]);
+    assert_success(&cleanup_out, "workspace cleanup --dry-run");
+
+    // Regardless of what was printed, the workspace directory must still exist.
+    assert!(
+        workspace_path.is_dir(),
+        "cleanup --dry-run must not remove the workspace directory: {}",
+        workspace_path.display()
+    );
+}

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -231,7 +231,10 @@ fn cleanup_dry_run_does_not_remove_workspace() {
     let new_out = shaka(&repo, &["workspace", "new", "feat-bar"]);
     assert_success(&new_out, "workspace new");
     let workspace_path = parent.path().join("repo-feat-bar");
-    assert!(workspace_path.is_dir(), "workspace dir should exist before cleanup");
+    assert!(
+        workspace_path.is_dir(),
+        "workspace dir should exist before cleanup"
+    );
 
     let cleanup_out = shaka(&repo, &["workspace", "cleanup", "--dry-run"]);
     assert_success(&cleanup_out, "workspace cleanup --dry-run");


### PR DESCRIPTION
Adds `shaka workspace cleanup [--dry-run]` which walks all workspaces, finds bookmarks ahead of `main@origin`, and forgets any workspace where a bookmark's PR has been merged on GitHub. Extends `PrInfo` in `gh.rs` with a `PrState` enum (querying all PR states instead of only open) so merged PRs are visible. Repos without a git remote (e.g. CI tempdirs) get a warning and clean exit rather than a fatal error. Closes #104.