### PR TITLE
refactor(shaka): centralize ANSI color consts in term module

### DIFF
--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -1,11 +1,7 @@
 use clap::Subcommand;
 use serde_json::Value;
 
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
 #[derive(Subcommand)]
 pub enum CiCommand {

--- a/tools/shaka/src/commit.rs
+++ b/tools/shaka/src/commit.rs
@@ -3,12 +3,7 @@ use std::process::Command;
 
 use clap::Subcommand;
 
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const GREEN: &str = "\x1b[32m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 const TYPES: &[&str] = &[
     "feat", "fix", "docs", "chore", "refactor", "test", "style", "perf", "ci", "build",

--- a/tools/shaka/src/domain/inventory.rs
+++ b/tools/shaka/src/domain/inventory.rs
@@ -5,12 +5,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 const SCHEMA: &str = include_str!("../../schema/domain.cue");
 

--- a/tools/shaka/src/issue/audit.rs
+++ b/tools/shaka/src/issue/audit.rs
@@ -3,11 +3,7 @@ use std::process::Command;
 use serde_json::Value;
 
 use crate::gh;
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET};
 
 // Every open issue must carry at least one of these labels. New scope
 // labels must be added here AND created in the repo (`gh label create`).

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -9,6 +9,7 @@ mod jj;
 mod preflight;
 mod project;
 mod repo;
+mod term;
 mod whitespace;
 mod workspace;
 

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -2,12 +2,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 enum CheckResult {
     Pass,

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -4,13 +4,7 @@ use std::process::Command;
 use serde::Deserialize;
 
 use crate::project::schema_check;
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuleResult {

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -4,12 +4,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 const SCHEMA: &str = include_str!("../../schema/project.cue");
 const SLOTS: &[&str] = &["apps", "infra", "nix", "packages", "services", "tools"];

--- a/tools/shaka/src/project/new.rs
+++ b/tools/shaka/src/project/new.rs
@@ -2,11 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::project::{audit, generate_justfiles, schema_check};
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET};
 
 const SLOTS: &[&str] = &["apps", "packages", "projects", "tools"];
 

--- a/tools/shaka/src/project/schema_check.rs
+++ b/tools/shaka/src/project/schema_check.rs
@@ -2,12 +2,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 pub const SCHEMA: &str = include_str!("../../schema/project.cue");
 const SLOTS: &[&str] = &["apps", "infra", "nix", "packages", "services", "tools"];

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -1,13 +1,7 @@
 use serde_json::{json, Value};
 
 use crate::gh;
-
-// ANSI escape codes
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
 #[derive(Clone, Copy, PartialEq)]
 enum Status {

--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -3,13 +3,7 @@ use std::process::Command;
 
 use crate::gh::{self, PrState};
 use crate::project::schema_check;
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 #[derive(Debug, PartialEq, Eq)]
 enum BumpResult {

--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -1,11 +1,7 @@
 use crate::gh;
 use crate::jj;
 use crate::repo::send::{resolve_bookmark, split_message};
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET};
 
 pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
     let description = match jj::current_description() {

--- a/tools/shaka/src/repo/rebase_open_prs.rs
+++ b/tools/shaka/src/repo/rebase_open_prs.rs
@@ -4,12 +4,7 @@ use std::process::Command;
 use serde_json::json;
 
 use crate::gh::{self, OpenPr};
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
 const STATUS_CONTEXT: &str = "auto-rebase";
 const OPT_OUT_LABEL: &str = "do-not-rebase";

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -1,11 +1,6 @@
 use crate::gh;
 use crate::jj;
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const YELLOW: &str = "\x1b[33m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
 pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
     let description = match jj::current_description() {

--- a/tools/shaka/src/repo/status.rs
+++ b/tools/shaka/src/repo/status.rs
@@ -2,13 +2,7 @@ use serde::Serialize;
 
 use crate::gh;
 use crate::jj;
-
-const GREEN: &str = "\x1b[32m";
-const YELLOW: &str = "\x1b[33m";
-const RED: &str = "\x1b[31m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 #[derive(Serialize)]
 struct Status {

--- a/tools/shaka/src/repo/sync.rs
+++ b/tools/shaka/src/repo/sync.rs
@@ -1,9 +1,5 @@
 use crate::jj;
-
-const GREEN: &str = "\x1b[32m";
-const RED: &str = "\x1b[31m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, GREEN, RED, RESET};
 
 pub fn run(dry_run: bool) {
     if dry_run {

--- a/tools/shaka/src/term.rs
+++ b/tools/shaka/src/term.rs
@@ -1,0 +1,6 @@
+pub const RED: &str = "\x1b[31m";
+pub const GREEN: &str = "\x1b[32m";
+pub const YELLOW: &str = "\x1b[33m";
+pub const BOLD: &str = "\x1b[1m";
+pub const DIM: &str = "\x1b[2m";
+pub const RESET: &str = "\x1b[0m";

--- a/tools/shaka/src/whitespace.rs
+++ b/tools/shaka/src/whitespace.rs
@@ -3,13 +3,7 @@ use std::path::{Path, PathBuf};
 use clap::Subcommand;
 
 use crate::jj;
-
-const RED: &str = "\x1b[31m";
-const GREEN: &str = "\x1b[32m";
-const YELLOW: &str = "\x1b[33m";
-const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 const BOM: &[u8] = b"\xef\xbb\xbf";
 const BINARY_PROBE: usize = 8192;

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -9,11 +9,7 @@ use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
 
-const RED: &str = "\x1b[31m";
-const GREEN: &str = "\x1b[32m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const RESET: &str = "\x1b[0m";
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 #[derive(Subcommand)]
 pub enum WorkspaceCommand {

--- a/tools/shaka/src/workspace/status.rs
+++ b/tools/shaka/src/workspace/status.rs
@@ -1,8 +1,6 @@
 use serde::Serialize;
 
-use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET};
-
-const YELLOW: &str = "\x1b[33m";
+use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET, YELLOW};
 use crate::jj;
 
 #[derive(Serialize)]


### PR DESCRIPTION
The same ANSI escape consts (GREEN, RED, YELLOW, BOLD, DIM, RESET) were
redeclared in 19 files across tools/shaka/src/. Consolidate them into a
new tools/shaka/src/term.rs and have callers import via
use crate::term::{...}; (or via super:: for the workspace submodule
which already pulls helpers from its mod.rs).

Closes #44