### PR TITLE
ci: cancel superseded workflow runs on new pushes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,14 @@ on:
   # change.
   workflow_dispatch:
 
+# Cancel an in-flight run when a new commit lands on the same PR branch:
+# `jj git push` and force-pushes during iteration would otherwise leave the
+# previous run churning to completion for nothing. Pushes to `main` never
+# cancel — that run gates the next batch of PRs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
+
 jobs:
   # ── Detect changed paths ──────────────────────────────────────
   # Build jobs use these outputs to skip when their inputs haven't


### PR DESCRIPTION
Iteration on a PR branch (`jj git push`, fixups, rebases-on-main) used to
leave the previous in-flight run churning to completion for nothing — it
couldn't merge anything since the PR's required check is the new run, so
the wall-clock cost was just GitHub Actions minutes and duplicate failed
or canceled notifications.

A workflow-scoped `concurrency:` block keyed on `github.ref` cancels the
old run as soon as a new push starts. The cancel predicate is gated on
`pull_request` or non-main refs so a push to `main` (the post-merge run
that gates the next batch of PRs) is never cancelled.

Closes #163