### PR TITLE
ci: add id-token + workflow_dispatch to auto-rebase

### DIFF
--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -12,6 +12,10 @@ name: Auto-rebase PRs
 on:
   push:
     branches: [main]
+  # Manual trigger from the Actions UI — useful for verifying the App
+  # install or a rotated private key without waiting for main to move
+  # organically.
+  workflow_dispatch:
 
 # A second push to main that lands while we're rebasing makes the in-flight
 # run stale — its rebases would target an out-of-date base. Cancel it; the
@@ -23,6 +27,12 @@ concurrency:
 jobs:
   rebase:
     runs-on: ubuntu-latest
+    # `id-token: write` lets DeterminateSystems/nix-installer-action mint an
+    # OIDC token for FlakeHub — `nix develop ./tools/shaka` resolves the
+    # `kolohelios-nix` private flake input via FlakeHub and fails without it.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,22 @@ If you need a new per-project check, extend the appropriate template in
 `validate` recipe picks it up. If it spans projects, add it to `CHECKS`.
 Either way, do **not** add a new GitHub Actions job.
 
+The exception is automation that responds to repo events rather than
+gating PRs — e.g. `auto-rebase-prs.yaml` rebases open PRs on `push:
+main`. These can't live in `shaka preflight` because they don't gate
+the current change set. Two things to remember when adding one:
+
+- **`permissions: id-token: write`** is required on the job if it
+  runs `nix develop` — `DeterminateSystems/nix-installer-action`
+  mints an OIDC token to authenticate with FlakeHub for private
+  inputs like `kolohelios-nix`, and fails without it.
+- **Force-push or status-write operations need a GitHub App token,
+  not `GITHUB_TOKEN`.** Pushes via `GITHUB_TOKEN` don't re-trigger CI
+  on the destination branch; this is a documented GitHub limitation.
+  See `.github/auto-rebase-app.md` for the `kolohelios-bot` setup
+  pattern (mint via `actions/create-github-app-token@v2`, pass to
+  `actions/checkout` and `GH_TOKEN`).
+
 ### Running `shaka`
 
 `shaka` is **not** on `$PATH` globally. Always invoke it via the wrapper:


### PR DESCRIPTION
The first run of auto-rebase-prs.yaml after #161 merged failed at
`nix develop` because the job had no `id-token: write` permission, so
DeterminateSystems/nix-installer-action couldn't mint an OIDC token
for FlakeHub — and `kolohelios-nix` is a private FlakeHub input. The
existing validate job in main.yaml has the permission; I'd missed
copying it.

`workflow_dispatch` is added so we can verify the App install / token
mint without waiting for main to move organically.

CLAUDE.md picks up the lesson under the "Build system" section: when
adding a non-preflight workflow, remember `id-token: write` for nix +
the App-token pattern (vs GITHUB_TOKEN) for push or status-write.