### PR TITLE
fix(shaka): persist workspace issue link for cleanup post-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ tfplan
 *.pem
 *.key
 .env
+
+# Shaka local state (e.g. workspace ↔ issue links — see tools/shaka/src/workspace/issue_link.rs)
+.shaka/

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -178,6 +178,69 @@ pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
     Ok(Some(PrInfo { number, url, state }))
 }
 
+/// Find the merged PR that closed the given issue, if any.
+///
+/// Uses `gh issue view N --json state,closedByPullRequestsReferences`. GitHub
+/// only populates `closedByPullRequestsReferences` for PRs that were merged
+/// with an autoclose keyword (`Closes #N`, `Fixes #N`, …) — exactly the
+/// signal we want for `shaka workspace cleanup` to identify a workspace whose
+/// work has landed, even after `repo sync` has deleted the local bookmark.
+///
+/// Returns `Ok(None)` if the issue is open, has no closing PR reference, or
+/// the issue does not exist. Returns the first referenced PR if multiple.
+pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &n.to_string(),
+            "--json",
+            "state,closedByPullRequestsReferences",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GhError {
+            message: format!("gh issue view {n}: {}", stderr.trim()),
+        });
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    if body.trim().is_empty() {
+        return Ok(None);
+    }
+    let parsed: Value = serde_json::from_str(&body).map_err(|e| GhError {
+        message: format!("failed to parse JSON from gh issue view {n}: {e}"),
+    })?;
+
+    if parsed["state"].as_str() != Some("CLOSED") {
+        return Ok(None);
+    }
+
+    let Some(first) = parsed["closedByPullRequestsReferences"]
+        .as_array()
+        .and_then(|arr| arr.first())
+    else {
+        return Ok(None);
+    };
+
+    let number = first["number"].as_u64().ok_or_else(|| GhError {
+        message: format!("closing PR for issue #{n} missing 'number' field"),
+    })?;
+    let url = first["url"]
+        .as_str()
+        .ok_or_else(|| GhError {
+            message: format!("closing PR for issue #{n} missing 'url' field"),
+        })?
+        .to_string();
+    Ok(Some(PrInfo {
+        number,
+        url,
+        state: PrState::Merged,
+    }))
+}
+
 /// Run `gh pr create` and return the PR URL.
 pub fn pr_create(title: &str, body: &str, head: &str) -> Result<String, GhError> {
     let output = Command::new("gh")

--- a/tools/shaka/src/workspace/cleanup.rs
+++ b/tools/shaka/src/workspace/cleanup.rs
@@ -1,6 +1,8 @@
+use super::issue_link;
 use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET};
 use crate::{gh, jj};
 use std::fs;
+use std::path::Path;
 
 /// A workspace that has a merged PR and is eligible for cleanup.
 struct MergedWorkspace {
@@ -8,18 +10,23 @@ struct MergedWorkspace {
     pr_url: String,
 }
 
-/// Walk all workspaces, find ones whose bookmarks ahead of `main@origin` have
-/// a merged PR on the remote, and clean them up (or preview with --dry-run).
+/// Walk all workspaces, find ones whose work has landed via a merged PR,
+/// and clean them up (or preview with --dry-run).
 ///
-/// Design note: we use a bookmark-convention approach for v1. For each
-/// workspace we enumerate all bookmarks in `main@origin..<workspace>@` and
-/// query GitHub for each via `gh::pr_for_head`. If any bookmark resolves to a
-/// merged PR the workspace is a cleanup candidate.
+/// Detection strategy, in order:
 ///
-/// Trade-off: a workspace with multiple bookmarks where only one has a merged
-/// PR will still be cleaned up. This is intentional — if the branch landed,
-/// the workspace's purpose is done. A future revision could require all
-/// bookmarks to be merged before cleaning.
+/// 1. **Persisted issue link.** `shaka workspace new --issue N` records the
+///    issue under `<repo_root>/.shaka/workspaces/<name>.json`. We query
+///    GitHub for the PR that closed that issue (`gh issue view --json
+///    closedByPullRequestsReferences`). This is the durable path and
+///    survives `repo sync` deleting the local bookmark.
+/// 2. **`i<N>` name inference.** For workspaces created with `--issue N`
+///    before persistence existed, the name itself encodes the issue.
+/// 3. **Bookmark scan.** For workspaces created with an arbitrary `<name>`,
+///    enumerate bookmarks in `main@origin..<workspace>@` and ask GitHub for
+///    each via `pr_for_head`. This breaks once the bookmark has been
+///    deleted post-merge — the persisted link path above is what fixes
+///    issue #164.
 pub fn run(dry_run: bool) {
     let repo_root = match jj::repo_root() {
         Ok(p) => p,
@@ -50,30 +57,11 @@ pub fn run(dry_run: bool) {
             continue;
         }
 
-        let revset = format!("main@origin..{}@", ws.name);
-        // Workspace may not have any commits ahead of main@origin, or
-        // main@origin doesn't exist in this repo — treat both as no bookmarks.
-        let bookmarks = jj::bookmarks_on(&revset).unwrap_or_default();
-
-        if bookmarks.is_empty() {
-            continue;
-        }
-
-        for bookmark in &bookmarks {
-            match gh::pr_for_head(&repo, bookmark) {
-                Ok(Some(pr)) if pr.state == gh::PrState::Merged => {
-                    candidates.push(MergedWorkspace {
-                        name: ws.name.clone(),
-                        pr_url: pr.url.clone(),
-                    });
-                    // One merged bookmark is enough to flag this workspace.
-                    break;
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    eprintln!("{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}");
-                }
-            }
+        if let Some(pr_url) = resolve_merged_pr(&repo_root, &repo, &ws.name) {
+            candidates.push(MergedWorkspace {
+                name: ws.name.clone(),
+                pr_url,
+            });
         }
     }
 
@@ -111,10 +99,59 @@ pub fn run(dry_run: bool) {
                 }
             }
 
+            if let Err(e) = issue_link::remove(&repo_root, &candidate.name) {
+                eprintln!(
+                    "{DIM}warn:{RESET} failed to remove issue link for {}: {e}",
+                    candidate.name
+                );
+            }
+
             println!(
                 "{GREEN}{BOLD}forgot{RESET} workspace {BOLD}{}{RESET} (merged: {})",
                 candidate.name, candidate.pr_url
             );
         }
     }
+}
+
+/// Try each detection strategy in order and return the merged-PR URL on the
+/// first hit.
+fn resolve_merged_pr(repo_root: &Path, repo: &str, name: &str) -> Option<String> {
+    // 1. Persisted issue link.
+    let issue_from_link = issue_link::read(repo_root, name)
+        .map_err(|e| eprintln!("{DIM}warn:{RESET} reading issue link for {name}: {e}"))
+        .ok()
+        .flatten()
+        .map(|l| l.issue);
+
+    // 2. Name inference: i<N>.
+    let issue_from_name = name
+        .strip_prefix('i')
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|_| issue_from_link.is_none());
+
+    if let Some(issue) = issue_from_link.or(issue_from_name) {
+        match gh::merged_pr_for_issue(issue) {
+            Ok(Some(pr)) => return Some(pr.url),
+            Ok(None) => {} // issue not yet closed by a merged PR
+            Err(e) => {
+                eprintln!("{DIM}warn:{RESET} could not query PR for issue #{issue}: {e}");
+            }
+        }
+    }
+
+    // 3. Bookmark scan (legacy path; works only pre-sync).
+    let revset = format!("main@origin..{name}@");
+    let bookmarks = jj::bookmarks_on(&revset).unwrap_or_default();
+    for bookmark in &bookmarks {
+        match gh::pr_for_head(repo, bookmark) {
+            Ok(Some(pr)) if pr.state == gh::PrState::Merged => return Some(pr.url),
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}");
+            }
+        }
+    }
+
+    None
 }

--- a/tools/shaka/src/workspace/forget.rs
+++ b/tools/shaka/src/workspace/forget.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
-use super::{die, workspace_path, BOLD, GREEN, RESET};
+use super::issue_link;
+use super::{die, workspace_path, BOLD, DIM, GREEN, RESET};
 use crate::jj;
 
 pub fn run(name: &str, force: bool) {
@@ -57,6 +58,10 @@ pub fn run(name: &str, force: bool) {
                 path.display()
             ));
         }
+    }
+
+    if let Err(e) = issue_link::remove(&repo_root, name) {
+        eprintln!("{DIM}warn:{RESET} failed to remove issue link for {name}: {e}");
     }
 
     println!("{GREEN}{BOLD}forgot{RESET} workspace {BOLD}{name}{RESET}");

--- a/tools/shaka/src/workspace/issue_link.rs
+++ b/tools/shaka/src/workspace/issue_link.rs
@@ -1,0 +1,92 @@
+//! Persisted workspace → issue mapping.
+//!
+//! When `shaka workspace new --issue N` runs, we record the issue number under
+//! `<repo_root>/.shaka/workspaces/<name>.json`. `cleanup` reads this back to
+//! find the merged PR that closed the issue, even after `repo sync` has
+//! deleted the local bookmark (which makes the prior bookmark-based detection
+//! miss). The directory is gitignored.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IssueLink {
+    pub issue: u64,
+}
+
+/// Directory that holds per-workspace link files.
+fn dir(repo_root: &Path) -> PathBuf {
+    repo_root.join(".shaka").join("workspaces")
+}
+
+/// Path to the link file for a given workspace name.
+pub fn path(repo_root: &Path, name: &str) -> PathBuf {
+    dir(repo_root).join(format!("{name}.json"))
+}
+
+/// Persist `{ "issue": N }` for the given workspace. Creates parent dirs.
+pub fn write(repo_root: &Path, name: &str, link: &IssueLink) -> io::Result<()> {
+    let dir = dir(repo_root);
+    fs::create_dir_all(&dir)?;
+    let body = serde_json::to_string_pretty(link).map_err(io::Error::other)?;
+    fs::write(path(repo_root, name), body)
+}
+
+/// Read the link for a workspace. Returns `Ok(None)` if the file is absent —
+/// pre-existing workspaces from before this fix won't have one.
+pub fn read(repo_root: &Path, name: &str) -> io::Result<Option<IssueLink>> {
+    let p = path(repo_root, name);
+    match fs::read_to_string(&p) {
+        Ok(s) => serde_json::from_str(&s)
+            .map(Some)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Remove the link file if present. Missing file is not an error.
+pub fn remove(repo_root: &Path, name: &str) -> io::Result<()> {
+    match fs::remove_file(path(repo_root, name)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn round_trip() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), "i42", &IssueLink { issue: 42 }).unwrap();
+        let got = read(dir.path(), "i42").unwrap();
+        assert_eq!(got, Some(IssueLink { issue: 42 }));
+    }
+
+    #[test]
+    fn read_missing_returns_none() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(read(dir.path(), "nope").unwrap(), None);
+    }
+
+    #[test]
+    fn remove_missing_is_ok() {
+        let dir = TempDir::new().unwrap();
+        remove(dir.path(), "nope").unwrap();
+    }
+
+    #[test]
+    fn remove_clears_file() {
+        let dir = TempDir::new().unwrap();
+        write(dir.path(), "i1", &IssueLink { issue: 1 }).unwrap();
+        remove(dir.path(), "i1").unwrap();
+        assert_eq!(read(dir.path(), "i1").unwrap(), None);
+    }
+}

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -1,5 +1,6 @@
 mod cleanup;
 mod forget;
+mod issue_link;
 mod list;
 mod new;
 mod status;

--- a/tools/shaka/src/workspace/new.rs
+++ b/tools/shaka/src/workspace/new.rs
@@ -1,3 +1,4 @@
+use super::issue_link::{self, IssueLink};
 use super::{die, workspace_path, BOLD, DIM, GREEN, RESET};
 use crate::{gh, jj};
 
@@ -38,6 +39,11 @@ pub fn run(name: Option<&str>, issue: Option<u64>) {
     }
 
     if let Some((n, title)) = issue_info {
+        // Persist the issue link so `cleanup` can find the merged PR even
+        // after `repo sync` deletes the local bookmark (see issue #164).
+        if let Err(e) = issue_link::write(&repo_root, &derived_name, &IssueLink { issue: n }) {
+            die(&format!("failed to record issue link: {e}"));
+        }
         println!(
             "{GREEN}{BOLD}created{RESET} workspace {BOLD}{derived_name}{RESET} at \
              {DIM}{}{RESET} (issue #{n}: {title})",

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -216,6 +216,37 @@ fn forget_refuses_default_workspace() {
     assert!(stderr.contains("default"), "unexpected stderr: {stderr}");
 }
 
+/// `workspace forget` should also remove the persisted issue link so the
+/// `.shaka/workspaces/` directory does not accumulate stale entries.
+/// Issue #164: the link is what `cleanup` consults post-`repo sync`.
+#[test]
+fn forget_removes_issue_link() {
+    let parent = TempDir::new().expect("tempdir");
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+
+    let new_out = shaka(&repo, &["workspace", "new", "i42"]);
+    assert_success(&new_out, "workspace new i42");
+
+    // Simulate the link the `--issue` path would have written (we can't
+    // exercise `--issue` in tests because it needs `gh` + network).
+    let link_dir = repo.join(".shaka").join("workspaces");
+    std::fs::create_dir_all(&link_dir).unwrap();
+    let link_path = link_dir.join("i42.json");
+    std::fs::write(&link_path, r#"{"issue":42}"#).unwrap();
+    assert!(link_path.exists(), "fixture link not written");
+
+    let forget_out = shaka(&repo, &["workspace", "forget", "i42", "--force"]);
+    assert_success(&forget_out, "workspace forget i42 --force");
+
+    assert!(
+        !link_path.exists(),
+        "expected issue link to be removed: {}",
+        link_path.display()
+    );
+}
+
 #[test]
 fn cleanup_dry_run_does_not_remove_workspace() {
     // Verify that `cleanup --dry-run` exits successfully and leaves the


### PR DESCRIPTION
`shaka workspace cleanup` previously found candidates by enumerating
bookmarks in `main@origin..<workspace>@` and asking GitHub for each PR.
With `deleteBranchOnMerge: true` (the only setting allowed in this repo)
plus rebase-only merges, the source bookmark is deleted on merge and
`shaka repo sync` propagates the deletion locally. The bookmark scan
then comes up empty, no candidates are surfaced, and users have to fall
back to `shaka workspace forget --force <name>`.

Fix by recording the issue number at workspace creation time. When
`shaka workspace new --issue N` runs, write `{ "issue": N }` to
`<repo_root>/.shaka/workspaces/<name>.json`. Cleanup then resolves the
merged PR via `gh issue view --json closedByPullRequestsReferences`,
which is durable across `repo sync` because it does not depend on local
bookmark state.

For workspaces created with `--issue` before the link existed, infer
the issue from the conventional `i<N>` workspace name. The legacy
bookmark scan stays as a final fallback for arbitrary `<name>`-style
workspaces. `forget` and `cleanup` both prune the link file so the
`.shaka/workspaces/` directory does not accumulate stale entries.

Closes #164