### PR TITLE
refactor(shaka): wire repo describe into send/pr/ship

### DIFF
--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -115,6 +115,51 @@ pub fn ahead_count(base: &str) -> Result<usize, JjError> {
     Ok(out.lines().filter(|l| !l.trim().is_empty()).count())
 }
 
+/// Title and body of a single commit. The body has been split off from
+/// the first line and trimmed of leading/trailing blank lines; an empty
+/// body is the empty string.
+#[derive(Debug, PartialEq, Eq)]
+pub struct CommitMessage {
+    pub title: String,
+    pub body: String,
+}
+
+/// Walk non-empty commits in `from..to`, oldest-first. Each entry's
+/// description is split into a title (first line) and body (everything
+/// after the first newline, with surrounding blank lines trimmed).
+pub fn commits_between(from: &str, to: &str) -> Result<Vec<CommitMessage>, JjError> {
+    const RECORD_END: &str = "\x1e\x1f";
+    let template = format!(r#"description ++ "{RECORD_END}\n""#);
+    let revset = format!("{from}..{to} ~ empty()");
+    let out = run(&[
+        "log",
+        "-r",
+        &revset,
+        "--reversed",
+        "-T",
+        &template,
+        "--no-graph",
+    ])?;
+    Ok(parse_commits_between(&out, RECORD_END))
+}
+
+fn parse_commits_between(out: &str, terminator: &str) -> Vec<CommitMessage> {
+    out.split(terminator)
+        .map(|chunk| chunk.trim_start_matches('\n'))
+        .filter(|chunk| !chunk.trim().is_empty())
+        .map(|chunk| match chunk.split_once('\n') {
+            Some((t, rest)) => CommitMessage {
+                title: t.trim_end().to_string(),
+                body: rest.trim_matches('\n').to_string(),
+            },
+            None => CommitMessage {
+                title: chunk.trim_end().to_string(),
+                body: String::new(),
+            },
+        })
+        .collect()
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct DirtyCounts {
     pub added: usize,
@@ -633,5 +678,59 @@ mod tests {
     fn parse_changed_paths_skips_blank_and_unknown() {
         let out = "\n? mystery\nM real.rs\n";
         assert_eq!(parse_changed_paths(out), vec!["real.rs"]);
+    }
+
+    const TERM: &str = "\x1e\x1f";
+
+    #[test]
+    fn parse_commits_between_single() {
+        let out = format!("feat: thing\n\nbody\n{TERM}\n");
+        let got = parse_commits_between(&out, TERM);
+        assert_eq!(
+            got,
+            vec![CommitMessage {
+                title: "feat: thing".to_string(),
+                body: "body".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_commits_between_title_only() {
+        let out = format!("feat: solo\n{TERM}\n");
+        let got = parse_commits_between(&out, TERM);
+        assert_eq!(
+            got,
+            vec![CommitMessage {
+                title: "feat: solo".to_string(),
+                body: String::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_commits_between_multiple_oldest_first() {
+        let out = format!(
+            "feat: a\n\nwhy a\n{TERM}\nfix: b\n\nwhy b\nspans lines\n{TERM}\n"
+        );
+        let got = parse_commits_between(&out, TERM);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].title, "feat: a");
+        assert_eq!(got[0].body, "why a");
+        assert_eq!(got[1].title, "fix: b");
+        assert_eq!(got[1].body, "why b\nspans lines");
+    }
+
+    #[test]
+    fn parse_commits_between_empty() {
+        assert!(parse_commits_between("", TERM).is_empty());
+        assert!(parse_commits_between("\n", TERM).is_empty());
+    }
+
+    #[test]
+    fn parse_commits_between_preserves_blank_lines_in_body() {
+        let out = format!("feat: x\n\npara 1\n\npara 2\n{TERM}\n");
+        let got = parse_commits_between(&out, TERM);
+        assert_eq!(got[0].body, "para 1\n\npara 2");
     }
 }

--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -710,9 +710,7 @@ mod tests {
 
     #[test]
     fn parse_commits_between_multiple_oldest_first() {
-        let out = format!(
-            "feat: a\n\nwhy a\n{TERM}\nfix: b\n\nwhy b\nspans lines\n{TERM}\n"
-        );
+        let out = format!("feat: a\n\nwhy a\n{TERM}\nfix: b\n\nwhy b\nspans lines\n{TERM}\n");
         let got = parse_commits_between(&out, TERM);
         assert_eq!(got.len(), 2);
         assert_eq!(got[0].title, "feat: a");

--- a/tools/shaka/src/repo/describe.rs
+++ b/tools/shaka/src/repo/describe.rs
@@ -74,19 +74,54 @@ fn is_footer_line(line: &str) -> bool {
     TRAILER_PREFIXES.iter().any(|p| lower.starts_with(p))
 }
 
+/// Synthesize a description from the current branch (`main@origin..@`).
+///
+/// Falls back to `@`'s description alone when `main@origin` doesn't
+/// resolve or the range walk yields nothing — e.g. a freshly-initialised
+/// repo without an origin, or a workspace whose `@` doesn't yet have a
+/// content diff. Errors only if `@` itself has no description to read.
+pub fn for_current_branch() -> Result<Description, String> {
+    if let Ok(commits) = jj::commits_between("main@origin", "@") {
+        if !commits.is_empty() {
+            return Ok(build(&commits).expect("non-empty commits yield a description"));
+        }
+    }
+    let description = jj::current_description().map_err(|e| e.to_string())?;
+    let trimmed = description.trim();
+    if trimmed.is_empty() {
+        return Err("no commits to describe and @ has no description".to_string());
+    }
+    Ok(from_message(trimmed))
+}
+
+/// Build a `Description` from a single commit message, applying the
+/// same footer-stripping logic as the multi-commit path. Used as the
+/// fallback when `main@origin` doesn't resolve.
+fn from_message(message: &str) -> Description {
+    let cm = match message.split_once('\n') {
+        Some((title, rest)) => CommitMessage {
+            title: title.trim().to_string(),
+            body: rest.trim_matches('\n').to_string(),
+        },
+        None => CommitMessage {
+            title: message.trim().to_string(),
+            body: String::new(),
+        },
+    };
+    Description {
+        title: cm.title.clone(),
+        body: extract_why(&cm.body),
+    }
+}
+
 pub fn run(json: bool) {
-    let commits = match jj::commits_between("main@origin", "@") {
-        Ok(c) => c,
+    let description = match for_current_branch() {
+        Ok(d) => d,
         Err(e) => {
             eprintln!("{RED}{BOLD}error:{RESET} {e}");
             std::process::exit(1);
         }
     };
-    if commits.is_empty() {
-        eprintln!("{RED}{BOLD}error:{RESET} no non-empty commits in main@origin..@");
-        std::process::exit(1);
-    }
-    let description = build(&commits).expect("non-empty commits yield a description");
 
     if json {
         match serde_json::to_string_pretty(&description) {
@@ -192,5 +227,19 @@ mod tests {
     fn footer_detection_rejects_prose() {
         assert!(!is_footer_line("This closes the loop somehow."));
         assert!(!is_footer_line("issue #5 was the trigger"));
+    }
+
+    #[test]
+    fn from_message_title_only() {
+        let got = from_message("feat: solo");
+        assert_eq!(got.title, "feat: solo");
+        assert_eq!(got.body, "");
+    }
+
+    #[test]
+    fn from_message_strips_footers() {
+        let got = from_message("feat: x\n\nthe why\n\nCloses #1");
+        assert_eq!(got.title, "feat: x");
+        assert_eq!(got.body, "the why");
     }
 }

--- a/tools/shaka/src/repo/describe.rs
+++ b/tools/shaka/src/repo/describe.rs
@@ -1,0 +1,196 @@
+use serde::Serialize;
+
+use crate::jj::{self, CommitMessage};
+use crate::term::{BOLD, RED, RESET};
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct Description {
+    pub title: String,
+    pub body: String,
+}
+
+/// Synthesize a PR title and body from the commits in `main@origin..@`.
+///
+/// Title is the tip commit's title verbatim. Body concatenates each
+/// commit's "why" — the body up to (but not including) any trailer
+/// footer like `Closes #N` or `Co-authored-by:` — joined with blank-line
+/// separators in chronological order. Returns `None` if `commits` is
+/// empty.
+pub fn build(commits: &[CommitMessage]) -> Option<Description> {
+    let tip = commits.last()?;
+    let title = tip.title.clone();
+    let body = synthesize_body(commits);
+    Some(Description { title, body })
+}
+
+fn synthesize_body(commits: &[CommitMessage]) -> String {
+    let parts: Vec<String> = commits
+        .iter()
+        .map(|c| extract_why(&c.body))
+        .filter(|s| !s.is_empty())
+        .collect();
+    parts.join("\n\n")
+}
+
+fn extract_why(body: &str) -> String {
+    let mut kept: Vec<&str> = Vec::new();
+    for line in body.lines() {
+        if is_footer_line(line) {
+            break;
+        }
+        kept.push(line);
+    }
+    while matches!(kept.last(), Some(l) if l.trim().is_empty()) {
+        kept.pop();
+    }
+    kept.join("\n")
+}
+
+fn is_footer_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    const ISSUE_PREFIXES: &[&str] = &[
+        "closes #",
+        "close #",
+        "fixes #",
+        "fix #",
+        "resolves #",
+        "resolve #",
+        "refs #",
+    ];
+    if ISSUE_PREFIXES.iter().any(|p| lower.starts_with(p)) {
+        return true;
+    }
+    const TRAILER_PREFIXES: &[&str] = &[
+        "co-authored-by:",
+        "signed-off-by:",
+        "reviewed-by:",
+        "acked-by:",
+        "tested-by:",
+        "reported-by:",
+        "suggested-by:",
+        "refs:",
+    ];
+    TRAILER_PREFIXES.iter().any(|p| lower.starts_with(p))
+}
+
+pub fn run(json: bool) {
+    let commits = match jj::commits_between("main@origin", "@") {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    if commits.is_empty() {
+        eprintln!("{RED}{BOLD}error:{RESET} no non-empty commits in main@origin..@");
+        std::process::exit(1);
+    }
+    let description = build(&commits).expect("non-empty commits yield a description");
+
+    if json {
+        match serde_json::to_string_pretty(&description) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} failed to serialize description: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        println!("{}", description.title);
+        if !description.body.is_empty() {
+            println!();
+            println!("{}", description.body);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cm(title: &str, body: &str) -> CommitMessage {
+        CommitMessage {
+            title: title.to_string(),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn build_single_commit_uses_title_and_body() {
+        let commits = vec![cm("feat(shaka): thing", "why this thing\nspans lines")];
+        let got = build(&commits).unwrap();
+        assert_eq!(got.title, "feat(shaka): thing");
+        assert_eq!(got.body, "why this thing\nspans lines");
+    }
+
+    #[test]
+    fn build_uses_tip_title() {
+        let commits = vec![
+            cm("feat: a", "why a"),
+            cm("test: b", "why b"),
+            cm("refactor: c", "why c"),
+        ];
+        let got = build(&commits).unwrap();
+        assert_eq!(got.title, "refactor: c");
+        assert_eq!(got.body, "why a\n\nwhy b\n\nwhy c");
+    }
+
+    #[test]
+    fn build_empty_returns_none() {
+        assert!(build(&[]).is_none());
+    }
+
+    #[test]
+    fn build_omits_commits_with_empty_body() {
+        let commits = vec![
+            cm("feat: a", "why a"),
+            cm("docs: b", ""),
+            cm("fix: c", "why c"),
+        ];
+        let got = build(&commits).unwrap();
+        assert_eq!(got.body, "why a\n\nwhy c");
+    }
+
+    #[test]
+    fn extract_why_strips_closes_footer() {
+        let body = "First paragraph.\n\nSecond paragraph.\n\nCloses #67";
+        assert_eq!(extract_why(body), "First paragraph.\n\nSecond paragraph.");
+    }
+
+    #[test]
+    fn extract_why_strips_multiple_trailer_lines() {
+        let body = "Why.\n\nCloses #1\nCo-authored-by: someone <a@b.c>\nSigned-off-by: x";
+        assert_eq!(extract_why(body), "Why.");
+    }
+
+    #[test]
+    fn extract_why_handles_no_footer() {
+        let body = "Just a why\nspread over\nthree lines";
+        assert_eq!(extract_why(body), body);
+    }
+
+    #[test]
+    fn extract_why_empty_body() {
+        assert_eq!(extract_why(""), "");
+    }
+
+    #[test]
+    fn extract_why_keeps_blank_lines_between_paragraphs() {
+        let body = "Para 1.\n\nPara 2.";
+        assert_eq!(extract_why(body), "Para 1.\n\nPara 2.");
+    }
+
+    #[test]
+    fn footer_detection_case_insensitive() {
+        assert!(is_footer_line("CLOSES #5"));
+        assert!(is_footer_line("Closes #5"));
+        assert!(is_footer_line("co-authored-by: someone"));
+    }
+
+    #[test]
+    fn footer_detection_rejects_prose() {
+        assert!(!is_footer_line("This closes the loop somehow."));
+        assert!(!is_footer_line("issue #5 was the trigger"));
+    }
+}

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -1,6 +1,6 @@
 mod audit;
 mod bump_locks;
-mod describe;
+pub mod describe;
 mod pr;
 mod rebase_open_prs;
 pub mod send;

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod bump_locks;
+mod describe;
 mod pr;
 mod rebase_open_prs;
 pub mod send;
@@ -77,6 +78,18 @@ pub enum RepoCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Synthesize a PR title and body from commits in main@origin..@
+    ///
+    /// Title is the tip commit's title verbatim. Body concatenates each
+    /// commit's "why" paragraph (the body up to any trailer footer like
+    /// `Closes #N` or `Co-authored-by:`) in chronological order, joined
+    /// by blank lines. Per project convention, no test plan section.
+    Describe {
+        /// Emit JSON (`{"title": "...", "body": "..."}`) instead of
+        /// human-readable text
+        #[arg(long)]
+        json: bool,
+    },
     /// Rebase every open PR whose base is `main` onto the current main@origin
     ///
     /// Intended to run from CI on `push: main`. PRs labeled `do-not-rebase`
@@ -126,6 +139,7 @@ pub fn run(cmd: RepoCommand) {
             dry_run,
         } => ship::run(bookmark, skip_preflight, dry_run),
         RepoCommand::Status { json } => status::run(json),
+        RepoCommand::Describe { json } => describe::run(json),
         RepoCommand::RebaseOpenPrs { dry_run } => rebase_open_prs::run(dry_run),
         RepoCommand::BumpLocks { input, pr_branch } => bump_locks::run(input, pr_branch),
     }

--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -1,6 +1,7 @@
 use crate::gh;
 use crate::jj;
-use crate::repo::send::{resolve_bookmark, split_message};
+use crate::repo::describe;
+use crate::repo::send::resolve_bookmark;
 use crate::term::{BOLD, GREEN, RED, RESET};
 
 pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
@@ -30,7 +31,15 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
         },
     };
 
-    let (title, body) = split_message(trimmed);
+    let synthesized = match describe::for_current_branch() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    let title = synthesized.title.as_str();
+    let body = synthesized.body.as_str();
 
     if dry_run {
         println!("would run: jj bookmark set {bookmark} -r @");

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -1,5 +1,6 @@
 use crate::gh;
 use crate::jj;
+use crate::repo::describe;
 use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
 pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
@@ -30,7 +31,15 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         },
     };
 
-    let (title, body) = split_message(trimmed);
+    let synthesized = match describe::for_current_branch() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    let title = synthesized.title.as_str();
+    let body = synthesized.body.as_str();
 
     if dry_run {
         println!("would run: jj bookmark set {bookmark} -r @");
@@ -105,33 +114,5 @@ pub fn resolve_bookmark(description: &str) -> Result<String, String> {
                 "could not derive bookmark from description; pass --bookmark".to_string()
             })
         }
-    }
-}
-
-/// Split a commit message into a PR title (first line) and body (the rest,
-/// with leading blank lines stripped).
-pub fn split_message(message: &str) -> (&str, &str) {
-    match message.split_once('\n') {
-        Some((title, rest)) => (title.trim(), rest.trim_start_matches('\n').trim_end()),
-        None => (message.trim(), ""),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::split_message;
-
-    #[test]
-    fn split_title_only() {
-        assert_eq!(split_message("feat: thing"), ("feat: thing", ""));
-    }
-
-    #[test]
-    fn split_title_and_body() {
-        let msg = "feat: thing\n\nlonger explanation\nspans lines\n";
-        assert_eq!(
-            split_message(msg),
-            ("feat: thing", "longer explanation\nspans lines"),
-        );
     }
 }

--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -2,7 +2,8 @@ use crate::commit::{self, CommitCommand};
 use crate::gh;
 use crate::jj;
 use crate::preflight;
-use crate::repo::send::{resolve_bookmark, split_message};
+use crate::repo::describe;
+use crate::repo::send::resolve_bookmark;
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 const SHIP_REVSET: &str = "main@origin..@";
@@ -35,7 +36,15 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
         },
     };
 
-    let (title, body) = split_message(trimmed);
+    let synthesized = match describe::for_current_branch() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    let title = synthesized.title.as_str();
+    let body = synthesized.body.as_str();
 
     if dry_run {
         println!("would run: jj git fetch");


### PR DESCRIPTION
Walks `from..to ~ empty()` oldest-first and returns each non-empty
commit's title and body as a `CommitMessage`. The description is split
on the first newline; surrounding blank lines on the body are trimmed.

Uses a `\x1e\x1f` record terminator in the jj template so commit
bodies (which contain arbitrary newlines and blank lines) parse
unambiguously. Existing `ahead_count` only returns a count, which is
insufficient for `repo describe` (#67) — that needs the actual commit
titles and bodies to synthesize a PR title and body.

Pure helper plus parser unit tests; no callers yet.

Walks `main@origin..@` and prints a PR title + body in the project's
preferred shape: title is the tip commit's title verbatim, body is each
commit's "why" paragraph in chronological order joined by blank lines.
Trailer footers (`Closes #N`, `Co-authored-by:`, etc.) are stripped
from the body — the closing keyword belongs on the commit so GitHub
auto-links and auto-closes on merge, but doesn't add signal in the PR
body. Per project convention, no test plan section is emitted.

`--json` mode prints `{"title": "...", "body": "..."}` for callers
that want to consume the synthesized output programmatically; default
prints the title and body to stdout. The next commit wires this into
`repo send` and `repo pr` so multi-commit branches get one-shot PR
creation without the user (or assistant) re-drafting the message.

`repo send`, `repo pr`, and `repo ship` previously took the `@`
commit's description verbatim as the PR title and body. That worked
for single-commit branches but lost signal on stacked branches —
only the tip's "why" made it into the PR description. With `repo
describe` available, all three commands now ask it for the
synthesized title and body, so multi-commit PRs get a body that
walks every commit's "why" in chronological order.

Single-commit branches see one subtle change: `Closes #N` and other
trailer footers are stripped from the PR body. The footer stays on
the commit (where GitHub still picks it up on merge), but the PR
body itself stays focused on the why. The fallback path (no
`main@origin`, e.g. a fresh repo) reads `@`'s description directly
so isolated test fixtures and bootstrap scenarios continue to work.

Removes the now-unused `split_message` helper from `repo::send` —
`describe::for_current_branch` subsumes it.