### PR TITLE
feat(shaka): wire cargo-machete into rust validate

### DIFF
--- a/apps/blogctl/flake.lock
+++ b/apps/blogctl/flake.lock
@@ -5,12 +5,12 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1777666070,
-        "narHash": "sha256-5QIY7TKHxoeTC3Mf3JQzf5dJf21HSL1cB/TCAkJpE7E=",
-        "rev": "a7e8ca49868f3fe0ccfb5e25b673d6a0c92ad629",
-        "revCount": 83,
+        "lastModified": 1778197493,
+        "narHash": "sha256-dZGWPXTCuqGVE9e6bH4SenUawKkNicKWt8DKL+LBirQ=",
+        "rev": "4f7be5457efa50301ff364c3dcda66dc1316fac4",
+        "revCount": 142,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.83%2Brev-a7e8ca49868f3fe0ccfb5e25b673d6a0c92ad629/019de53e-10b2-79f1-9d9b-04d05269b0e7/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.142%2Brev-4f7be5457efa50301ff364c3dcda66dc1316fac4/019e04d8-0ab0-7b80-b9d3-f4f8c1a74793/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/apps/blogctl/justfile
+++ b/apps/blogctl/justfile
@@ -19,6 +19,11 @@ lint:
 deny:
     cargo deny check
 
+# Macro-only deps can register as false positives — allowlist via
+# `package.metadata.cargo-machete.ignored` in the offending Cargo.toml.
+machete:
+    cargo machete
+
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -42,4 +47,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/flake.lock
+++ b/tools/shaka/flake.lock
@@ -5,12 +5,12 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1777661405,
-        "narHash": "sha256-5QIY7TKHxoeTC3Mf3JQzf5dJf21HSL1cB/TCAkJpE7E=",
-        "rev": "8a3b87d2ca4e7dcc2613b8bca0d277e4548163c7",
-        "revCount": 81,
+        "lastModified": 1778197493,
+        "narHash": "sha256-dZGWPXTCuqGVE9e6bH4SenUawKkNicKWt8DKL+LBirQ=",
+        "rev": "4f7be5457efa50301ff364c3dcda66dc1316fac4",
+        "revCount": 142,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.81%2Brev-8a3b87d2ca4e7dcc2613b8bca0d277e4548163c7/019de4e5-203d-7c71-9f66-a364395ff182/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.142%2Brev-4f7be5457efa50301ff364c3dcda66dc1316fac4/019e04d8-0ab0-7b80-b9d3-f4f8c1a74793/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/tools/shaka/justfile
+++ b/tools/shaka/justfile
@@ -19,6 +19,11 @@ lint:
 deny:
     cargo deny check
 
+# Macro-only deps can register as false positives — allowlist via
+# `package.metadata.cargo-machete.ignored` in the offending Cargo.toml.
+machete:
+    cargo machete
+
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -42,4 +47,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -29,6 +29,11 @@ lint:
 deny:
     cargo deny check
 
+# Macro-only deps can register as false positives — allowlist via
+# `package.metadata.cargo-machete.ignored` in the offending Cargo.toml.
+machete:
+    cargo machete
+
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -52,7 +57,7 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check
 "#;
 
 const NIX_LIB_TEMPLATE: &str = r#"nix-fmt-check:
@@ -330,7 +335,7 @@ mod tests {
         assert!(RUST_TEMPLATE.contains("fmt-check"));
         assert!(RUST_TEMPLATE.contains("clippy"));
         assert!(RUST_TEMPLATE.contains(
-            "validate: fmt-check lint deny test coverage nix-fmt-check flake-check whitespace-check"
+            "validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check"
         ));
     }
 
@@ -338,6 +343,13 @@ mod tests {
     fn rust_template_includes_deny_recipe() {
         assert!(RUST_TEMPLATE.contains("deny:"));
         assert!(RUST_TEMPLATE.contains("cargo deny check"));
+    }
+
+    #[test]
+    fn rust_template_includes_machete_recipe() {
+        assert!(RUST_TEMPLATE.contains("machete:"));
+        assert!(RUST_TEMPLATE.contains("cargo machete"));
+        assert!(RUST_TEMPLATE.contains("package.metadata.cargo-machete.ignored"));
     }
 
     #[test]


### PR DESCRIPTION
Adds a `machete` recipe to the rust justfile template and chains it
into `validate`. Bumps `kolohelios-nix` in the consumer flake.locks
(`tools/shaka`, `apps/blogctl`) to pull in the rolling release that
adds `cargo-machete` to `workflowPackages`. Macro-only false positives
allowlist via `package.metadata.cargo-machete.ignored`.

Closes #48