### PR TITLE
ci: free disk space before validate to avoid devbox flake-check OOM

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,6 +68,20 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      # `nix flake check` for infra/devbox evaluates the full NixOS system
+      # closure (kernel modules, etc.) and routinely exhausts the runner's
+      # ~14GB of free disk. Pruning the preinstalled Android/dotnet/Haskell
+      # toolchains the repo never uses reclaims ~25GB and keeps the daemon
+      # from crashing mid-evaluation.
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true


### PR DESCRIPTION
`shaka preflight` runs each project's `just validate`, and `infra/devbox`'s `validate` runs `nix flake check` which evaluates the full NixOS system closure (kernel modules, etc.). On a stock `ubuntu-latest` runner with ~14GB free, the nix daemon crashes mid-evaluation with `No space left on device` — most recently observed on PR #162.

This adds `jlumbroso/free-disk-space@main` as the first step after `actions/checkout@v5` in the `Validate` job. Settings:

- Free Android (~14GB), .NET (~2GB), Haskell (~5GB), Docker preloaded images, swap, and the GitHub tool cache. Total reclaim ~25GB.
- Skip `large-packages` — that path runs `apt purge` on llvm/etc. and adds ~2 minutes to the job; we don't need it for the headroom we're getting from the other categories.

Step is placed before `nix-installer-action` so nix has the freed space available from the start.