### PR TITLE
test(ci): ungate flakehub-push to exercise it on this PR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -205,6 +205,9 @@ jobs:
     needs: [changes, validate, build-shaka, build-nix-lib, build-image]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/nix-installer-action@main

--- a/tools/shaka/flake.lock
+++ b/tools/shaka/flake.lock
@@ -5,14 +5,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "path": "../../nix/kolohelios-nix",
-        "type": "path"
+        "lastModified": 1777661405,
+        "narHash": "sha256-5QIY7TKHxoeTC3Mf3JQzf5dJf21HSL1cB/TCAkJpE7E=",
+        "rev": "8a3b87d2ca4e7dcc2613b8bca0d277e4548163c7",
+        "revCount": 81,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.81%2Brev-8a3b87d2ca4e7dcc2613b8bca0d277e4548163c7/019de4e5-203d-7c71-9f66-a364395ff182/source.tar.gz"
       },
       "original": {
-        "path": "../../nix/kolohelios-nix",
-        "type": "path"
-      },
-      "parent": []
+        "type": "tarball",
+        "url": "https://flakehub.com/f/kolohelios/kolohelios-nix/%2A.tar.gz"
+      }
     },
     "nixpkgs": {
       "locked": {

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -2,7 +2,7 @@
   description = "shaka — build tooling for kolohelios";
 
   inputs = {
-    kolohelios-nix.url = "path:../../nix/kolohelios-nix";
+    kolohelios-nix.url = "https://flakehub.com/f/kolohelios/kolohelios-nix/*.tar.gz";
     nixpkgs.follows = "kolohelios-nix/nixpkgs";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -252,7 +252,10 @@ fn read_meta(schema_path: &Path, project_dir: &Path) -> Result<ProjectMeta, Stri
 }
 
 fn write_schema() -> std::io::Result<PathBuf> {
-    let path = std::env::temp_dir().join("shaka-generate-schema.cue");
+    // Per-process filename — see schema_check::write_schema for the
+    // rationale (parallel test invocations race on a shared path).
+    let path =
+        std::env::temp_dir().join(format!("shaka-generate-schema-{}.cue", std::process::id()));
     let mut f = std::fs::File::create(&path)?;
     f.write_all(SCHEMA.as_bytes())?;
     Ok(path)

--- a/tools/shaka/src/project/schema_check.rs
+++ b/tools/shaka/src/project/schema_check.rs
@@ -114,7 +114,11 @@ fn validate_project(schema_path: &Path, project_dir: &Path) -> ProjectResult {
 }
 
 pub fn write_schema() -> std::io::Result<PathBuf> {
-    let path = std::env::temp_dir().join("shaka-project-schema.cue");
+    // Per-process filename so integration tests that spawn multiple shaka
+    // subprocesses in parallel don't race on the same file (cue would see a
+    // half-written schema and fail with "reference '#Project' not found").
+    let path =
+        std::env::temp_dir().join(format!("shaka-project-schema-{}.cue", std::process::id()));
     let mut f = std::fs::File::create(&path)?;
     f.write_all(SCHEMA.as_bytes())?;
     Ok(path)


### PR DESCRIPTION
Temporarily remove the `event_name == 'push'` condition on the
build-shaka and build-nix-lib jobs' flakehub-push steps so this PR's
CI actually runs the steps that have been silently broken on main.
Verifies the parent commit's fix.

DROP BEFORE MERGE — restoring the gate is the last commit to land
on this branch.