### PR TITLE
fix(infra/devbox): use flakehub url for kolohelios-nix input

### DIFF
--- a/apps/blogctl/flake.lock
+++ b/apps/blogctl/flake.lock
@@ -5,14 +5,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "path": "../../nix/kolohelios-nix",
-        "type": "path"
+        "lastModified": 1777666070,
+        "narHash": "sha256-5QIY7TKHxoeTC3Mf3JQzf5dJf21HSL1cB/TCAkJpE7E=",
+        "rev": "a7e8ca49868f3fe0ccfb5e25b673d6a0c92ad629",
+        "revCount": 83,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.83%2Brev-a7e8ca49868f3fe0ccfb5e25b673d6a0c92ad629/019de53e-10b2-79f1-9d9b-04d05269b0e7/source.tar.gz"
       },
       "original": {
-        "path": "../../nix/kolohelios-nix",
-        "type": "path"
-      },
-      "parent": []
+        "type": "tarball",
+        "url": "https://flakehub.com/f/kolohelios/kolohelios-nix/%2A.tar.gz"
+      }
     },
     "nixpkgs": {
       "locked": {

--- a/apps/blogctl/flake.nix
+++ b/apps/blogctl/flake.nix
@@ -2,7 +2,7 @@
   description = "blogctl";
 
   inputs = {
-    kolohelios-nix.url = "path:../../nix/kolohelios-nix";
+    kolohelios-nix.url = "https://flakehub.com/f/kolohelios/kolohelios-nix/*.tar.gz";
     nixpkgs.follows = "kolohelios-nix/nixpkgs";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/infra/devbox/flake.lock
+++ b/infra/devbox/flake.lock
@@ -5,14 +5,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "path": "../../nix/kolohelios-nix",
-        "type": "path"
+        "lastModified": 1777666070,
+        "narHash": "sha256-5QIY7TKHxoeTC3Mf3JQzf5dJf21HSL1cB/TCAkJpE7E=",
+        "rev": "a7e8ca49868f3fe0ccfb5e25b673d6a0c92ad629",
+        "revCount": 83,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.83%2Brev-a7e8ca49868f3fe0ccfb5e25b673d6a0c92ad629/019de53e-10b2-79f1-9d9b-04d05269b0e7/source.tar.gz"
       },
       "original": {
-        "path": "../../nix/kolohelios-nix",
-        "type": "path"
-      },
-      "parent": []
+        "type": "tarball",
+        "url": "https://flakehub.com/f/kolohelios/kolohelios-nix/%2A.tar.gz"
+      }
     },
     "nixpkgs": {
       "locked": {

--- a/infra/devbox/flake.nix
+++ b/infra/devbox/flake.nix
@@ -2,7 +2,7 @@
   description = "kolohelios — devbox NixOS configuration and Linode image";
 
   inputs = {
-    kolohelios-nix.url = "path:../../nix/kolohelios-nix";
+    kolohelios-nix.url = "https://flakehub.com/f/kolohelios/kolohelios-nix/*.tar.gz";
     nixpkgs.follows = "kolohelios-nix/nixpkgs";
   };
 


### PR DESCRIPTION
Same fix as the prior commit, applied to infra/devbox. Sibling jj
workspaces can't resolve relative `path:` flake inputs in pure-eval
mode; switching to the FlakeHub URL (matching `tools/shaka`) makes
`nix flake check` and `just validate` green from any sibling.

Closes #220