### PR TITLE
feat(kolohelios-nix): add vale to workflowPackages

### DIFF
--- a/nix/kolohelios-nix/README.md
+++ b/nix/kolohelios-nix/README.md
@@ -10,8 +10,8 @@ shares one nixpkgs revision and project closures hit the cache together.
 - `lib.forEachSupportedSystem` — helper that maps a function over every
   supported system, providing a system-specific `pkgs`.
 - `lib.workflowPackages` — the workflow-tool list (jujutsu, git, just, jq,
-  cue, nixfmt-rfc-style, nil, typos) that every project's devShell wants;
-  consumers spread it and add project-specific tools on top.
+  cue, nixfmt-rfc-style, nil, typos, vale) that every project's devShell
+  wants; consumers spread it and add project-specific tools on top.
 - `formatter` — `nixfmt-rfc-style` per system, used by `nix fmt`.
 
 ## Usage from a consumer flake

--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -49,6 +49,7 @@
           typos
           cargo-deny
           cargo-machete
+          vale
         ];
     in
     {


### PR DESCRIPTION
First of two PRs for #14. Adds vale to the shared workflow-tool list
in `kolohelios-nix` so it joins typos as a repo-wide linter available
in every project's devShell.

This must land and publish to FlakeHub before the follow-up PR can
bump `tools/shaka`'s lock and wire up `.vale.ini` plus the preflight
gate.