### PR TITLE
feat(shaka): add issue audit to enforce scope-label policy

### DIFF
--- a/tools/shaka/src/issue/audit.rs
+++ b/tools/shaka/src/issue/audit.rs
@@ -1,0 +1,113 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+use crate::gh;
+
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+// Every open issue must carry at least one of these labels. New scope
+// labels must be added here AND created in the repo (`gh label create`).
+const SCOPE_LABELS: &[&str] = &[
+    "ci",
+    "claude",
+    "infra/devbox",
+    "meta",
+    "nix",
+    "pollen-alert",
+    "portfolio",
+    "shaka",
+];
+
+pub fn run(repo_arg: Option<String>) {
+    let repo = match repo_arg {
+        Some(r) => r,
+        None => match gh::detect_repo() {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                eprintln!("Hint: pass --repo owner/repo explicitly");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    println!("{BOLD}Auditing {repo}{RESET}");
+    println!("Scope labels: {}\n", SCOPE_LABELS.join(", "));
+
+    let issues = match list_open_issues(&repo) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let mut violators: Vec<(u64, String)> = Vec::new();
+    for issue in &issues {
+        let labels: Vec<&str> = issue["labels"]
+            .as_array()
+            .map(|arr| arr.iter().filter_map(|l| l["name"].as_str()).collect())
+            .unwrap_or_default();
+        let has_scope = labels.iter().any(|l| SCOPE_LABELS.contains(l));
+        if !has_scope {
+            let n = issue["number"].as_u64().unwrap_or(0);
+            let title = issue["title"].as_str().unwrap_or("").to_string();
+            violators.push((n, title));
+        }
+    }
+
+    if violators.is_empty() {
+        println!(
+            "{GREEN}{BOLD}All {} open issue(s) carry a scope label{RESET}",
+            issues.len()
+        );
+        return;
+    }
+
+    println!("{BOLD}Open issues missing a scope label:{RESET}");
+    for (n, title) in &violators {
+        println!("  {RED}#{n}{RESET}  {title}");
+    }
+    println!(
+        "\n{RED}{BOLD}{} issue(s) need attention{RESET}",
+        violators.len()
+    );
+    std::process::exit(1);
+}
+
+// `gh issue list` rather than the REST API directly, since the REST API
+// mixes PRs into the issues endpoint while the gh CLI filters them out.
+fn list_open_issues(repo: &str) -> Result<Vec<Value>, gh::GhError> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "1000",
+            "--json",
+            "number,title,labels",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(gh::GhError {
+            message: format!("gh issue list: {}", stderr.trim()),
+        });
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&body).map_err(|e| gh::GhError {
+        message: format!("failed to parse JSON from gh issue list: {e}"),
+    })?;
+
+    Ok(parsed.as_array().cloned().unwrap_or_default())
+}

--- a/tools/shaka/src/issue/mod.rs
+++ b/tools/shaka/src/issue/mod.rs
@@ -1,0 +1,19 @@
+mod audit;
+
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum IssueCommand {
+    /// Audit open issues for missing scope labels
+    Audit {
+        /// Repository in owner/repo format (auto-detected from git remote if omitted)
+        #[arg(long)]
+        repo: Option<String>,
+    },
+}
+
+pub fn run(cmd: IssueCommand) {
+    match cmd {
+        IssueCommand::Audit { repo } => audit::run(repo),
+    }
+}

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -4,6 +4,7 @@ mod ci;
 mod commit;
 mod domain;
 mod gh;
+mod issue;
 mod jj;
 mod preflight;
 mod project;
@@ -36,6 +37,11 @@ enum Commands {
     Domain {
         #[command(subcommand)]
         command: domain::DomainCommand,
+    },
+    /// GitHub issue tooling (audit scope-label policy, etc.)
+    Issue {
+        #[command(subcommand)]
+        command: issue::IssueCommand,
     },
     /// Run every validation check CI runs (nix flake check, tofu validate, tofu plan)
     Preflight {
@@ -78,6 +84,7 @@ fn main() {
         Commands::Ci { command } => ci::run(command),
         Commands::Commit { command } => commit::run(command),
         Commands::Domain { command } => domain::run(command),
+        Commands::Issue { command } => issue::run(command),
         Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
         Commands::Project { command } => project::run(command),
         Commands::Repo { command } => repo::run(command),


### PR DESCRIPTION
Every open GitHub issue must carry at least one scope label (project / area). Type labels (`bug`, `enhancement`, `documentation`, etc.) don't count. The scope set is hardcoded in `tools/shaka/src/issue/audit.rs` (`ci`, `claude`, `infra/devbox`, `meta`, `nix`, `pollen-alert`, `portfolio`, `shaka`); adding a new scope is an edit + a `gh label create`. `shaka issue audit` lists open issues missing a scope label and exits non-zero if any exist; auto-detects the repo from the jj git remote, with `--repo owner/repo` overriding. The 12 previously unlabeled issues plus #26 (only had a type label) have been triaged. Out of scope: wiring into `shaka preflight` (issue hygiene isn't a code-correctness gate); the rest of the `shaka issue` surface (list, create, show, close, link) on #15. Local validate gate inside sibling workspaces tracked in #210.

Closes #209