### PR TITLE
fix(shaka): pass --repo to gh pr create for sibling workspaces

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -247,10 +247,13 @@ pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
 }
 
 /// Run `gh pr create` and return the PR URL.
-pub fn pr_create(title: &str, body: &str, head: &str) -> Result<String, GhError> {
+///
+/// Passes `--repo` so this works inside a sibling jj workspace where
+/// `gh`'s implicit walk-up for `.git` would fail. See issue #221.
+pub fn pr_create(repo: &str, title: &str, body: &str, head: &str) -> Result<String, GhError> {
     let output = Command::new("gh")
         .args([
-            "pr", "create", "--title", title, "--body", body, "--head", head,
+            "pr", "create", "--repo", repo, "--title", title, "--body", body, "--head", head,
         ])
         .output()?;
     if !output.status.success() {

--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -65,7 +65,7 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
 
     match gh::pr_for_head(&repo, &bookmark) {
         Ok(Some(pr)) => println!("{GREEN}{BOLD}pushed{RESET} (PR: {})", pr.url),
-        Ok(None) => match gh::pr_create(title, body, &bookmark) {
+        Ok(None) => match gh::pr_create(&repo, title, body, &bookmark) {
             Ok(url) => println!("{GREEN}{BOLD}created{RESET} ({url})"),
             Err(e) => {
                 eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -74,7 +74,7 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
 
     match gh::pr_for_head(&repo, &bookmark) {
         Ok(Some(pr)) => println!("{GREEN}{BOLD}pushed{RESET} (PR exists: {})", pr.url),
-        Ok(None) => match gh::pr_create(title, body, &bookmark) {
+        Ok(None) => match gh::pr_create(&repo, title, body, &bookmark) {
             Ok(url) => println!("{GREEN}{BOLD}sent{RESET} ({url})"),
             Err(e) => {
                 eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");


### PR DESCRIPTION
Without `--repo`, `gh pr create` walks up looking for `.git` and
fails inside a sibling jj workspace (the colocated git dir lives only
in the primary tree). Both callers (`repo/pr.rs`, `repo/send.rs`)
already detect the repo via `gh::detect_repo()` for the preceding
`pr_for_head` call, so passing it through to `pr_create` is a
two-line change at each site.

Closes #221