### PR TITLE
chore: flip FlakeHub package visibility to public

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -143,7 +143,7 @@ jobs:
         with:
           directory: tools/shaka
           name: kolohelios/shaka
-          visibility: private
+          visibility: public
           rolling: true
 
   build-nix-lib:
@@ -169,7 +169,7 @@ jobs:
         with:
           directory: nix/kolohelios-nix
           name: kolohelios/kolohelios-nix
-          visibility: private
+          visibility: public
           rolling: true
 
   build-image:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,7 @@ this before scripting against `jj`:
 ## Issue tracking
 
 Work is tracked in **GitHub Issues**. References like `#21` are GitHub issue
-numbers; use `gh issue view <n>` to read them. The repo is private and does
-not use GitHub Advanced Security — do not propose features that depend on
-GHAS (code scanning, secret scanning Push Protection, etc.).
+numbers; use `gh issue view <n>` to read them.
 
 ## Secrets
 
@@ -252,8 +250,6 @@ restate two rules that `/start` and `/ship` would otherwise enforce:
 - **Don't add CI jobs to `.github/workflows/main.yaml`** for new validation
   steps — extend `shaka preflight` so CI and local stay in lockstep.
 - **Don't add Claude Code attribution** to commits, code, or docs.
-- **Don't propose GHAS-dependent features** (this repo is private, no
-  Enterprise).
 - **Don't run mutating `git` commands.** The repo is jj-colocated; `git
   stash`, `git stash pop`, `git checkout`, `git reset`, `git commit`,
   `git rebase`, `git merge` all desync the working copy from jj's view.


### PR DESCRIPTION
Switch \`kolohelios/shaka\` and \`kolohelios/kolohelios-nix\` from
\`visibility: private\` to \`public\` on FlakeHub. The repo itself is
about to flip public; there's no reason for the published flakes
to remain locked down. Drops the FlakeHub-auth requirement for any
external consumer of either package.

Also drops two stale claims from CLAUDE.md that the repo is private
and that GHAS is unavailable:

- The \"repo is private\" line in the Issue tracking section.
- The \"Don't propose GHAS-dependent features\" bullet in the
  Things to avoid section.

GHAS is free on public repos, so once the repo flips, those
constraints no longer apply. Removing rather than inverting —
neutral about whether to use GHAS, just no longer false.