### PR TITLE
chore(claude): allowlist jj bookmark in settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
       "Bash(cargo test *)",
       "Bash(gh label list *)",
       "Bash(jj log *)",
+      "Bash(jj bookmark *)",
       "Bash(cue vet *)",
       "Bash(jj diff *)",
       "Bash(cue export *)",


### PR DESCRIPTION
`/start` and `/ship` both call `jj bookmark create` / `jj bookmark set`,
which currently triggers a permission prompt every time. Bookmark
mutations are scoped to the local working copy and trivially reversible,
matching the risk profile of the existing read-only `jj` allowlist
entries.

Closes #78