### PR TITLE
feat(shaka): add cargo-deny to preflight

### DIFF
--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -47,6 +47,7 @@
           nixfmt-rfc-style
           nil
           typos
+          cargo-deny
         ];
     in
     {

--- a/tools/shaka/Cargo.toml
+++ b/tools/shaka/Cargo.toml
@@ -2,6 +2,7 @@
 name = "shaka"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [[bin]]
 name = "shaka"

--- a/tools/shaka/deny.toml
+++ b/tools/shaka/deny.toml
@@ -1,0 +1,24 @@
+[advisories]
+version = 2
+unmaintained = "all"
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+]
+private = { ignore = true }
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/tools/shaka/justfile
+++ b/tools/shaka/justfile
@@ -16,6 +16,9 @@ fmt-check:
 lint:
     cargo clippy --all-targets -- -D warnings
 
+deny:
+    cargo deny check
+
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -36,4 +39,4 @@ nix-fmt-check:
 flake-check:
     nix flake check
 
-validate: fmt-check lint test coverage nix-fmt-check flake-check
+validate: fmt-check lint deny test coverage nix-fmt-check flake-check

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -31,6 +31,9 @@ fmt-check:
 lint:
     cargo clippy --all-targets -- -D warnings
 
+deny:
+    cargo deny check
+
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -51,7 +54,7 @@ nix-fmt-check:
 flake-check:
     nix flake check
 
-validate: fmt-check lint test coverage nix-fmt-check flake-check
+validate: fmt-check lint deny test coverage nix-fmt-check flake-check
 "#;
 
 const NIX_LIB_TEMPLATE: &str = r#"nix-fmt-check:
@@ -295,7 +298,13 @@ mod tests {
         assert!(RUST_TEMPLATE.contains("fmt-check"));
         assert!(RUST_TEMPLATE.contains("clippy"));
         assert!(RUST_TEMPLATE
-            .contains("validate: fmt-check lint test coverage nix-fmt-check flake-check"));
+            .contains("validate: fmt-check lint deny test coverage nix-fmt-check flake-check"));
+    }
+
+    #[test]
+    fn rust_template_includes_deny_recipe() {
+        assert!(RUST_TEMPLATE.contains("deny:"));
+        assert!(RUST_TEMPLATE.contains("cargo deny check"));
     }
 
     #[test]


### PR DESCRIPTION
cargo-deny enforces four supply-chain concerns in one tool: advisories
(RustSec vulnerabilities, unmaintained crates), bans (duplicate
versions, wildcards), licenses (allowlist), and sources (only
crates.io). Wired in per-project so `shaka preflight --since` only
re-runs it for changed rust projects.

Per-project deny.toml exploits cargo-deny's default lookup in the
manifest dir, which keeps the recipe trivial and lets each rust project
own its policy. Marked shaka itself `publish = false` so the licenses
check ignores the workspace crate.

Closes #47