### PR TITLE
ci: maximize /nix volume so devbox flake-check fits

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,19 +69,25 @@ jobs:
         with:
           fetch-depth: 0
       # `nix flake check` for infra/devbox evaluates the full NixOS system
-      # closure (kernel modules, etc.) and routinely exhausts the runner's
-      # ~14GB of free disk. Pruning the preinstalled Android/dotnet/Haskell
-      # toolchains the repo never uses reclaims ~25GB and keeps the daemon
-      # from crashing mid-evaluation.
-      - uses: jlumbroso/free-disk-space@main
+      # closure and exhausts the runner's ~14GB free /. Pruning preinstalled
+      # toolchains alone (jlumbroso/free-disk-space) reclaimed ~25GB but
+      # still wasn't enough — the closure pulled clang and OOMed. Instead,
+      # carve an LVM volume out of the runner's unallocated disk + the
+      # freed tool space and mount it at /nix before nix installs.
+      # Yields ~75GB at /nix.
+      - name: Maximize disk for /nix
+        uses: easimon/maximize-build-space@master
         with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: true
+          root-reserve-mb: 1024
+          temp-reserve-mb: 100
+          swap-size-mb: 1024
+          overprovision-lvm: true
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
+          build-mount-path: /nix
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true


### PR DESCRIPTION
#167 added `jlumbroso/free-disk-space` to reclaim ~25GB on the runner before validate. Still not enough: `infra/devbox`'s `nix flake check` evaluates the full NixOS closure (kernel, clang, etc.) and OOMs disk during clang substitution.

Switches to `easimon/maximize-build-space@master`, which removes the same toolchains AND carves an LVM volume out of the runner's unallocated space (the runner has ~70GB unallocated by default) and mounts it at `/nix` before `nix-installer-action` runs. Net available at `/nix` jumps from ~14GB to ~75GB.

Settings:

- `root-reserve-mb: 1024` — keep 1GB at `/` for actions/checkout, build artifacts.
- `swap-size-mb: 1024` — small swap so OOM during heavy nix builds doesn't kill the daemon outright.
- `overprovision-lvm: true` — eat into reserved sectors too.
- `build-mount-path: /nix` — pre-mount the volume where nix-installer expects it.
- Toolchain prunes mirror what `jlumbroso/free-disk-space` was doing, plus codeql.