### PR TITLE
fix(ci): bump create-github-app-token to v3 for node 24

### DIFF
--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ vars.KOLOHELIOS_BOT_APP_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ the current change set. Two things to remember when adding one:
   not `GITHUB_TOKEN`.** Pushes via `GITHUB_TOKEN` don't re-trigger CI
   on the destination branch; this is a documented GitHub limitation.
   See `.github/auto-rebase-app.md` for the `kolohelios-bot` setup
-  pattern (mint via `actions/create-github-app-token@v2`, pass to
+  pattern (mint via `actions/create-github-app-token@v3`, pass to
   `actions/checkout` and `GH_TOKEN`).
 
 ### Running `shaka`


### PR DESCRIPTION
Upstream v3 (2026-03-14) ships Node 24, clearing the deprecation
warning that fires on every auto-rebase run. Breaking changes in v3
don't apply: we don't set HTTP(S)_PROXY, and we use GitHub-hosted
runners (already on runner v2.327.1+).

Closes #218