### PR TITLE
docs(shaka): document snafu convention for new error types

### DIFF
--- a/tools/shaka/Cargo.lock
+++ b/tools/shaka/Cargo.lock
@@ -353,7 +353,29 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "snafu",
  "tempfile",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/tools/shaka/Cargo.toml
+++ b/tools/shaka/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+snafu = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tools/shaka/README.md
+++ b/tools/shaka/README.md
@@ -44,3 +44,50 @@ nix develop . --command just validate
 ```
 
 runs the same fmt/clippy/test/coverage/flake checks CI runs for this project.
+
+## Error handling
+
+Shaka uses [`snafu`](https://docs.rs/snafu) for all per-module error
+types. New subcommands and modules should follow the same pattern rather
+than rolling a hand-written struct + `Display` + `From<io::Error>` impls
+(the form every existing error used before #252).
+
+A new error type looks like:
+
+```rust
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum MyError {
+    #[snafu(display("failed to run foo: {source}"))]
+    Spawn { source: std::io::Error },
+
+    #[snafu(display("foo {command}: {stderr}"))]
+    FooCommand { command: String, stderr: String },
+
+    #[snafu(display("failed to parse JSON from {context}: {source}"))]
+    JsonParse {
+        context: String,
+        source: serde_json::Error,
+    },
+}
+```
+
+Conventions:
+
+- One variant per *user-distinguishable* failure mode, not per call site.
+  Two call sites that produce identical user messages collapse into one
+  variant.
+- Wrap underlying errors with `source: SomeError` rather than baking them
+  into a `format!` string. `std::error::Error::source()` then walks the
+  cause chain — see
+  `object_store::registry::tests::parse_project_error_exposes_serde_source`
+  for the canonical test.
+- Use `.context(SomeSnafu { ... })` for eager arguments,
+  `.with_context(|_| SomeSnafu { ... })` when the context selector
+  contains a `format!` call (so the allocation only happens on the error
+  path).
+- Mark the enum `#[snafu(visibility(pub(crate)))]` so cross-module callers
+  can construct the context selectors when they shell out via the same
+  helper but need to fail with the wrapped error type.

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -1,38 +1,44 @@
-use std::fmt;
 use std::process::Command;
 
 use serde_json::Value;
+use snafu::{OptionExt, ResultExt, Snafu};
 
-#[derive(Debug)]
-pub struct GhError {
-    pub message: String,
-}
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum GhError {
+    #[snafu(display("failed to run command: {source}"))]
+    Spawn { source: std::io::Error },
 
-impl fmt::Display for GhError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
+    #[snafu(display("{command}: {stderr}"))]
+    GhCommand { command: String, stderr: String },
 
-impl From<std::io::Error> for GhError {
-    fn from(e: std::io::Error) -> Self {
-        GhError {
-            message: format!("failed to run command: {e}"),
-        }
-    }
+    #[snafu(display("{context}: {source}"))]
+    JsonParse {
+        context: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("failed to serialize JSON: {source}"))]
+    JsonSerialize { source: serde_json::Error },
+
+    #[snafu(display("{message}"))]
+    Schema { message: String },
 }
 
 /// Run `gh api <endpoint>` and return parsed JSON.
 pub fn api_get(endpoint: &str) -> Result<Value, GhError> {
     let output = Command::new("gh")
         .args(["api", endpoint, "-H", "Accept: application/vnd.github+json"])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh api {endpoint}: {stderr}"),
-        });
+        return GhCommandSnafu {
+            command: format!("gh api {endpoint}"),
+            stderr: stderr.to_string(),
+        }
+        .fail();
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
@@ -40,8 +46,8 @@ pub fn api_get(endpoint: &str) -> Result<Value, GhError> {
         return Ok(Value::Null);
     }
 
-    serde_json::from_str(&body).map_err(|e| GhError {
-        message: format!("failed to parse JSON from gh api {endpoint}: {e}"),
+    serde_json::from_str(&body).context(JsonParseSnafu {
+        context: format!("failed to parse JSON from gh api {endpoint}"),
     })
 }
 
@@ -56,7 +62,8 @@ pub fn api_get_status(endpoint: &str) -> Result<i32, GhError> {
             "Accept: application/vnd.github+json",
             "--include",
         ])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     // First line is the HTTP status line, e.g. "HTTP/2.0 204 No Content"
@@ -69,9 +76,10 @@ pub fn api_get_status(endpoint: &str) -> Result<i32, GhError> {
         }
     }
 
-    Err(GhError {
+    SchemaSnafu {
         message: format!("could not parse status from gh api {endpoint}"),
-    })
+    }
+    .fail()
 }
 
 /// Run `gh api -X PATCH <endpoint>` with a JSON body on stdin.
@@ -90,9 +98,7 @@ pub fn api_put(endpoint: &str, body: &Value) -> Result<Value, GhError> {
 }
 
 fn api_write(method: &str, endpoint: &str, body: &Value) -> Result<Value, GhError> {
-    let body_str = serde_json::to_string(body).map_err(|e| GhError {
-        message: format!("failed to serialize JSON: {e}"),
-    })?;
+    let body_str = serde_json::to_string(body).context(JsonSerializeSnafu)?;
 
     let output = Command::new("gh")
         .args([
@@ -115,13 +121,16 @@ fn api_write(method: &str, endpoint: &str, body: &Value) -> Result<Value, GhErro
                 stdin.write_all(body_str.as_bytes())?;
             }
             child.wait_with_output()
-        })?;
+        })
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh api -X {method} {endpoint}: {stderr}"),
-        });
+        return GhCommandSnafu {
+            command: format!("gh api -X {method} {endpoint}"),
+            stderr: stderr.to_string(),
+        }
+        .fail();
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -129,8 +138,8 @@ fn api_write(method: &str, endpoint: &str, body: &Value) -> Result<Value, GhErro
         return Ok(Value::Null);
     }
 
-    serde_json::from_str(&stdout).map_err(|e| GhError {
-        message: format!("failed to parse JSON: {e}"),
+    serde_json::from_str(&stdout).context(JsonParseSnafu {
+        context: "failed to parse JSON".to_string(),
     })
 }
 
@@ -159,12 +168,12 @@ pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
     let Some(first) = result.as_array().and_then(|arr| arr.first()) else {
         return Ok(None);
     };
-    let number = first["number"].as_u64().ok_or_else(|| GhError {
+    let number = first["number"].as_u64().with_context(|| SchemaSnafu {
         message: format!("PR for head {head} missing 'number' field"),
     })?;
     let url = first["html_url"]
         .as_str()
-        .ok_or_else(|| GhError {
+        .with_context(|| SchemaSnafu {
             message: format!("PR for head {head} missing 'html_url' field"),
         })?
         .to_string();
@@ -202,21 +211,24 @@ pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
             "--json",
             "state,closedByPullRequestsReferences",
         ])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh issue view {n}: {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: format!("gh issue view {n}"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
     if body.trim().is_empty() {
         return Ok(None);
     }
-    let parsed: Value = serde_json::from_str(&body).map_err(|e| GhError {
-        message: format!("failed to parse JSON from gh issue view {n}: {e}"),
+    let parsed: Value = serde_json::from_str(&body).context(JsonParseSnafu {
+        context: format!("failed to parse JSON from gh issue view {n}"),
     })?;
 
     if parsed["state"].as_str() != Some("CLOSED") {
@@ -230,12 +242,12 @@ pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
         return Ok(None);
     };
 
-    let number = first["number"].as_u64().ok_or_else(|| GhError {
+    let number = first["number"].as_u64().with_context(|| SchemaSnafu {
         message: format!("closing PR for issue #{n} missing 'number' field"),
     })?;
     let url = first["url"]
         .as_str()
-        .ok_or_else(|| GhError {
+        .with_context(|| SchemaSnafu {
             message: format!("closing PR for issue #{n} missing 'url' field"),
         })?
         .to_string();
@@ -270,13 +282,16 @@ pub fn pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError> {
             "--json",
             "number,state,url",
         ])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh pr list (search Closes #{n}): {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: format!("gh pr list (search Closes #{n})"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
@@ -284,18 +299,18 @@ pub fn pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError> {
 }
 
 pub(crate) fn parse_pr_for_issue(body: &str) -> Result<Option<PrInfo>, GhError> {
-    let value: Value = serde_json::from_str(body).map_err(|e| GhError {
-        message: format!("failed to parse gh pr list JSON: {e}"),
+    let value: Value = serde_json::from_str(body).context(JsonParseSnafu {
+        context: "failed to parse gh pr list JSON".to_string(),
     })?;
     let Some(first) = value.as_array().and_then(|a| a.first()) else {
         return Ok(None);
     };
-    let number = first["number"].as_u64().ok_or_else(|| GhError {
-        message: "PR missing 'number' field".into(),
+    let number = first["number"].as_u64().context(SchemaSnafu {
+        message: "PR missing 'number' field",
     })?;
     let url = first["url"]
         .as_str()
-        .ok_or_else(|| GhError {
+        .with_context(|| SchemaSnafu {
             message: format!("PR #{number} missing 'url' field"),
         })?
         .to_string();
@@ -306,9 +321,10 @@ pub(crate) fn parse_pr_for_issue(body: &str) -> Result<Option<PrInfo>, GhError> 
         Some("MERGED") => PrState::Merged,
         Some("CLOSED") => PrState::Closed,
         other => {
-            return Err(GhError {
+            return SchemaSnafu {
                 message: format!("PR #{number} has unexpected state {other:?}"),
-            });
+            }
+            .fail();
         }
     };
     Ok(Some(PrInfo { number, url, state }))
@@ -323,12 +339,15 @@ pub fn pr_create(repo: &str, title: &str, body: &str, head: &str) -> Result<Stri
         .args([
             "pr", "create", "--repo", repo, "--title", title, "--body", body, "--head", head,
         ])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh pr create: {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: "gh pr create".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
     let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
     Ok(url)
@@ -349,13 +368,16 @@ pub fn issue_title(n: u64) -> Result<String, GhError> {
             "--jq",
             ".title",
         ])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh issue view {n}: {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: format!("gh issue view {n}"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -387,13 +409,16 @@ pub fn list_open_prs_against(base: &str) -> Result<Vec<OpenPr>, GhError> {
             "--json",
             "number,headRefName,headRefOid,url,labels",
         ])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh pr list: {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: "gh pr list".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
@@ -401,33 +426,33 @@ pub fn list_open_prs_against(base: &str) -> Result<Vec<OpenPr>, GhError> {
 }
 
 pub(crate) fn parse_open_prs(body: &str) -> Result<Vec<OpenPr>, GhError> {
-    let value: Value = serde_json::from_str(body).map_err(|e| GhError {
-        message: format!("failed to parse gh pr list JSON: {e}"),
+    let value: Value = serde_json::from_str(body).context(JsonParseSnafu {
+        context: "failed to parse gh pr list JSON".to_string(),
     })?;
-    let arr = value.as_array().ok_or_else(|| GhError {
-        message: "gh pr list did not return an array".into(),
+    let arr = value.as_array().context(SchemaSnafu {
+        message: "gh pr list did not return an array",
     })?;
 
     arr.iter()
         .map(|v| {
-            let number = v["number"].as_u64().ok_or_else(|| GhError {
-                message: "PR missing 'number'".into(),
+            let number = v["number"].as_u64().context(SchemaSnafu {
+                message: "PR missing 'number'",
             })?;
             let head_ref = v["headRefName"]
                 .as_str()
-                .ok_or_else(|| GhError {
+                .with_context(|| SchemaSnafu {
                     message: format!("PR #{number} missing 'headRefName'"),
                 })?
                 .to_string();
             let head_sha = v["headRefOid"]
                 .as_str()
-                .ok_or_else(|| GhError {
+                .with_context(|| SchemaSnafu {
                     message: format!("PR #{number} missing 'headRefOid'"),
                 })?
                 .to_string();
             let url = v["url"]
                 .as_str()
-                .ok_or_else(|| GhError {
+                .with_context(|| SchemaSnafu {
                     message: format!("PR #{number} missing 'url'"),
                 })?
                 .to_string();
@@ -527,12 +552,17 @@ pub fn list_issues(
         args.push(m.to_string());
     }
 
-    let output = Command::new("gh").args(&args).output()?;
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .context(SpawnSnafu)?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("gh issue list: {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: "gh issue list".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
@@ -540,21 +570,21 @@ pub fn list_issues(
 }
 
 pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError> {
-    let value: Value = serde_json::from_str(body).map_err(|e| GhError {
-        message: format!("failed to parse gh issue list JSON: {e}"),
+    let value: Value = serde_json::from_str(body).context(JsonParseSnafu {
+        context: "failed to parse gh issue list JSON".to_string(),
     })?;
-    let arr = value.as_array().ok_or_else(|| GhError {
-        message: "gh issue list did not return an array".into(),
+    let arr = value.as_array().context(SchemaSnafu {
+        message: "gh issue list did not return an array",
     })?;
 
     arr.iter()
         .map(|v| {
-            let number = v["number"].as_u64().ok_or_else(|| GhError {
-                message: "issue missing 'number'".into(),
+            let number = v["number"].as_u64().context(SchemaSnafu {
+                message: "issue missing 'number'",
             })?;
             let title = v["title"]
                 .as_str()
-                .ok_or_else(|| GhError {
+                .with_context(|| SchemaSnafu {
                     message: format!("issue #{number} missing 'title'"),
                 })?
                 .to_string();
@@ -562,9 +592,10 @@ pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError>
                 Some("OPEN") => IssueState::Open,
                 Some("CLOSED") => IssueState::Closed,
                 other => {
-                    return Err(GhError {
+                    return SchemaSnafu {
                         message: format!("issue #{number} has unexpected state {other:?}"),
-                    });
+                    }
+                    .fail();
                 }
             };
             let labels = v["labels"]
@@ -578,7 +609,7 @@ pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError>
                 .unwrap_or_default();
             let url = v["url"]
                 .as_str()
-                .ok_or_else(|| GhError {
+                .with_context(|| SchemaSnafu {
                     message: format!("issue #{number} missing 'url'"),
                 })?
                 .to_string();
@@ -616,13 +647,16 @@ pub fn detect_repo_or_env() -> Result<String, GhError> {
 pub fn detect_repo() -> Result<String, GhError> {
     let output = Command::new("jj")
         .args(["git", "remote", "list"])
-        .output()?;
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(GhError {
-            message: format!("jj git remote list: {}", stderr.trim()),
-        });
+        return GhCommandSnafu {
+            command: "jj git remote list".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -639,11 +673,11 @@ pub fn detect_repo() -> Result<String, GhError> {
                 None
             }
         })
-        .ok_or_else(|| GhError {
-            message: "no jj git remote named 'origin' found".into(),
+        .context(SchemaSnafu {
+            message: "no jj git remote named 'origin' found",
         })?;
 
-    parse_repo_from_url(&url).ok_or_else(|| GhError {
+    parse_repo_from_url(&url).with_context(|| SchemaSnafu {
         message: format!("could not parse owner/repo from remote URL: {url}"),
     })
 }

--- a/tools/shaka/src/issue/audit.rs
+++ b/tools/shaka/src/issue/audit.rs
@@ -78,6 +78,8 @@ pub fn run(repo_arg: Option<String>) {
 // `gh issue list` rather than the REST API directly, since the REST API
 // mixes PRs into the issues endpoint while the gh CLI filters them out.
 fn list_open_issues(repo: &str) -> Result<Vec<Value>, gh::GhError> {
+    use snafu::ResultExt;
+
     let output = Command::new("gh")
         .args([
             "issue",
@@ -91,18 +93,21 @@ fn list_open_issues(repo: &str) -> Result<Vec<Value>, gh::GhError> {
             "--json",
             "number,title,labels",
         ])
-        .output()?;
+        .output()
+        .context(gh::SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(gh::GhError {
-            message: format!("gh issue list: {}", stderr.trim()),
-        });
+        return gh::GhCommandSnafu {
+            command: "gh issue list".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
-    let parsed: Value = serde_json::from_str(&body).map_err(|e| gh::GhError {
-        message: format!("failed to parse JSON from gh issue list: {e}"),
+    let parsed: Value = serde_json::from_str(&body).context(gh::JsonParseSnafu {
+        context: "failed to parse JSON from gh issue list".to_string(),
     })?;
 
     Ok(parsed.as_array().cloned().unwrap_or_default())

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -1,45 +1,70 @@
-use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[derive(Debug)]
-pub struct JjError {
-    pub message: String,
-}
+use snafu::{OptionExt, ResultExt, Snafu};
 
-impl fmt::Display for JjError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
+#[derive(Debug, Snafu)]
+pub enum JjError {
+    #[snafu(display("failed to run jj: {source}"))]
+    Spawn { source: std::io::Error },
 
-impl From<std::io::Error> for JjError {
-    fn from(e: std::io::Error) -> Self {
-        JjError {
-            message: format!("failed to run jj: {e}"),
-        }
-    }
+    #[snafu(display("jj {command}: {stderr}"))]
+    JjCommand { command: String, stderr: String },
+
+    #[snafu(display("jj {command} exited with status {status}"))]
+    StreamingExit {
+        command: String,
+        status: std::process::ExitStatus,
+    },
+
+    #[snafu(display("revset {revset:?} matched no revisions"))]
+    RevsetEmpty { revset: String },
+
+    #[snafu(display("revset {revset:?} matched multiple revisions"))]
+    RevsetMultiple { revset: String },
+
+    #[snafu(display("stat {path}: {source}"))]
+    Stat {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("read {path}: {source}"))]
+    Read {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("could not derive primary workspace root from .jj/repo target {target}"))]
+    PrimaryRootDerive { target: String },
+
+    #[snafu(display("workspace path is not valid UTF-8: {path}"))]
+    WorkspacePathInvalidUtf8 { path: String },
 }
 
 /// Run `jj` with the given args, returning stdout on success.
 pub fn run(args: &[&str]) -> Result<String, JjError> {
-    let output = Command::new("jj").args(args).output()?;
+    let output = Command::new("jj").args(args).output().context(SpawnSnafu)?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(JjError {
-            message: format!("jj {}: {}", args.join(" "), stderr.trim()),
-        });
+        return JjCommandSnafu {
+            command: args.join(" "),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Run `jj` and stream stdout/stderr to the parent's stdio.
 pub fn run_streaming(args: &[&str]) -> Result<(), JjError> {
-    let status = Command::new("jj").args(args).status()?;
+    let status = Command::new("jj").args(args).status().context(SpawnSnafu)?;
     if !status.success() {
-        return Err(JjError {
-            message: format!("jj {} exited with status {status}", args.join(" ")),
-        });
+        return StreamingExitSnafu {
+            command: args.join(" "),
+            status,
+        }
+        .fail();
     }
     Ok(())
 }
@@ -69,13 +94,9 @@ pub fn commit_id_of(revset: &str) -> Result<String, JjError> {
         "--no-graph",
     ])?;
     let mut ids = out.lines().map(str::trim).filter(|l| !l.is_empty());
-    let first = ids.next().ok_or_else(|| JjError {
-        message: format!("revset {revset:?} matched no revisions"),
-    })?;
+    let first = ids.next().context(RevsetEmptySnafu { revset })?;
     if ids.next().is_some() {
-        return Err(JjError {
-            message: format!("revset {revset:?} matched multiple revisions"),
-        });
+        return RevsetMultipleSnafu { revset }.fail();
     }
     Ok(first.to_string())
 }
@@ -313,20 +334,17 @@ pub fn repo_root() -> Result<PathBuf, JjError> {
 pub fn primary_workspace_root() -> Result<PathBuf, JjError> {
     let cur = repo_root()?;
     let repo_marker = cur.join(".jj").join("repo");
-    let metadata = std::fs::metadata(&repo_marker).map_err(|e| JjError {
-        message: format!("stat {}: {e}", repo_marker.display()),
+    let metadata = std::fs::metadata(&repo_marker).context(StatSnafu {
+        path: repo_marker.display().to_string(),
     })?;
     if metadata.is_dir() {
         return Ok(cur);
     }
-    let content = std::fs::read_to_string(&repo_marker).map_err(|e| JjError {
-        message: format!("read {}: {e}", repo_marker.display()),
+    let content = std::fs::read_to_string(&repo_marker).context(ReadSnafu {
+        path: repo_marker.display().to_string(),
     })?;
-    primary_root_from_repo_marker(content.trim()).ok_or_else(|| JjError {
-        message: format!(
-            "could not derive primary workspace root from .jj/repo target {}",
-            content.trim()
-        ),
+    primary_root_from_repo_marker(content.trim()).context(PrimaryRootDeriveSnafu {
+        target: content.trim().to_string(),
     })
 }
 
@@ -384,8 +402,8 @@ pub fn workspace_add(name: &str, path: &Path) -> Result<(), JjError> {
         "add",
         "--name",
         name,
-        path.to_str().ok_or_else(|| JjError {
-            message: format!("workspace path is not valid UTF-8: {}", path.display()),
+        path.to_str().context(WorkspacePathInvalidUtf8Snafu {
+            path: path.display().to_string(),
         })?,
     ])
 }

--- a/tools/shaka/src/object_store/client.rs
+++ b/tools/shaka/src/object_store/client.rs
@@ -5,37 +5,48 @@
 //! `LINODE_TOKEN`. Following shaka's existing pattern (`gh.rs`, `jj.rs`)
 //! we shell out to `curl` rather than pull in `reqwest` and its TLS deps.
 
-use std::fmt;
 use std::process::Command;
 
 use serde_json::{json, Value};
+use snafu::{OptionExt, ResultExt, Snafu};
 
 const API_BASE: &str = "https://api.linode.com/v4";
 
-#[derive(Debug)]
-pub struct LinodeError {
-    pub message: String,
-}
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum LinodeError {
+    #[snafu(display("failed to run curl: {source}"))]
+    Spawn { source: std::io::Error },
 
-impl fmt::Display for LinodeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
+    #[snafu(display("LINODE_TOKEN is not set in the environment"))]
+    TokenMissing,
 
-impl From<std::io::Error> for LinodeError {
-    fn from(e: std::io::Error) -> Self {
-        LinodeError {
-            message: format!("failed to run curl: {e}"),
-        }
-    }
+    #[snafu(display("curl {method} {endpoint}: {stderr}"))]
+    CurlCommand {
+        method: String,
+        endpoint: String,
+        stderr: String,
+    },
+
+    #[snafu(display("could not parse HTTP status from curl output: {output:?}"))]
+    StatusParse { output: String },
+
+    #[snafu(display("failed to parse JSON from {method} {endpoint}: {source}"))]
+    JsonParse {
+        method: String,
+        endpoint: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("{message}"))]
+    Schema { message: String },
 }
 
 /// Read the Linode personal access token from `LINODE_TOKEN`.
 pub fn token_from_env() -> Result<String, LinodeError> {
-    std::env::var("LINODE_TOKEN").map_err(|_| LinodeError {
-        message: "LINODE_TOKEN is not set in the environment".into(),
-    })
+    std::env::var("LINODE_TOKEN")
+        .ok()
+        .context(TokenMissingSnafu)
 }
 
 #[derive(Debug)]
@@ -94,13 +105,19 @@ fn request(
     }
     args.push(url);
 
-    let output = Command::new("curl").args(&args).output()?;
+    let output = Command::new("curl")
+        .args(&args)
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LinodeError {
-            message: format!("curl {method} {endpoint}: {}", stderr.trim()),
-        });
+        return CurlCommandSnafu {
+            method: method.to_string(),
+            endpoint: endpoint.to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -108,14 +125,19 @@ fn request(
         Some((b, s)) => (b, s),
         None => ("", stdout.as_ref()),
     };
-    let status: u16 = status_part.trim().parse().map_err(|_| LinodeError {
-        message: format!("could not parse HTTP status from curl output: {stdout:?}"),
-    })?;
+    let status: u16 = status_part
+        .trim()
+        .parse()
+        .ok()
+        .with_context(|| StatusParseSnafu {
+            output: stdout.to_string(),
+        })?;
     let body_json = if body_part.trim().is_empty() {
         Value::Null
     } else {
-        serde_json::from_str(body_part).map_err(|e| LinodeError {
-            message: format!("failed to parse JSON from {method} {endpoint}: {e}"),
+        serde_json::from_str(body_part).with_context(|_| JsonParseSnafu {
+            method: method.to_string(),
+            endpoint: endpoint.to_string(),
         })?
     };
     Ok(HttpResponse {
@@ -140,7 +162,7 @@ pub fn get_bucket(token: &str, cluster: &str, label: &str) -> Result<Option<Valu
         return Ok(None);
     }
     if !resp.ok() {
-        return Err(LinodeError {
+        return SchemaSnafu {
             message: format!(
                 "GET {endpoint} returned HTTP {} ({})",
                 resp.status,
@@ -149,7 +171,8 @@ pub fn get_bucket(token: &str, cluster: &str, label: &str) -> Result<Option<Valu
                     .map(|e| e.to_string())
                     .unwrap_or_else(|| "no error body".into())
             ),
-        });
+        }
+        .fail();
     }
     Ok(Some(resp.body))
 }
@@ -164,12 +187,13 @@ pub fn create_bucket(token: &str, cluster: &str, label: &str) -> Result<Value, L
     });
     let resp = post(token, "/object-storage/buckets", Some(&body))?;
     if !resp.ok() {
-        return Err(LinodeError {
+        return SchemaSnafu {
             message: format!(
                 "POST /object-storage/buckets returned HTTP {} ({})",
                 resp.status, resp.body
             ),
-        });
+        }
+        .fail();
     }
     Ok(resp.body)
 }
@@ -193,26 +217,26 @@ pub fn create_bucket_key(
     });
     let resp = post(token, "/object-storage/keys", Some(&body))?;
     if !resp.ok() {
-        return Err(LinodeError {
+        return SchemaSnafu {
             message: format!(
                 "POST /object-storage/keys returned HTTP {} ({})",
                 resp.status, resp.body
             ),
-        });
+        }
+        .fail();
     }
     let access_key = resp.body["access_key"]
         .as_str()
-        .ok_or_else(|| LinodeError {
-            message: "create_bucket_key response missing 'access_key'".into(),
+        .context(SchemaSnafu {
+            message: "create_bucket_key response missing 'access_key'",
         })?
         .to_string();
     let secret_key = resp.body["secret_key"]
         .as_str()
-        .ok_or_else(|| LinodeError {
+        .context(SchemaSnafu {
             message: "create_bucket_key response missing 'secret_key' \
                 (Linode only returns the secret on creation — \
-                deletion via the Linode console is required to retry)"
-                .into(),
+                deletion via the Linode console is required to retry)",
         })?
         .to_string();
     Ok(BucketKey {

--- a/tools/shaka/src/object_store/registry.rs
+++ b/tools/shaka/src/object_store/registry.rs
@@ -170,8 +170,27 @@ pub fn validate_uniqueness(entries: &[Entry]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::error::Error as _;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn parse_project_error_exposes_serde_source() {
+        // Demonstrates that snafu's #[snafu(source)] field threads the
+        // underlying serde_json::Error through std::error::Error::source(),
+        // so callers can downcast / walk the chain instead of grepping
+        // a flattened format! string.
+        let err: RegistryError = serde_json::from_str::<ProjectFile>("not json")
+            .with_context(|_| ParseProjectSnafu {
+                file: "fixture.cue".to_string(),
+            })
+            .unwrap_err();
+        let source = err.source().expect("source should be present");
+        assert!(
+            source.downcast_ref::<serde_json::Error>().is_some(),
+            "source should downcast to serde_json::Error, got {source:?}"
+        );
+    }
 
     fn ns(kind: &str, name: &str) -> Namespace {
         Namespace {

--- a/tools/shaka/src/object_store/registry.rs
+++ b/tools/shaka/src/object_store/registry.rs
@@ -6,11 +6,11 @@
 //! keeps the demand adjacent to the project that needs it without losing
 //! global protection.
 
-use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde::Deserialize;
+use snafu::{ResultExt, Snafu};
 
 use crate::project::schema_check;
 
@@ -34,15 +34,26 @@ pub struct Entry {
     pub namespace: Namespace,
 }
 
-#[derive(Debug)]
-pub struct RegistryError {
-    pub message: String,
-}
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum RegistryError {
+    #[snafu(display("could not write schema: {source}"))]
+    WriteSchema { source: std::io::Error },
 
-impl fmt::Display for RegistryError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
+    #[snafu(display("failed to run cue export {file}: {source}"))]
+    SpawnCueExport {
+        file: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("cue export {file}: {stderr}"))]
+    CueExport { file: String, stderr: String },
+
+    #[snafu(display("failed to parse {file} as JSON: {source}"))]
+    ParseProject {
+        file: String,
+        source: serde_json::Error,
+    },
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -60,9 +71,7 @@ struct ObjectStorageBlock {
 /// Walk every project.cue under `root` and collect declared namespaces.
 /// Returns entries sorted by `(kind, name, project)` for stable output.
 pub fn collect(root: &Path) -> Result<Vec<Entry>, RegistryError> {
-    let schema_path = schema_check::write_schema().map_err(|e| RegistryError {
-        message: format!("could not write schema: {e}"),
-    })?;
+    let schema_path = schema_check::write_schema().context(WriteSchemaSnafu)?;
     let mut entries = Vec::new();
     for project_dir in schema_check::discover(root) {
         let project_file = project_dir.join("project.cue");
@@ -99,21 +108,23 @@ fn read_project(schema: &Path, file: &Path) -> Result<ProjectFile, RegistryError
         .arg(schema)
         .arg(file)
         .output()
-        .map_err(|e| RegistryError {
-            message: format!("failed to run cue export {}: {e}", file.display()),
+        .with_context(|_| SpawnCueExportSnafu {
+            file: file.display().to_string(),
         })?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(RegistryError {
-            message: format!("cue export {}: {}", file.display(), stderr.trim()),
-        });
+        return CueExportSnafu {
+            file: file.display().to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     if stdout.trim().is_empty() {
         return Ok(ProjectFile::default());
     }
-    serde_json::from_str(&stdout).map_err(|e| RegistryError {
-        message: format!("failed to parse {} as JSON: {e}", file.display()),
+    serde_json::from_str(&stdout).with_context(|_| ParseProjectSnafu {
+        file: file.display().to_string(),
     })
 }
 

--- a/tools/shaka/src/object_store/s3.rs
+++ b/tools/shaka/src/object_store/s3.rs
@@ -7,28 +7,22 @@
 //! run in CI without secrets configured.
 
 use std::collections::BTreeSet;
-use std::fmt;
 use std::process::Command;
 
 use serde_json::Value;
+use snafu::{ResultExt, Snafu};
 
-#[derive(Debug)]
-pub struct S3Error {
-    pub message: String,
-}
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum S3Error {
+    #[snafu(display("failed to run aws: {source}"))]
+    Spawn { source: std::io::Error },
 
-impl fmt::Display for S3Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
+    #[snafu(display("aws s3api list-objects-v2: {stderr}"))]
+    ListObjects { stderr: String },
 
-impl From<std::io::Error> for S3Error {
-    fn from(e: std::io::Error) -> Self {
-        S3Error {
-            message: format!("failed to run aws: {e}"),
-        }
-    }
+    #[snafu(display("failed to parse aws s3api JSON: {source}"))]
+    JsonParse { source: serde_json::Error },
 }
 
 /// True iff both `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set.
@@ -83,13 +77,17 @@ fn list_prefixes(bucket: &str, cluster: &str, prefix: &str) -> Result<BTreeSet<S
         args.push("--prefix");
         args.push(prefix);
     }
-    let output = Command::new("aws").args(&args).output()?;
+    let output = Command::new("aws")
+        .args(&args)
+        .output()
+        .context(SpawnSnafu)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(S3Error {
-            message: format!("aws s3api list-objects-v2: {}", stderr.trim()),
-        });
+        return ListObjectsSnafu {
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -97,9 +95,7 @@ fn list_prefixes(bucket: &str, cluster: &str, prefix: &str) -> Result<BTreeSet<S
         return Ok(BTreeSet::new());
     }
 
-    let parsed: Value = serde_json::from_str(&stdout).map_err(|e| S3Error {
-        message: format!("failed to parse aws s3api JSON: {e}"),
-    })?;
+    let parsed: Value = serde_json::from_str(&stdout).context(JsonParseSnafu)?;
 
     let mut prefixes = BTreeSet::new();
     if let Some(arr) = parsed["CommonPrefixes"].as_array() {

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -225,7 +225,7 @@ fn check_branch_protection(repo: &str) -> Vec<Check> {
     let data = match gh::api_get(&format!("/repos/{repo}/branches/main/protection")) {
         Ok(v) => v,
         Err(e) => {
-            let msg = e.message.to_string();
+            let msg = e.to_string();
             if msg.contains("404") || msg.contains("not protected") || msg.contains("Not Found") {
                 return vec![Check::fail("Branch protection", "not enabled on main")];
             }

--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -116,8 +116,8 @@ fn publish_pr(input: &str, branch: &str, updated: &[PathBuf]) -> Result<(), Stri
     git(&["commit", "-m", &title])?;
     git(&["push", "--force-with-lease", "origin", branch])?;
 
-    let repo = gh::detect_repo_or_env().map_err(|e| e.message)?;
-    if let Some(pr) = gh::pr_for_head(&repo, branch).map_err(|e| e.message)? {
+    let repo = gh::detect_repo_or_env().map_err(|e| e.to_string())?;
+    if let Some(pr) = gh::pr_for_head(&repo, branch).map_err(|e| e.to_string())? {
         if pr.state == PrState::Open {
             println!("{GREEN}{BOLD}updated existing PR:{RESET} {}", pr.url);
             return Ok(());
@@ -125,7 +125,7 @@ fn publish_pr(input: &str, branch: &str, updated: &[PathBuf]) -> Result<(), Stri
     }
 
     let body = format_pr_body(input, updated);
-    let url = gh::pr_create(&repo, &title, &body, branch).map_err(|e| e.message)?;
+    let url = gh::pr_create(&repo, &title, &body, branch).map_err(|e| e.to_string())?;
     println!("{GREEN}{BOLD}created PR:{RESET} {url}");
     Ok(())
 }


### PR DESCRIPTION
The conversion of the five existing hand-rolled errors to snafu set the
pattern; subsequent modules should follow it rather than re-deriving the
shape from existing code. Capture the rules: variant per failure mode,
`source: ...` for cause-chains, .context vs .with_context, and the
pub(crate) visibility marker that lets cross-module callers construct
selectors directly.

Closes #252