### PR TITLE
feat(kolohelios-nix): add cargo-machete to workflowPackages

### DIFF
--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -48,6 +48,7 @@
           nil
           typos
           cargo-deny
+          cargo-machete
         ];
     in
     {


### PR DESCRIPTION
Adds the unused-dependency detector to the shared workflow package list so every consumer flake gets it on PATH after their next kolohelios-nix bump. Wires up the dependency for #48; the consumer-side recipe and lock bumps land in a follow-up PR.