### PR TITLE
feat(shaka): add issue list subcommand

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -451,6 +451,152 @@ pub(crate) fn parse_open_prs(body: &str) -> Result<Vec<OpenPr>, GhError> {
         .collect()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListState {
+    Open,
+    Closed,
+    All,
+}
+
+impl ListState {
+    fn as_arg(self) -> &'static str {
+        match self {
+            ListState::Open => "open",
+            ListState::Closed => "closed",
+            ListState::All => "all",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IssueState {
+    Open,
+    Closed,
+}
+
+impl IssueState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IssueState::Open => "OPEN",
+            IssueState::Closed => "CLOSED",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueSummary {
+    pub number: u64,
+    pub title: String,
+    pub state: IssueState,
+    pub labels: Vec<String>,
+    pub url: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// List GitHub issues from `repo` matching the given filters.
+///
+/// Shells out to `gh issue list --json number,title,state,labels,url,createdAt,updatedAt`.
+/// `labels` are AND-combined when more than one is supplied.
+pub fn list_issues(
+    repo: &str,
+    state: ListState,
+    labels: &[String],
+    milestone: Option<&str>,
+    limit: u32,
+) -> Result<Vec<IssueSummary>, GhError> {
+    let limit = limit.to_string();
+    let mut args: Vec<String> = vec![
+        "issue".into(),
+        "list".into(),
+        "--repo".into(),
+        repo.into(),
+        "--state".into(),
+        state.as_arg().into(),
+        "--limit".into(),
+        limit,
+        "--json".into(),
+        "number,title,state,labels,url,createdAt,updatedAt".into(),
+    ];
+    for label in labels {
+        args.push("--label".into());
+        args.push(label.clone());
+    }
+    if let Some(m) = milestone {
+        args.push("--milestone".into());
+        args.push(m.to_string());
+    }
+
+    let output = Command::new("gh").args(&args).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GhError {
+            message: format!("gh issue list: {}", stderr.trim()),
+        });
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    parse_issue_list(&body)
+}
+
+pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError> {
+    let value: Value = serde_json::from_str(body).map_err(|e| GhError {
+        message: format!("failed to parse gh issue list JSON: {e}"),
+    })?;
+    let arr = value.as_array().ok_or_else(|| GhError {
+        message: "gh issue list did not return an array".into(),
+    })?;
+
+    arr.iter()
+        .map(|v| {
+            let number = v["number"].as_u64().ok_or_else(|| GhError {
+                message: "issue missing 'number'".into(),
+            })?;
+            let title = v["title"]
+                .as_str()
+                .ok_or_else(|| GhError {
+                    message: format!("issue #{number} missing 'title'"),
+                })?
+                .to_string();
+            let state = match v["state"].as_str() {
+                Some("OPEN") => IssueState::Open,
+                Some("CLOSED") => IssueState::Closed,
+                other => {
+                    return Err(GhError {
+                        message: format!("issue #{number} has unexpected state {other:?}"),
+                    });
+                }
+            };
+            let labels = v["labels"]
+                .as_array()
+                .map(|labels| {
+                    labels
+                        .iter()
+                        .filter_map(|l| l["name"].as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let url = v["url"]
+                .as_str()
+                .ok_or_else(|| GhError {
+                    message: format!("issue #{number} missing 'url'"),
+                })?
+                .to_string();
+            let created_at = v["createdAt"].as_str().unwrap_or("").to_string();
+            let updated_at = v["updatedAt"].as_str().unwrap_or("").to_string();
+            Ok(IssueSummary {
+                number,
+                title,
+                state,
+                labels,
+                url,
+                created_at,
+                updated_at,
+            })
+        })
+        .collect()
+}
+
 /// Detect owner/repo. Prefers `$GITHUB_REPOSITORY` (set in GitHub Actions),
 /// falling back to [`detect_repo`] for local invocations.
 pub fn detect_repo_or_env() -> Result<String, GhError> {
@@ -622,5 +768,57 @@ mod tests {
     fn parse_pr_for_issue_unknown_state_errors() {
         let body = r#"[{"number": 1, "state": "WAT", "url": "u"}]"#;
         assert!(parse_pr_for_issue(body).is_err());
+    }
+
+    #[test]
+    fn parse_issue_list_extracts_fields() {
+        let body = r#"[
+            {
+                "number": 244,
+                "title": "feat(shaka): add issue list",
+                "state": "OPEN",
+                "labels": [{"name": "shaka"}, {"name": "good first issue"}],
+                "url": "https://github.com/o/r/issues/244",
+                "createdAt": "2026-05-06T00:00:00Z",
+                "updatedAt": "2026-05-06T01:00:00Z"
+            },
+            {
+                "number": 209,
+                "title": "feat(shaka): add issue audit",
+                "state": "CLOSED",
+                "labels": [],
+                "url": "https://github.com/o/r/issues/209",
+                "createdAt": "2026-05-01T00:00:00Z",
+                "updatedAt": "2026-05-03T00:00:00Z"
+            }
+        ]"#;
+        let issues = parse_issue_list(body).unwrap();
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].number, 244);
+        assert_eq!(issues[0].state, IssueState::Open);
+        assert_eq!(issues[0].labels, vec!["shaka", "good first issue"]);
+        assert_eq!(issues[0].url, "https://github.com/o/r/issues/244");
+        assert_eq!(issues[1].state, IssueState::Closed);
+        assert_eq!(issues[1].labels, Vec::<String>::new());
+    }
+
+    #[test]
+    fn parse_issue_list_empty() {
+        assert!(parse_issue_list("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_issue_list_missing_field_errors() {
+        let body = r#"[{"number": 1, "state": "OPEN", "labels": [], "url": "u"}]"#;
+        assert!(parse_issue_list(body).is_err());
+    }
+
+    #[test]
+    fn parse_issue_list_unknown_state_errors() {
+        let body = r#"[{
+            "number": 1, "title": "t", "state": "WEIRD",
+            "labels": [], "url": "u", "createdAt": "", "updatedAt": ""
+        }]"#;
+        assert!(parse_issue_list(body).is_err());
     }
 }

--- a/tools/shaka/src/issue/list.rs
+++ b/tools/shaka/src/issue/list.rs
@@ -1,0 +1,246 @@
+use serde_json::{json, Value};
+
+use crate::gh::{self, IssueState, IssueSummary, ListState};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+
+pub fn run(
+    repo_arg: Option<String>,
+    state: ListState,
+    labels: Vec<String>,
+    milestone: Option<String>,
+    limit: u32,
+    json_out: bool,
+) {
+    let repo = match repo_arg {
+        Some(r) => r,
+        None => match gh::detect_repo() {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                eprintln!("Hint: pass --repo owner/repo explicitly");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    let issues = match gh::list_issues(&repo, state, &labels, milestone.as_deref(), limit) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if json_out {
+        let payload = build_payload(&repo, state, &labels, milestone.as_deref(), &issues);
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} serialize JSON: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        print!("{}", render_tree(&repo, state, &issues));
+    }
+}
+
+fn render_tree(repo: &str, state: ListState, issues: &[IssueSummary]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{BOLD}shaka issue list{RESET}\n"));
+    out.push_str(&format!(
+        "{DIM}├── repo: {repo}  state: {}  count: {}{RESET}\n",
+        state_arg_str(state),
+        issues.len()
+    ));
+
+    if issues.is_empty() {
+        out.push_str(&format!("{DIM}└── (no issues){RESET}\n"));
+        return out;
+    }
+
+    out.push_str(&format!("{DIM}│{RESET}\n"));
+    let n_width = issues
+        .iter()
+        .map(|i| digit_count(i.number))
+        .max()
+        .unwrap_or(1);
+    for issue in issues {
+        let state_color = match issue.state {
+            IssueState::Open => GREEN,
+            IssueState::Closed => YELLOW,
+        };
+        let labels_str = if issue.labels.is_empty() {
+            "(none)".to_string()
+        } else {
+            issue.labels.join(", ")
+        };
+        out.push_str(&format!(
+            "├── {BOLD}#{:<width$}{RESET}  {state_color}{}{RESET}  {}\n",
+            issue.number,
+            issue.state.as_str(),
+            issue.title,
+            width = n_width,
+        ));
+        out.push_str(&format!("{DIM}│   labels: {labels_str}{RESET}\n"));
+    }
+    out.push_str(&format!("{DIM}└── {} issue(s){RESET}\n", issues.len()));
+    out
+}
+
+fn build_payload(
+    repo: &str,
+    state: ListState,
+    labels: &[String],
+    milestone: Option<&str>,
+    issues: &[IssueSummary],
+) -> Value {
+    let issues_value: Vec<Value> = issues
+        .iter()
+        .map(|i| {
+            json!({
+                "number": i.number,
+                "title": i.title,
+                "state": i.state.as_str(),
+                "labels": i.labels,
+                "url": i.url,
+                "createdAt": i.created_at,
+                "updatedAt": i.updated_at,
+            })
+        })
+        .collect();
+    json!({
+        "repo": repo,
+        "filters": {
+            "state": state_arg_str(state),
+            "labels": labels,
+            "milestone": milestone,
+        },
+        "count": issues.len(),
+        "issues": issues_value,
+    })
+}
+
+fn state_arg_str(state: ListState) -> &'static str {
+    match state {
+        ListState::Open => "open",
+        ListState::Closed => "closed",
+        ListState::All => "all",
+    }
+}
+
+fn digit_count(n: u64) -> usize {
+    if n == 0 {
+        1
+    } else {
+        let mut c = 0;
+        let mut x = n;
+        while x > 0 {
+            c += 1;
+            x /= 10;
+        }
+        c
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::new();
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next();
+                for d in chars.by_ref() {
+                    if d.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    fn issue(number: u64, state: IssueState, labels: &[&str], title: &str) -> IssueSummary {
+        IssueSummary {
+            number,
+            title: title.to_string(),
+            state,
+            labels: labels.iter().map(|s| s.to_string()).collect(),
+            url: format!("https://github.com/o/r/issues/{number}"),
+            created_at: "2026-05-06T00:00:00Z".to_string(),
+            updated_at: "2026-05-06T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn renders_empty_list_with_summary_branch() {
+        let out = strip_ansi(&render_tree("o/r", ListState::Open, &[]));
+        assert!(out.contains("shaka issue list"));
+        assert!(out.contains("├── repo: o/r  state: open  count: 0"));
+        assert!(out.contains("└── (no issues)"));
+    }
+
+    #[test]
+    fn renders_issues_with_aligned_numbers_and_labels() {
+        let issues = vec![
+            issue(15, IssueState::Open, &["shaka"], "umbrella"),
+            issue(244, IssueState::Open, &["shaka"], "list slice"),
+            issue(209, IssueState::Closed, &[], "audit slice"),
+        ];
+        let out = strip_ansi(&render_tree("o/r", ListState::All, &issues));
+        assert!(out.contains("├── repo: o/r  state: all  count: 3"));
+        // numbers right-padded to width 3 (longest is "244")
+        assert!(out.contains("├── #15   OPEN  umbrella"));
+        assert!(out.contains("├── #244  OPEN  list slice"));
+        assert!(out.contains("├── #209  CLOSED  audit slice"));
+        assert!(out.contains("│   labels: shaka"));
+        assert!(out.contains("│   labels: (none)"));
+        assert!(out.contains("└── 3 issue(s)"));
+    }
+
+    #[test]
+    fn payload_shape_is_normalized() {
+        let issues = vec![issue(1, IssueState::Open, &["shaka"], "t")];
+        let payload = build_payload(
+            "o/r",
+            ListState::Open,
+            &["shaka".to_string()],
+            Some("v1"),
+            &issues,
+        );
+        assert_eq!(payload["repo"], "o/r");
+        assert_eq!(payload["filters"]["state"], "open");
+        assert_eq!(payload["filters"]["labels"], json!(["shaka"]));
+        assert_eq!(payload["filters"]["milestone"], "v1");
+        assert_eq!(payload["count"], 1);
+        assert_eq!(payload["issues"][0]["number"], 1);
+        assert_eq!(payload["issues"][0]["state"], "OPEN");
+        assert_eq!(payload["issues"][0]["labels"], json!(["shaka"]));
+        assert_eq!(
+            payload["issues"][0]["url"],
+            "https://github.com/o/r/issues/1"
+        );
+    }
+
+    #[test]
+    fn payload_milestone_null_when_absent() {
+        let payload = build_payload("o/r", ListState::Open, &[], None, &[]);
+        assert!(payload["filters"]["milestone"].is_null());
+        assert_eq!(payload["filters"]["labels"], json!([]));
+        assert_eq!(payload["count"], 0);
+    }
+
+    #[test]
+    fn digit_count_sanity() {
+        assert_eq!(digit_count(0), 1);
+        assert_eq!(digit_count(9), 1);
+        assert_eq!(digit_count(10), 2);
+        assert_eq!(digit_count(999), 3);
+        assert_eq!(digit_count(1000), 4);
+    }
+}

--- a/tools/shaka/src/issue/mod.rs
+++ b/tools/shaka/src/issue/mod.rs
@@ -1,7 +1,27 @@
 mod audit;
 mod brief;
+mod list;
 
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
+
+use crate::gh::ListState;
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum StateArg {
+    Open,
+    Closed,
+    All,
+}
+
+impl From<StateArg> for ListState {
+    fn from(s: StateArg) -> Self {
+        match s {
+            StateArg::Open => ListState::Open,
+            StateArg::Closed => ListState::Closed,
+            StateArg::All => ListState::All,
+        }
+    }
+}
 
 #[derive(Subcommand)]
 pub enum IssueCommand {
@@ -22,6 +42,27 @@ pub enum IssueCommand {
         #[arg(long)]
         json: bool,
     },
+    /// List issues with optional filters
+    List {
+        /// Repository in owner/repo format (auto-detected from git remote if omitted)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Filter by state
+        #[arg(long, value_enum, default_value_t = StateArg::Open)]
+        state: StateArg,
+        /// Filter by label (repeatable; AND semantics)
+        #[arg(long = "label")]
+        labels: Vec<String>,
+        /// Filter by milestone title
+        #[arg(long)]
+        milestone: Option<String>,
+        /// Maximum number of issues to return
+        #[arg(long, default_value_t = 30)]
+        limit: u32,
+        /// Emit normalized JSON instead of the human-readable tree
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub fn run(cmd: IssueCommand) {
@@ -32,5 +73,13 @@ pub fn run(cmd: IssueCommand) {
             no_fetch,
             json,
         } => brief::run(number, no_fetch, json),
+        IssueCommand::List {
+            repo,
+            state,
+            labels,
+            milestone,
+            limit,
+            json,
+        } => list::run(repo, state.into(), labels, milestone, limit, json),
     }
 }


### PR DESCRIPTION
Adds `shaka issue list` — filtered, formatted listing of GitHub issues,
mirroring the tree visual language of `shaka issue brief` /
`shaka issue audit`. First slice off the #15 umbrella after `audit`.

Flags: `--repo`, `--state {open|closed|all}` (default open),
`--label <l>` (repeatable, AND), `--milestone`, `--limit` (default
30), `--json`. The `--json` shape is normalized (our struct, stable)
rather than the raw `gh` payload, matching the precedent set by
`brief --json`.

A new `gh::list_issues` helper plus `IssueSummary` / `IssueState` /
`ListState` types underpin the command; `audit`'s existing
`list_open_issues` private helper is left untouched (different field
set, different defaults; no refactor warranted yet).

Closes #244