### PR TITLE
feat(shaka): per-project audit rule overrides via project.cue

### DIFF
--- a/tools/shaka/audit-config.cue
+++ b/tools/shaka/audit-config.cue
@@ -1,0 +1,12 @@
+package audit
+
+#AuditConfig & {
+	rules: [
+		{name: "readme-present", severity: "fail"},
+		{name: "gitignore-present", severity: "fail"},
+		{name: "rust-has-tests", severity: "fail"},
+		{name: "rust-coverage-threshold-nonzero", severity: "fail"},
+		{name: "rust-license-dual", severity: "fail"},
+		{name: "kolohelios-nix-via-flakehub", severity: "fail"},
+	]
+}

--- a/tools/shaka/schema/audit-config.cue
+++ b/tools/shaka/schema/audit-config.cue
@@ -1,0 +1,12 @@
+package audit
+
+#Severity: "fail" | "off"
+
+#Rule: {
+	name:     string & =~"^[a-z][a-z0-9-]*$"
+	severity: #Severity
+}
+
+#AuditConfig: {
+	rules: [...#Rule]
+}

--- a/tools/shaka/schema/project.cue
+++ b/tools/shaka/schema/project.cue
@@ -6,10 +6,19 @@ package project
 	purpose: string & !=""
 }
 
+#AuditOverride: {
+	rule:          string & =~"^[a-z][a-z0-9-]*$"
+	severity:      "fail" | "off"
+	justification: string & !=""
+}
+
 #Project: {
 	name: string & =~"^[a-z][a-z0-9-]*$"
 	objectStorage?: {
 		namespaces: [...#Namespace]
+	}
+	audit?: {
+		overrides: [...#AuditOverride]
 	}
 } & ({
 	kind: "rust"

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 
@@ -6,10 +7,31 @@ use serde::Deserialize;
 use crate::project::schema_check;
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
+const AUDIT_CONFIG_SCHEMA: &str = include_str!("../../schema/audit-config.cue");
+const AUDIT_CONFIG_DATA: &str = include_str!("../../audit-config.cue");
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuleResult {
     Pass,
     Fail(String),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum Severity {
+    Fail,
+    Off,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditConfigEntry {
+    name: String,
+    severity: Severity,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditConfig {
+    rules: Vec<AuditConfigEntry>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Copy)]
@@ -225,6 +247,21 @@ pub fn run() {
         }
     };
 
+    let rules = rules();
+
+    let severities = match load_audit_config() {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} could not load audit-config.cue: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if let Err(e) = validate_severities(&severities, &rules) {
+        eprintln!("{RED}{BOLD}error:{RESET} audit-config / rule registry mismatch:\n{e}");
+        std::process::exit(1);
+    }
+
     let projects = schema_check::discover(Path::new("."));
     if projects.is_empty() {
         println!("{YELLOW}no projects found{RESET}");
@@ -233,11 +270,10 @@ pub fn run() {
 
     println!("{BOLD}audit:{RESET} {} projects", projects.len());
 
-    let rules = rules();
     let mut failures = 0usize;
 
     for project in &projects {
-        audit_project(project, &schema_path, &rules, &mut failures);
+        audit_project(project, &schema_path, &rules, &severities, &mut failures);
     }
 
     println!();
@@ -252,6 +288,7 @@ fn audit_project(
     project: &Path,
     schema_path: &Path,
     rules: &[Box<dyn Rule>],
+    severities: &HashMap<String, Severity>,
     failures: &mut usize,
 ) {
     let display = project.display();
@@ -275,6 +312,9 @@ fn audit_project(
     let mut applied = 0usize;
     for rule in rules {
         if !rule.applies(&meta) {
+            continue;
+        }
+        if severities.get(rule.name()) == Some(&Severity::Off) {
             continue;
         }
         applied += 1;
@@ -317,6 +357,75 @@ fn load_meta(schema_path: &Path, project_cue: &Path) -> Result<ProjectMeta, Stri
     }
 
     serde_json::from_slice(&output.stdout).map_err(|e| format!("could not parse project.cue: {e}"))
+}
+
+fn load_audit_config() -> Result<HashMap<String, Severity>, String> {
+    let dir = std::env::temp_dir().join(format!("shaka-audit-config-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).map_err(|e| format!("could not create temp dir: {e}"))?;
+    let schema_path = dir.join("schema-audit-config.cue");
+    let data_path = dir.join("audit-config.cue");
+    std::fs::write(&schema_path, AUDIT_CONFIG_SCHEMA)
+        .map_err(|e| format!("could not write audit schema: {e}"))?;
+    std::fs::write(&data_path, AUDIT_CONFIG_DATA)
+        .map_err(|e| format!("could not write audit config: {e}"))?;
+
+    let output = Command::new("cue")
+        .arg("export")
+        .arg("--out")
+        .arg("json")
+        .arg(&schema_path)
+        .arg(&data_path)
+        .output()
+        .map_err(|e| format!("failed to spawn cue: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(format!("cue export failed: {detail}"));
+    }
+    let cfg: AuditConfig = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("could not parse audit-config: {e}"))?;
+
+    let mut map = HashMap::new();
+    for entry in cfg.rules {
+        if map.insert(entry.name.clone(), entry.severity).is_some() {
+            return Err(format!("duplicate audit rule name: {}", entry.name));
+        }
+    }
+    Ok(map)
+}
+
+fn validate_severities(
+    severities: &HashMap<String, Severity>,
+    rules: &[Box<dyn Rule>],
+) -> Result<(), String> {
+    let registry: HashSet<&str> = rules.iter().map(|r| r.name()).collect();
+    let mut errors = Vec::new();
+
+    let mut unknown: Vec<&String> = severities
+        .keys()
+        .filter(|k| !registry.contains(k.as_str()))
+        .collect();
+    unknown.sort();
+    for name in unknown {
+        errors.push(format!("  unknown rule in audit-config: {name}"));
+    }
+
+    let mut missing: Vec<&str> = rules
+        .iter()
+        .map(|r| r.name())
+        .filter(|n| !severities.contains_key(*n))
+        .collect();
+    missing.sort();
+    for name in missing {
+        errors.push(format!("  audit-config missing severity for rule: {name}"));
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("\n"))
+    }
 }
 
 fn has_rust_tests(project_dir: &Path) -> bool {
@@ -748,5 +857,45 @@ mod tests {
             RustLicenseDual.check(tmp.path(), &rust_meta()),
             RuleResult::Fail(_)
         ));
+    }
+
+    fn severities_all_fail() -> HashMap<String, Severity> {
+        rules()
+            .iter()
+            .map(|r| (r.name().to_string(), Severity::Fail))
+            .collect()
+    }
+
+    #[test]
+    fn embedded_audit_config_loads_and_matches_registry() {
+        let severities = load_audit_config().expect("audit-config.cue must load");
+        validate_severities(&severities, &rules())
+            .expect("embedded audit-config must cover every registered rule");
+    }
+
+    #[test]
+    fn validate_severities_errors_on_unknown_rule_name() {
+        let mut severities = severities_all_fail();
+        severities.insert("ghost-rule".into(), Severity::Fail);
+        match validate_severities(&severities, &rules()) {
+            Err(msg) => assert!(msg.contains("ghost-rule"), "got: {msg}"),
+            Ok(()) => panic!("expected Err for unknown rule"),
+        }
+    }
+
+    #[test]
+    fn validate_severities_errors_on_missing_rule() {
+        let mut severities = severities_all_fail();
+        severities.remove("readme-present");
+        match validate_severities(&severities, &rules()) {
+            Err(msg) => assert!(msg.contains("readme-present"), "got: {msg}"),
+            Ok(()) => panic!("expected Err for missing rule"),
+        }
+    }
+
+    #[test]
+    fn validate_severities_passes_when_every_rule_has_a_severity() {
+        validate_severities(&severities_all_fail(), &rules())
+            .expect("all-fail map must satisfy parity check");
     }
 }

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -54,12 +54,28 @@ pub struct Coverage {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct AuditOverride {
+    pub rule: String,
+    pub severity: Severity,
+    #[allow(dead_code)]
+    pub justification: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProjectAuditConfig {
+    #[serde(default)]
+    pub overrides: Vec<AuditOverride>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ProjectMeta {
     #[allow(dead_code)]
     pub name: String,
     pub kind: ProjectKind,
     #[serde(default)]
     pub coverage: Option<Coverage>,
+    #[serde(default)]
+    pub audit: Option<ProjectAuditConfig>,
 }
 
 pub trait Rule {
@@ -308,13 +324,31 @@ fn audit_project(
         }
     };
 
+    let overrides: &[AuditOverride] = meta
+        .audit
+        .as_ref()
+        .map(|a| a.overrides.as_slice())
+        .unwrap_or(&[]);
+
+    let effective = match effective_severities(severities, overrides, rules) {
+        Ok(map) => map,
+        Err(unknown) => {
+            println!(
+                "  {RED}{BOLD}FAIL{RESET}  {display} ({DIM}unknown rule(s) in audit.overrides: {}{RESET})",
+                unknown.join(", ")
+            );
+            *failures += unknown.len();
+            return;
+        }
+    };
+
     let mut project_failures: Vec<(String, String)> = Vec::new();
     let mut applied = 0usize;
     for rule in rules {
         if !rule.applies(&meta) {
             continue;
         }
-        if severities.get(rule.name()) == Some(&Severity::Off) {
+        if effective.get(rule.name()) == Some(&Severity::Off) {
             continue;
         }
         applied += 1;
@@ -393,6 +427,29 @@ fn load_audit_config() -> Result<HashMap<String, Severity>, String> {
         }
     }
     Ok(map)
+}
+
+fn effective_severities(
+    base: &HashMap<String, Severity>,
+    overrides: &[AuditOverride],
+    rules: &[Box<dyn Rule>],
+) -> Result<HashMap<String, Severity>, Vec<String>> {
+    let registry: HashSet<&str> = rules.iter().map(|r| r.name()).collect();
+    let mut unknown: Vec<String> = overrides
+        .iter()
+        .filter(|ov| !registry.contains(ov.rule.as_str()))
+        .map(|ov| ov.rule.clone())
+        .collect();
+    unknown.sort();
+    unknown.dedup();
+    if !unknown.is_empty() {
+        return Err(unknown);
+    }
+    let mut effective = base.clone();
+    for ov in overrides {
+        effective.insert(ov.rule.clone(), ov.severity);
+    }
+    Ok(effective)
 }
 
 fn validate_severities(
@@ -497,6 +554,7 @@ mod tests {
                 line: CoverageThreshold { fail: 30 },
                 branch: CoverageThreshold { fail: 20 },
             }),
+            audit: None,
         }
     }
 
@@ -505,6 +563,7 @@ mod tests {
             name: "demo".into(),
             kind: ProjectKind::Infra,
             coverage: None,
+            audit: None,
         }
     }
 
@@ -897,5 +956,60 @@ mod tests {
     fn validate_severities_passes_when_every_rule_has_a_severity() {
         validate_severities(&severities_all_fail(), &rules())
             .expect("all-fail map must satisfy parity check");
+    }
+
+    fn ov(rule: &str, severity: Severity) -> AuditOverride {
+        AuditOverride {
+            rule: rule.into(),
+            severity,
+            justification: "test".into(),
+        }
+    }
+
+    #[test]
+    fn effective_severities_no_overrides_returns_base() {
+        let base = severities_all_fail();
+        let got = effective_severities(&base, &[], &rules()).expect("clean parity");
+        assert_eq!(got, base);
+    }
+
+    #[test]
+    fn effective_severities_override_disables_rule() {
+        let base = severities_all_fail();
+        let overrides = [ov("rust-has-tests", Severity::Off)];
+        let got = effective_severities(&base, &overrides, &rules()).expect("clean parity");
+        assert_eq!(got["rust-has-tests"], Severity::Off);
+        assert_eq!(got["readme-present"], Severity::Fail);
+    }
+
+    #[test]
+    fn effective_severities_override_can_raise_off_to_fail() {
+        let mut base = severities_all_fail();
+        base.insert("rust-has-tests".into(), Severity::Off);
+        let overrides = [ov("rust-has-tests", Severity::Fail)];
+        let got = effective_severities(&base, &overrides, &rules()).expect("clean parity");
+        assert_eq!(got["rust-has-tests"], Severity::Fail);
+    }
+
+    #[test]
+    fn effective_severities_unknown_override_rule_errors() {
+        let base = severities_all_fail();
+        let overrides = [ov("not-a-real-rule", Severity::Off)];
+        match effective_severities(&base, &overrides, &rules()) {
+            Err(unknown) => {
+                assert_eq!(unknown, vec!["not-a-real-rule"]);
+            }
+            Ok(_) => panic!("expected Err"),
+        }
+    }
+
+    #[test]
+    fn effective_severities_dedups_unknown_names() {
+        let base = severities_all_fail();
+        let overrides = [ov("ghost-a", Severity::Off), ov("ghost-a", Severity::Fail)];
+        match effective_severities(&base, &overrides, &rules()) {
+            Err(unknown) => assert_eq!(unknown, vec!["ghost-a"]),
+            Ok(_) => panic!("expected Err"),
+        }
     }
 }

--- a/tools/shaka/tests/fixtures/schema/invalid/audit-override-bad-severity.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/audit-override-bad-severity.cue
@@ -1,0 +1,15 @@
+package project
+
+#Project & {
+	name: "shaka"
+	kind: "infra"
+	audit: {
+		overrides: [
+			{
+				rule:          "readme-present"
+				severity:      "warn"
+				justification: "wanted to soft-warn"
+			},
+		]
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/audit-override-empty-justification.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/audit-override-empty-justification.cue
@@ -1,0 +1,15 @@
+package project
+
+#Project & {
+	name: "shaka"
+	kind: "infra"
+	audit: {
+		overrides: [
+			{
+				rule:          "readme-present"
+				severity:      "off"
+				justification: ""
+			},
+		]
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-with-audit-overrides.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-with-audit-overrides.cue
@@ -1,0 +1,23 @@
+package project
+
+#Project & {
+	name: "shaka"
+	kind: "rust"
+	coverage: {
+		line: {
+			fail: 30
+		}
+		branch: {
+			fail: 50
+		}
+	}
+	audit: {
+		overrides: [
+			{
+				rule:          "rust-has-tests"
+				severity:      "off"
+				justification: "scaffolding-only crate; no behavior to cover yet"
+			},
+		]
+	}
+}


### PR DESCRIPTION
Projects can now opt out of (or back into) specific audit rules with a
required justification. The schema gains an optional audit.overrides
list, and audit::run threads each project's overrides on top of the
global severity map before walking the rule registry.

Schema (tools/shaka/schema/project.cue):
  audit?: overrides: [...{
    rule:          string & =~"^[a-z][a-z0-9-]*$"
    severity:      "fail" | "off"
    justification: string & !=""
  }]

Empty justification and any non-{fail,off} severity are rejected by the
schema (covered by new fixtures under tests/fixtures/schema/). Unknown
rule names in audit.overrides fail the project's audit at runtime.

Closes #151