### PR TITLE
feat(shaka): add workspace and PR to issue brief --json

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -246,6 +246,74 @@ pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
     }))
 }
 
+/// Find a PR (open, closed, or merged) whose body references `Closes #n`.
+/// Returns the first match (most recently updated by gh's default sort).
+///
+/// Relies on the repo convention of `Closes #N` in PR bodies (CLAUDE.md);
+/// `Fixes`/`Resolves` aren't matched. For merged PRs that closed the issue
+/// you can also use [`merged_pr_for_issue`] — this helper additionally
+/// catches *open* PRs, which `closedByPullRequestsReferences` does not.
+pub fn pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError> {
+    let query = format!("in:body Closes #{n}");
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--search",
+            &query,
+            "--state",
+            "all",
+            "--limit",
+            "1",
+            "--json",
+            "number,state,url",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GhError {
+            message: format!("gh pr list (search Closes #{n}): {}", stderr.trim()),
+        });
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    parse_pr_for_issue(&body)
+}
+
+pub(crate) fn parse_pr_for_issue(body: &str) -> Result<Option<PrInfo>, GhError> {
+    let value: Value = serde_json::from_str(body).map_err(|e| GhError {
+        message: format!("failed to parse gh pr list JSON: {e}"),
+    })?;
+    let Some(first) = value.as_array().and_then(|a| a.first()) else {
+        return Ok(None);
+    };
+    let number = first["number"].as_u64().ok_or_else(|| GhError {
+        message: "PR missing 'number' field".into(),
+    })?;
+    let url = first["url"]
+        .as_str()
+        .ok_or_else(|| GhError {
+            message: format!("PR #{number} missing 'url' field"),
+        })?
+        .to_string();
+    // gh pr list reports state as upper-case OPEN/CLOSED/MERGED (unlike the
+    // REST API which uses lower-case open/closed plus a separate merged_at).
+    let state = match first["state"].as_str() {
+        Some("OPEN") => PrState::Open,
+        Some("MERGED") => PrState::Merged,
+        Some("CLOSED") => PrState::Closed,
+        other => {
+            return Err(GhError {
+                message: format!("PR #{number} has unexpected state {other:?}"),
+            });
+        }
+    };
+    Ok(Some(PrInfo { number, url, state }))
+}
+
 /// Run `gh pr create` and return the PR URL.
 ///
 /// Passes `--repo` so this works inside a sibling jj workspace where
@@ -516,5 +584,43 @@ mod tests {
     fn parse_open_prs_missing_field_errors() {
         let body = r#"[{"number": 1, "headRefName": "x", "url": "u"}]"#;
         assert!(parse_open_prs(body).is_err());
+    }
+
+    #[test]
+    fn parse_pr_for_issue_open() {
+        let body = r#"[{"number": 42, "state": "OPEN", "url": "https://gh.com/o/r/pull/42"}]"#;
+        let pr = parse_pr_for_issue(body).unwrap().unwrap();
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.state, PrState::Open);
+        assert_eq!(pr.url, "https://gh.com/o/r/pull/42");
+    }
+
+    #[test]
+    fn parse_pr_for_issue_merged() {
+        let body = r#"[{"number": 7, "state": "MERGED", "url": "u"}]"#;
+        assert_eq!(
+            parse_pr_for_issue(body).unwrap().unwrap().state,
+            PrState::Merged
+        );
+    }
+
+    #[test]
+    fn parse_pr_for_issue_closed() {
+        let body = r#"[{"number": 7, "state": "CLOSED", "url": "u"}]"#;
+        assert_eq!(
+            parse_pr_for_issue(body).unwrap().unwrap().state,
+            PrState::Closed
+        );
+    }
+
+    #[test]
+    fn parse_pr_for_issue_empty() {
+        assert!(parse_pr_for_issue("[]").unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_pr_for_issue_unknown_state_errors() {
+        let body = r#"[{"number": 1, "state": "WAT", "url": "u"}]"#;
+        assert!(parse_pr_for_issue(body).is_err());
     }
 }

--- a/tools/shaka/src/issue/brief.rs
+++ b/tools/shaka/src/issue/brief.rs
@@ -2,7 +2,8 @@ use std::process::Command;
 
 use serde_json::{json, Value};
 
-use crate::gh;
+use crate::gh::{self, PrInfo, PrState};
+use crate::workspace::{self, WorkspaceRef};
 
 const BOLD: &str = "\x1b[1m";
 const DIM: &str = "\x1b[2m";
@@ -40,11 +41,25 @@ pub fn run(n: u64, no_fetch: bool, json_out: bool) {
         }
     };
 
+    let workspace = workspace::find_for_issue(n);
+    let pr = match gh::pr_for_issue(&repo, n) {
+        Ok(p) => p,
+        Err(e) => {
+            // PR lookup is best-effort metadata, not load-bearing. A search
+            // failure (rate limit, transient API hiccup) shouldn't fail the
+            // whole brief — warn and continue with `pr: null`.
+            eprintln!("{DIM}warn:{RESET} could not query PR for issue #{n}: {e}");
+            None
+        }
+    };
+
     if json_out {
-        let payload = json!({
-            "fetch": fetch_output,
-            "issue": issue,
-        });
+        let payload = build_payload(
+            fetch_output.as_deref(),
+            &issue,
+            workspace.as_ref(),
+            pr.as_ref(),
+        );
         match serde_json::to_string_pretty(&payload) {
             Ok(s) => println!("{s}"),
             Err(e) => {
@@ -53,7 +68,55 @@ pub fn run(n: u64, no_fetch: bool, json_out: bool) {
             }
         }
     } else {
-        print!("{}", render_tree(n, fetch_output.as_deref(), &issue));
+        print!(
+            "{}",
+            render_tree(
+                n,
+                fetch_output.as_deref(),
+                &issue,
+                workspace.as_ref(),
+                pr.as_ref()
+            )
+        );
+    }
+}
+
+fn build_payload(
+    fetch: Option<&str>,
+    issue: &Value,
+    workspace: Option<&WorkspaceRef>,
+    pr: Option<&PrInfo>,
+) -> Value {
+    let workspace_value = workspace
+        .map(|w| {
+            json!({
+                "name": w.name,
+                "path": w.path.to_string_lossy(),
+            })
+        })
+        .unwrap_or(Value::Null);
+    let pr_value = pr
+        .map(|p| {
+            json!({
+                "number": p.number,
+                "url": p.url,
+                "state": pr_state_str(&p.state),
+            })
+        })
+        .unwrap_or(Value::Null);
+    json!({
+        "fetch": fetch,
+        "issue": issue,
+        "workspace": workspace_value,
+        "pr": pr_value,
+    })
+}
+
+fn pr_state_str(s: &PrState) -> &'static str {
+    match s {
+        PrState::Open => "OPEN",
+        PrState::Closed => "CLOSED",
+        PrState::Merged => "MERGED",
     }
 }
 
@@ -102,7 +165,13 @@ fn fetch_issue(repo: &str, n: u64) -> Result<Value, String> {
         .map_err(|e| format!("failed to parse JSON from gh issue view {n}: {e}"))
 }
 
-fn render_tree(n: u64, fetch: Option<&str>, issue: &Value) -> String {
+fn render_tree(
+    n: u64,
+    fetch: Option<&str>,
+    issue: &Value,
+    workspace: Option<&WorkspaceRef>,
+    pr: Option<&PrInfo>,
+) -> String {
     let mut out = String::new();
     out.push_str(&format!("{BOLD}shaka issue brief #{n}{RESET}\n"));
 
@@ -151,6 +220,24 @@ fn render_tree(n: u64, fetch: Option<&str>, issue: &Value) -> String {
     ));
     if !url.is_empty() {
         out.push_str(&format!("│   {DIM}{url}{RESET}\n"));
+    }
+    if let Some(ws) = workspace {
+        out.push_str(&format!(
+            "│   workspace: {BOLD}{}{RESET}  {DIM}{}{RESET}\n",
+            ws.name,
+            ws.path.display()
+        ));
+    }
+    if let Some(pr) = pr {
+        let (pr_color, pr_label) = match pr.state {
+            PrState::Open => (GREEN, "open"),
+            PrState::Merged => (YELLOW, "merged"),
+            PrState::Closed => (RED, "closed"),
+        };
+        out.push_str(&format!(
+            "│   pr: {BOLD}#{}{RESET} ({pr_color}{pr_label}{RESET})  {DIM}{}{RESET}\n",
+            pr.number, pr.url
+        ));
     }
     if !body.trim().is_empty() {
         out.push_str("│\n");
@@ -227,7 +314,7 @@ mod tests {
             "comments": [],
         });
 
-        let out = strip_ansi(&render_tree(216, Some(""), &issue));
+        let out = strip_ansi(&render_tree(216, Some(""), &issue, None, None));
         assert!(out.contains("shaka issue brief #216"));
         assert!(out.contains("├── fetching from origin"));
         assert!(out.contains("│   nothing changed"));
@@ -238,6 +325,8 @@ mod tests {
         assert!(out.contains("│   First line."));
         assert!(out.contains("│   Second paragraph."));
         assert!(out.contains("└── comments (0)"));
+        assert!(!out.contains("workspace:"));
+        assert!(!out.contains("pr:"));
     }
 
     #[test]
@@ -254,7 +343,7 @@ mod tests {
             "comments": [],
         });
 
-        let out = strip_ansi(&render_tree(1, None, &issue));
+        let out = strip_ansi(&render_tree(1, None, &issue, None, None));
         assert!(out.contains("├── fetching from origin (skipped)"));
         assert!(out.contains("labels: (none)"));
     }
@@ -276,12 +365,94 @@ mod tests {
             ],
         });
 
-        let out = strip_ansi(&render_tree(5, Some(""), &issue));
+        let out = strip_ansi(&render_tree(5, Some(""), &issue, None, None));
         assert!(out.contains("└── comments (2)"));
         assert!(out.contains("    ├── alice — 2026-04-01"));
         assert!(out.contains("    │   first"));
         assert!(out.contains("    └── bob — 2026-04-02"));
         assert!(out.contains("        second"));
         assert!(out.contains("        line"));
+    }
+
+    fn minimal_issue() -> Value {
+        json!({
+            "number": 231,
+            "title": "t",
+            "state": "OPEN",
+            "labels": [],
+            "author": {"login": "u"},
+            "body": "",
+            "url": "",
+            "createdAt": "",
+            "comments": [],
+        })
+    }
+
+    #[test]
+    fn renders_workspace_and_pr_when_present() {
+        let issue = minimal_issue();
+        let ws = WorkspaceRef {
+            name: "i231".to_string(),
+            path: std::path::PathBuf::from("/Users/me/code/kolohelios-i231"),
+        };
+        let pr = PrInfo {
+            number: 234,
+            url: "https://github.com/o/r/pull/234".to_string(),
+            state: PrState::Open,
+        };
+        let out = strip_ansi(&render_tree(231, Some(""), &issue, Some(&ws), Some(&pr)));
+        assert!(out.contains("│   workspace: i231  /Users/me/code/kolohelios-i231"));
+        assert!(out.contains("│   pr: #234 (open)  https://github.com/o/r/pull/234"));
+    }
+
+    #[test]
+    fn renders_pr_states_with_labels() {
+        let issue = minimal_issue();
+        for (state, label) in [
+            (PrState::Open, "open"),
+            (PrState::Merged, "merged"),
+            (PrState::Closed, "closed"),
+        ] {
+            let pr = PrInfo {
+                number: 1,
+                url: "u".to_string(),
+                state,
+            };
+            let out = strip_ansi(&render_tree(1, Some(""), &issue, None, Some(&pr)));
+            assert!(
+                out.contains(&format!("pr: #1 ({label})")),
+                "missing label {label} in: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn payload_includes_nullable_workspace_and_pr() {
+        let issue = minimal_issue();
+        let payload = build_payload(Some(""), &issue, None, None);
+        assert!(payload.get("workspace").unwrap().is_null());
+        assert!(payload.get("pr").unwrap().is_null());
+        assert_eq!(payload["fetch"], json!(""));
+        assert_eq!(payload["issue"]["number"], 231);
+    }
+
+    #[test]
+    fn payload_populates_workspace_and_pr() {
+        let issue = minimal_issue();
+        let ws = WorkspaceRef {
+            name: "i231".to_string(),
+            path: std::path::PathBuf::from("/tmp/kolohelios-i231"),
+        };
+        let pr = PrInfo {
+            number: 234,
+            url: "https://github.com/o/r/pull/234".to_string(),
+            state: PrState::Merged,
+        };
+        let payload = build_payload(None, &issue, Some(&ws), Some(&pr));
+        assert_eq!(payload["workspace"]["name"], "i231");
+        assert_eq!(payload["workspace"]["path"], "/tmp/kolohelios-i231");
+        assert_eq!(payload["pr"]["number"], 234);
+        assert_eq!(payload["pr"]["state"], "MERGED");
+        assert_eq!(payload["pr"]["url"], "https://github.com/o/r/pull/234");
     }
 }

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -302,6 +302,41 @@ pub fn repo_root() -> Result<PathBuf, JjError> {
     Ok(PathBuf::from(out.trim()))
 }
 
+/// Absolute path of the *default* (primary) workspace's working copy,
+/// regardless of which workspace this process is running inside.
+///
+/// Sibling workspaces have `.jj/repo` as a *file* whose contents point to
+/// the default workspace's `.jj/repo` directory; the primary's working
+/// copy is the grandparent of that path. Callers that need to read repo-
+/// wide state stored at the primary (e.g. `.shaka/workspaces/*.json`)
+/// should use this rather than [`repo_root`].
+pub fn primary_workspace_root() -> Result<PathBuf, JjError> {
+    let cur = repo_root()?;
+    let repo_marker = cur.join(".jj").join("repo");
+    let metadata = std::fs::metadata(&repo_marker).map_err(|e| JjError {
+        message: format!("stat {}: {e}", repo_marker.display()),
+    })?;
+    if metadata.is_dir() {
+        return Ok(cur);
+    }
+    let content = std::fs::read_to_string(&repo_marker).map_err(|e| JjError {
+        message: format!("read {}: {e}", repo_marker.display()),
+    })?;
+    primary_root_from_repo_marker(content.trim()).ok_or_else(|| JjError {
+        message: format!(
+            "could not derive primary workspace root from .jj/repo target {}",
+            content.trim()
+        ),
+    })
+}
+
+fn primary_root_from_repo_marker(target: &str) -> Option<PathBuf> {
+    Path::new(target)
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+}
+
 /// Information about a single jj workspace, surfaced from `jj workspace
 /// list`.
 #[derive(Debug, PartialEq, Eq)]
@@ -435,6 +470,17 @@ mod tests {
     #[test]
     fn slugify_basic() {
         assert_eq!(slugify("Add Commit Lint", 50), "add-commit-lint");
+    }
+
+    #[test]
+    fn primary_root_from_marker() {
+        let got = primary_root_from_repo_marker("/Users/me/code/kolohelios/.jj/repo");
+        assert_eq!(got, Some(PathBuf::from("/Users/me/code/kolohelios")));
+    }
+
+    #[test]
+    fn primary_root_from_marker_too_short() {
+        assert_eq!(primary_root_from_repo_marker("/"), None);
     }
 
     #[test]

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
 
+use crate::jj;
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 #[derive(Subcommand)]
@@ -57,6 +58,37 @@ pub fn run(cmd: WorkspaceCommand) {
         WorkspaceCommand::Status { json } => status::run(json),
         WorkspaceCommand::Cleanup { dry_run } => cleanup::run(dry_run),
     }
+}
+
+/// A workspace linked to a specific GitHub issue.
+pub struct WorkspaceRef {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+/// Find the workspace whose persisted issue link points at issue `n`. Skips
+/// the default workspace and any workspace without a link file (legacy
+/// workspaces created before the link was persisted, or ad-hoc named ones).
+///
+/// Uses [`jj::primary_workspace_root`] so this works identically whether
+/// the caller is in the primary tree or a sibling — `.shaka/workspaces/`
+/// only exists at the primary.
+pub fn find_for_issue(n: u64) -> Option<WorkspaceRef> {
+    let primary = jj::primary_workspace_root().ok()?;
+    let workspaces = jj::workspaces().ok()?;
+    for ws in workspaces {
+        if ws.name == "default" {
+            continue;
+        }
+        let link = issue_link::read(&primary, &ws.name).ok().flatten();
+        if link.map(|l| l.issue) == Some(n) {
+            return Some(WorkspaceRef {
+                name: ws.name.clone(),
+                path: workspace_path(&primary, &ws.name),
+            });
+        }
+    }
+    None
 }
 
 /// Path where a workspace directory lives, by convention:


### PR DESCRIPTION
Extend the `--json` payload of `shaka issue brief` with two nullable
top-level fields, and surface the same data as extra metadata lines
in the human tree.

- `workspace`: `{ name, path }` if a sibling jj workspace's persisted
  issue link points at this issue. Discovery walks `jj workspaces` and
  reads `.shaka/workspaces/<name>.json` from the *primary* tree (a new
  `jj::primary_workspace_root` helper resolves it via `.jj/repo` so
  this works identically from inside a sibling workspace).
- `pr`: `{ number, url, state }` for the most-recent PR (open, closed,
  or merged) whose body contains `Closes #N`. Open PRs aren't visible
  via `closedByPullRequestsReferences`, so we use a `gh pr list
  --search` query against the repo convention enforced by CLAUDE.md.
  Errors degrade to `pr: null` rather than failing the whole brief.

Sub-agents reading the JSON payload can now route based on whether a
workspace already exists for the issue or whether a PR is in flight,
without a follow-up `shaka workspace list` / `gh pr list` round-trip.

Closes #231