### PR TITLE
feat(shaka): domain inventory subcommand

### DIFF
--- a/tools/shaka/src/domain/inventory.rs
+++ b/tools/shaka/src/domain/inventory.rs
@@ -1,0 +1,313 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+const SCHEMA: &str = include_str!("../../schema/domain.cue");
+
+pub const REFRESH_SNIPPET: &str = "\
+REFRESH PROCEDURE
+
+Hover has no API. To refresh the snapshot, sign in at
+https://www.hover.com/control_panel and paste this snippet into DevTools:
+
+  (() => {
+    const keys = ['name', 'status', 'expiry_date', 'whois_privacy',
+                  'locked', 'autorenew', 'nameservers'];
+    const data = $('#app').data('props').initialData.data.domains
+      .map(d => Object.fromEntries(keys.map(k => [k, d[k]])));
+    const blob = new Blob([JSON.stringify(data, null, 2)],
+                          { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'hover-snapshot.json';
+    a.click();
+  })();
+
+`hover-snapshot.json` lands in ~/Downloads. Pass it via `--input`.
+
+The Blob-download form (rather than a clipboard `copy()` snippet) is
+deliberate: clipboard-paste-of-DOM patterns match credential-stealer
+signatures (Atomic, StealC) and are blocked by macOS Sequoia's XProtect
+clipboard scanner. See \"Things to avoid\" in CLAUDE.md.";
+
+#[derive(Debug, Deserialize)]
+struct HoverEntry {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistryEntry {
+    name: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InventoryDiff {
+    pub adds: Vec<String>,
+    pub removes: Vec<String>,
+}
+
+impl InventoryDiff {
+    pub fn has_drift(&self) -> bool {
+        !self.adds.is_empty() || !self.removes.is_empty()
+    }
+}
+
+pub fn run(input: &Path, registry_dir: &Path) {
+    let hover = match load_snapshot(input) {
+        Ok(names) => names,
+        Err(e) => die(&format!("could not read snapshot {}: {e}", input.display())),
+    };
+
+    let schema_path = match write_schema() {
+        Ok(p) => p,
+        Err(e) => die(&format!("could not write schema: {e}")),
+    };
+
+    let registry = match load_registry(registry_dir, &schema_path) {
+        Ok(names) => names,
+        Err(e) => die(&format!(
+            "could not read registry {}: {e}",
+            registry_dir.display()
+        )),
+    };
+
+    if registry.is_empty() {
+        eprintln!(
+            "{YELLOW}{BOLD}registry is empty{RESET} ({})",
+            registry_dir.display()
+        );
+        eprintln!(
+            "  {DIM}populate the directory with one CUE file per domain (see tools/shaka/schema/domain.cue){RESET}"
+        );
+        eprintln!(
+            "  {DIM}snapshot has {} domain(s); all are reported as adds below{RESET}",
+            hover.len()
+        );
+        eprintln!();
+    }
+
+    let diff = diff_inventory(&hover, &registry);
+    print_diff(&diff);
+
+    if diff.has_drift() {
+        std::process::exit(1);
+    }
+}
+
+fn load_snapshot(path: &Path) -> Result<BTreeSet<String>, String> {
+    let bytes = std::fs::read(path).map_err(|e| e.to_string())?;
+    let entries: Vec<HoverEntry> =
+        serde_json::from_slice(&bytes).map_err(|e| format!("invalid snapshot JSON: {e}"))?;
+    let names: Vec<String> = entries.into_iter().map(|e| e.name).collect();
+    let dups = find_duplicates(&names);
+    if !dups.is_empty() {
+        return Err(format!("duplicate names in snapshot: {}", dups.join(", ")));
+    }
+    Ok(names.into_iter().collect())
+}
+
+fn load_registry(dir: &Path, schema_path: &Path) -> Result<BTreeSet<String>, String> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeSet::new()),
+        Err(e) => return Err(e.to_string()),
+    };
+
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.extension().and_then(|s| s.to_str()) == Some("cue"))
+        .collect();
+    files.sort();
+
+    let mut names: Vec<String> = Vec::with_capacity(files.len());
+    for file in &files {
+        let entry = export_registry_file(schema_path, file)?;
+        names.push(entry.name);
+    }
+
+    let dups = find_duplicates(&names);
+    if !dups.is_empty() {
+        return Err(format!("duplicate names in registry: {}", dups.join(", ")));
+    }
+    Ok(names.into_iter().collect())
+}
+
+fn export_registry_file(schema_path: &Path, file: &Path) -> Result<RegistryEntry, String> {
+    let output = Command::new("cue")
+        .arg("export")
+        .arg("--out")
+        .arg("json")
+        .arg(schema_path)
+        .arg(file)
+        .output()
+        .map_err(|e| format!("failed to spawn cue: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(format!("cue export {}: {detail}", file.display()));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("could not parse {}: {e}", file.display()))
+}
+
+fn write_schema() -> std::io::Result<PathBuf> {
+    let path = std::env::temp_dir().join(format!("shaka-domain-schema-{}.cue", std::process::id()));
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(SCHEMA.as_bytes())?;
+    Ok(path)
+}
+
+pub fn diff_inventory(hover: &BTreeSet<String>, registry: &BTreeSet<String>) -> InventoryDiff {
+    InventoryDiff {
+        adds: hover.difference(registry).cloned().collect(),
+        removes: registry.difference(hover).cloned().collect(),
+    }
+}
+
+pub fn find_duplicates(names: &[String]) -> Vec<String> {
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for name in names {
+        *counts.entry(name.as_str()).or_insert(0) += 1;
+    }
+    counts
+        .into_iter()
+        .filter(|(_, c)| *c > 1)
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
+fn print_diff(diff: &InventoryDiff) {
+    if !diff.has_drift() {
+        println!("{GREEN}{BOLD}inventory matches{RESET}");
+        return;
+    }
+
+    println!(
+        "{BOLD}inventory drift:{RESET} {} add(s), {} remove(s)",
+        diff.adds.len(),
+        diff.removes.len()
+    );
+    for name in &diff.removes {
+        println!("  {RED}- {name}{RESET}");
+    }
+    for name in &diff.adds {
+        println!("  {GREEN}+ {name}{RESET}");
+    }
+}
+
+fn die(msg: &str) -> ! {
+    eprintln!("{RED}{BOLD}error:{RESET} {msg}");
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(items: &[&str]) -> BTreeSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn diff_empty_when_sets_equal() {
+        let h = names(&["a.com", "b.com"]);
+        let r = names(&["a.com", "b.com"]);
+        let d = diff_inventory(&h, &r);
+        assert!(d.adds.is_empty());
+        assert!(d.removes.is_empty());
+        assert!(!d.has_drift());
+    }
+
+    #[test]
+    fn diff_reports_adds_when_hover_has_new() {
+        let h = names(&["a.com", "b.com", "c.com"]);
+        let r = names(&["a.com"]);
+        let d = diff_inventory(&h, &r);
+        assert_eq!(d.adds, vec!["b.com", "c.com"]);
+        assert!(d.removes.is_empty());
+        assert!(d.has_drift());
+    }
+
+    #[test]
+    fn diff_reports_removes_when_registry_has_extra() {
+        let h = names(&["a.com"]);
+        let r = names(&["a.com", "b.com", "c.com"]);
+        let d = diff_inventory(&h, &r);
+        assert!(d.adds.is_empty());
+        assert_eq!(d.removes, vec!["b.com", "c.com"]);
+        assert!(d.has_drift());
+    }
+
+    #[test]
+    fn diff_reports_both_adds_and_removes() {
+        let h = names(&["a.com", "b.com"]);
+        let r = names(&["b.com", "c.com"]);
+        let d = diff_inventory(&h, &r);
+        assert_eq!(d.adds, vec!["a.com"]);
+        assert_eq!(d.removes, vec!["c.com"]);
+    }
+
+    #[test]
+    fn diff_against_empty_registry_makes_everything_an_add() {
+        let h = names(&["a.com", "b.com"]);
+        let r: BTreeSet<String> = BTreeSet::new();
+        let d = diff_inventory(&h, &r);
+        assert_eq!(d.adds, vec!["a.com", "b.com"]);
+        assert!(d.removes.is_empty());
+    }
+
+    #[test]
+    fn diff_results_are_sorted() {
+        let h = names(&["z.com", "a.com", "m.com"]);
+        let r: BTreeSet<String> = BTreeSet::new();
+        let d = diff_inventory(&h, &r);
+        assert_eq!(d.adds, vec!["a.com", "m.com", "z.com"]);
+    }
+
+    #[test]
+    fn find_duplicates_returns_empty_for_unique_names() {
+        let v = vec!["a.com".into(), "b.com".into(), "c.com".into()];
+        assert!(find_duplicates(&v).is_empty());
+    }
+
+    #[test]
+    fn find_duplicates_reports_repeated_names() {
+        let v = vec![
+            "a.com".into(),
+            "b.com".into(),
+            "a.com".into(),
+            "c.com".into(),
+            "b.com".into(),
+        ];
+        assert_eq!(find_duplicates(&v), vec!["a.com", "b.com"]);
+    }
+
+    #[test]
+    fn find_duplicates_does_not_double_report_triples() {
+        let v = vec!["a.com".into(), "a.com".into(), "a.com".into()];
+        assert_eq!(find_duplicates(&v), vec!["a.com"]);
+    }
+
+    #[test]
+    fn find_duplicates_results_are_sorted() {
+        let v = vec![
+            "z.com".into(),
+            "a.com".into(),
+            "z.com".into(),
+            "a.com".into(),
+        ];
+        assert_eq!(find_duplicates(&v), vec!["a.com", "z.com"]);
+    }
+}

--- a/tools/shaka/src/domain/mod.rs
+++ b/tools/shaka/src/domain/mod.rs
@@ -1,0 +1,32 @@
+mod inventory;
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum DomainCommand {
+    /// Diff a Hover snapshot against the per-domain registry
+    #[command(after_help = inventory::REFRESH_SNIPPET)]
+    Inventory {
+        /// Path to a sanitized Hover snapshot JSON (see --help for the refresh procedure)
+        #[arg(long, value_name = "FILE")]
+        input: PathBuf,
+        /// Directory of per-domain CUE registry files (one #Domain instance per file)
+        #[arg(
+            long,
+            value_name = "DIR",
+            default_value = "infra/cloudflare-dns/domains"
+        )]
+        registry_dir: PathBuf,
+    },
+}
+
+pub fn run(cmd: DomainCommand) {
+    match cmd {
+        DomainCommand::Inventory {
+            input,
+            registry_dir,
+        } => inventory::run(&input, &registry_dir),
+    }
+}

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod ci;
 mod commit;
+mod domain;
 mod gh;
 mod jj;
 mod preflight;
@@ -30,6 +31,11 @@ enum Commands {
     Commit {
         #[command(subcommand)]
         command: commit::CommitCommand,
+    },
+    /// Domain inventory and drift tooling
+    Domain {
+        #[command(subcommand)]
+        command: domain::DomainCommand,
     },
     /// Run every validation check CI runs (nix flake check, tofu validate, tofu plan)
     Preflight {
@@ -71,6 +77,7 @@ fn main() {
         }
         Commands::Ci { command } => ci::run(command),
         Commands::Commit { command } => commit::run(command),
+        Commands::Domain { command } => domain::run(command),
         Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
         Commands::Project { command } => project::run(command),
         Commands::Repo { command } => repo::run(command),

--- a/tools/shaka/tests/domain_inventory.rs
+++ b/tools/shaka/tests/domain_inventory.rs
@@ -1,0 +1,143 @@
+//! Integration tests for `shaka domain inventory`.
+//!
+//! Each test pairs a snapshot JSON fixture with a registry directory fixture
+//! (real CUE files under `tests/fixtures/domain/registry/<case>/`) and asserts
+//! exit code + diff content from the spawned shaka binary.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+
+fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/domain")
+}
+
+fn snapshot(name: &str) -> PathBuf {
+    fixtures_root().join("snapshot").join(name)
+}
+
+fn registry(case: &str) -> PathBuf {
+    fixtures_root().join("registry").join(case)
+}
+
+fn run_inventory(input: &Path, registry_dir: &Path) -> std::process::Output {
+    Command::new(SHAKA_BIN)
+        .args(["domain", "inventory", "--input"])
+        .arg(input)
+        .arg("--registry-dir")
+        .arg(registry_dir)
+        .output()
+        .expect("failed to spawn shaka")
+}
+
+fn stdout_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn stderr_of(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+#[test]
+fn matching_registry_exits_zero() {
+    let out = run_inventory(&snapshot("two-domains.json"), &registry("matching"));
+    let stdout = stdout_of(&out);
+    let stderr = stderr_of(&out);
+    assert!(
+        out.status.success(),
+        "expected success, got {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        out.status.code()
+    );
+    assert!(stdout.contains("inventory matches"), "stdout: {stdout}");
+}
+
+#[test]
+fn drifted_registry_exits_nonzero_with_diff() {
+    let out = run_inventory(&snapshot("two-domains.json"), &registry("drifted"));
+    let stdout = stdout_of(&out);
+    assert!(!out.status.success(), "stdout: {stdout}");
+    assert!(stdout.contains("inventory drift"), "stdout: {stdout}");
+    // snapshot has alpha+beta; drifted registry has alpha+gamma.
+    // Expect: + beta.example (in snapshot, missing from registry)
+    //         - gamma.example (in registry, missing from snapshot)
+    assert!(stdout.contains("+ beta.example"), "stdout: {stdout}");
+    assert!(stdout.contains("- gamma.example"), "stdout: {stdout}");
+    assert!(!stdout.contains("alpha.example"), "stdout: {stdout}");
+}
+
+#[test]
+fn empty_registry_special_cases_with_message() {
+    let out = run_inventory(&snapshot("two-domains.json"), &registry("empty"));
+    let stdout = stdout_of(&out);
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "stdout: {stdout}\nstderr: {stderr}");
+    assert!(stderr.contains("registry is empty"), "stderr: {stderr}");
+    assert!(stdout.contains("+ alpha.example"), "stdout: {stdout}");
+    assert!(stdout.contains("+ beta.example"), "stdout: {stdout}");
+}
+
+#[test]
+fn missing_registry_dir_treated_as_empty() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let nonexistent = tmp.path().join("does-not-exist");
+    let out = run_inventory(&snapshot("two-domains.json"), &nonexistent);
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "stderr: {stderr}");
+    assert!(stderr.contains("registry is empty"), "stderr: {stderr}");
+}
+
+#[test]
+fn duplicate_registry_names_fail_loud() {
+    let out = run_inventory(&snapshot("two-domains.json"), &registry("duplicate"));
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("duplicate names in registry"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("alpha.example"), "stderr: {stderr}");
+}
+
+#[test]
+fn duplicate_snapshot_names_fail_loud() {
+    let out = run_inventory(&snapshot("duplicate.json"), &registry("matching"));
+    let stderr = stderr_of(&out);
+    assert!(!out.status.success(), "stderr: {stderr}");
+    assert!(
+        stderr.contains("duplicate names in snapshot"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("alpha.example"), "stderr: {stderr}");
+}
+
+#[test]
+fn real_hover_snapshot_against_empty_registry_lists_all() {
+    let snap = fixtures_root().join("hover/snapshot-2026-05-02.json");
+    let out = run_inventory(&snap, &registry("empty"));
+    let stdout = stdout_of(&out);
+    assert!(!out.status.success(), "stdout: {stdout}");
+    // 52 entries in the sanitized snapshot, all reported as adds.
+    let add_lines = stdout.lines().filter(|l| l.contains("+ ")).count();
+    assert_eq!(
+        add_lines, 52,
+        "expected 52 add lines, got {add_lines}\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn help_includes_refresh_snippet() {
+    let out = Command::new(SHAKA_BIN)
+        .args(["domain", "inventory", "--help"])
+        .output()
+        .expect("failed to spawn shaka");
+    assert!(out.status.success());
+    let stdout = stdout_of(&out);
+    assert!(stdout.contains("REFRESH PROCEDURE"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("hover.com/control_panel"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("Blob"), "stdout: {stdout}");
+    assert!(stdout.contains("XProtect"), "stdout: {stdout}");
+}

--- a/tools/shaka/tests/fixtures/domain/registry/drifted/alpha-example.cue
+++ b/tools/shaka/tests/fixtures/domain/registry/drifted/alpha-example.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "alpha.example"
+	disposition:    "personal-alt"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/registry/drifted/gamma-example.cue
+++ b/tools/shaka/tests/fixtures/domain/registry/drifted/gamma-example.cue
@@ -1,0 +1,7 @@
+package domain
+
+#Domain & {
+	name:        "gamma.example"
+	disposition: "let-expire"
+	nameservers: "unmanaged"
+}

--- a/tools/shaka/tests/fixtures/domain/registry/duplicate/alpha-one.cue
+++ b/tools/shaka/tests/fixtures/domain/registry/duplicate/alpha-one.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "alpha.example"
+	disposition:    "personal-alt"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/registry/duplicate/alpha-two.cue
+++ b/tools/shaka/tests/fixtures/domain/registry/duplicate/alpha-two.cue
@@ -1,0 +1,7 @@
+package domain
+
+#Domain & {
+	name:        "alpha.example"
+	disposition: "park"
+	nameservers: "unmanaged"
+}

--- a/tools/shaka/tests/fixtures/domain/registry/matching/alpha-example.cue
+++ b/tools/shaka/tests/fixtures/domain/registry/matching/alpha-example.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "alpha.example"
+	disposition:    "personal-alt"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/registry/matching/beta-example.cue
+++ b/tools/shaka/tests/fixtures/domain/registry/matching/beta-example.cue
@@ -1,0 +1,8 @@
+package domain
+
+#Domain & {
+	name:           "beta.example"
+	disposition:    "personal-alt"
+	nameservers:    "cloudflare"
+	dnssec_enabled: false
+}

--- a/tools/shaka/tests/fixtures/domain/snapshot/duplicate.json
+++ b/tools/shaka/tests/fixtures/domain/snapshot/duplicate.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "alpha.example",
+    "status": "active",
+    "expiry_date": "2027-01-01",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": ["nora.ns.cloudflare.com", "kayden.ns.cloudflare.com"]
+  },
+  {
+    "name": "alpha.example",
+    "status": "active",
+    "expiry_date": "2027-01-01",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": ["nora.ns.cloudflare.com", "kayden.ns.cloudflare.com"]
+  }
+]

--- a/tools/shaka/tests/fixtures/domain/snapshot/two-domains.json
+++ b/tools/shaka/tests/fixtures/domain/snapshot/two-domains.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "alpha.example",
+    "status": "active",
+    "expiry_date": "2027-01-01",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": ["nora.ns.cloudflare.com", "kayden.ns.cloudflare.com"]
+  },
+  {
+    "name": "beta.example",
+    "status": "active",
+    "expiry_date": "2027-01-01",
+    "whois_privacy": "on",
+    "locked": "on",
+    "autorenew": "on",
+    "nameservers": ["nora.ns.cloudflare.com", "kayden.ns.cloudflare.com"]
+  }
+]


### PR DESCRIPTION
Implements `shaka domain inventory --input <file>` to diff a sanitized
Hover snapshot against the per-domain CUE registry under
`infra/cloudflare-dns/domains/`. Reports adds (present at Hover, missing
from registry) and removes (declared in registry, gone from Hover);
exits non-zero on any drift.

The `--registry-dir` flag (default: `infra/cloudflare-dns/domains`)
makes the command usable against alternate registry trees and drives
integration tests against fixtures under `tests/fixtures/domain/registry/`.

`--help` carries the canonical refresh procedure as `after_help`: a
DevTools snippet that builds the snapshot in-page and triggers a Blob
download. The Blob form (rather than `copy()` to clipboard) avoids
matching credential-stealer signatures (Atomic, StealC) blocked by
macOS Sequoia's XProtect — see CLAUDE.md "Things to avoid".

Edge cases handled explicitly:
  - Empty (or missing) registry: special-case message pointing at
    `infra/cloudflare-dns/domains/`, then lists every snapshot entry
    as an add. Exits non-zero.
  - Duplicate names on either side: fail loud rather than silently
    deduplicate; a duplicate registry entry violates a schema
    invariant and a duplicate Hover entry warrants investigation.

Not wired into `shaka preflight`. Inventory is human-paste-driven
(Hover has no API) and cannot run unattended; it's a manual-sync tool,
not a gate.

Closes #202
