### PR TITLE
ci: auto-rebase open PRs onto main when main moves

### DIFF
--- a/.github/auto-rebase-app.md
+++ b/.github/auto-rebase-app.md
@@ -1,0 +1,107 @@
+# kolohelios-bot GitHub App
+
+The `auto-rebase-prs.yaml` workflow authenticates as the **kolohelios-bot**
+GitHub App. The App's settings, secrets, and install scope are recorded
+here so they can be reproduced (after rotation, recreation, or migration to
+another account).
+
+## Why a GitHub App, not `GITHUB_TOKEN`
+
+Pushes authenticated via the workflow's default `GITHUB_TOKEN` **do not
+re-trigger CI** on the branch they push to. After auto-rebase force-pushes
+a PR branch, we want the PR's normal CI to re-run against the new tip —
+otherwise the PR shows green checks against stale state. A GitHub App
+token is a separate identity, so its pushes are treated as ordinary
+contributor pushes and CI runs.
+
+The App also keeps the rebase commits' `committer` field as
+`kolohelios-bot[bot]` rather than `github-actions[bot]`, which makes the
+provenance obvious in `git log`.
+
+## App settings
+
+Reproduce these on https://github.com/settings/apps/new (personal account)
+if the App needs to be recreated.
+
+### Basic info
+
+| Field | Value |
+| --- | --- |
+| GitHub App name | `kolohelios-bot` |
+| Description | Automation account for the kolohelios monorepo. Rebases open PRs onto main when main moves and posts `auto-rebase` commit statuses. May expand to other repo automation that needs to act outside personal credentials. |
+| Homepage URL | `https://github.com/kolohelios/kolohelios` *(placeholder; required field, not used at runtime)* |
+
+### Identifying and authorizing users
+
+All off — we authenticate as the App, not on behalf of users.
+
+- Callback URL: blank
+- Request user authorization (OAuth) during installation: **off**
+- Enable Device Flow: **off**
+
+### Post installation
+
+- Setup URL: blank
+- Redirect on update: **off**
+
+### Webhook
+
+- Active: **off**
+
+We don't subscribe to App events; the trigger is `push: main` in the
+workflow itself. Leaving Webhook → Active off avoids GitHub asking for a
+Webhook URL.
+
+### Permissions
+
+**Repository permissions:**
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Contents | Read & write | Force-push rebased branches |
+| Commit statuses | Read & write | Post the `auto-rebase` status |
+| Pull requests | Read | List open PRs against main |
+| Metadata | Read | Mandatory for all Apps |
+
+Everything else: **No access**.
+
+**Organization permissions:** all **No access**.
+**Account permissions:** all **No access**.
+
+### Subscribe to events
+
+None (webhook is off).
+
+### Where can this app be installed?
+
+**Only on this account** — locks installation to the `kolohelios` user
+account.
+
+## Repo configuration
+
+After creating the App, install it on `kolohelios/kolohelios` only and
+populate two repo-level entries:
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Variable | `KOLOHELIOS_BOT_APP_ID` | The numeric App ID (top of the App's settings page) |
+| Secret | `KOLOHELIOS_BOT_APP_PRIVATE_KEY` | The full `.pem` contents downloaded from "Generate a private key" — including `-----BEGIN/END PRIVATE KEY-----` lines |
+
+Both are referenced as `${{ vars.KOLOHELIOS_BOT_APP_ID }}` and
+`${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}` in the workflow.
+
+## Branch protection
+
+**Do not** mark the `auto-rebase` commit status as a required check.
+The check only appears on a PR after `main` moves while the PR is open
+— making it required would block every PR that opens against the
+current tip of main, since no auto-rebase has run yet for that PR. The
+status is informational: a failing `auto-rebase` flags a conflict the
+author needs to resolve, but doesn't itself gate merge.
+
+## Rotation
+
+Private keys can be re-generated from the App's settings page at any
+time. After regenerating, update the `KOLOHELIOS_BOT_APP_PRIVATE_KEY`
+secret in repo settings and revoke the old key. Workflow runs in flight
+will fail on token mint after revocation; new runs use the new key.

--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -1,0 +1,55 @@
+name: Auto-rebase PRs
+
+# When main moves, rebase every open PR whose base is `main` onto the new
+# tip. Conflicts surface as a failing `auto-rebase` commit status on the PR
+# head; the workflow run goes red so the failure is visible in the Actions
+# UI as well. PRs labeled `do-not-rebase` are skipped.
+#
+# Authenticates as the kolohelios-bot GitHub App so force-push and status
+# posting bypass the GITHUB_TOKEN's contents-write/checks-write limits and
+# (more importantly) so post-rebase pushes re-trigger CI on each PR — which
+# pushes via the default GITHUB_TOKEN do not.
+on:
+  push:
+    branches: [main]
+
+# A second push to main that lands while we're rebasing makes the in-flight
+# run stale — its rebases would target an out-of-date base. Cancel it; the
+# new run will pick up every PR that still needs attention.
+concurrency:
+  group: auto-rebase-prs
+  cancel-in-progress: true
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.KOLOHELIOS_BOT_APP_ID }}
+          private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: actions/cache@v5
+        with:
+          path: |
+            tools/shaka/target/
+            ~/.cargo/registry/
+            ~/.cargo/git/
+          key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-
+      - name: Configure git identity for rebase commits
+        run: |
+          git config --global user.name 'kolohelios-bot[bot]'
+          git config --global user.email '${{ vars.KOLOHELIOS_BOT_APP_ID }}+kolohelios-bot[bot]@users.noreply.github.com'
+      - name: Rebase open PRs
+        run: nix develop ./tools/shaka --command tools/shaka/bin/shaka repo rebase-open-prs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,35 @@ wrapper subsumes both.
   any sub-agent brief. (#146 will eventually have `shaka commit lint`
   catch this automatically.)
 
+### Auto-rebase on `main` movement
+
+When `main@origin` moves, `.github/workflows/auto-rebase-prs.yaml`
+rebases every open PR whose base is `main` onto the new tip. Successful
+rebases force-push the PR branch (with `--force-with-lease`) and post a
+`success` `auto-rebase` commit status; conflicts post a `failure`
+status on the PR head describing the conflicting paths, and the
+workflow run goes red.
+
+- **Opt out with the `do-not-rebase` label.** Apply it to a PR you
+  don't want the bot touching (e.g. one you're actively rebasing
+  yourself).
+- **`auto-rebase` is informational, not a required check.** It only
+  appears on a PR after `main` has moved — making it required would
+  block every freshly-opened PR. Its job is to flag conflicts the
+  author needs to resolve, not to gate merge.
+- **After a bot rebase, run `jj git fetch` locally.** The bookmark
+  tracks the change_id, so jj reconciles automatically: the local
+  bookmark moves to the rebased commit and your `@` (if it was on the
+  bookmark) follows. To resolve a conflict the bot couldn't, run
+  `jj rebase --branch <bookmark> -d main@origin` then
+  `jj git push --bookmark <bookmark>`.
+- **The bot authenticates as the `kolohelios-bot` GitHub App** —
+  required so post-rebase pushes re-trigger the PR's normal CI (which
+  pushes via `GITHUB_TOKEN` do not). App settings, secret/variable
+  names, and rotation steps live in `.github/auto-rebase-app.md`.
+- See also #147 (`shaka repo rebase-wip`), the local-side companion
+  for branches you're actively iterating on.
+
 ### Working with jj
 
 A few jj behaviors trip up agents whose mental model comes from git. Read

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -79,6 +79,11 @@ pub fn api_patch(endpoint: &str, body: &Value) -> Result<Value, GhError> {
     api_write("PATCH", endpoint, body)
 }
 
+/// Run `gh api -X POST <endpoint>` with a JSON body on stdin.
+pub fn api_post(endpoint: &str, body: &Value) -> Result<Value, GhError> {
+    api_write("POST", endpoint, body)
+}
+
 /// Run `gh api -X PUT <endpoint>` with a JSON body on stdin.
 pub fn api_put(endpoint: &str, body: &Value) -> Result<Value, GhError> {
     api_write("PUT", endpoint, body)
@@ -286,6 +291,106 @@ pub fn issue_title(n: u64) -> Result<String, GhError> {
     Ok(title)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenPr {
+    pub number: u64,
+    pub head_ref: String,
+    pub head_sha: String,
+    pub url: String,
+    pub labels: Vec<String>,
+}
+
+/// List open PRs whose base is `base`, with the fields needed for rebasing.
+///
+/// Shells out to `gh pr list --base <base> --state open --json
+/// number,headRefName,headRefOid,url,labels`.
+pub fn list_open_prs_against(base: &str) -> Result<Vec<OpenPr>, GhError> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--base",
+            base,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,headRefOid,url,labels",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GhError {
+            message: format!("gh pr list: {}", stderr.trim()),
+        });
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    parse_open_prs(&body)
+}
+
+pub(crate) fn parse_open_prs(body: &str) -> Result<Vec<OpenPr>, GhError> {
+    let value: Value = serde_json::from_str(body).map_err(|e| GhError {
+        message: format!("failed to parse gh pr list JSON: {e}"),
+    })?;
+    let arr = value.as_array().ok_or_else(|| GhError {
+        message: "gh pr list did not return an array".into(),
+    })?;
+
+    arr.iter()
+        .map(|v| {
+            let number = v["number"].as_u64().ok_or_else(|| GhError {
+                message: "PR missing 'number'".into(),
+            })?;
+            let head_ref = v["headRefName"]
+                .as_str()
+                .ok_or_else(|| GhError {
+                    message: format!("PR #{number} missing 'headRefName'"),
+                })?
+                .to_string();
+            let head_sha = v["headRefOid"]
+                .as_str()
+                .ok_or_else(|| GhError {
+                    message: format!("PR #{number} missing 'headRefOid'"),
+                })?
+                .to_string();
+            let url = v["url"]
+                .as_str()
+                .ok_or_else(|| GhError {
+                    message: format!("PR #{number} missing 'url'"),
+                })?
+                .to_string();
+            let labels = v["labels"]
+                .as_array()
+                .map(|labels| {
+                    labels
+                        .iter()
+                        .filter_map(|l| l["name"].as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            Ok(OpenPr {
+                number,
+                head_ref,
+                head_sha,
+                url,
+                labels,
+            })
+        })
+        .collect()
+}
+
+/// Detect owner/repo. Prefers `$GITHUB_REPOSITORY` (set in GitHub Actions),
+/// falling back to [`detect_repo`] for local invocations.
+pub fn detect_repo_or_env() -> Result<String, GhError> {
+    if let Ok(r) = std::env::var("GITHUB_REPOSITORY") {
+        if !r.is_empty() {
+            return Ok(r);
+        }
+    }
+    detect_repo()
+}
+
 /// Detect owner/repo from the jj git remote named "origin".
 ///
 /// Uses `jj git remote list` rather than `git remote get-url` so that this
@@ -370,5 +475,43 @@ mod tests {
             parse_repo_from_url("https://github.com/owner/repo"),
             Some("owner/repo".into())
         );
+    }
+
+    #[test]
+    fn parse_open_prs_extracts_fields() {
+        let body = r#"[
+            {
+                "number": 12,
+                "headRefName": "feat/x",
+                "headRefOid": "abc123",
+                "url": "https://github.com/o/r/pull/12",
+                "labels": [{"name": "ci"}, {"name": "do-not-rebase"}]
+            },
+            {
+                "number": 13,
+                "headRefName": "fix/y",
+                "headRefOid": "def456",
+                "url": "https://github.com/o/r/pull/13",
+                "labels": []
+            }
+        ]"#;
+        let prs = parse_open_prs(body).unwrap();
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].number, 12);
+        assert_eq!(prs[0].head_ref, "feat/x");
+        assert_eq!(prs[0].head_sha, "abc123");
+        assert_eq!(prs[0].labels, vec!["ci", "do-not-rebase"]);
+        assert_eq!(prs[1].labels, Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_open_prs_empty() {
+        assert!(parse_open_prs("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_open_prs_missing_field_errors() {
+        let body = r#"[{"number": 1, "headRefName": "x", "url": "u"}]"#;
+        assert!(parse_open_prs(body).is_err());
     }
 }

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod pr;
+mod rebase_open_prs;
 pub mod send;
 mod status;
 mod sync;
@@ -54,6 +55,17 @@ pub enum RepoCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Rebase every open PR whose base is `main` onto the current main@origin
+    ///
+    /// Intended to run from CI on `push: main`. PRs labeled `do-not-rebase`
+    /// are skipped. Successful rebases force-push with a lease and post a
+    /// `success` commit status (context: `auto-rebase`); conflicts post a
+    /// `failure` status on the PR head and the workflow exits non-zero.
+    RebaseOpenPrs {
+        /// Print what would happen without rebasing or pushing
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 pub fn run(cmd: RepoCommand) {
@@ -67,5 +79,6 @@ pub fn run(cmd: RepoCommand) {
         } => send::run(bookmark, no_pr, dry_run),
         RepoCommand::Pr { bookmark, dry_run } => pr::run(bookmark, dry_run),
         RepoCommand::Status { json } => status::run(json),
+        RepoCommand::RebaseOpenPrs { dry_run } => rebase_open_prs::run(dry_run),
     }
 }

--- a/tools/shaka/src/repo/rebase_open_prs.rs
+++ b/tools/shaka/src/repo/rebase_open_prs.rs
@@ -1,0 +1,455 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::json;
+
+use crate::gh::{self, OpenPr};
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+const STATUS_CONTEXT: &str = "auto-rebase";
+const OPT_OUT_LABEL: &str = "do-not-rebase";
+const STATUS_DESCRIPTION_LIMIT: usize = 140;
+
+pub fn run(dry_run: bool) {
+    let repo = match gh::detect_repo_or_env() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let prs = match gh::list_open_prs_against("main") {
+        Ok(prs) => prs,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} listing open PRs: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if prs.is_empty() {
+        println!("no open PRs against main");
+        return;
+    }
+
+    println!(
+        "{BOLD}{} open PR{} against main{RESET}",
+        prs.len(),
+        if prs.len() == 1 { "" } else { "s" }
+    );
+
+    let target_url = github_run_url();
+    let mut had_conflict = false;
+
+    for pr in prs {
+        if pr.labels.iter().any(|l| l == OPT_OUT_LABEL) {
+            println!(
+                "  {YELLOW}skip{RESET} #{} (label '{OPT_OUT_LABEL}')",
+                pr.number
+            );
+            continue;
+        }
+        match rebase_one(&repo, &pr, target_url.as_deref(), dry_run) {
+            Ok(Outcome::UpToDate) => {
+                println!("  {GREEN}up-to-date{RESET} #{}", pr.number);
+            }
+            Ok(Outcome::Rebased { new_sha }) => {
+                println!(
+                    "  {GREEN}rebased{RESET} #{} (now {})",
+                    pr.number,
+                    short_sha(&new_sha)
+                );
+            }
+            Ok(Outcome::WouldRebase) => {
+                println!("  {YELLOW}would rebase{RESET} #{}", pr.number);
+            }
+            Ok(Outcome::ConcurrentPush) => {
+                println!(
+                    "  {YELLOW}deferred{RESET} #{} (head moved during rebase)",
+                    pr.number
+                );
+            }
+            Ok(Outcome::Conflict { files }) => {
+                had_conflict = true;
+                println!(
+                    "  {RED}conflict{RESET} #{} — {}",
+                    pr.number,
+                    summarize_files(&files)
+                );
+            }
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error{RESET} #{}: {e}", pr.number);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if had_conflict {
+        std::process::exit(1);
+    }
+}
+
+#[derive(Debug)]
+enum Outcome {
+    UpToDate,
+    Rebased { new_sha: String },
+    WouldRebase,
+    ConcurrentPush,
+    Conflict { files: Vec<String> },
+}
+
+fn rebase_one(
+    repo: &str,
+    pr: &OpenPr,
+    target_url: Option<&str>,
+    dry_run: bool,
+) -> Result<Outcome, String> {
+    git(&["fetch", "origin", &pr.head_ref, "main"])?;
+
+    let merge_base = git_capture(&["merge-base", "origin/main", &pr.head_sha])?
+        .trim()
+        .to_string();
+    let main_sha = git_capture(&["rev-parse", "origin/main"])?
+        .trim()
+        .to_string();
+    if merge_base == main_sha {
+        return Ok(Outcome::UpToDate);
+    }
+
+    if dry_run {
+        return Ok(Outcome::WouldRebase);
+    }
+
+    let worktree = PathBuf::from(format!("/tmp/auto-rebase-{}", pr.number));
+    cleanup_worktree(&worktree);
+    git(&[
+        "worktree",
+        "add",
+        "--detach",
+        worktree
+            .to_str()
+            .ok_or_else(|| "non-utf8 worktree path".to_string())?,
+        &pr.head_sha,
+    ])?;
+
+    let result = run_rebase(repo, pr, &worktree, target_url);
+    cleanup_worktree(&worktree);
+    result
+}
+
+fn run_rebase(
+    repo: &str,
+    pr: &OpenPr,
+    worktree: &Path,
+    target_url: Option<&str>,
+) -> Result<Outcome, String> {
+    let rebase = Command::new("git")
+        .current_dir(worktree)
+        .args(["rebase", "origin/main"])
+        .output()
+        .map_err(|e| format!("git rebase: {e}"))?;
+
+    if !rebase.status.success() {
+        let files = unmerged_files(worktree);
+        let _ = Command::new("git")
+            .current_dir(worktree)
+            .args(["rebase", "--abort"])
+            .output();
+        let description = format!("Rebase failed — {}", summarize_files(&files));
+        post_status(repo, &pr.head_sha, "failure", target_url, &description)?;
+        return Ok(Outcome::Conflict { files });
+    }
+
+    let new_sha = git_capture_in(worktree, &["rev-parse", "HEAD"])?
+        .trim()
+        .to_string();
+
+    let push = Command::new("git")
+        .current_dir(worktree)
+        .args([
+            "push",
+            &format!("--force-with-lease={}:{}", pr.head_ref, pr.head_sha),
+            "origin",
+            &format!("HEAD:refs/heads/{}", pr.head_ref),
+        ])
+        .output()
+        .map_err(|e| format!("git push: {e}"))?;
+
+    if !push.status.success() {
+        let stderr = String::from_utf8_lossy(&push.stderr);
+        if is_lease_rejection(&stderr) {
+            return Ok(Outcome::ConcurrentPush);
+        }
+        return Err(format!("git push: {}", stderr.trim()));
+    }
+
+    let main_short = git_capture(&["rev-parse", "--short", "origin/main"])?
+        .trim()
+        .to_string();
+    post_status(
+        repo,
+        &new_sha,
+        "success",
+        target_url,
+        &format!("Rebased onto main@{main_short}"),
+    )?;
+    Ok(Outcome::Rebased { new_sha })
+}
+
+fn post_status(
+    repo: &str,
+    sha: &str,
+    state: &str,
+    target_url: Option<&str>,
+    description: &str,
+) -> Result<(), String> {
+    let mut body = json!({
+        "state": state,
+        "context": STATUS_CONTEXT,
+        "description": truncate(description, STATUS_DESCRIPTION_LIMIT),
+    });
+    if let Some(url) = target_url {
+        body["target_url"] = json!(url);
+    }
+    let endpoint = format!("/repos/{repo}/statuses/{sha}");
+    gh::api_post(&endpoint, &body).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn github_run_url() -> Option<String> {
+    let server = std::env::var("GITHUB_SERVER_URL")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let repo = std::env::var("GITHUB_REPOSITORY")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let run_id = std::env::var("GITHUB_RUN_ID")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    Some(format!("{server}/{repo}/actions/runs/{run_id}"))
+}
+
+fn cleanup_worktree(path: &Path) {
+    if let Some(s) = path.to_str() {
+        let _ = Command::new("git")
+            .args(["worktree", "remove", "--force", s])
+            .output();
+    }
+}
+
+fn unmerged_files(worktree: &Path) -> Vec<String> {
+    let Ok(output) = Command::new("git")
+        .current_dir(worktree)
+        .args(["status", "--porcelain"])
+        .output()
+    else {
+        return vec![];
+    };
+    parse_unmerged(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn git(args: &[&str]) -> Result<(), String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| format!("git {}: {e}", args.first().unwrap_or(&"")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git {}: {}",
+            args.first().unwrap_or(&""),
+            stderr.trim()
+        ));
+    }
+    Ok(())
+}
+
+fn git_capture(args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| format!("git {}: {e}", args.first().unwrap_or(&"")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git {}: {}",
+            args.first().unwrap_or(&""),
+            stderr.trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn git_capture_in(dir: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .map_err(|e| format!("git {}: {e}", args.first().unwrap_or(&"")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git {}: {}",
+            args.first().unwrap_or(&""),
+            stderr.trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn parse_unmerged(stdout: &str) -> Vec<String> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            if line.len() < 4 {
+                return None;
+            }
+            let xy = &line[..2];
+            if xy.contains('U') || xy == "AA" || xy == "DD" {
+                line.get(3..).map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn summarize_files(files: &[String]) -> String {
+    if files.is_empty() {
+        return "see workflow log for details".into();
+    }
+    let shown: Vec<&str> = files.iter().take(3).map(|s| s.as_str()).collect();
+    if files.len() <= 3 {
+        format!("conflicts in: {}", shown.join(", "))
+    } else {
+        format!(
+            "conflicts in: {} (and {} more)",
+            shown.join(", "),
+            files.len() - 3
+        )
+    }
+}
+
+fn is_lease_rejection(stderr: &str) -> bool {
+    stderr.contains("stale info") || stderr.contains("[rejected]")
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(n.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unmerged_parses_uu_lines() {
+        let stdout = "UU src/lib.rs\nUU README.md\n M tools/foo.rs\n?? tmp.txt\n";
+        let files = parse_unmerged(stdout);
+        assert_eq!(files, vec!["src/lib.rs", "README.md"]);
+    }
+
+    #[test]
+    fn unmerged_parses_aa_dd() {
+        let stdout = "AA both-added.rs\nDD both-deleted.rs\nAU added-by-us.rs\n";
+        let files = parse_unmerged(stdout);
+        assert_eq!(
+            files,
+            vec!["both-added.rs", "both-deleted.rs", "added-by-us.rs"]
+        );
+    }
+
+    #[test]
+    fn unmerged_skips_unmodified() {
+        assert!(parse_unmerged(" M staged.rs\n M other.rs\n").is_empty());
+    }
+
+    #[test]
+    fn summarize_empty() {
+        assert_eq!(summarize_files(&[]), "see workflow log for details");
+    }
+
+    #[test]
+    fn summarize_few() {
+        let files = vec!["a.rs".into(), "b.rs".into()];
+        assert_eq!(summarize_files(&files), "conflicts in: a.rs, b.rs");
+    }
+
+    #[test]
+    fn summarize_exactly_three() {
+        let files = vec!["a.rs".into(), "b.rs".into(), "c.rs".into()];
+        assert_eq!(summarize_files(&files), "conflicts in: a.rs, b.rs, c.rs");
+    }
+
+    #[test]
+    fn summarize_many() {
+        let files = vec![
+            "a.rs".into(),
+            "b.rs".into(),
+            "c.rs".into(),
+            "d.rs".into(),
+            "e.rs".into(),
+        ];
+        assert_eq!(
+            summarize_files(&files),
+            "conflicts in: a.rs, b.rs, c.rs (and 2 more)"
+        );
+    }
+
+    #[test]
+    fn truncate_short_unchanged() {
+        assert_eq!(truncate("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_exact_length_unchanged() {
+        let s = "x".repeat(10);
+        assert_eq!(truncate(&s, 10), s);
+    }
+
+    #[test]
+    fn truncate_long_replaces_with_ellipsis() {
+        let s = "x".repeat(200);
+        let out = truncate(&s, 140);
+        assert_eq!(out.chars().count(), 140);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn lease_rejection_stale_info() {
+        assert!(is_lease_rejection(
+            " ! [rejected]        feat/x -> feat/x (stale info)"
+        ));
+    }
+
+    #[test]
+    fn lease_rejection_plain_rejected() {
+        assert!(is_lease_rejection(
+            " ! [rejected]        feat/x -> feat/x (non-fast-forward)"
+        ));
+    }
+
+    #[test]
+    fn lease_rejection_unrelated_error_false() {
+        assert!(!is_lease_rejection("fatal: unable to access remote"));
+    }
+
+    #[test]
+    fn short_sha_truncates() {
+        assert_eq!(short_sha("abcdef0123456789"), "abcdef0");
+    }
+}


### PR DESCRIPTION
When main@origin moves, .github/workflows/auto-rebase-prs.yaml runs
`shaka repo rebase-open-prs`. The subcommand fetches every open PR
whose base is main, rebases each in a per-PR git worktree, force-pushes
with a lease on success, and posts an `auto-rebase` commit status —
`success` on the new head, or `failure` (with the conflicting paths)
on the original head when the rebase can't proceed cleanly. PRs labeled
`do-not-rebase` are skipped; conflicts make the workflow run go red so
the failure surfaces in the Actions UI as well as on the PR.

The workflow authenticates as a new `kolohelios-bot` GitHub App so
post-rebase pushes re-trigger normal CI — pushes via GITHUB_TOKEN do
not. App settings, repo secret/variable names, and rotation steps
live in .github/auto-rebase-app.md so they're reproducible without
consulting GitHub UI from memory.

The status is informational, not a required check: it only appears on
a PR after main has moved while the PR is open, so requiring it would
block freshly-opened PRs. Its job is to flag conflicts the author
needs to resolve, not to gate merge.

Local-side counterpart for branches you're actively iterating on is
#147.

Closes #161