### PR TITLE
feat(shaka): add domain inventory schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,3 +281,13 @@ restate two rules that `/start` and `/ship` would otherwise enforce:
   Even if validate passed earlier in your session, a final tweak can
   introduce `cargo fmt` or `clippy` violations. The CI failure cycle is
   slow; the immediately-before-push validate is the cheap insurance.
+- **Don't document or automate clipboard-paste-of-DOM patterns.** Snippets
+  shaped like "open DevTools, paste this `JSON.stringify(...)` of
+  authenticated DOM data, copy the result" match credential-stealer
+  signatures (Atomic, StealC, etc.) and are blocked by macOS Sequoia's
+  XProtect clipboard scanner. They're also a pattern users should rightly
+  distrust on sight. When extracting structured data from an authenticated
+  browser session, build the payload in-page and trigger a `Blob` download
+  instead — no clipboard transit, no XProtect involvement, no
+  cargo-cultable shape that resembles malware. See `shaka domain
+  inventory --help` for the canonical example.

--- a/tools/shaka/schema/domain.cue
+++ b/tools/shaka/schema/domain.cue
@@ -1,0 +1,40 @@
+package domain
+
+// #Domain is the per-domain inventory entry. Each domain we own has one of
+// these declared as a CUE file under `infra/cloudflare-dns/domains/`.
+//
+// The shape is consumed by:
+//   - terraform (infra/cloudflare-dns) provisions CF zones for entries
+//     where `nameservers: "cloudflare"`. TF emits a `domain_expectations`
+//     output (per-domain { ns_pair, dnssec_enabled }); that output is the
+//     stable contract `shaka domain check` reads at check-time, decoupling
+//     the check from TF state file shape.
+//   - `shaka domain check` for the static fields TF doesn't see:
+//     `disposition` and `expiry_warn_days`. The lock requirement is
+//     hardcoded — every domain we own must be `clientTransferProhibited`
+//     in WHOIS. DNSSEC drift is detected by comparing DS-at-registry to
+//     DNSKEY-from-CF dynamically; no expected DS is declared here, since
+//     declaring it would invert source-of-truth (the registry is what
+//     resolvers see).
+//   - `shaka domain inventory` cross-references the projected Hover paste
+//     under `tests/fixtures/domain/hover/snapshot-*.json` against the
+//     declared registry, reporting adds/removes.
+//
+// `nameservers` selects which checks apply:
+//   - "cloudflare":    NS check expects the TF-output ns_pair; DNSSEC
+//                      validated when `dnssec_enabled: true`.
+//   - "linode-legacy": migration-pending; NS/DNSSEC checks skipped, but
+//                      expiry and lock checks still run.
+//   - "unmanaged":     held but not pointed anywhere actively; only
+//                      expiry and lock are enforced.
+
+#Domain: {
+	name:              string & =~"^[a-z0-9][a-z0-9-]*(\\.[a-z]{2,})+$"
+	disposition:       "portfolio-canonical" | "portfolio-alias" | "personal-alt" | "product-reserve" | "park" | "let-expire"
+	expiry_warn_days?: int & >0
+} & ({
+	nameservers:    "cloudflare"
+	dnssec_enabled: bool
+} | {
+	nameservers: "linode-legacy" | "unmanaged"
+})

--- a/tools/shaka/tests/fixtures/domain/hover/snapshot-2026-05-02.json
+++ b/tools/shaka/tests/fixtures/domain/hover/snapshot-2026-05-02.json
@@ -1,0 +1,686 @@
+[
+  {
+    "name": "theedwards.us",
+    "status": "active",
+    "expiry_date": "2026-07-06",
+    "whois_privacy": "unsupported",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.com",
+    "status": "active",
+    "expiry_date": "2027-03-26",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.me",
+    "status": "active",
+    "expiry_date": "2027-03-26",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.blog",
+    "status": "active",
+    "expiry_date": "2026-05-06",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "genderneutralrobot.com",
+    "status": "active",
+    "expiry_date": "2026-10-14",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "clo-thing.com",
+    "status": "active",
+    "expiry_date": "2026-11-23",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "snarkoverflow.org",
+    "status": "active",
+    "expiry_date": "2026-11-23",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.dev",
+    "status": "active",
+    "expiry_date": "2026-05-11",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "violentlyintroverted.com",
+    "status": "active",
+    "expiry_date": "2026-11-19",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "customhomecost.com",
+    "status": "active",
+    "expiry_date": "2026-12-22",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "suxy.design",
+    "status": "active",
+    "expiry_date": "2027-04-24",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "extramedium.fish",
+    "status": "active",
+    "expiry_date": "2027-05-01",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "twobyteam.com",
+    "status": "active",
+    "expiry_date": "2027-05-01",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "epiphanic.info",
+    "status": "active",
+    "expiry_date": "2026-05-16",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "off",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "wayposting.com",
+    "status": "active",
+    "expiry_date": "2026-12-30",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "wayposting.org",
+    "status": "active",
+    "expiry_date": "2026-12-30",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "wayposting.app",
+    "status": "active",
+    "expiry_date": "2026-12-30",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "wayposting.net",
+    "status": "active",
+    "expiry_date": "2026-12-30",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "buzzingo.app",
+    "status": "active",
+    "expiry_date": "2026-10-29",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "buzzingo.org",
+    "status": "active",
+    "expiry_date": "2026-10-29",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.cloud",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.us",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "unsupported",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "findph.one",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "takesonetoknow.one",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohe.me",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohe.dev",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohe.cloud",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohe.app",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.net",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.app",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "kayden.ns.cloudflare.com",
+      "nora.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohelios.co",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "kolohe.co",
+    "status": "active",
+    "expiry_date": "2026-11-08",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "nora.ns.cloudflare.com",
+      "kayden.ns.cloudflare.com"
+    ]
+  },
+  {
+    "name": "cosmicchuckle.com",
+    "status": "active",
+    "expiry_date": "2027-04-21",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "eelings.com",
+    "status": "active",
+    "expiry_date": "2027-04-28",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "eelings.app",
+    "status": "active",
+    "expiry_date": "2027-04-28",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "dashprism.com",
+    "status": "active",
+    "expiry_date": "2027-04-28",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "dashprism.app",
+    "status": "active",
+    "expiry_date": "2027-04-28",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.com",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.app",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.dev",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.net",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "getzetlk.com",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.us",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "unsupported",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com",
+      "ns1.linode.com",
+      "ns2.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.link",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlk.monster",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "zetlkemail.com",
+    "status": "active",
+    "expiry_date": "2026-08-02",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "kolohelabs.com",
+    "status": "active",
+    "expiry_date": "2026-09-25",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "kolohelabs.dev",
+    "status": "active",
+    "expiry_date": "2026-09-25",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "kolohelabs.app",
+    "status": "active",
+    "expiry_date": "2026-09-25",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "kolohelabs.net",
+    "status": "active",
+    "expiry_date": "2026-09-25",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "cinctra.com",
+    "status": "active",
+    "expiry_date": "2027-04-11",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  },
+  {
+    "name": "cinctra.org",
+    "status": "active",
+    "expiry_date": "2027-04-11",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": [
+      "ns1.linode.com",
+      "ns2.linode.com",
+      "ns3.linode.com",
+      "ns4.linode.com",
+      "ns5.linode.com"
+    ]
+  }
+]

--- a/tools/shaka/tests/fixtures/domain/invalid/bad-disposition.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/bad-disposition.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "kolohelios.com"
+	disposition:    "main-site"
+	nameservers:    "cloudflare"
+	dnssec_enabled: true
+}

--- a/tools/shaka/tests/fixtures/domain/invalid/dnssec-on-linode-legacy.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/dnssec-on-linode-legacy.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "zetlk.com"
+	disposition:    "product-reserve"
+	nameservers:    "linode-legacy"
+	dnssec_enabled: true
+}

--- a/tools/shaka/tests/fixtures/domain/invalid/missing-disposition.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/missing-disposition.cue
@@ -1,0 +1,7 @@
+package domain
+
+#Domain & {
+	name:           "kolohelios.com"
+	nameservers:    "cloudflare"
+	dnssec_enabled: true
+}

--- a/tools/shaka/tests/fixtures/domain/invalid/missing-dnssec-on-cloudflare.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/missing-dnssec-on-cloudflare.cue
@@ -1,0 +1,7 @@
+package domain
+
+#Domain & {
+	name:        "kolohelios.com"
+	disposition: "portfolio-canonical"
+	nameservers: "cloudflare"
+}

--- a/tools/shaka/tests/fixtures/domain/invalid/missing-nameservers.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/missing-nameservers.cue
@@ -1,0 +1,6 @@
+package domain
+
+#Domain & {
+	name:        "kolohelios.com"
+	disposition: "portfolio-canonical"
+}

--- a/tools/shaka/tests/fixtures/domain/invalid/negative-expiry-warn.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/negative-expiry-warn.cue
@@ -1,0 +1,9 @@
+package domain
+
+#Domain & {
+	name:             "kolohelios.com"
+	disposition:      "portfolio-canonical"
+	nameservers:      "cloudflare"
+	dnssec_enabled:   true
+	expiry_warn_days: -1
+}

--- a/tools/shaka/tests/fixtures/domain/invalid/uppercase-name.cue
+++ b/tools/shaka/tests/fixtures/domain/invalid/uppercase-name.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "Kolohelios.com"
+	disposition:    "portfolio-canonical"
+	nameservers:    "cloudflare"
+	dnssec_enabled: true
+}

--- a/tools/shaka/tests/fixtures/domain/valid/expiry-warn-override.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/expiry-warn-override.cue
@@ -1,0 +1,9 @@
+package domain
+
+#Domain & {
+	name:              "kolohelios.com"
+	disposition:       "portfolio-canonical"
+	nameservers:       "cloudflare"
+	dnssec_enabled:    true
+	expiry_warn_days:  60
+}

--- a/tools/shaka/tests/fixtures/domain/valid/let-expire-unmanaged.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/let-expire-unmanaged.cue
@@ -1,0 +1,7 @@
+package domain
+
+#Domain & {
+	name:        "epiphanic.info"
+	disposition: "let-expire"
+	nameservers: "unmanaged"
+}

--- a/tools/shaka/tests/fixtures/domain/valid/park-cloudflare.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/park-cloudflare.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "genderneutralrobot.com"
+	disposition:    "park"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/valid/personal-alt-cloudflare.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/personal-alt-cloudflare.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "kolohe.me"
+	disposition:    "personal-alt"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/valid/portfolio-alias-cloudflare-no-dnssec.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/portfolio-alias-cloudflare-no-dnssec.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "kolohelios.me"
+	disposition:    "portfolio-alias"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/valid/portfolio-canonical-cloudflare-dnssec.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/portfolio-canonical-cloudflare-dnssec.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "kolohelios.com"
+	disposition:    "portfolio-canonical"
+	nameservers:    "cloudflare"
+	dnssec_enabled: true
+}

--- a/tools/shaka/tests/fixtures/domain/valid/product-reserve-linode-legacy.cue
+++ b/tools/shaka/tests/fixtures/domain/valid/product-reserve-linode-legacy.cue
@@ -1,0 +1,7 @@
+package domain
+
+#Domain & {
+	name:        "zetlk.com"
+	disposition: "product-reserve"
+	nameservers: "linode-legacy"
+}

--- a/tools/shaka/tests/schema_domain.rs
+++ b/tools/shaka/tests/schema_domain.rs
@@ -1,0 +1,66 @@
+//! Integration tests for the domain.cue schema.
+//!
+//! Runs `cue vet -c` against fixtures in `tests/fixtures/domain/{valid,invalid}/`.
+//! Each fixture is a complete `#Domain` instance that should be accepted or
+//! rejected by the shipped schema. The test walks both directories and
+//! asserts every fixture in `valid/` passes and every fixture in `invalid/`
+//! fails — adding a new fixture is enough to extend coverage.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SCHEMA_PATH: &str = "schema/domain.cue";
+
+fn cue_vet(schema: &Path, fixture: &Path) -> bool {
+    Command::new("cue")
+        .arg("vet")
+        .arg("-c")
+        .arg(schema)
+        .arg(fixture)
+        .output()
+        .expect("failed to spawn cue (is it on PATH?)")
+        .status
+        .success()
+}
+
+fn fixtures_in(subdir: &str) -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/domain")
+        .join(subdir);
+    let mut out: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|_| panic!("missing fixture dir: {}", dir.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "cue").unwrap_or(false))
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn every_valid_fixture_is_accepted() {
+    let schema = Path::new(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_PATH);
+    let fixtures = fixtures_in("valid");
+    assert!(!fixtures.is_empty(), "no valid fixtures found");
+    for fixture in fixtures {
+        assert!(
+            cue_vet(&schema, &fixture),
+            "expected {} to pass cue vet but it failed",
+            fixture.display()
+        );
+    }
+}
+
+#[test]
+fn every_invalid_fixture_is_rejected() {
+    let schema = Path::new(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_PATH);
+    let fixtures = fixtures_in("invalid");
+    assert!(!fixtures.is_empty(), "no invalid fixtures found");
+    for fixture in fixtures {
+        assert!(
+            !cue_vet(&schema, &fixture),
+            "expected {} to fail cue vet but it passed",
+            fixture.display()
+        );
+    }
+}


### PR DESCRIPTION
Locks the per-domain data shape that future `shaka domain` subcommands
will consume. Files declared under `infra/cloudflare-dns/domains/`
validate against `#Domain` in `tools/shaka/schema/domain.cue`.

Two orthogonal axes shape the schema. `disposition` is what a domain
is for — portfolio-canonical, portfolio-alias, personal-alt,
product-reserve, park, let-expire — matching the classification in #197.
`nameservers` is where it points, and selects which drift checks apply:
`cloudflare` honors NS and DNSSEC checks against terraform's
`domain_expectations` output (a stable contract that decouples
`shaka domain check` from TF state file shape); `linode-legacy` and
`unmanaged` skip NS/DNSSEC but still get expiry and lock checks.
`dnssec_enabled` is structurally permitted only on `cloudflare`, since
those are the zones we manage end-to-end.

The actual DNSSEC check compares DS-at-registry to DNSKEY-from-CF
dynamically — declaring an expected DS would invert source-of-truth.
The `clientTransferProhibited` lock requirement is hardcoded for every
owned domain, not a per-domain field.

Out of scope: no per-domain registry files yet (those land alongside
#187 once `infra/cloudflare-dns` exists), no `shaka domain` CLI parser
(`check` lands in #200, `inventory` in a follow-up filed with this
PR). `tests/fixtures/domain/hover/snapshot-2026-05-02.json` is a
sanitized 52-domain projection of the Hover control panel state
(PII-stripped: name, status, expiry_date, whois_privacy, locked,
autorenew, nameservers only) for the inventory follow-up to test
against.

Closes #199