### PR TITLE
fix(ci): colocate jj before preflight so push:main runs succeed

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -111,10 +111,14 @@ jobs:
             ~/.cargo/git/
           key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
           restore-keys: cargo-${{ runner.os }}-
+      # `actions/checkout` produces a git-only tree. shaka's preflight and
+      # commit lint both shell out to jj, so colocate before either runs —
+      # otherwise `push: main` (which skips commit lint) breaks preflight.
+      - name: Colocate jj on the git checkout
+        run: nix develop ./tools/shaka --command jj git init --colocate
       - name: shaka commit lint
         if: github.event_name == 'pull_request'
         run: |
-          nix develop ./tools/shaka --command jj git init --colocate
           nix develop ./tools/shaka --command tools/shaka/bin/shaka commit lint \
             -r '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}'
       - name: shaka preflight

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -141,12 +141,18 @@ pub fn file_list(revset: &str, paths: &[String]) -> Result<Vec<String>, JjError>
         .collect())
 }
 
-/// Paths changed in the given revset, repo-root-relative. Renames and
+/// Paths changed between two revisions, repo-root-relative. Renames and
 /// copies expand to both the source and destination paths so callers
 /// reasoning about per-project impact see every project the change
 /// touches.
-pub fn changed_paths(revset: &str) -> Result<Vec<String>, JjError> {
-    let out = run(&["diff", "--summary", "-r", revset])?;
+///
+/// Uses `--from`/`--to` rather than the `from..to` revset because CI
+/// runs against the synthetic `refs/pull/<n>/merge` test-merge — a
+/// merge commit whose first parent is the base. `from..to` evaluates
+/// to a revset jj rejects as having gaps, but `--from`/`--to` just
+/// diffs two trees regardless of topology.
+pub fn changed_paths(from: &str, to: &str) -> Result<Vec<String>, JjError> {
+    let out = run(&["diff", "--summary", "--from", from, "--to", to])?;
     Ok(parse_changed_paths(&out))
 }
 

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -223,12 +223,9 @@ fn just_validate(project_dir: &Path) -> CheckResult {
 
 fn changed_paths(since: &str) -> Result<Vec<String>, String> {
     // Resolve via jj rather than git so this works inside a sibling
-    // workspace whose `.git` isn't reachable on the filesystem. The
-    // revset spans `<since>..@` so paths reflect the calling workspace's
-    // `@`, not whatever the colocated index happens to point at. See
+    // workspace whose `.git` isn't reachable on the filesystem. See
     // issue #210.
-    let revset = format!("{since}..@");
-    crate::jj::changed_paths(&revset).map_err(|e| e.to_string())
+    crate::jj::changed_paths(since, "@").map_err(|e| e.to_string())
 }
 
 fn matches_any(path: &str, patterns: &[&str]) -> bool {


### PR DESCRIPTION
`shaka preflight --since` shells out to `jj diff --summary` to scope
checks to changed paths, but the only step that ran
`jj git init --colocate` was the PR-gated `shaka commit lint`. On
`push: main` that step is skipped and preflight fails with
"There is no jj repo in '.'" against a bare git checkout.

Hoist the colocate into its own unconditional step before lint and
preflight so preflight no longer depends on whether commit lint
happened to run.

Closes #227