### PR TITLE
feat(blogctl): workdir README, kind frontmatter, abandoned rename

### DIFF
--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -1,14 +1,14 @@
 # blogctl
 
 CLI for managing Markdown blog post drafts across a linear workflow.
-Drafts and prompts live in a private workdir outside this repo (passed via
+Drafts live in a private workdir outside this repo (passed via
 `--workdir`); `blogctl` itself ships only as tooling.
 
 ## Workflow stages
 
 ```
 concept → ideation → editing → final-editing → published
-                                                  archive (terminal)
+                                                  abandoned (terminal)
 ```
 
 Stage is encoded in two places that must agree: the directory the file
@@ -24,16 +24,16 @@ loudly on any mismatch.
   editing/
   final-editing/
   published/
-  archive/
-  history/
-    published-posts/
-  prompts/
+  abandoned/
   .blog-os.toml
+  README.md
+  <prompt files>
 ```
 
-`history/` and `prompts/` are reserved extension points for upcoming
-features (historical-consistency checks, OpenRouter prompt loading); they
-are scaffolded eagerly by `init`.
+`init` writes the stage directories, `.blog-os.toml`, and a generated
+`README.md`. Prompt files (loaded by future OpenRouter integration) live
+at the workdir root next to the config; refresh the README from
+`blogctl`'s baked-in template via `blogctl readme regenerate`.
 
 ## Commands
 
@@ -50,7 +50,7 @@ blogctl demote  <slug> --workdir <path>
 title (override with `--slug`). `promote`/`demote` move the file across
 stage directories and rewrite `status:` and `updated_at:` in the
 frontmatter. `published` won't demote without a future `--force` flag;
-`archive` is reserved for a future explicit transition.
+`abandoned` is reserved for a future explicit transition.
 
 ## Markdown file format
 

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 
 use crate::commands;
 use crate::error::Result;
+use crate::kind::Kind;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -31,6 +32,10 @@ pub enum Command {
         /// Override the auto-derived slug.
         #[arg(long)]
         slug: Option<String>,
+        /// Surface this targets: `post` (short-form feed) or `article`
+        /// (long-form). Drives prompt/exit-criteria selection downstream.
+        #[arg(long, value_enum, default_value_t = Kind::Post)]
+        kind: Kind,
     },
     /// List every post in the workdir, grouped by stage.
     List {
@@ -55,6 +60,22 @@ pub enum Command {
         #[arg(long, value_name = "PATH")]
         workdir: PathBuf,
     },
+    /// Manage the generated workdir `README.md`.
+    Readme {
+        #[command(subcommand)]
+        action: ReadmeAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ReadmeAction {
+    /// Overwrite the workdir `README.md` with the canonical template
+    /// baked into `blogctl`. Use after a `blogctl` upgrade to pick up
+    /// template changes.
+    Regenerate {
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+    },
 }
 
 pub fn run() -> Result<()> {
@@ -69,11 +90,15 @@ pub fn dispatch(cmd: Command) -> Result<()> {
             title,
             workdir,
             slug,
-        } => commands::new::run(title, workdir, slug),
+            kind,
+        } => commands::new::run(title, workdir, slug, kind),
         Command::List { workdir } => commands::list::run(workdir),
         Command::Show { slug, workdir } => commands::show::run(slug, workdir),
         Command::Promote { slug, workdir } => commands::promote::run(slug, workdir),
         Command::Demote { slug, workdir } => commands::demote::run(slug, workdir),
+        Command::Readme { action } => match action {
+            ReadmeAction::Regenerate { workdir } => commands::readme::regenerate(workdir),
+        },
     }
 }
 
@@ -96,13 +121,37 @@ mod tests {
                 "--slug",
                 "hello",
             ],
+            vec![
+                "blogctl",
+                "new",
+                "Hello",
+                "--workdir",
+                "/tmp/wd",
+                "--kind",
+                "article",
+            ],
             vec!["blogctl", "list", "--workdir", "/tmp/wd"],
             vec!["blogctl", "show", "hello", "--workdir", "/tmp/wd"],
             vec!["blogctl", "promote", "hello", "--workdir", "/tmp/wd"],
             vec!["blogctl", "demote", "hello", "--workdir", "/tmp/wd"],
+            vec!["blogctl", "readme", "regenerate", "--workdir", "/tmp/wd"],
         ] {
             assert!(Cli::try_parse_from(args.clone()).is_ok(), "{args:?}");
         }
+    }
+
+    #[test]
+    fn new_rejects_unknown_kind() {
+        let args = vec![
+            "blogctl",
+            "new",
+            "Hello",
+            "--workdir",
+            "/tmp/wd",
+            "--kind",
+            "essay",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
     }
 
     #[test]

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod init;
 pub mod list;
 pub mod new;
 pub mod promote;
+pub mod readme;
 pub mod show;

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -3,12 +3,18 @@ use std::path::PathBuf;
 use time::OffsetDateTime;
 
 use crate::error::Result;
+use crate::kind::Kind;
 use crate::post::{Post, PostMetadata};
 use crate::stage::Stage;
 use crate::storage::{Repository, Workdir};
 use crate::{slug, Error};
 
-pub fn run(title: String, workdir: PathBuf, slug_override: Option<String>) -> Result<()> {
+pub fn run(
+    title: String,
+    workdir: PathBuf,
+    slug_override: Option<String>,
+    kind: Kind,
+) -> Result<()> {
     if title.trim().is_empty() {
         return Err(Error::EmptyTitle(title));
     }
@@ -23,6 +29,7 @@ pub fn run(title: String, workdir: PathBuf, slug_override: Option<String>) -> Re
     let metadata = PostMetadata {
         title,
         slug: resolved_slug.clone(),
+        kind,
         status: Stage::Concept,
         created_at: now,
         updated_at: now,

--- a/apps/blogctl/src/commands/readme.rs
+++ b/apps/blogctl/src/commands/readme.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use crate::error::Result;
+use crate::storage::{Repository, Workdir};
+
+pub fn regenerate(workdir: PathBuf) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    repo.write_readme(true)?;
+    println!("regenerated {}", repo.workdir().readme_path().display());
+    Ok(())
+}

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -39,6 +39,9 @@ pub enum Error {
     #[error("invalid stage {0:?}")]
     InvalidStage(String),
 
+    #[error("invalid kind {0:?}: expected `post` or `article`")]
+    InvalidKind(String),
+
     #[error("invalid slug {0:?}: {1}")]
     InvalidSlug(String, String),
 

--- a/apps/blogctl/src/kind.rs
+++ b/apps/blogctl/src/kind.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+use std::str::FromStr;
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// Surface a post is destined for. Mirrors LinkedIn's split: `post` is
+/// short-form feed content; `article` is long-form with its own
+/// permanent URL. Drives prompt selection, exit-criteria thresholds,
+/// and optional model overrides per stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum Kind {
+    #[default]
+    Post,
+    Article,
+}
+
+impl Kind {
+    pub const ALL: &'static [Kind] = &[Kind::Post, Kind::Article];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Kind::Post => "post",
+            Kind::Article => "article",
+        }
+    }
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Kind {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "post" => Ok(Kind::Post),
+            "article" => Ok(Kind::Article),
+            other => Err(Error::InvalidKind(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_round_trips_for_each_kind() {
+        for &k in Kind::ALL {
+            assert_eq!(k.as_str().parse::<Kind>().unwrap(), k);
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unknown_kind() {
+        let err = "essay".parse::<Kind>().unwrap_err();
+        assert!(matches!(err, Error::InvalidKind(_)));
+    }
+
+    #[test]
+    fn default_is_post() {
+        assert_eq!(Kind::default(), Kind::Post);
+    }
+}

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod cli;
 pub mod commands;
 pub mod error;
+pub mod kind;
 pub mod post;
 pub mod slug;
 pub mod stage;
 pub mod storage;
 
 pub use error::{Error, Result};
+pub use kind::Kind;
 pub use post::{Post, PostMetadata};
 pub use stage::Stage;
 pub use storage::{Repository, Workdir};

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::error::{Error, Result};
+use crate::kind::Kind;
 use crate::stage::Stage;
 
 /// Frontmatter metadata. Mirrors the YAML block at the top of every post
@@ -13,6 +14,7 @@ use crate::stage::Stage;
 pub struct PostMetadata {
     pub title: String,
     pub slug: String,
+    pub kind: Kind,
     pub status: Stage,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
@@ -136,6 +138,7 @@ mod tests {
         PostMetadata {
             title: "Example Title".into(),
             slug: "example-title".into(),
+            kind: Kind::Post,
             status: Stage::Concept,
             created_at: datetime!(2026-05-03 00:00:00 UTC),
             updated_at: datetime!(2026-05-03 00:00:00 UTC),
@@ -154,6 +157,7 @@ mod tests {
         let raw = r#"---
 title: "Example Title"
 slug: example-title
+kind: post
 status: concept
 created_at: 2026-05-03T00:00:00Z
 updated_at: 2026-05-03T00:00:00Z
@@ -167,11 +171,47 @@ Draft text here.
         let post = parse(raw).unwrap();
         assert_eq!(post.metadata.title, "Example Title");
         assert_eq!(post.metadata.slug, "example-title");
+        assert_eq!(post.metadata.kind, Kind::Post);
         assert_eq!(post.metadata.status, Stage::Concept);
         assert!(post.metadata.tags.is_empty());
         assert!(post.metadata.todoist_task_id.is_none());
         assert!(!post.metadata.history_checked);
         assert_eq!(post.body, "\nDraft text here.\n");
+    }
+
+    #[test]
+    fn parse_round_trips_article_kind() {
+        let raw = r#"---
+title: "Long-form essay"
+slug: long-form-essay
+kind: article
+status: ideation
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+---
+
+Body.
+"#;
+        let post = parse(raw).unwrap();
+        assert_eq!(post.metadata.kind, Kind::Article);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_kind() {
+        let raw = r#"---
+title: "X"
+slug: x
+kind: essay
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+---
+
+Body.
+"#;
+        assert!(matches!(parse(raw), Err(Error::FrontmatterParse { .. })));
     }
 
     #[test]
@@ -227,7 +267,7 @@ Draft text here.
 
     #[test]
     fn parse_tolerates_body_lines_starting_with_dashes() {
-        let raw = "---\ntitle: T\nslug: t\nstatus: concept\ncreated_at: 2026-05-03T00:00:00Z\nupdated_at: 2026-05-03T00:00:00Z\ntags: []\n---\n\n--- not a delimiter ---\n";
+        let raw = "---\ntitle: T\nslug: t\nkind: post\nstatus: concept\ncreated_at: 2026-05-03T00:00:00Z\nupdated_at: 2026-05-03T00:00:00Z\ntags: []\n---\n\n--- not a delimiter ---\n";
         let post = parse(raw).unwrap();
         assert!(post.body.contains("--- not a delimiter ---"));
     }

--- a/apps/blogctl/src/stage.rs
+++ b/apps/blogctl/src/stage.rs
@@ -13,7 +13,7 @@ pub enum Stage {
     Editing,
     FinalEditing,
     Published,
-    Archive,
+    Abandoned,
 }
 
 impl Stage {
@@ -23,7 +23,7 @@ impl Stage {
         Stage::Editing,
         Stage::FinalEditing,
         Stage::Published,
-        Stage::Archive,
+        Stage::Abandoned,
     ];
 
     pub fn dirname(self) -> &'static str {
@@ -33,7 +33,7 @@ impl Stage {
             Stage::Editing => "editing",
             Stage::FinalEditing => "final-editing",
             Stage::Published => "published",
-            Stage::Archive => "archive",
+            Stage::Abandoned => "abandoned",
         }
     }
 
@@ -44,7 +44,7 @@ impl Stage {
             Stage::Editing => "editing",
             Stage::FinalEditing => "final-editing",
             Stage::Published => "published",
-            Stage::Archive => "archive",
+            Stage::Abandoned => "abandoned",
         }
     }
 
@@ -53,19 +53,19 @@ impl Stage {
     }
 
     /// Promote along the linear workflow: concept → ideation → editing →
-    /// final-editing → published. Archive and Published are terminal.
+    /// final-editing → published. Abandoned and Published are terminal.
     pub fn promote(self) -> Result<Stage> {
         match self {
             Stage::Concept => Ok(Stage::Ideation),
             Stage::Ideation => Ok(Stage::Editing),
             Stage::Editing => Ok(Stage::FinalEditing),
             Stage::FinalEditing => Ok(Stage::Published),
-            Stage::Published | Stage::Archive => Err(Error::PromoteFromTerminal(self)),
+            Stage::Published | Stage::Abandoned => Err(Error::PromoteFromTerminal(self)),
         }
     }
 
     /// Demote one step back. Concept can't demote; Published refuses
-    /// without an explicit force (a future flag); Archive can't demote.
+    /// without an explicit force (a future flag); Abandoned can't demote.
     pub fn demote(self) -> Result<Stage> {
         match self {
             Stage::Concept => Err(Error::DemoteFromInitial(self)),
@@ -73,7 +73,7 @@ impl Stage {
             Stage::Editing => Ok(Stage::Ideation),
             Stage::FinalEditing => Ok(Stage::Editing),
             Stage::Published => Err(Error::DemotePublished),
-            Stage::Archive => Err(Error::DemoteFromInitial(self)),
+            Stage::Abandoned => Err(Error::DemoteFromInitial(self)),
         }
     }
 }
@@ -93,7 +93,7 @@ impl FromStr for Stage {
             "editing" => Ok(Stage::Editing),
             "final-editing" => Ok(Stage::FinalEditing),
             "published" => Ok(Stage::Published),
-            "archive" => Ok(Stage::Archive),
+            "abandoned" => Ok(Stage::Abandoned),
             other => Err(Error::InvalidStage(other.to_string())),
         }
     }
@@ -118,9 +118,9 @@ mod tests {
     }
 
     #[test]
-    fn promote_from_archive_is_terminal() {
-        let err = Stage::Archive.promote().unwrap_err();
-        assert!(matches!(err, Error::PromoteFromTerminal(Stage::Archive)));
+    fn promote_from_abandoned_is_terminal() {
+        let err = Stage::Abandoned.promote().unwrap_err();
+        assert!(matches!(err, Error::PromoteFromTerminal(Stage::Abandoned)));
     }
 
     #[test]

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -9,9 +9,12 @@ use crate::post::{Post, PostMetadata};
 use crate::stage::Stage;
 
 const CONFIG_FILE: &str = ".blog-os.toml";
-const HISTORY_DIR: &str = "history";
-const HISTORY_PUBLISHED: &str = "history/published-posts";
-const PROMPTS_DIR: &str = "prompts";
+const README_FILE: &str = "README.md";
+
+/// Canonical workdir README, baked in at build time. `init` writes this
+/// file when one is not already present; `readme regenerate` overwrites
+/// whatever is currently there.
+pub const README_TEMPLATE: &str = include_str!("../templates/workdir-readme.md");
 
 /// On-disk config persisted at `<workdir>/.blog-os.toml`. Versioned so we
 /// can evolve the schema as features land (OpenRouter, Todoist, …).
@@ -50,6 +53,10 @@ impl Workdir {
         self.root.join(CONFIG_FILE)
     }
 
+    pub fn readme_path(&self) -> PathBuf {
+        self.root.join(README_FILE)
+    }
+
     pub fn stage_dir(&self, stage: Stage) -> PathBuf {
         self.root.join(stage.dirname())
     }
@@ -58,16 +65,11 @@ impl Workdir {
         self.stage_dir(stage).join(format!("{slug}.md"))
     }
 
-    /// All directories that should exist after `init`. Stage directories
-    /// hold drafts; `history/` and `prompts/` are reserved for future
-    /// features but are scaffolded eagerly so users don't have to mkdir
-    /// before first use.
+    /// All directories that should exist after `init`. Only the stage
+    /// directories — prompt files live at the workdir root next to
+    /// `.blog-os.toml` and `README.md`.
     pub fn directories(&self) -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = Stage::ALL.iter().map(|s| self.stage_dir(*s)).collect();
-        dirs.push(self.root.join(HISTORY_DIR));
-        dirs.push(self.root.join(HISTORY_PUBLISHED));
-        dirs.push(self.root.join(PROMPTS_DIR));
-        dirs
+        Stage::ALL.iter().map(|s| self.stage_dir(*s)).collect()
     }
 }
 
@@ -117,6 +119,7 @@ impl Repository {
         let config_path = self.workdir.config_path();
         let serialized = toml::to_string(&Config::current()).map_err(Error::ConfigSerialize)?;
         fs::write(&config_path, serialized).map_err(|e| Error::io(&config_path, e))?;
+        self.write_readme(false)?;
         Ok(())
     }
 
@@ -124,6 +127,19 @@ impl Repository {
         let path = self.workdir.config_path();
         let raw = fs::read_to_string(&path).map_err(|e| Error::io(&path, e))?;
         toml::from_str(&raw).map_err(|source| Error::ConfigParse { path, source })
+    }
+
+    /// Write the canonical README into the workdir. Returns `true` if
+    /// the file was (over)written, `false` if a README already existed
+    /// and `force` was false (init's path — preserves a user's
+    /// pre-existing README).
+    pub fn write_readme(&self, force: bool) -> Result<bool> {
+        let path = self.workdir.readme_path();
+        if path.exists() && !force {
+            return Ok(false);
+        }
+        fs::write(&path, README_TEMPLATE).map_err(|e| Error::io(&path, e))?;
+        Ok(true)
     }
 
     /// Persist a brand-new post in its claimed stage directory. Fails if
@@ -281,6 +297,7 @@ mod tests {
             PostMetadata {
                 title: format!("Title {slug}"),
                 slug: slug.to_string(),
+                kind: crate::kind::Kind::Post,
                 status: stage,
                 created_at: datetime!(2026-05-03 00:00:00 UTC),
                 updated_at: datetime!(2026-05-03 00:00:00 UTC),
@@ -300,14 +317,19 @@ mod tests {
     }
 
     #[test]
-    fn init_creates_every_stage_and_extension_directory() {
+    fn init_creates_every_stage_directory_and_config() {
         let (tmp, _repo) = fresh_repo();
         for &stage in Stage::ALL {
             assert!(tmp.path().join(stage.dirname()).is_dir(), "{}", stage);
         }
-        assert!(tmp.path().join("history/published-posts").is_dir());
-        assert!(tmp.path().join("prompts").is_dir());
         assert!(tmp.path().join(".blog-os.toml").is_file());
+    }
+
+    #[test]
+    fn init_does_not_create_prompts_or_history_subdirs() {
+        let (tmp, _repo) = fresh_repo();
+        assert!(!tmp.path().join("prompts").exists());
+        assert!(!tmp.path().join("history").exists());
     }
 
     #[test]
@@ -315,6 +337,48 @@ mod tests {
         let (_tmp, repo) = fresh_repo();
         let cfg = repo.read_config().unwrap();
         assert_eq!(cfg.version, Config::CURRENT_VERSION);
+    }
+
+    #[test]
+    fn init_writes_readme_with_setup_directives() {
+        let (tmp, _repo) = fresh_repo();
+        let readme =
+            fs::read_to_string(tmp.path().join("README.md")).expect("README.md present after init");
+        assert!(readme.contains("jj git init --colocate"));
+        assert!(readme.contains("--allow-new"));
+        assert!(readme.contains("--allow-backwards"));
+        assert!(readme.contains("blogctl readme regenerate"));
+    }
+
+    #[test]
+    fn init_preserves_a_pre_existing_readme() {
+        let tmp = TempDir::new().unwrap();
+        let custom = "my hand-rolled README\n";
+        fs::write(tmp.path().join("README.md"), custom).unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        repo.init().unwrap();
+        let readme = fs::read_to_string(tmp.path().join("README.md")).unwrap();
+        assert_eq!(readme, custom, "init must not clobber a user's README");
+    }
+
+    #[test]
+    fn write_readme_force_overwrites_existing() {
+        let (tmp, repo) = fresh_repo();
+        fs::write(tmp.path().join("README.md"), "stale").unwrap();
+        let written = repo.write_readme(true).unwrap();
+        assert!(written);
+        let readme = fs::read_to_string(tmp.path().join("README.md")).unwrap();
+        assert!(readme.contains("jj git init --colocate"));
+    }
+
+    #[test]
+    fn write_readme_without_force_skips_existing() {
+        let (tmp, repo) = fresh_repo();
+        fs::write(tmp.path().join("README.md"), "user wrote this").unwrap();
+        let written = repo.write_readme(false).unwrap();
+        assert!(!written, "expected write_readme(false) to skip");
+        let readme = fs::read_to_string(tmp.path().join("README.md")).unwrap();
+        assert_eq!(readme, "user wrote this");
     }
 
     #[test]

--- a/apps/blogctl/templates/workdir-readme.md
+++ b/apps/blogctl/templates/workdir-readme.md
@@ -1,0 +1,91 @@
+# blog content workdir
+
+Private workdir for `blogctl`-managed blog post drafts. The Markdown
+files under each stage directory are the source of truth; `blogctl`
+reads them, moves them across the pipeline, and rewrites their
+frontmatter on stage transitions.
+
+## Workflow stages
+
+```
+concept → ideation → editing → final-editing → published
+                                                  abandoned (terminal)
+```
+
+Stage is encoded in two places that must agree: the directory the file
+sits in, and the `status:` field in its frontmatter. `blogctl` fails
+loudly on any mismatch.
+
+## Post kinds
+
+Every post declares a `kind:` in its frontmatter, mirroring LinkedIn's
+split:
+
+- **`post`** — short-form feed content. The default for `blogctl new`.
+- **`article`** — long-form with its own permanent URL.
+
+Kind drives prompt selection, exit-criteria thresholds, and optional
+per-stage model overrides. Both kinds traverse the same stage pipeline.
+
+```sh
+blogctl new "Title" --workdir .                  # kind: post
+blogctl new "Title" --workdir . --kind article   # kind: article
+```
+
+## Layout
+
+```
+<workdir>/
+  concepts/
+  ideation/
+  editing/
+  final-editing/
+  published/
+  abandoned/
+  .blog-os.toml
+  README.md
+  <prompt files>          # e.g. ideation-post.md, editing-article.md
+```
+
+Prompt files live at the workdir root next to `.blog-os.toml`. They are
+loaded by the OpenRouter integration; naming follows the pattern
+`<stage>-<kind>.md`.
+
+## Version control
+
+This workdir is a colocated `jj` + `git` repository. The convention is
+trunk-based — push directly to `main`, no pull requests.
+
+### One-time setup
+
+```sh
+gh repo create <name> --private --clone
+cd <name>
+jj git init --colocate
+blogctl init --workdir .
+jj describe -m "chore: scaffold workdir"
+jj bookmark create main -r @
+jj git push --allow-new
+```
+
+Two subtleties worth knowing:
+
+- `gh repo create --clone` gives you an empty dir with just `.git/`.
+  `jj git init --colocate` on top of an unborn-HEAD git repo works
+  fine — push the first commit with `--allow-new` to create the
+  remote `main` ref.
+- After this, the normal loop is `jj describe`, `jj new`,
+  `jj git push`. No PRs — `jj git push --bookmark main` advances
+  trunk directly. jj rejects non-fast-forward pushes by default; if
+  you ever rewrite `main` (squash, reorder, abandon), you'll need
+  `jj git push --allow-backwards` consciously.
+
+## Regenerating this README
+
+This file is generated from a template baked into `blogctl`. Don't edit
+it by hand — your edits will be overwritten the next time you
+regenerate. To pick up template changes after a `blogctl` upgrade:
+
+```sh
+blogctl readme regenerate --workdir .
+```

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -52,11 +52,15 @@ fn init_creates_expected_layout() {
         "editing",
         "final-editing",
         "published",
-        "archive",
-        "history/published-posts",
-        "prompts",
+        "abandoned",
     ] {
         assert!(tmp.path().join(d).is_dir(), "missing dir after init: {d}");
+    }
+    for absent in ["history", "prompts"] {
+        assert!(
+            !tmp.path().join(absent).exists(),
+            "should not create {absent}/"
+        );
     }
     assert!(tmp.path().join(".blog-os.toml").is_file());
 }
@@ -184,4 +188,55 @@ fn new_accepts_explicit_slug_override() {
         "new with --slug",
     );
     assert!(tmp.path().join("concepts/short.md").is_file());
+}
+
+#[test]
+fn init_writes_readme_template() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    let readme =
+        std::fs::read_to_string(tmp.path().join("README.md")).expect("README.md after init");
+    for needle in [
+        "jj git init --colocate",
+        "--allow-new",
+        "--allow-backwards",
+        "kind: post",
+    ] {
+        assert!(readme.contains(needle), "README missing {needle:?}");
+    }
+}
+
+#[test]
+fn readme_regenerate_overwrites_user_edits() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    std::fs::write(tmp.path().join("README.md"), "stale\n").unwrap();
+    assert_success(
+        &run(&["readme", "regenerate", "--workdir", &wd]),
+        "readme regenerate",
+    );
+    let readme = std::fs::read_to_string(tmp.path().join("README.md")).unwrap();
+    assert!(readme.contains("jj git init --colocate"));
+}
+
+#[test]
+fn new_writes_kind_into_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(
+        &run(&["new", "Long Form", "--workdir", &wd, "--kind", "article"]),
+        "new --kind article",
+    );
+    let body = std::fs::read_to_string(tmp.path().join("concepts/long-form.md")).unwrap();
+    assert!(body.contains("kind: article"));
+
+    assert_success(&run(&["new", "Short", "--workdir", &wd]), "new (default)");
+    let body = std::fs::read_to_string(tmp.path().join("concepts/short.md")).unwrap();
+    assert!(body.contains("kind: post"));
 }

--- a/apps/blogctl/tests/fixtures/frontmatter/invalid/unknown-kind.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/invalid/unknown-kind.md
@@ -1,11 +1,13 @@
 ---
-title: "Minimal"
-slug: minimal
-kind: post
-status: ideation
+title: "Bad Kind"
+slug: bad-kind
+kind: essay
+status: concept
 created_at: 2026-05-03T00:00:00Z
 updated_at: 2026-05-03T00:00:00Z
 tags: []
 todoist_task_id: null
 history_checked: false
 ---
+
+`essay` is not a valid kind — only `post` and `article` parse.

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/article.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/article.md
@@ -1,0 +1,16 @@
+---
+title: "Long-form Essay"
+slug: long-form-essay
+kind: article
+status: editing
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T12:00:00Z
+tags:
+  - longform
+todoist_task_id: null
+history_checked: false
+---
+
+# Long-form Essay
+
+A draft of a long-form article.

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/final-editing.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/final-editing.md
@@ -1,6 +1,7 @@
 ---
 title: "Approaching Polish"
 slug: approaching-polish
+kind: post
 status: final-editing
 created_at: 2026-05-03T00:00:00Z
 updated_at: 2026-05-03T11:00:00Z

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/full.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/full.md
@@ -1,6 +1,7 @@
 ---
 title: "Example Title"
 slug: example-title
+kind: post
 status: concept
 created_at: 2026-05-03T00:00:00Z
 updated_at: 2026-05-03T00:00:00Z


### PR DESCRIPTION
"Archive" implied old-but-kept; the stage is actually for drafts the user
decided not to ship, so rename to "Abandoned" to match the intent.

Drop history/ and prompts/ from \`init\` — history/ was duplicative of
published/ with no defined consumer, and prompt files are easier to find
at the workdir root next to \`.blog-os.toml\`.

Add a required \`kind: post | article\` frontmatter field mirroring
LinkedIn's split (post = short-form feed; article = long-form). The
downstream pipeline (#233) selects prompts and exit criteria per kind,
so the field needs to land first.

Bake the workdir README into the binary and write it on \`init\` so fresh
workdirs land with the jj/gh setup directives already documented;
\`blogctl readme regenerate\` is the explicit overwrite path for picking
up template changes after a \`blogctl\` upgrade.