### PR TITLE
chore(claude): expand allowlist and default to acceptEdits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,11 @@
 {
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "Bash(cargo build *)",
+      "Bash(cargo clippy *)",
+      "Bash(cargo test *)",
+      "Bash(gh label list *)",
       "Bash(jj log *)",
       "Bash(cue vet *)",
       "Bash(jj diff *)",


### PR DESCRIPTION
Reduces permission prompts during normal sessions by allowlisting three
read-only Bash patterns observed frequently in transcripts: cargo clippy,
cargo test, and gh label list. Adds defaultMode "acceptEdits" so file
edits no longer prompt — commands still do, and shaka preflight remains
the single CI gate, so the blast radius is bounded.