### PR TITLE
chore: enable CodeQL and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Rust crate dependencies for tools/shaka. Group minor + patch updates so
+  # routine bumps land as one PR per week instead of one per crate.
+  - package-ecosystem: cargo
+    directory: /tools/shaka
+    schedule:
+      interval: weekly
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions versions referenced in .github/workflows/. Grouped so an
+  # ecosystem-wide bump (common when actions release together) lands as one
+  # PR.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Sunday 04:30 UTC — re-run weekly so newly-published CodeQL queries
+    # exercise the codebase without depending on a push to main.
+    - cron: "30 4 * * 0"
+
+# Cancel an in-flight scan when a new commit lands on the same PR branch.
+# Pushes to main are never cancelled.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [rust]
+    steps:
+      - uses: actions/checkout@v5
+      # Rust CodeQL only supports `build-mode: none` — it extracts directly
+      # from source, no compile step required. No nix install, no cargo
+      # build, no cache.
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
Round out the GHAS rollout with the two pieces that need code:

**CodeQL** (\`.github/workflows/codeql.yml\`)
- Analyzes the Rust code in \`tools/shaka\` on push to main, on PRs
  targeting main, and weekly on Sunday at 04:30 UTC. The schedule
  picks up newly-published CodeQL queries without waiting for a
  push.
- \`build-mode: manual\` — runs \`cargo build\` inside the shaka
  flake's dev shell so CodeQL extracts the same artifacts the
  regular CI build produces.
- \`security-events: write\` for SARIF upload; cargo cache shared
  across runs.
- Not added to \`gate.needs\` in main.yaml — CodeQL findings are
  advisory while we triage the baseline. Promote to a required
  check once clean.

**Dependabot** (\`.github/dependabot.yml\`)
- Cargo for \`tools/shaka\`, weekly cadence, minor + patch grouped
  into one PR per week.
- GitHub Actions across the workflows directory, weekly, all
  updates grouped.
- Nix flake input updates are intentionally out of scope: the repo
  uses \`nixpkgs.follows = "kolohelios-nix/nixpkgs"\` to share one
  pin across flakes; per-flake Dependabot updates would defeat
  that. Revisit as a separate experiment.

Pure addition. No existing workflow changes.