### PR TITLE
feat(shaka): add actionlint to preflight

### DIFF
--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -84,6 +84,11 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
+              # actionlint runs in `shaka preflight` against
+              # `.github/workflows/`; shellcheck is its dependency for
+              # linting embedded `run:` scripts.
+              pkgs.actionlint
+              pkgs.shellcheck
             ]
             ++ (workflowPackages pkgs)
             # cargo-llvm-cov is needed by `just coverage`. Nixpkgs marks

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -51,6 +51,11 @@ const CHECKS: &[Check] = &[
         paths: &[],
         run: typos_check,
     },
+    Check {
+        name: "actionlint",
+        paths: &[".github/workflows/**"],
+        run: actionlint_check,
+    },
 ];
 
 pub fn run(keep_going: bool, since: Option<String>) {
@@ -283,6 +288,10 @@ fn shaka_project_lint() -> CheckResult {
 
 fn typos_check() -> CheckResult {
     run_command(&mut Command::new("typos"))
+}
+
+fn actionlint_check() -> CheckResult {
+    run_command(&mut Command::new("actionlint"))
 }
 
 fn spawn_self(args: &[&str]) -> CheckResult {


### PR DESCRIPTION
Adds actionlint (with shellcheck) to the shaka devshell and wires it
into `shaka preflight` as a repo-level check gated to changes under
`.github/workflows/`. Catches workflow syntax errors, bad runner
labels, expression-syntax mistakes, and embedded-shell issues before
they reach CI.

Closes #53