### PR TITLE
feat(shaka): add --issue flag to workspace new

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -173,6 +173,34 @@ pub fn pr_create(title: &str, body: &str, head: &str) -> Result<String, GhError>
     Ok(url)
 }
 
+/// Fetch the title of a GitHub issue by number.
+///
+/// Shells out to `gh issue view <n> --json title --jq .title`.
+/// Returns an error if `gh` is not authenticated or the issue does not exist.
+pub fn issue_title(n: u64) -> Result<String, GhError> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &n.to_string(),
+            "--json",
+            "title",
+            "--jq",
+            ".title",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GhError {
+            message: format!("gh issue view {n}: {}", stderr.trim()),
+        });
+    }
+
+    let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(title)
+}
+
 /// Detect owner/repo from the git remote origin URL.
 pub fn detect_repo() -> Result<String, GhError> {
     let output = Command::new("git")

--- a/tools/shaka/src/project/schema_check.rs
+++ b/tools/shaka/src/project/schema_check.rs
@@ -30,7 +30,7 @@ pub fn run() {
 
     let projects = discover(Path::new("."));
     if projects.is_empty() {
-        println!("{YELLOW}no projects found in slots {:?}{RESET}", SLOTS);
+        println!("{YELLOW}no projects found in slots {SLOTS:?}{RESET}");
         return;
     }
 

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -16,8 +16,15 @@ const RESET: &str = "\x1b[0m";
 pub enum WorkspaceCommand {
     /// Create a new jj workspace as a sibling of the repo
     New {
-        /// Workspace name (slug). Directory will be ../<repo-basename>-<name>
-        name: String,
+        /// Workspace name (slug). Directory will be ../<repo-basename>-<name>.
+        /// Mutually exclusive with --issue.
+        #[arg(conflicts_with = "issue")]
+        name: Option<String>,
+
+        /// GitHub issue number. Derives name as i<N> and prints the issue title.
+        /// Mutually exclusive with <name>.
+        #[arg(long, conflicts_with = "name")]
+        issue: Option<u64>,
     },
     /// List all jj workspaces in the repo
     List,
@@ -33,7 +40,7 @@ pub enum WorkspaceCommand {
 
 pub fn run(cmd: WorkspaceCommand) {
     match cmd {
-        WorkspaceCommand::New { name } => new::run(&name),
+        WorkspaceCommand::New { name, issue } => new::run(name.as_deref(), issue),
         WorkspaceCommand::List => list::run(),
         WorkspaceCommand::Forget { name, force } => forget::run(&name, force),
     }
@@ -73,5 +80,17 @@ mod tests {
     fn workspace_path_handles_temp_style_parent() {
         let p = workspace_path(Path::new("/tmp/abc/repo"), "i42");
         assert_eq!(p, Path::new("/tmp/abc/repo-i42"));
+    }
+
+    #[test]
+    fn issue_name_derivation() {
+        // Derived workspace name for issue N is "i<N>".
+        let n: u64 = 42;
+        let derived = format!("i{n}");
+        assert_eq!(derived, "i42");
+
+        let n: u64 = 102;
+        let derived = format!("i{n}");
+        assert_eq!(derived, "i102");
     }
 }

--- a/tools/shaka/src/workspace/new.rs
+++ b/tools/shaka/src/workspace/new.rs
@@ -1,13 +1,26 @@
 use super::{die, workspace_path, BOLD, DIM, GREEN, RESET};
-use crate::jj;
+use crate::{gh, jj};
 
-pub fn run(name: &str) {
+pub fn run(name: Option<&str>, issue: Option<u64>) {
+    // Resolve the workspace name and an optional confirmation suffix.
+    let (derived_name, issue_info) = match (name, issue) {
+        (Some(n), None) => (n.to_string(), None),
+        (None, Some(n)) => {
+            let title = match gh::issue_title(n) {
+                Ok(t) => t,
+                Err(e) => die(&format!("could not fetch issue #{n}: {e}")),
+            };
+            (format!("i{n}"), Some((n, title)))
+        }
+        _ => die("provide either a workspace <name> or --issue <N>"),
+    };
+
     let repo_root = match jj::repo_root() {
         Ok(p) => p,
         Err(e) => die(&e.to_string()),
     };
 
-    let path = workspace_path(&repo_root, name);
+    let path = workspace_path(&repo_root, &derived_name);
     if path.exists() {
         die(&format!("path already exists: {}", path.display()));
     }
@@ -16,16 +29,25 @@ pub fn run(name: &str) {
         Ok(w) => w,
         Err(e) => die(&e.to_string()),
     };
-    if workspaces.iter().any(|w| w.name == name) {
-        die(&format!("workspace already registered: {name}"));
+    if workspaces.iter().any(|w| w.name == derived_name) {
+        die(&format!("workspace already registered: {derived_name}"));
     }
 
-    if let Err(e) = jj::workspace_add(name, &path) {
+    if let Err(e) = jj::workspace_add(&derived_name, &path) {
         die(&e.to_string());
     }
 
-    println!(
-        "{GREEN}{BOLD}created{RESET} workspace {BOLD}{name}{RESET} at {DIM}{}{RESET}",
-        path.display()
-    );
+    if let Some((n, title)) = issue_info {
+        println!(
+            "{GREEN}{BOLD}created{RESET} workspace {BOLD}{derived_name}{RESET} at \
+             {DIM}{}{RESET} (issue #{n}: {title})",
+            path.display()
+        );
+    } else {
+        println!(
+            "{GREEN}{BOLD}created{RESET} workspace {BOLD}{derived_name}{RESET} at \
+             {DIM}{}{RESET}",
+            path.display()
+        );
+    }
 }

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -122,6 +122,41 @@ fn new_rejects_existing_path() {
 }
 
 #[test]
+fn new_rejects_name_and_issue_together() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    // Passing both <name> and --issue must be rejected by clap before any gh
+    // call is made, so no network access is needed.
+    let out = shaka(&repo, &["workspace", "new", "feat-foo", "--issue", "42"]);
+    assert!(
+        !out.status.success(),
+        "expected failure when both name and --issue are supplied"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflict"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn new_rejects_neither_name_nor_issue() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let out = shaka(&repo, &["workspace", "new"]);
+    assert!(
+        !out.status.success(),
+        "expected failure when neither name nor --issue are supplied"
+    );
+}
+
+#[test]
 fn forget_refuses_default_workspace() {
     let parent = TempDir::new().expect("tempdir");
     let repo = parent.path().join("repo");


### PR DESCRIPTION
Adds `--issue <N>` to `shaka workspace new`. When given, the workspace name is derived as `i<N>` and the issue title is fetched via `gh issue view` and printed as confirmation. Passing both a positional name and `--issue` is rejected by clap at parse time; passing neither also fails with a clear error. Includes a pre-existing clippy fix (uninlined format arg in schema-check).