### PR TITLE
feat(blogctl): theme frontmatter field with config-validated --theme

### DIFF
--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -58,6 +58,8 @@ frontmatter. `published` won't demote without a future `--force` flag;
 ---
 title: "Example Title"
 slug: example-title
+kind: post
+theme: standard
 status: concept
 created_at: 2026-05-03T00:00:00Z
 updated_at: 2026-05-03T00:00:00Z
@@ -69,7 +71,10 @@ history_checked: false
 Draft text here.
 ```
 
-Timestamps are RFC 3339 UTC. The Markdown file is the source of truth.
+Timestamps are RFC 3339 UTC. `kind` is one of `post` or `article`;
+`theme` is any name declared in `.blog-os.toml`'s `[themes.*]` table
+(the binary seeds `standard` and `parable`). The Markdown file is the
+source of truth.
 
 ## Extension points
 

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -36,6 +36,10 @@ pub enum Command {
         /// (long-form). Drives prompt/exit-criteria selection downstream.
         #[arg(long, value_enum, default_value_t = Kind::Post)]
         kind: Kind,
+        /// Narrative theme. Defaults to the workdir's
+        /// `defaults.theme`; must be declared in `[themes.*]`.
+        #[arg(long)]
+        theme: Option<String>,
     },
     /// List every post in the workdir, grouped by stage.
     List {
@@ -91,7 +95,8 @@ pub fn dispatch(cmd: Command) -> Result<()> {
             workdir,
             slug,
             kind,
-        } => commands::new::run(title, workdir, slug, kind),
+            theme,
+        } => commands::new::run(title, workdir, slug, kind, theme),
         Command::List { workdir } => commands::list::run(workdir),
         Command::Show { slug, workdir } => commands::show::run(slug, workdir),
         Command::Promote { slug, workdir } => commands::promote::run(slug, workdir),
@@ -129,6 +134,15 @@ mod tests {
                 "/tmp/wd",
                 "--kind",
                 "article",
+            ],
+            vec![
+                "blogctl",
+                "new",
+                "Hello",
+                "--workdir",
+                "/tmp/wd",
+                "--theme",
+                "parable",
             ],
             vec!["blogctl", "list", "--workdir", "/tmp/wd"],
             vec!["blogctl", "show", "hello", "--workdir", "/tmp/wd"],

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -14,6 +14,7 @@ pub fn run(
     workdir: PathBuf,
     slug_override: Option<String>,
     kind: Kind,
+    theme: Option<String>,
 ) -> Result<()> {
     if title.trim().is_empty() {
         return Err(Error::EmptyTitle(title));
@@ -24,12 +25,22 @@ pub fn run(
     };
 
     let repo = Repository::open(Workdir::new(&workdir))?;
+    let config = repo.read_config()?;
+    let resolved_theme = theme.unwrap_or_else(|| config.defaults.theme.clone());
+    if !config.themes.contains_key(&resolved_theme) {
+        let known: Vec<String> = config.themes.keys().cloned().collect();
+        return Err(Error::UnknownTheme {
+            theme: resolved_theme,
+            known,
+        });
+    }
 
     let now = OffsetDateTime::now_utc();
     let metadata = PostMetadata {
         title,
         slug: resolved_slug.clone(),
         kind,
+        theme: resolved_theme,
         status: Stage::Concept,
         created_at: now,
         updated_at: now,

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
     #[error("invalid kind {0:?}: expected `post` or `article`")]
     InvalidKind(String),
 
+    #[error("unknown theme {theme:?}: known themes are {}", known.join(", "))]
+    UnknownTheme { theme: String, known: Vec<String> },
+
     #[error("invalid slug {0:?}: {1}")]
     InvalidSlug(String, String),
 

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -6,6 +6,7 @@ use time::OffsetDateTime;
 use crate::error::{Error, Result};
 use crate::kind::Kind;
 use crate::stage::Stage;
+use crate::storage::DEFAULT_THEME;
 
 /// Frontmatter metadata. Mirrors the YAML block at the top of every post
 /// file. Fields stay required so a round-trip preserves shape; clients
@@ -15,6 +16,11 @@ pub struct PostMetadata {
     pub title: String,
     pub slug: String,
     pub kind: Kind,
+    /// Narrative theme. Validated against the workdir config's
+    /// `[themes.*]` table at `blogctl new` time; defaults to
+    /// `"standard"` on parse so posts predating this field still load.
+    #[serde(default = "default_theme")]
+    pub theme: String,
     pub status: Stage,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
@@ -26,6 +32,10 @@ pub struct PostMetadata {
     pub todoist_task_id: Option<String>,
     #[serde(default)]
     pub history_checked: bool,
+}
+
+fn default_theme() -> String {
+    DEFAULT_THEME.to_string()
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -139,6 +149,7 @@ mod tests {
             title: "Example Title".into(),
             slug: "example-title".into(),
             kind: Kind::Post,
+            theme: "standard".into(),
             status: Stage::Concept,
             created_at: datetime!(2026-05-03 00:00:00 UTC),
             updated_at: datetime!(2026-05-03 00:00:00 UTC),
@@ -158,6 +169,7 @@ mod tests {
 title: "Example Title"
 slug: example-title
 kind: post
+theme: parable
 status: concept
 created_at: 2026-05-03T00:00:00Z
 updated_at: 2026-05-03T00:00:00Z
@@ -172,11 +184,30 @@ Draft text here.
         assert_eq!(post.metadata.title, "Example Title");
         assert_eq!(post.metadata.slug, "example-title");
         assert_eq!(post.metadata.kind, Kind::Post);
+        assert_eq!(post.metadata.theme, "parable");
         assert_eq!(post.metadata.status, Stage::Concept);
         assert!(post.metadata.tags.is_empty());
         assert!(post.metadata.todoist_task_id.is_none());
         assert!(!post.metadata.history_checked);
         assert_eq!(post.body, "\nDraft text here.\n");
+    }
+
+    #[test]
+    fn parse_defaults_theme_to_standard_when_field_missing() {
+        let raw = r#"---
+title: "Pre-theme post"
+slug: pre-theme-post
+kind: post
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+---
+
+Body.
+"#;
+        let post = parse(raw).unwrap();
+        assert_eq!(post.metadata.theme, "standard");
     }
 
     #[test]

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -11,6 +12,15 @@ use crate::stage::Stage;
 const CONFIG_FILE: &str = ".blog-os.toml";
 const README_FILE: &str = "README.md";
 
+/// Default narrative theme. Used by `PostMetadata`'s serde default and by
+/// `Config::current()` to seed `defaults.theme`.
+pub const DEFAULT_THEME: &str = "standard";
+
+/// Themes pre-declared by `init`. Keeps the validation list non-empty
+/// out of the box so `blogctl new --theme parable` works on a fresh
+/// workdir without the user editing the config first.
+const STARTER_THEMES: &[&str] = &["standard", "parable"];
+
 /// Canonical workdir README, baked in at build time. `init` writes this
 /// file when one is not already present; `readme regenerate` overwrites
 /// whatever is currently there.
@@ -21,14 +31,53 @@ pub const README_TEMPLATE: &str = include_str!("../templates/workdir-readme.md")
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     pub version: u32,
+    #[serde(default)]
+    pub defaults: Defaults,
+    #[serde(default)]
+    pub themes: BTreeMap<String, ThemeConfig>,
+}
+
+/// Workdir-wide defaults. Currently just the theme `blogctl new` selects
+/// when `--theme` is not given; will grow as additional defaults land.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Defaults {
+    #[serde(default = "default_theme_name")]
+    pub theme: String,
+}
+
+impl Default for Defaults {
+    fn default() -> Self {
+        Self {
+            theme: DEFAULT_THEME.to_string(),
+        }
+    }
+}
+
+fn default_theme_name() -> String {
+    DEFAULT_THEME.to_string()
+}
+
+/// Per-theme configuration. The `prompts` map is reserved for the
+/// run-stage resolver (#233) — it stays empty in this slice but the
+/// schema slot is here so the file format doesn't churn later.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ThemeConfig {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub prompts: BTreeMap<String, String>,
 }
 
 impl Config {
     pub const CURRENT_VERSION: u32 = 1;
 
     pub fn current() -> Self {
+        let themes = STARTER_THEMES
+            .iter()
+            .map(|name| (name.to_string(), ThemeConfig::default()))
+            .collect();
         Self {
             version: Self::CURRENT_VERSION,
+            defaults: Defaults::default(),
+            themes,
         }
     }
 }
@@ -298,6 +347,7 @@ mod tests {
                 title: format!("Title {slug}"),
                 slug: slug.to_string(),
                 kind: crate::kind::Kind::Post,
+                theme: DEFAULT_THEME.to_string(),
                 status: stage,
                 created_at: datetime!(2026-05-03 00:00:00 UTC),
                 updated_at: datetime!(2026-05-03 00:00:00 UTC),
@@ -337,6 +387,30 @@ mod tests {
         let (_tmp, repo) = fresh_repo();
         let cfg = repo.read_config().unwrap();
         assert_eq!(cfg.version, Config::CURRENT_VERSION);
+    }
+
+    #[test]
+    fn init_seeds_default_theme_and_starter_themes() {
+        let (_tmp, repo) = fresh_repo();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(cfg.defaults.theme, DEFAULT_THEME);
+        assert!(cfg.themes.contains_key("standard"));
+        assert!(cfg.themes.contains_key("parable"));
+    }
+
+    #[test]
+    fn config_with_only_version_back_fills_defaults_and_themes() {
+        let tmp = TempDir::new().unwrap();
+        // Simulate a workdir from before the themes field landed: just
+        // `version = 1` in the config file.
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        fs::write(repo.workdir().config_path(), "version = 1\n").unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(cfg.defaults.theme, DEFAULT_THEME);
+        assert!(cfg.themes.is_empty());
     }
 
     #[test]

--- a/apps/blogctl/templates/workdir-readme.md
+++ b/apps/blogctl/templates/workdir-readme.md
@@ -32,6 +32,24 @@ blogctl new "Title" --workdir .                  # kind: post
 blogctl new "Title" --workdir . --kind article   # kind: article
 ```
 
+## Themes
+
+Themes are a narrative-style layer over the kind × stage grid. Each
+post declares a `theme:` in its frontmatter, validated against the
+`[themes.*]` table in `.blog-os.toml` at create time. `init` seeds two
+themes; you can add more by declaring `[themes.<name>]` in the config.
+
+- **`standard`** — default prose. Used when `--theme` is not given.
+- **`parable`** — allegorical narrative.
+
+```sh
+blogctl new "Title" --workdir .                   # theme: standard (default)
+blogctl new "Title" --workdir . --theme parable   # theme: parable
+```
+
+Theme drives prompt selection at `blogctl run-stage` time (model and
+exit criteria stay theme-agnostic for now).
+
 ## Layout
 
 ```
@@ -44,12 +62,12 @@ blogctl new "Title" --workdir . --kind article   # kind: article
   abandoned/
   .blog-os.toml
   README.md
-  <prompt files>          # e.g. ideation-post.md, editing-article.md
+  <prompt files>          # e.g. ideation-post-standard.md
 ```
 
 Prompt files live at the workdir root next to `.blog-os.toml`. They are
 loaded by the OpenRouter integration; naming follows the pattern
-`<stage>-<kind>.md`.
+`<stage>-<kind>-<theme>.md`.
 
 ## Version control
 

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -240,3 +240,36 @@ fn new_writes_kind_into_frontmatter() {
     let body = std::fs::read_to_string(tmp.path().join("concepts/short.md")).unwrap();
     assert!(body.contains("kind: post"));
 }
+
+#[test]
+fn new_writes_theme_into_frontmatter() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+
+    assert_success(&run(&["new", "Default", "--workdir", &wd]), "new (default)");
+    let body = std::fs::read_to_string(tmp.path().join("concepts/default.md")).unwrap();
+    assert!(body.contains("theme: standard"));
+
+    assert_success(
+        &run(&["new", "Allegory", "--workdir", &wd, "--theme", "parable"]),
+        "new --theme parable",
+    );
+    let body = std::fs::read_to_string(tmp.path().join("concepts/allegory.md")).unwrap();
+    assert!(body.contains("theme: parable"));
+}
+
+#[test]
+fn new_rejects_unknown_theme_with_known_list() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    let out = run(&["new", "Bogus", "--workdir", &wd, "--theme", "noir"]);
+    assert!(!out.status.success());
+    let err = stderr(&out);
+    assert!(err.contains("unknown theme"), "stderr was: {err}");
+    assert!(err.contains("standard"), "stderr was: {err}");
+    assert!(err.contains("parable"), "stderr was: {err}");
+}

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/parable.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/parable.md
@@ -1,0 +1,17 @@
+---
+title: "The Two Architects"
+slug: the-two-architects
+kind: post
+theme: parable
+status: ideation
+created_at: 2026-05-06T00:00:00Z
+updated_at: 2026-05-06T00:00:00Z
+tags:
+  - allegory
+todoist_task_id: null
+history_checked: false
+---
+
+# The Two Architects
+
+Once there were two architects, and only one of them drew on paper.


### PR DESCRIPTION
Themes are a narrative-style layer over the kind × stage grid. Each
post declares a \`theme:\` (validated against the workdir config), and
the eventual run-stage resolver (#233) will use it to pick prompts.

\`Config\` grows two new fields: \`defaults.theme\` and a
\`themes: BTreeMap<String, ThemeConfig>\` table, both with serde
defaults so configs predating these fields back-fill cleanly. \`init\`
seeds the default theme as \`standard\` and pre-declares
\`[themes.standard]\` and \`[themes.parable]\` so \`blogctl new --theme
parable\` works on a fresh workdir without manual config edits.

\`PostMetadata.theme\` is a \`String\`, not a closed enum, because themes
live in TOML, not the binary. It defaults to \`"standard"\` on parse so
fixtures predating the field load without churn. \`blogctl new --theme\`
defaults from \`config.defaults.theme\`, validates against the config's
\`[themes.*]\` keys, and errors with the known-theme list on miss — so
typos surface at create time rather than at run-stage.

\`ThemeConfig.prompts\` is reserved for #233's resolver; this slice
leaves it empty. Per-theme model and exit-criteria overrides are
deferred until a real need shows up (per the issue's out-of-scope).

Closes #238.