### PR TITLE
feat(shaka): add whitespace hygiene check

### DIFF
--- a/infra/devbox/justfile
+++ b/infra/devbox/justfile
@@ -7,7 +7,10 @@ tofu-validate:
 nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
-validate: tofu-validate nix-fmt-check
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: tofu-validate nix-fmt-check whitespace-check
 
 plan:
     cd terraform && tofu init -input=false && tofu plan

--- a/nix/kolohelios-nix/justfile
+++ b/nix/kolohelios-nix/justfile
@@ -7,4 +7,7 @@ nix-fmt-check:
 flake-check:
     nix flake check
 
-validate: nix-fmt-check flake-check
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/justfile
+++ b/tools/shaka/justfile
@@ -39,4 +39,7 @@ nix-fmt-check:
 flake-check:
     nix flake check
 
-validate: fmt-check lint deny test coverage nix-fmt-check flake-check
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -7,6 +7,7 @@ mod jj;
 mod preflight;
 mod project;
 mod repo;
+mod whitespace;
 mod workspace;
 
 #[derive(Parser)]
@@ -49,6 +50,11 @@ enum Commands {
         #[command(subcommand)]
         command: repo::RepoCommand,
     },
+    /// Whitespace and line-ending hygiene (check, fix)
+    Whitespace {
+        #[command(subcommand)]
+        command: whitespace::WhitespaceCommand,
+    },
     /// jj workspace management (sibling working copies)
     Workspace {
         #[command(subcommand)]
@@ -68,6 +74,7 @@ fn main() {
         Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
         Commands::Project { command } => project::run(command),
         Commands::Repo { command } => repo::run(command),
+        Commands::Whitespace { command } => whitespace::run(command),
         Commands::Workspace { command } => workspace::run(command),
     }
 }

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -54,7 +54,10 @@ nix-fmt-check:
 flake-check:
     nix flake check
 
-validate: fmt-check lint deny test coverage nix-fmt-check flake-check
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check
 "#;
 
 const NIX_LIB_TEMPLATE: &str = r#"nix-fmt-check:
@@ -63,7 +66,10 @@ const NIX_LIB_TEMPLATE: &str = r#"nix-fmt-check:
 flake-check:
     nix flake check
 
-validate: nix-fmt-check flake-check
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: nix-fmt-check flake-check whitespace-check
 "#;
 
 // Infra projects intentionally do NOT run `nix flake check` in `validate`.
@@ -79,7 +85,10 @@ const INFRA_TEMPLATE: &str = r#"tofu-validate:
 nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
-validate: tofu-validate nix-fmt-check
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: tofu-validate nix-fmt-check whitespace-check
 
 plan:
     cd terraform && tofu init -input=false && tofu plan
@@ -278,7 +287,19 @@ mod tests {
     fn nix_lib_template_runs_flake_check() {
         assert!(NIX_LIB_TEMPLATE.contains("flake-check:"));
         assert!(NIX_LIB_TEMPLATE.contains("nix flake check"));
-        assert!(NIX_LIB_TEMPLATE.contains("validate: nix-fmt-check flake-check"));
+        assert!(NIX_LIB_TEMPLATE.contains("validate: nix-fmt-check flake-check whitespace-check"));
+    }
+
+    #[test]
+    fn all_templates_run_whitespace_check() {
+        for tpl in [RUST_TEMPLATE, NIX_LIB_TEMPLATE, INFRA_TEMPLATE] {
+            assert!(tpl.contains("whitespace-check:"));
+            assert!(tpl.contains("../../tools/shaka/bin/shaka whitespace check"));
+            assert!(
+                tpl.contains("whitespace-check\n"),
+                "validate chain must include whitespace-check"
+            );
+        }
     }
 
     #[test]
@@ -310,8 +331,9 @@ mod tests {
     fn rust_template_includes_quality_recipes() {
         assert!(RUST_TEMPLATE.contains("fmt-check"));
         assert!(RUST_TEMPLATE.contains("clippy"));
-        assert!(RUST_TEMPLATE
-            .contains("validate: fmt-check lint deny test coverage nix-fmt-check flake-check"));
+        assert!(RUST_TEMPLATE.contains(
+            "validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check"
+        ));
     }
 
     #[test]
@@ -346,6 +368,6 @@ mod tests {
 
     #[test]
     fn infra_template_validate_omits_flake_check() {
-        assert!(INFRA_TEMPLATE.contains("validate: tofu-validate nix-fmt-check\n"));
+        assert!(INFRA_TEMPLATE.contains("validate: tofu-validate nix-fmt-check whitespace-check\n"));
     }
 }

--- a/tools/shaka/src/whitespace.rs
+++ b/tools/shaka/src/whitespace.rs
@@ -1,0 +1,561 @@
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use clap::Subcommand;
+
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const YELLOW: &str = "\x1b[33m";
+const DIM: &str = "\x1b[2m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+const BOM: &[u8] = b"\xef\xbb\xbf";
+const BINARY_PROBE: usize = 8192;
+
+#[derive(Subcommand)]
+pub enum WhitespaceCommand {
+    /// Report whitespace and line-ending issues across tracked files
+    Check {
+        /// Limit the scan to these paths (default: current directory)
+        #[arg(default_value = ".")]
+        paths: Vec<String>,
+    },
+    /// Rewrite tracked files in place to fix whitespace and line-ending issues
+    Fix {
+        #[arg(default_value = ".")]
+        paths: Vec<String>,
+    },
+}
+
+pub fn run(cmd: WhitespaceCommand) {
+    let result = match cmd {
+        WhitespaceCommand::Check { paths } => check(&paths),
+        WhitespaceCommand::Fix { paths } => fix(&paths),
+    };
+    if !result {
+        std::process::exit(1);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Issue {
+    Bom,
+    Crlf { lines: Vec<usize> },
+    TrailingWhitespace { lines: Vec<usize> },
+    MissingTrailingNewline,
+    MultipleTrailingNewlines,
+}
+
+impl Issue {
+    fn label(&self) -> &'static str {
+        match self {
+            Issue::Bom => "BOM",
+            Issue::Crlf { .. } => "CRLF line endings",
+            Issue::TrailingWhitespace { .. } => "trailing whitespace",
+            Issue::MissingTrailingNewline => "missing trailing newline",
+            Issue::MultipleTrailingNewlines => "multiple trailing newlines",
+        }
+    }
+
+    fn lines(&self) -> Option<&[usize]> {
+        match self {
+            Issue::Crlf { lines } | Issue::TrailingWhitespace { lines } => Some(lines),
+            _ => None,
+        }
+    }
+}
+
+fn check(paths: &[String]) -> bool {
+    let files = match git_ls_files(paths) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            return false;
+        }
+    };
+
+    let mut scanned = 0usize;
+    let mut bad_files = 0usize;
+    let mut total_issues = 0usize;
+    let mut first = true;
+
+    for file in &files {
+        let bytes = match std::fs::read(file) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if is_binary(&bytes) {
+            continue;
+        }
+        scanned += 1;
+        let issues = scan_bytes(&bytes);
+        if issues.is_empty() {
+            continue;
+        }
+        bad_files += 1;
+        total_issues += issues.len();
+        if first {
+            first = false;
+        }
+        print_file_issues(file, &issues);
+    }
+
+    if bad_files == 0 {
+        println!("{GREEN}{BOLD}whitespace check passed{RESET} ({scanned} text files scanned)");
+        true
+    } else {
+        eprintln!(
+            "\n{RED}{BOLD}whitespace check failed{RESET}: {total_issues} issue(s) in {bad_files} file(s)"
+        );
+        eprintln!("{YELLOW}Run `shaka whitespace fix` to repair.{RESET}");
+        false
+    }
+}
+
+fn fix(paths: &[String]) -> bool {
+    let files = match git_ls_files(paths) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            return false;
+        }
+    };
+
+    let mut changed = 0usize;
+    let mut scanned = 0usize;
+
+    for file in &files {
+        let bytes = match std::fs::read(file) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if is_binary(&bytes) {
+            continue;
+        }
+        scanned += 1;
+        let new_bytes = fix_bytes(&bytes);
+        if new_bytes != bytes {
+            if let Err(e) = std::fs::write(file, &new_bytes) {
+                eprintln!("{RED}{BOLD}error:{RESET} writing {}: {e}", file.display());
+                return false;
+            }
+            println!("  {GREEN}{BOLD}fixed{RESET}    {}", file.display());
+            changed += 1;
+        }
+    }
+
+    println!("\n{GREEN}{BOLD}whitespace fix:{RESET} rewrote {changed} of {scanned} files");
+    true
+}
+
+fn print_file_issues(file: &Path, issues: &[Issue]) {
+    println!("\n{BOLD}{}{RESET}", file.display());
+    for issue in issues {
+        match issue.lines() {
+            Some(lines) if !lines.is_empty() => {
+                let preview: Vec<String> = lines.iter().take(5).map(|l| l.to_string()).collect();
+                let suffix = if lines.len() > 5 {
+                    format!(" (+{} more)", lines.len() - 5)
+                } else {
+                    String::new()
+                };
+                println!(
+                    "  {RED}{}{RESET} {DIM}lines {}{}{RESET}",
+                    issue.label(),
+                    preview.join(", "),
+                    suffix
+                );
+            }
+            _ => {
+                println!("  {RED}{}{RESET}", issue.label());
+            }
+        }
+    }
+}
+
+/// Scan the bytes of a single file and return the issues it contains.
+pub fn scan_bytes(content: &[u8]) -> Vec<Issue> {
+    let mut issues = Vec::new();
+
+    let body = if content.starts_with(BOM) {
+        issues.push(Issue::Bom);
+        &content[BOM.len()..]
+    } else {
+        content
+    };
+
+    let mut crlf_lines = Vec::new();
+    let mut tw_lines = Vec::new();
+    for (idx, line) in body.split(|&b| b == b'\n').enumerate() {
+        let lineno = idx + 1;
+        let (logical, has_cr) = strip_cr(line);
+        if has_cr {
+            crlf_lines.push(lineno);
+        }
+        if logical.last().is_some_and(|&b| b == b' ' || b == b'\t') {
+            tw_lines.push(lineno);
+        }
+    }
+    // `split` produces N+1 segments for N newlines. The final segment (which
+    // is empty when the file ends with `\n`) is not a real line — drop it
+    // from per-line diagnostics so we don't report the "phantom" line after a
+    // trailing newline.
+    if body.last() == Some(&b'\n') {
+        let phantom = body.split(|&b| b == b'\n').count();
+        if let Some(p) = tw_lines.last() {
+            if *p == phantom {
+                tw_lines.pop();
+            }
+        }
+        if let Some(p) = crlf_lines.last() {
+            if *p == phantom {
+                crlf_lines.pop();
+            }
+        }
+    }
+    if !crlf_lines.is_empty() {
+        issues.push(Issue::Crlf { lines: crlf_lines });
+    }
+    if !tw_lines.is_empty() {
+        issues.push(Issue::TrailingWhitespace { lines: tw_lines });
+    }
+
+    let trailing_nl = trailing_newline_count(body);
+    if !body.is_empty() {
+        if trailing_nl == 0 {
+            issues.push(Issue::MissingTrailingNewline);
+        } else if trailing_nl >= 2 {
+            issues.push(Issue::MultipleTrailingNewlines);
+        }
+    }
+
+    issues
+}
+
+/// Rewrite the bytes of a single file to remove all whitespace issues.
+pub fn fix_bytes(content: &[u8]) -> Vec<u8> {
+    let body = if content.starts_with(BOM) {
+        &content[BOM.len()..]
+    } else {
+        content
+    };
+
+    let cleaned: Vec<Vec<u8>> = body
+        .split(|&b| b == b'\n')
+        .map(|line| {
+            let (no_cr, _) = strip_cr(line);
+            let end = no_cr
+                .iter()
+                .rposition(|&b| b != b' ' && b != b'\t')
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            no_cr[..end].to_vec()
+        })
+        .collect();
+
+    let mut joined: Vec<u8> = Vec::new();
+    for (i, line) in cleaned.iter().enumerate() {
+        if i > 0 {
+            joined.push(b'\n');
+        }
+        joined.extend_from_slice(line);
+    }
+
+    if joined.is_empty() {
+        return joined;
+    }
+
+    let trim_end = joined
+        .iter()
+        .rposition(|&b| b != b'\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let mut out = joined[..trim_end].to_vec();
+
+    if trim_end > 0 {
+        out.push(b'\n');
+    } else if joined.len() == 1 {
+        // Original was a single `\n` — preserve it (one trailing newline, no
+        // content). Anything longer that's all-newlines collapses to empty.
+        out.push(b'\n');
+    }
+
+    out
+}
+
+fn strip_cr(line: &[u8]) -> (&[u8], bool) {
+    if line.last() == Some(&b'\r') {
+        (&line[..line.len() - 1], true)
+    } else {
+        (line, false)
+    }
+}
+
+fn trailing_newline_count(body: &[u8]) -> usize {
+    body.iter().rev().take_while(|&&b| b == b'\n').count()
+}
+
+fn is_binary(bytes: &[u8]) -> bool {
+    bytes.iter().take(BINARY_PROBE).any(|&b| b == 0)
+}
+
+fn git_ls_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
+    let mut cmd = Command::new("git");
+    cmd.args(["ls-files", "-z", "--"]);
+    if paths.is_empty() {
+        cmd.arg(".");
+    } else {
+        for p in paths {
+            cmd.arg(p);
+        }
+    }
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git ls-files failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(output
+        .stdout
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .map(|s| PathBuf::from(std::ffi::OsStr::from_bytes(s)))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issues(bytes: &[u8]) -> Vec<Issue> {
+        scan_bytes(bytes)
+    }
+
+    #[test]
+    fn empty_file_has_no_issues() {
+        assert_eq!(issues(b""), vec![]);
+    }
+
+    #[test]
+    fn single_newline_file_passes() {
+        assert_eq!(issues(b"\n"), vec![]);
+    }
+
+    #[test]
+    fn well_formed_file_passes() {
+        assert_eq!(issues(b"hello\nworld\n"), vec![]);
+    }
+
+    #[test]
+    fn missing_trailing_newline_is_flagged() {
+        assert_eq!(issues(b"hello"), vec![Issue::MissingTrailingNewline]);
+    }
+
+    #[test]
+    fn multiple_trailing_newlines_flagged() {
+        assert_eq!(issues(b"hello\n\n"), vec![Issue::MultipleTrailingNewlines]);
+        assert_eq!(
+            issues(b"hello\n\n\n\n"),
+            vec![Issue::MultipleTrailingNewlines]
+        );
+    }
+
+    #[test]
+    fn trailing_space_is_flagged_with_line_number() {
+        assert_eq!(
+            issues(b"hello \nworld\n"),
+            vec![Issue::TrailingWhitespace { lines: vec![1] }]
+        );
+    }
+
+    #[test]
+    fn trailing_tab_is_flagged() {
+        assert_eq!(
+            issues(b"hello\t\n"),
+            vec![Issue::TrailingWhitespace { lines: vec![1] }]
+        );
+    }
+
+    #[test]
+    fn crlf_is_flagged_with_line_number() {
+        assert_eq!(
+            issues(b"hello\r\nworld\n"),
+            vec![Issue::Crlf { lines: vec![1] }]
+        );
+    }
+
+    #[test]
+    fn bom_is_flagged() {
+        let mut content = b"\xef\xbb\xbf".to_vec();
+        content.extend_from_slice(b"hello\n");
+        assert_eq!(issues(&content), vec![Issue::Bom]);
+    }
+
+    #[test]
+    fn bom_is_stripped_before_per_line_checks() {
+        // BOM is followed by content without a trailing newline.
+        let mut content = b"\xef\xbb\xbf".to_vec();
+        content.extend_from_slice(b"hello");
+        let result = issues(&content);
+        assert!(result.contains(&Issue::Bom));
+        assert!(result.contains(&Issue::MissingTrailingNewline));
+    }
+
+    #[test]
+    fn multiple_issues_are_collected() {
+        // Trailing space on line 1, CRLF on line 1, no trailing newline.
+        assert_eq!(
+            issues(b"hello \r\nworld"),
+            vec![
+                Issue::Crlf { lines: vec![1] },
+                Issue::TrailingWhitespace { lines: vec![1] },
+                Issue::MissingTrailingNewline,
+            ]
+        );
+    }
+
+    #[test]
+    fn crlf_line_numbers_track_actual_lines() {
+        assert_eq!(
+            issues(b"a\nb\r\nc\r\n"),
+            vec![Issue::Crlf { lines: vec![2, 3] }]
+        );
+    }
+
+    #[test]
+    fn phantom_trailing_line_is_not_reported() {
+        // Without the phantom-line filter, a trailing-newline file would
+        // record a spurious "line N+1" with empty content. Verify lines stay
+        // bounded by real content lines.
+        let result = issues(b"hello \n");
+        assert_eq!(result, vec![Issue::TrailingWhitespace { lines: vec![1] }]);
+    }
+
+    #[test]
+    fn fix_empty_stays_empty() {
+        assert_eq!(fix_bytes(b""), b"");
+    }
+
+    #[test]
+    fn fix_well_formed_is_unchanged() {
+        let input = b"hello\nworld\n";
+        assert_eq!(fix_bytes(input), input);
+    }
+
+    #[test]
+    fn fix_adds_missing_trailing_newline() {
+        assert_eq!(fix_bytes(b"hello"), b"hello\n");
+    }
+
+    #[test]
+    fn fix_collapses_multiple_trailing_newlines() {
+        assert_eq!(fix_bytes(b"hello\n\n\n"), b"hello\n");
+    }
+
+    #[test]
+    fn fix_strips_trailing_whitespace_per_line() {
+        assert_eq!(fix_bytes(b"hello \nworld\t\n"), b"hello\nworld\n");
+    }
+
+    #[test]
+    fn fix_normalizes_crlf_to_lf() {
+        assert_eq!(fix_bytes(b"hello\r\nworld\r\n"), b"hello\nworld\n");
+    }
+
+    #[test]
+    fn fix_strips_bom() {
+        let mut input = b"\xef\xbb\xbf".to_vec();
+        input.extend_from_slice(b"hello\n");
+        assert_eq!(fix_bytes(&input), b"hello\n");
+    }
+
+    #[test]
+    fn fix_handles_combined_issues() {
+        let mut input = b"\xef\xbb\xbf".to_vec();
+        input.extend_from_slice(b"hello \r\nworld\t\r\n\n\n");
+        assert_eq!(fix_bytes(&input), b"hello\nworld\n");
+    }
+
+    #[test]
+    fn fix_preserves_single_newline_only_file() {
+        assert_eq!(fix_bytes(b"\n"), b"\n");
+    }
+
+    #[test]
+    fn fix_collapses_pure_newline_file_to_empty() {
+        assert_eq!(fix_bytes(b"\n\n\n"), b"");
+    }
+
+    #[test]
+    fn fix_collapses_whitespace_only_file_to_empty() {
+        // All lines are whitespace-only; after trim they're empty; output is
+        // the empty file (consistent with the "whitespace-only file is
+        // pathological" decision).
+        assert_eq!(fix_bytes(b"   \n\t\n"), b"");
+    }
+
+    #[test]
+    fn fix_is_idempotent_on_check_passing_inputs() {
+        for input in [
+            &b""[..],
+            &b"\n"[..],
+            &b"hello\n"[..],
+            &b"hello\nworld\n"[..],
+            &b"a\n\nb\n"[..], // internal blank line preserved
+        ] {
+            assert!(
+                scan_bytes(input).is_empty(),
+                "input itself should pass: {:?}",
+                input
+            );
+            assert_eq!(fix_bytes(input), input, "fix changed a passing input");
+        }
+    }
+
+    #[test]
+    fn fix_output_always_passes_check() {
+        for input in [
+            &b"hello"[..],
+            &b"hello \n"[..],
+            &b"hello\r\n"[..],
+            &b"hello\n\n\n"[..],
+            &b"\xef\xbb\xbfhello\n"[..],
+            &b"\xef\xbb\xbfhello \r\n\n"[..],
+        ] {
+            let fixed = fix_bytes(input);
+            assert!(
+                scan_bytes(&fixed).is_empty(),
+                "fix({:?}) = {:?} still has issues",
+                input,
+                fixed
+            );
+        }
+    }
+
+    #[test]
+    fn binary_detected_by_nul_byte() {
+        assert!(is_binary(b"abc\0def"));
+        assert!(!is_binary(b"abc\ndef\n"));
+        assert!(!is_binary(b""));
+    }
+
+    #[test]
+    fn binary_probe_capped_at_first_chunk() {
+        // A NUL beyond the probe window is not detected; we accept this as a
+        // documented heuristic limit.
+        let mut data = vec![b'a'; BINARY_PROBE];
+        data.push(0);
+        assert!(!is_binary(&data));
+    }
+
+    #[test]
+    fn internal_blank_lines_are_preserved() {
+        assert_eq!(fix_bytes(b"a\n\nb\n"), b"a\n\nb\n");
+        assert_eq!(scan_bytes(b"a\n\nb\n"), vec![]);
+    }
+}

--- a/tools/shaka/tests/whitespace.rs
+++ b/tools/shaka/tests/whitespace.rs
@@ -1,0 +1,234 @@
+//! Integration tests for `shaka whitespace check|fix`.
+//!
+//! Each test stages a small set of files into a fresh git repo inside a
+//! tempdir and runs the shaka binary against it. The fixtures are written
+//! programmatically rather than checked in: byte-level differences (BOM,
+//! CRLF, trailing whitespace) don't survive editor or git normalization
+//! reliably and are easier to inspect as named byte literals than as files.
+//! The pure-scanner unit tests in `src/whitespace.rs` cover content
+//! semantics; these tests cover the wiring (CLI args, git ls-files
+//! enumeration, exit codes, output mentions the right files).
+
+use std::path::Path;
+use std::process::Command;
+
+const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+
+struct Repo {
+    root: tempfile::TempDir,
+}
+
+impl Repo {
+    fn new(files: &[(&str, &[u8])]) -> Self {
+        let root = tempfile::TempDir::new().unwrap();
+        for (name, bytes) in files {
+            let path = root.path().join(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, bytes).unwrap();
+        }
+        run(root.path(), &["git", "init", "-q"]);
+        // Disable any line-ending normalization so the test bytes survive
+        // `git add` round-trips intact.
+        run(root.path(), &["git", "config", "core.autocrlf", "false"]);
+        run(root.path(), &["git", "config", "core.safecrlf", "false"]);
+        run(root.path(), &["git", "add", "-A"]);
+        Repo { root }
+    }
+
+    fn path(&self) -> &Path {
+        self.root.path()
+    }
+
+    fn shaka(&self, args: &[&str]) -> std::process::Output {
+        Command::new(SHAKA_BIN)
+            .args(args)
+            .current_dir(self.root.path())
+            .output()
+            .expect("failed to spawn shaka")
+    }
+
+    fn read(&self, name: &str) -> Vec<u8> {
+        std::fs::read(self.path().join(name)).unwrap()
+    }
+}
+
+fn run(cwd: &Path, argv: &[&str]) {
+    let status = Command::new(argv[0])
+        .args(&argv[1..])
+        .current_dir(cwd)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn {}: {e}", argv[0]));
+    assert!(status.success(), "{:?} failed", argv);
+}
+
+fn stdout_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn check_passes_on_clean_repo() {
+    let repo = Repo::new(&[("a.txt", b"hello\n"), ("b.txt", b"world\n")]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    let stdout = stdout_of(&out);
+    assert!(
+        out.status.success(),
+        "expected success, got {:?}\nstdout: {stdout}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    assert!(
+        stdout.contains("whitespace check passed"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn check_fails_on_trailing_whitespace() {
+    let repo = Repo::new(&[("bad.txt", b"hello \nworld\n")]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(!out.status.success());
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(combined.contains("bad.txt"), "output: {combined}");
+    assert!(
+        combined.contains("trailing whitespace"),
+        "output: {combined}"
+    );
+}
+
+#[test]
+fn check_fails_on_crlf() {
+    let repo = Repo::new(&[("bad.txt", b"hello\r\nworld\n")]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(!out.status.success());
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(combined.contains("CRLF"), "output: {combined}");
+}
+
+#[test]
+fn check_fails_on_bom() {
+    let mut bytes = b"\xef\xbb\xbf".to_vec();
+    bytes.extend_from_slice(b"hello\n");
+    let repo = Repo::new(&[("bad.txt", &bytes)]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(!out.status.success());
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(combined.contains("BOM"), "output: {combined}");
+}
+
+#[test]
+fn check_fails_on_missing_trailing_newline() {
+    let repo = Repo::new(&[("bad.txt", b"hello")]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(!out.status.success());
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(
+        combined.contains("missing trailing newline"),
+        "output: {combined}"
+    );
+}
+
+#[test]
+fn check_skips_binary_files() {
+    let repo = Repo::new(&[
+        ("img.bin", b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR"),
+        ("text.txt", b"hello\n"),
+    ]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    let stdout = stdout_of(&out);
+    assert!(
+        out.status.success(),
+        "binary file was incorrectly flagged\nstdout: {stdout}\nstderr: {}",
+        stderr_of(&out)
+    );
+}
+
+#[test]
+fn check_skips_untracked_files() {
+    let repo = Repo::new(&[("a.txt", b"hello\n")]);
+    // Add a polluted file that isn't tracked — git ls-files should skip it.
+    std::fs::write(repo.path().join("untracked.txt"), b"trailing \n").unwrap();
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(
+        out.status.success(),
+        "untracked file was incorrectly flagged\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+}
+
+#[test]
+fn check_respects_path_arg_scope() {
+    let repo = Repo::new(&[
+        ("good/clean.txt", b"hello\n"),
+        ("bad/dirty.txt", b"trailing \n"),
+    ]);
+    // Scope to good/ — should pass even though bad/ has issues.
+    let out = repo.shaka(&["whitespace", "check", "good"]);
+    assert!(
+        out.status.success(),
+        "path-scoped check leaked into unrelated dir\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+    // Scope to bad/ — should fail.
+    let out = repo.shaka(&["whitespace", "check", "bad"]);
+    assert!(!out.status.success());
+}
+
+#[test]
+fn fix_rewrites_files_in_place() {
+    let mut bom = b"\xef\xbb\xbf".to_vec();
+    bom.extend_from_slice(b"hello \r\n\n\n");
+    let repo = Repo::new(&[
+        ("a.txt", b"hello"),
+        ("b.txt", bom.as_slice()),
+        ("c.txt", b"already-clean\n"),
+    ]);
+    let out = repo.shaka(&["whitespace", "fix"]);
+    assert!(
+        out.status.success(),
+        "fix exited non-zero\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+    assert_eq!(repo.read("a.txt"), b"hello\n");
+    assert_eq!(repo.read("b.txt"), b"hello\n");
+    assert_eq!(repo.read("c.txt"), b"already-clean\n");
+
+    // After fix, check should pass.
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(
+        out.status.success(),
+        "check failed after fix\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+}
+
+#[test]
+fn check_default_path_scans_cwd_subtree() {
+    let repo = Repo::new(&[
+        ("project/a.txt", b"hello\n"),
+        ("project/sub/b.txt", b"trailing \n"),
+        ("other/c.txt", b"trailing \n"),
+    ]);
+    // Run from inside project/ — should fail on sub/b.txt but ignore other/.
+    let out = Command::new(SHAKA_BIN)
+        .args(["whitespace", "check"])
+        .current_dir(repo.path().join("project"))
+        .output()
+        .expect("failed to spawn shaka");
+    assert!(!out.status.success(), "expected failure inside project/");
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(combined.contains("sub/b.txt"), "output: {combined}");
+    assert!(
+        !combined.contains("other/c.txt"),
+        "leaked outside cwd: {combined}"
+    );
+}


### PR DESCRIPTION
Add `shaka whitespace check|fix` to detect and repair trailing
whitespace, missing/extra trailing newlines, CRLF line endings, and
UTF-8 BOMs across tracked text files. The scanner uses `git ls-files`
so gitignored and untracked files are skipped automatically; binary
files are detected by NUL byte in the first 8 KiB.

The check is wired into each project's `validate` recipe via the
generated justfile templates, so `shaka preflight` picks it up
automatically without a new repo-level CHECKS entry. Auto-fix
(`shaka whitespace fix`) is idempotent and consistent with the
checker — every check-passing input is fix-stable.

Closes #52.