### PR TITLE
docs(claude): switch /start to shaka issue brief

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -44,9 +44,9 @@ the relevant files directly. Don't guess; read the referenced material.
 
 ### 2. Create a workspace
 
-**Default: every issue gets its own `shaka workspace`.** This keeps the
-primary tree clean for sync, audit, and cross-cutting reads, and it means
-the user's WIP elsewhere is undisturbed.
+**Every issue gets its own `shaka workspace` — no exceptions.** This keeps
+the primary tree clean for sync, audit, and cross-cutting reads, and it
+means the user's WIP elsewhere is undisturbed.
 
 ```
 tools/shaka/bin/shaka workspace new --issue $1
@@ -55,13 +55,6 @@ tools/shaka/bin/shaka workspace new --issue $1
 This creates a sibling working copy at `../kolohelios-i$1` parented on the
 current `main@origin` (already up-to-date from the previous step's fetch).
 If the command errors (path collision, repo lock), stop and report.
-
-**Opt-out:** if the user explicitly asks to work in-place ("in-place", "in
-primary", or similar), skip workspace creation. Then run `shaka repo status
---json` in primary — if `dirty.total > 0` or `ahead > 0` and `bookmarks` is
-empty, surface the WIP and let the user decide before proceeding. The
-in-place path is reserved for trivial doc tweaks; default to workspace
-otherwise.
 
 ### 3. Create the bookmark
 
@@ -84,8 +77,6 @@ workspace path (`/Users/jedwards/code/kolohelios-i$1`):
 ```
 jj bookmark create <name> -r @
 ```
-
-For the in-place opt-out path, run from the primary tree.
 
 ### 4. Plan and confirm
 
@@ -110,7 +101,6 @@ confirm or redirect before writing any code.
 Halt and report to the user when:
 
 - `shaka workspace new` errors (path collision, repo lock)
-- In the in-place opt-out path: `@` has WIP without a bookmark
 - `shaka issue brief` fails (issue doesn't exist, auth missing)
 - The issue title doesn't yield an obvious conventional type and labels
   don't disambiguate

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,6 +1,6 @@
 ---
 description: Start working on a GitHub issue — create workspace, read, bookmark, and plan
-allowed-tools: Bash(shaka repo sync), Bash(shaka repo status:*), Bash(shaka workspace new:*), Bash(jj *), Bash(gh issue view:*), Bash(gh issue list:*), Read, Glob, Grep
+allowed-tools: Bash(shaka repo sync), Bash(shaka repo status:*), Bash(shaka workspace new:*), Bash(tools/shaka/bin/shaka issue brief:*), Bash(jj *), Read, Glob, Grep
 argument-hint: <issue-number>
 ---
 
@@ -19,27 +19,42 @@ assumptions, file reads, or plans from earlier work into the new task. Don't
 proceed unless the conversation is fresh or the user explicitly confirms it's
 fine to continue.
 
-### 1. Create a workspace
+### 1. Read the issue
+
+Fetch the issue body and any comments in one shot:
+
+```
+tools/shaka/bin/shaka issue brief $1
+```
+
+This runs `jj git fetch` (so the next step's workspace parents on the
+latest main), then prints a tree-formatted summary of the issue header,
+body, and comments. If the issue doesn't exist, `brief` exits non-zero
+with a clear error — stop and report rather than guessing.
+
+Summarize for the user from the brief output:
+
+- The scope (what the issue is asking for)
+- Acceptance criteria (explicit or implied)
+- Any constraints or conventions called out
+
+If the issue references other issues (`#NN`), files, or prior PRs, read
+those for context too — `shaka issue brief <N>` for sibling issues, or
+the relevant files directly. Don't guess; read the referenced material.
+
+### 2. Create a workspace
 
 **Default: every issue gets its own `shaka workspace`.** This keeps the
 primary tree clean for sync, audit, and cross-cutting reads, and it means
 the user's WIP elsewhere is undisturbed.
-
-Fetch first so the new workspace parents on the latest main:
-
-```
-jj git fetch
-```
-
-Then create the workspace:
 
 ```
 tools/shaka/bin/shaka workspace new --issue $1
 ```
 
 This creates a sibling working copy at `../kolohelios-i$1` parented on the
-current `main@origin`. If the command errors (path collision, repo lock),
-stop and report.
+current `main@origin` (already up-to-date from the previous step's fetch).
+If the command errors (path collision, repo lock), stop and report.
 
 **Opt-out:** if the user explicitly asks to work in-place ("in-place", "in
 primary", or similar), skip workspace creation. Then run `shaka repo status
@@ -47,18 +62,6 @@ primary", or similar), skip workspace creation. Then run `shaka repo status
 empty, surface the WIP and let the user decide before proceeding. The
 in-place path is reserved for trivial doc tweaks; default to workspace
 otherwise.
-
-### 2. Read the issue
-
-Run `gh issue view $1` and read the full body. If the issue has comments
-worth reading, run `gh issue view $1 --comments`. Summarize for the user:
-
-- The scope (what the issue is asking for)
-- Acceptance criteria (explicit or implied)
-- Any constraints or conventions called out
-
-If the issue references other issues (`#NN`), files, or prior PRs, read
-those for context too. Don't guess — read the actual referenced material.
 
 ### 3. Create the bookmark
 
@@ -108,7 +111,7 @@ Halt and report to the user when:
 
 - `shaka workspace new` errors (path collision, repo lock)
 - In the in-place opt-out path: `@` has WIP without a bookmark
-- `gh issue view` fails (issue doesn't exist, auth missing)
+- `shaka issue brief` fails (issue doesn't exist, auth missing)
 - The issue title doesn't yield an obvious conventional type and labels
   don't disambiguate
 - The user has not confirmed the plan

--- a/tools/shaka/src/issue/brief.rs
+++ b/tools/shaka/src/issue/brief.rs
@@ -1,0 +1,287 @@
+use std::process::Command;
+
+use serde_json::{json, Value};
+
+use crate::gh;
+
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const RESET: &str = "\x1b[0m";
+
+pub fn run(n: u64, no_fetch: bool, json_out: bool) {
+    let fetch_output = if no_fetch {
+        None
+    } else {
+        match jj_git_fetch() {
+            Ok(out) => Some(out),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} jj git fetch: {e}");
+                std::process::exit(1);
+            }
+        }
+    };
+
+    let repo = match gh::detect_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let issue = match fetch_issue(&repo, n) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if json_out {
+        let payload = json!({
+            "fetch": fetch_output,
+            "issue": issue,
+        });
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} serialize JSON: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        print!("{}", render_tree(n, fetch_output.as_deref(), &issue));
+    }
+}
+
+fn jj_git_fetch() -> Result<String, String> {
+    let output = Command::new("jj")
+        .args(["git", "fetch"])
+        .output()
+        .map_err(|e| format!("failed to run jj git fetch: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(stderr.trim().to_string());
+    }
+
+    // jj writes the bookmark-update report to stderr; concatenate so we
+    // capture it whether jj or future versions choose stdout instead.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Ok(format!("{stdout}{stderr}").trim().to_string())
+}
+
+// Pass `--repo` so this works inside a sibling jj workspace where gh's
+// implicit walk-up for `.git` would fail. Same fix as pr_create (#221).
+fn fetch_issue(repo: &str, n: u64) -> Result<Value, String> {
+    let fields = "number,title,state,labels,author,body,url,createdAt,comments";
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "view",
+            &n.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            fields,
+        ])
+        .output()
+        .map_err(|e| format!("failed to run gh: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh issue view {n}: {}", stderr.trim()));
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&body)
+        .map_err(|e| format!("failed to parse JSON from gh issue view {n}: {e}"))
+}
+
+fn render_tree(n: u64, fetch: Option<&str>, issue: &Value) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{BOLD}shaka issue brief #{n}{RESET}\n"));
+
+    match fetch {
+        Some("") => {
+            out.push_str(&format!("{DIM}├── fetching from origin{RESET}\n"));
+            out.push_str(&format!("{DIM}│   nothing changed{RESET}\n"));
+        }
+        Some(text) => {
+            out.push_str(&format!("{DIM}├── fetching from origin{RESET}\n"));
+            for line in text.lines() {
+                out.push_str(&format!("{DIM}│   {line}{RESET}\n"));
+            }
+        }
+        None => {
+            out.push_str(&format!("{DIM}├── fetching from origin (skipped){RESET}\n"));
+        }
+    }
+
+    let title = issue["title"].as_str().unwrap_or("");
+    let state = issue["state"].as_str().unwrap_or("");
+    let labels: Vec<&str> = issue["labels"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|l| l["name"].as_str()).collect())
+        .unwrap_or_default();
+    let author = issue["author"]["login"].as_str().unwrap_or("");
+    let url = issue["url"].as_str().unwrap_or("");
+    let body = issue["body"].as_str().unwrap_or("");
+    let empty: Vec<Value> = Vec::new();
+    let comments = issue["comments"].as_array().unwrap_or(&empty);
+
+    let state_color = match state {
+        "OPEN" => GREEN,
+        "CLOSED" => YELLOW,
+        _ => RED,
+    };
+    let labels_str = if labels.is_empty() {
+        "(none)".to_string()
+    } else {
+        labels.join(", ")
+    };
+
+    out.push_str(&format!("├── {BOLD}#{n}{RESET} {title}\n"));
+    out.push_str(&format!(
+        "│   state: {state_color}{state}{RESET}  labels: {labels_str}  author: {author}\n"
+    ));
+    if !url.is_empty() {
+        out.push_str(&format!("│   {DIM}{url}{RESET}\n"));
+    }
+    if !body.trim().is_empty() {
+        out.push_str("│\n");
+        for line in body.lines() {
+            if line.is_empty() {
+                out.push_str("│\n");
+            } else {
+                out.push_str(&format!("│   {line}\n"));
+            }
+        }
+    }
+
+    let count = comments.len();
+    out.push_str(&format!("└── comments ({count})\n"));
+    for (i, comment) in comments.iter().enumerate() {
+        let last = i + 1 == count;
+        let head_prefix = if last {
+            "    └──"
+        } else {
+            "    ├──"
+        };
+        let cont_prefix = if last { "       " } else { "    │  " };
+        let cauthor = comment["author"]["login"].as_str().unwrap_or("");
+        let created = comment["createdAt"].as_str().unwrap_or("");
+        let cbody = comment["body"].as_str().unwrap_or("");
+        let date = created.split('T').next().unwrap_or(created);
+        out.push_str(&format!("{head_prefix} {BOLD}{cauthor}{RESET} — {date}\n"));
+        for line in cbody.lines() {
+            if line.is_empty() {
+                out.push_str(&format!("{cont_prefix}\n"));
+            } else {
+                out.push_str(&format!("{cont_prefix} {line}\n"));
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next();
+                for d in chars.by_ref() {
+                    if d.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn renders_issue_with_body_and_no_comments() {
+        let issue = json!({
+            "number": 216,
+            "title": "feat(shaka): issue brief",
+            "state": "OPEN",
+            "labels": [{"name": "shaka"}],
+            "author": {"login": "kolohelios"},
+            "body": "First line.\n\nSecond paragraph.",
+            "url": "https://github.com/kolohelios/kolohelios/issues/216",
+            "createdAt": "2026-05-01T12:00:00Z",
+            "comments": [],
+        });
+
+        let out = strip_ansi(&render_tree(216, Some(""), &issue));
+        assert!(out.contains("shaka issue brief #216"));
+        assert!(out.contains("├── fetching from origin"));
+        assert!(out.contains("│   nothing changed"));
+        assert!(out.contains("├── #216 feat(shaka): issue brief"));
+        assert!(out.contains("state: OPEN"));
+        assert!(out.contains("labels: shaka"));
+        assert!(out.contains("author: kolohelios"));
+        assert!(out.contains("│   First line."));
+        assert!(out.contains("│   Second paragraph."));
+        assert!(out.contains("└── comments (0)"));
+    }
+
+    #[test]
+    fn renders_skipped_fetch() {
+        let issue = json!({
+            "number": 1,
+            "title": "x",
+            "state": "OPEN",
+            "labels": [],
+            "author": {"login": "u"},
+            "body": "",
+            "url": "",
+            "createdAt": "",
+            "comments": [],
+        });
+
+        let out = strip_ansi(&render_tree(1, None, &issue));
+        assert!(out.contains("├── fetching from origin (skipped)"));
+        assert!(out.contains("labels: (none)"));
+    }
+
+    #[test]
+    fn renders_comments_with_tree_continuation() {
+        let issue = json!({
+            "number": 5,
+            "title": "t",
+            "state": "OPEN",
+            "labels": [],
+            "author": {"login": "u"},
+            "body": "",
+            "url": "",
+            "createdAt": "",
+            "comments": [
+                {"author": {"login": "alice"}, "createdAt": "2026-04-01T00:00:00Z", "body": "first"},
+                {"author": {"login": "bob"}, "createdAt": "2026-04-02T00:00:00Z", "body": "second\nline"},
+            ],
+        });
+
+        let out = strip_ansi(&render_tree(5, Some(""), &issue));
+        assert!(out.contains("└── comments (2)"));
+        assert!(out.contains("    ├── alice — 2026-04-01"));
+        assert!(out.contains("    │   first"));
+        assert!(out.contains("    └── bob — 2026-04-02"));
+        assert!(out.contains("        second"));
+        assert!(out.contains("        line"));
+    }
+}

--- a/tools/shaka/src/issue/mod.rs
+++ b/tools/shaka/src/issue/mod.rs
@@ -1,4 +1,5 @@
 mod audit;
+mod brief;
 
 use clap::Subcommand;
 
@@ -10,10 +11,26 @@ pub enum IssueCommand {
         #[arg(long)]
         repo: Option<String>,
     },
+    /// Fetch + view + comments for an issue in one shot
+    Brief {
+        /// GitHub issue number
+        number: u64,
+        /// Skip the `jj git fetch` step
+        #[arg(long)]
+        no_fetch: bool,
+        /// Emit structured JSON instead of the human-readable tree
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub fn run(cmd: IssueCommand) {
     match cmd {
         IssueCommand::Audit { repo } => audit::run(repo),
+        IssueCommand::Brief {
+            number,
+            no_fetch,
+            json,
+        } => brief::run(number, no_fetch, json),
     }
 }


### PR DESCRIPTION
Replace the explicit `jj git fetch` + `gh issue view` + `gh issue view
--comments` ritual in step 1/2 with a single `shaka issue brief $1`
call. The fetch now happens inside `brief`, so step 2's workspace
creation still parents on the latest `main@origin`.

Updates `allowed-tools` to drop `gh issue view` / `gh issue list` and
add the `shaka issue brief` invocation pattern. Stop conditions
reference `shaka issue brief` instead of bare `gh issue view`.

Closes #216