### PR TITLE
fix(shaka): work inside jj sibling workspaces

### DIFF
--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -126,6 +126,73 @@ fn parse_diff_summary(out: &str) -> DirtyCounts {
     counts
 }
 
+/// List tracked files at `revset`, optionally restricted to `paths`.
+/// Path output is relative to the cwd, matching jj's default behaviour.
+pub fn file_list(revset: &str, paths: &[String]) -> Result<Vec<String>, JjError> {
+    let mut args: Vec<&str> = vec!["file", "list", "-r", revset];
+    for p in paths {
+        args.push(p.as_str());
+    }
+    let out = run(&args)?;
+    Ok(out
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Paths changed in the given revset, repo-root-relative. Renames and
+/// copies expand to both the source and destination paths so callers
+/// reasoning about per-project impact see every project the change
+/// touches.
+pub fn changed_paths(revset: &str) -> Result<Vec<String>, JjError> {
+    let out = run(&["diff", "--summary", "-r", revset])?;
+    Ok(parse_changed_paths(&out))
+}
+
+fn parse_changed_paths(out: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for line in out.lines() {
+        let mut chars = line.chars();
+        let prefix = chars.next();
+        let space = chars.next();
+        if space != Some(' ') {
+            continue;
+        }
+        let rest = &line[2..];
+        match prefix {
+            Some('M' | 'A' | 'D') if !rest.is_empty() => paths.push(rest.to_string()),
+            Some('R' | 'C') => expand_rename(rest, &mut paths),
+            _ => {}
+        }
+    }
+    paths
+}
+
+// jj renders renames/copies with brace-folded common affixes, e.g.
+// `R sub/{old.txt => new.txt}` or `R {old/path => new/path}/file`. We expand
+// both sides so each affected path is visible to project-level filtering.
+fn expand_rename(rest: &str, out: &mut Vec<String>) {
+    if let (Some(open), Some(close)) = (rest.find('{'), rest.rfind('}')) {
+        if open < close {
+            let prefix = &rest[..open];
+            let suffix = &rest[close + 1..];
+            let inner = &rest[open + 1..close];
+            if let Some((old, new)) = inner.split_once(" => ") {
+                out.push(format!("{prefix}{old}{suffix}"));
+                out.push(format!("{prefix}{new}{suffix}"));
+                return;
+            }
+        }
+    }
+    if let Some((old, new)) = rest.split_once(" => ") {
+        out.push(old.to_string());
+        out.push(new.to_string());
+        return;
+    }
+    out.push(rest.to_string());
+}
+
 /// Short change id of the current change (`@`).
 pub fn current_change_id() -> Result<String, JjError> {
     let out = run(&[
@@ -448,5 +515,53 @@ mod tests {
         assert_eq!(counts.added, 1);
         assert_eq!(counts.modified, 0);
         assert_eq!(counts.deleted, 0);
+    }
+
+    #[test]
+    fn parse_changed_paths_plain_letters() {
+        let out = "M a.rs\nA b.rs\nD c.rs\n";
+        assert_eq!(parse_changed_paths(out), vec!["a.rs", "b.rs", "c.rs"]);
+    }
+
+    #[test]
+    fn parse_changed_paths_rename_no_common_affix() {
+        let out = "R {old.txt => new.txt}\n";
+        assert_eq!(parse_changed_paths(out), vec!["old.txt", "new.txt"]);
+    }
+
+    #[test]
+    fn parse_changed_paths_rename_common_prefix() {
+        let out = "R sub/{c.txt => d.txt}\n";
+        assert_eq!(parse_changed_paths(out), vec!["sub/c.txt", "sub/d.txt"]);
+    }
+
+    #[test]
+    fn parse_changed_paths_rename_common_suffix() {
+        let out = "R {old-side => new-side}/file.txt\n";
+        assert_eq!(
+            parse_changed_paths(out),
+            vec!["old-side/file.txt", "new-side/file.txt"]
+        );
+    }
+
+    #[test]
+    fn parse_changed_paths_rename_no_braces_arrow() {
+        let out = "R old new\n";
+        // Accept the plain-arrow fallback; whichever form jj emits we
+        // surface both sides.
+        let parsed = parse_changed_paths(out);
+        assert!(parsed.iter().any(|p| p == "old new") || parsed == vec!["old", "new"]);
+    }
+
+    #[test]
+    fn parse_changed_paths_copy_expands_both() {
+        let out = "C {src.rs => dst.rs}\n";
+        assert_eq!(parse_changed_paths(out), vec!["src.rs", "dst.rs"]);
+    }
+
+    #[test]
+    fn parse_changed_paths_skips_blank_and_unknown() {
+        let out = "\n? mystery\nM real.rs\n";
+        assert_eq!(parse_changed_paths(out), vec!["real.rs"]);
     }
 }

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -222,20 +222,13 @@ fn just_validate(project_dir: &Path) -> CheckResult {
 }
 
 fn changed_paths(since: &str) -> Result<Vec<String>, String> {
-    let output = Command::new("git")
-        .args(["diff", "--name-only", since])
-        .output()
-        .map_err(|e| format!("failed to spawn git: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(format!("git diff failed: {stderr}"));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(String::from)
-        .collect())
+    // Resolve via jj rather than git so this works inside a sibling
+    // workspace whose `.git` isn't reachable on the filesystem. The
+    // revset spans `<since>..@` so paths reflect the calling workspace's
+    // `@`, not whatever the colocated index happens to point at. See
+    // issue #210.
+    let revset = format!("{since}..@");
+    crate::jj::changed_paths(&revset).map_err(|e| e.to_string())
 }
 
 fn matches_any(path: &str, patterns: &[&str]) -> bool {
@@ -291,7 +284,29 @@ fn typos_check() -> CheckResult {
 }
 
 fn actionlint_check() -> CheckResult {
-    run_command(&mut Command::new("actionlint"))
+    // Pass workflow paths explicitly so actionlint doesn't walk up
+    // looking for a `.git` directory — that walk fails inside a jj
+    // sibling workspace whose colocated `.git` lives only in the
+    // primary tree. Discovery via `jj file list` also gives us a
+    // workspace-correct view of which workflows exist. See issue #210.
+    let tracked = match crate::jj::file_list("@", &[".github/workflows".to_string()]) {
+        Ok(paths) => paths,
+        Err(e) => {
+            return CheckResult::Fail {
+                detail: format!("could not list workflows: {e}"),
+            };
+        }
+    };
+    let workflows: Vec<String> = tracked
+        .into_iter()
+        .filter(|p| p.ends_with(".yaml") || p.ends_with(".yml"))
+        .collect();
+    if workflows.is_empty() {
+        return CheckResult::Pass;
+    }
+    let mut cmd = Command::new("actionlint");
+    cmd.args(&workflows);
+    run_command(&mut cmd)
 }
 
 fn spawn_self(args: &[&str]) -> CheckResult {

--- a/tools/shaka/src/whitespace.rs
+++ b/tools/shaka/src/whitespace.rs
@@ -1,8 +1,8 @@
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use clap::Subcommand;
+
+use crate::jj;
 
 const RED: &str = "\x1b[31m";
 const GREEN: &str = "\x1b[32m";
@@ -68,7 +68,7 @@ impl Issue {
 }
 
 fn check(paths: &[String]) -> bool {
-    let files = match git_ls_files(paths) {
+    let files = match list_tracked_files(paths) {
         Ok(f) => f,
         Err(e) => {
             eprintln!("{RED}{BOLD}error:{RESET} {e}");
@@ -115,7 +115,7 @@ fn check(paths: &[String]) -> bool {
 }
 
 fn fix(paths: &[String]) -> bool {
-    let files = match git_ls_files(paths) {
+    let files = match list_tracked_files(paths) {
         Ok(f) => f,
         Err(e) => {
             eprintln!("{RED}{BOLD}error:{RESET} {e}");
@@ -301,31 +301,21 @@ fn is_binary(bytes: &[u8]) -> bool {
     bytes.iter().take(BINARY_PROBE).any(|&b| b == 0)
 }
 
-fn git_ls_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
-    let mut cmd = Command::new("git");
-    cmd.args(["ls-files", "-z", "--"]);
-    if paths.is_empty() {
-        cmd.arg(".");
+// Enumerate via jj rather than git so the listing reflects the calling
+// jj workspace's `@`. `git ls-files` reads the colocated index, which is
+// pinned to the primary workspace and never sees files added in a
+// sibling workspace's `@`. See issue #210.
+fn list_tracked_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
+    let owned: Vec<String>;
+    let arg_slice: &[String] = if paths.is_empty() {
+        owned = vec![".".to_string()];
+        &owned
     } else {
-        for p in paths {
-            cmd.arg(p);
-        }
-    }
-    let output = cmd
-        .output()
-        .map_err(|e| format!("failed to spawn git: {e}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "git ls-files failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    Ok(output
-        .stdout
-        .split(|&b| b == 0)
-        .filter(|s| !s.is_empty())
-        .map(|s| PathBuf::from(std::ffi::OsStr::from_bytes(s)))
-        .collect())
+        paths
+    };
+    jj::file_list("@", arg_slice)
+        .map(|files| files.into_iter().map(PathBuf::from).collect())
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/tools/shaka/tests/whitespace.rs
+++ b/tools/shaka/tests/whitespace.rs
@@ -1,13 +1,14 @@
 //! Integration tests for `shaka whitespace check|fix`.
 //!
-//! Each test stages a small set of files into a fresh git repo inside a
-//! tempdir and runs the shaka binary against it. The fixtures are written
-//! programmatically rather than checked in: byte-level differences (BOM,
-//! CRLF, trailing whitespace) don't survive editor or git normalization
-//! reliably and are easier to inspect as named byte literals than as files.
-//! The pure-scanner unit tests in `src/whitespace.rs` cover content
-//! semantics; these tests cover the wiring (CLI args, git ls-files
-//! enumeration, exit codes, output mentions the right files).
+//! Each test stages a small set of files into a fresh jj-colocated repo
+//! inside a tempdir and runs the shaka binary against it. The fixtures
+//! are written programmatically rather than checked in: byte-level
+//! differences (BOM, CRLF, trailing whitespace) don't survive editor
+//! normalization reliably and are easier to inspect as named byte
+//! literals than as files. The pure-scanner unit tests in
+//! `src/whitespace.rs` cover content semantics; these tests cover the
+//! wiring (CLI args, jj-based file enumeration, exit codes, output
+//! mentions the right files).
 
 use std::path::Path;
 use std::process::Command;
@@ -28,12 +29,16 @@ impl Repo {
             }
             std::fs::write(&path, bytes).unwrap();
         }
-        run(root.path(), &["git", "init", "-q"]);
-        // Disable any line-ending normalization so the test bytes survive
-        // `git add` round-trips intact.
+        run(root.path(), &["jj", "git", "init", "--colocate"]);
+        // Disable any line-ending normalization on the colocated git so
+        // the test bytes survive snapshot round-trips intact.
         run(root.path(), &["git", "config", "core.autocrlf", "false"]);
         run(root.path(), &["git", "config", "core.safecrlf", "false"]);
-        run(root.path(), &["git", "add", "-A"]);
+        // Snapshot the seeded files into `@`, then advance `@` past
+        // them. Sibling workspaces created later parent on `@-`, so the
+        // seeded files have to be a committed ancestor — not in primary's
+        // current `@` — for them to be visible across workspaces.
+        run(root.path(), &["jj", "new"]);
         Repo { root }
     }
 
@@ -149,14 +154,19 @@ fn check_skips_binary_files() {
 }
 
 #[test]
-fn check_skips_untracked_files() {
-    let repo = Repo::new(&[("a.txt", b"hello\n")]);
-    // Add a polluted file that isn't tracked — git ls-files should skip it.
-    std::fs::write(repo.path().join("untracked.txt"), b"trailing \n").unwrap();
+fn check_skips_gitignored_files() {
+    // jj auto-snapshots files in the working tree, so the only durable
+    // way to keep a file out of `@`'s tree is to .gitignore it. Verify
+    // that whitespace check honors that exclusion.
+    let repo = Repo::new(&[
+        ("a.txt", b"hello\n"),
+        (".gitignore", b"build/\n"),
+        ("build/garbage.txt", b"trailing \n"),
+    ]);
     let out = repo.shaka(&["whitespace", "check"]);
     assert!(
         out.status.success(),
-        "untracked file was incorrectly flagged\nstdout: {}\nstderr: {}",
+        "ignored file was incorrectly flagged\nstdout: {}\nstderr: {}",
         stdout_of(&out),
         stderr_of(&out)
     );
@@ -209,6 +219,83 @@ fn fix_rewrites_files_in_place() {
         stdout_of(&out),
         stderr_of(&out)
     );
+}
+
+#[test]
+fn check_runs_inside_jj_sibling_workspace() {
+    // Regression for #210: in a jj sibling workspace, `.git` isn't
+    // reachable on the filesystem because the colocated `.git` lives
+    // only under the primary tree. shaka must enumerate via jj rather
+    // than walking up for git.
+    let repo = Repo::new(&[("a.txt", b"trailing \n")]);
+    let parent = tempfile::TempDir::new().unwrap();
+    let sibling = parent.path().join("ws-sibling");
+    run(
+        repo.path(),
+        &[
+            "jj",
+            "workspace",
+            "add",
+            "--name",
+            "ws-sibling",
+            sibling.to_str().unwrap(),
+        ],
+    );
+
+    let out = Command::new(SHAKA_BIN)
+        .args(["whitespace", "check"])
+        .current_dir(&sibling)
+        .output()
+        .expect("failed to spawn shaka");
+    assert!(
+        !out.status.success(),
+        "expected failure on bad whitespace from sibling\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(combined.contains("a.txt"), "output: {combined}");
+    assert!(
+        combined.contains("trailing whitespace"),
+        "output: {combined}"
+    );
+}
+
+#[test]
+fn check_finds_files_added_only_in_sibling() {
+    // The crux of #210: a file that exists only in the sibling
+    // workspace's `@` is invisible to primary's git index. Using jj for
+    // enumeration ensures shaka still scans it.
+    let repo = Repo::new(&[("clean.txt", b"hello\n")]);
+    let parent = tempfile::TempDir::new().unwrap();
+    let sibling = parent.path().join("ws-sibling");
+    run(
+        repo.path(),
+        &[
+            "jj",
+            "workspace",
+            "add",
+            "--name",
+            "ws-sibling",
+            sibling.to_str().unwrap(),
+        ],
+    );
+
+    std::fs::write(sibling.join("polluted.txt"), b"trailing \n").unwrap();
+
+    let out = Command::new(SHAKA_BIN)
+        .args(["whitespace", "check"])
+        .current_dir(&sibling)
+        .output()
+        .expect("failed to spawn shaka");
+    assert!(
+        !out.status.success(),
+        "sibling-only file went undetected\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(combined.contains("polluted.txt"), "output: {combined}");
 }
 
 #[test]


### PR DESCRIPTION
`shaka` shelled out to git in three places that all assumed `.git` was reachable on the filesystem walk-up: `whitespace check` via `git ls-files`, `preflight --since` via `git diff --name-only`, and `actionlint` walking up looking for the repo root. None of those work inside a sibling working copy created by `jj workspace add`, where the colocated `.git` lives only under the primary tree.

Translating git invocations to use `--git-dir`/`-C` against the primary tree looks tempting but is wrong: primary's git index reflects primary's `@`, never the sibling's. A file added in a sibling and not yet in a commit reachable from primary would silently disappear from `git ls-files`, masking whitespace issues right when you most want to see them.

Switch to jj as the source of truth — it always knows about the calling workspace's `@` and is already a hard dependency of the repo. `whitespace check|fix` enumerates via `jj file list -r @`; `preflight --since` computes changed paths via `jj diff --summary -r '<since>..@'` (expanding renames); `actionlint` discovers workflows via `jj file list` and is invoked with explicit paths so it never walks up.

Closes #210
Closes #208