### PR TITLE
docs(claude): make workspace-per-issue the default for /start

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,10 +1,10 @@
 ---
-description: Start working on a GitHub issue — sync, read, bookmark, and plan
-allowed-tools: Bash(shaka repo sync), Bash(shaka repo status:*), Bash(jj *), Bash(gh issue view:*), Bash(gh issue list:*), Read, Glob, Grep
+description: Start working on a GitHub issue — create workspace, read, bookmark, and plan
+allowed-tools: Bash(shaka repo sync), Bash(shaka repo status:*), Bash(shaka workspace new:*), Bash(jj *), Bash(gh issue view:*), Bash(gh issue list:*), Read, Glob, Grep
 argument-hint: <issue-number>
 ---
 
-Pick up GitHub issue `$1` and set up the workspace to work on it. Walk the
+Pick up GitHub issue `$1` and set up a workspace to work on it. Walk the
 user through each step, surface anything that needs human judgment, and stop
 for confirmation before writing code.
 
@@ -19,29 +19,36 @@ assumptions, file reads, or plans from earlier work into the new task. Don't
 proceed unless the conversation is fresh or the user explicitly confirms it's
 fine to continue.
 
-### 1. Check for in-progress work
+### 1. Create a workspace
 
-Run `shaka repo status --json` for a structured snapshot (`bookmarks`,
-`change_id`, `parent.is_main_origin`, `dirty`, `ahead`, `pr`). If `dirty.total
-> 0` or `ahead > 0` and `bookmarks` is empty, there's WIP without a bookmark —
-surface the current change to the user before doing anything else. The change
-will be preserved either way, but the user should decide whether to:
+**Default: every issue gets its own `shaka workspace`.** This keeps the
+primary tree clean for sync, audit, and cross-cutting reads, and it means
+the user's WIP elsewhere is undisturbed.
 
-- Set a bookmark on it first (`jj bookmark create <name> -r @`)
-- Continue and let it sit as an orphan change reachable via `jj log`
-- Abort the `/start` flow
+Fetch first so the new workspace parents on the latest main:
 
-Don't proceed silently if there's WIP without a bookmark.
+```
+jj git fetch
+```
 
-### 2. Sync on main@origin
+Then create the workspace:
 
-Run `shaka repo sync` to fetch and rebase the working copy onto
-`main@origin`. If it errors (conflicts, network), stop and report.
+```
+tools/shaka/bin/shaka workspace new --issue $1
+```
 
-Re-run `shaka repo status --json` to confirm `parent.is_main_origin` is `true`
-and `dirty.total` is `0`.
+This creates a sibling working copy at `../kolohelios-i$1` parented on the
+current `main@origin`. If the command errors (path collision, repo lock),
+stop and report.
 
-### 3. Read the issue
+**Opt-out:** if the user explicitly asks to work in-place ("in-place", "in
+primary", or similar), skip workspace creation. Then run `shaka repo status
+--json` in primary — if `dirty.total > 0` or `ahead > 0` and `bookmarks` is
+empty, surface the WIP and let the user decide before proceeding. The
+in-place path is reserved for trivial doc tweaks; default to workspace
+otherwise.
+
+### 2. Read the issue
 
 Run `gh issue view $1` and read the full body. If the issue has comments
 worth reading, run `gh issue view $1 --comments`. Summarize for the user:
@@ -53,7 +60,7 @@ worth reading, run `gh issue view $1 --comments`. Summarize for the user:
 If the issue references other issues (`#NN`), files, or prior PRs, read
 those for context too. Don't guess — read the actual referenced material.
 
-### 4. Propose a bookmark name
+### 3. Propose a bookmark name
 
 Derive a bookmark from the issue title in the form
 `<type>/<short-description>`:
@@ -67,9 +74,16 @@ Derive a bookmark from the issue title in the form
   `feat/skills-start-issue`).
 
 Propose the name to the user and wait for confirmation or a counter-suggestion
-before creating it. Then run `jj bookmark create <name> -r @`.
+before creating it. Then, from the new workspace path
+(`/Users/jedwards/code/kolohelios-i$1`):
 
-### 5. Plan and confirm
+```
+jj bookmark create <name> -r @
+```
+
+For the in-place opt-out path, run from the primary tree.
+
+### 4. Plan and confirm
 
 Outline an implementation approach in the response — files to touch,
 sequencing of commits (one logical change per commit, per project
@@ -79,6 +93,8 @@ confirm or redirect before writing any code.
 ## Conventions
 
 - One issue per bookmark — don't mix work from multiple issues.
+- One workspace per issue — keeps primary clean for sync, audit, and
+  cross-cutting reads.
 - Bookmark `<type>` must match the conventional commit type used in the
   eventual commit(s).
 - Never use `git` for working-copy mutations — only `jj`.
@@ -89,8 +105,8 @@ confirm or redirect before writing any code.
 
 Halt and report to the user when:
 
-- `@` has WIP without a bookmark (step 1)
-- `shaka repo sync` hits a conflict or network error
+- `shaka workspace new` errors (path collision, repo lock)
+- In the in-place opt-out path: `@` has WIP without a bookmark
 - `gh issue view` fails (issue doesn't exist, auth missing)
 - The issue title doesn't yield an obvious conventional type and labels
   don't disambiguate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,20 +204,31 @@ hand for now — `project new` only ships the rust template:
 5. If the project introduces new preflight checks, add them to
    `tools/shaka/src/preflight.rs` rather than to CI YAML.
 
-## Parallel work in jj workspaces
+## Workspaces
 
-For non-trivial work that splits into independent slices (typically a
-parent issue with N sibling sub-issues), `shaka workspace` lets you run
-multiple Claude Code sessions or sub-agents in parallel without
-trampling each other.
+**Every issue gets its own `shaka workspace`.** `/start` invokes
+`shaka workspace new --issue <N>` by default; the user can opt out
+("in-place") for trivial doc tweaks. The primary tree is reserved for
+sync, audit, and cross-cutting reads — never carrying WIP for the
+issue you're picking up.
+
+Why workspace-per-issue is the default:
+
+- Primary stays clean. Cross-cutting ops (`shaka repo sync`,
+  `shaka repo audit`, `gh`-from-cwd, reading state across all in-flight
+  changes) never compete with WIP for some specific issue.
+- Parallel slices are free. Pick up a second issue while the first is
+  in CI; both have their own filesystem trees but share `.jj/repo`.
+- Hygiene is solved. `shaka workspace cleanup` finds merged workspaces
+  via persisted issue links (no longer dependent on bookmark presence).
 
 Shape:
 
-1. `shaka workspace new --issue <N>` (or `shaka workspace new <name>`)
+1. `/start <N>` (or manually: `shaka workspace new --issue <N>`)
    creates a sibling working copy at `../kolohelios-i<N>` that shares
    the same `.jj/repo` but has its own `@`. Each workspace has a
-   filesystem-level full copy of the repo (~66 files) but the underlying
-   commit storage is shared.
+   filesystem-level full copy of the repo but the underlying commit
+   storage is shared.
 2. Run `claude` inside each workspace, or spawn sub-agents pointed at
    each workspace's path. Each session bookmarks, commits, and pushes
    independently. Concurrent jj operations are serialized via the repo
@@ -228,12 +239,10 @@ Shape:
    `jj git push --bookmark <name>` (jj allows the non-fast-forward
    "move sideways" without `--force` for rebased branches).
 4. `shaka workspace status` shows a per-workspace summary at any time.
-5. `shaka workspace cleanup` forgets workspaces whose PRs have merged.
-   Caveat: this repo has `deleteBranchOnMerge: true`, so after `repo
-   sync` the local bookmark is gone (jj propagates the remote
-   deletion) and `cleanup`'s bookmark-based lookup misses the
-   workspace. Fall back to `shaka workspace forget --force <name>`
-   per workspace until #164 lands.
+5. `shaka workspace cleanup` forgets workspaces whose PRs have merged
+   (uses the persisted issue link, so it works regardless of remote
+   branch deletion). Workspaces created without `--issue` (ad-hoc
+   names) need `shaka workspace forget --force <name>`.
 
 When briefing sub-agents to work in their own workspaces, the brief must
 restate two rules that `/start` and `/ship` would otherwise enforce:


### PR DESCRIPTION
In practice every issue gets its own `shaka workspace`, but `/start`
and the CLAUDE.md docs framed workspaces as for "non-trivial parallel
work". Update both to reflect actual usage: workspace creation is
step 1 of `/start`, the primary tree is reserved for sync/audit/
cross-cutting reads, and there's a brief opt-out path for trivial doc
tweaks.

Also drop the stale "until #164 lands" reference — #164 (cleanup
post-sync) merged via #184; the cleanup paragraph now describes
current behavior.

Closes #205