### PR TITLE
feat(shaka): add doc-check to rust template validate chain

### DIFF
--- a/apps/blogctl/justfile
+++ b/apps/blogctl/justfile
@@ -16,6 +16,9 @@ fmt-check:
 lint:
     cargo clippy --all-targets -- -D warnings
 
+doc-check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
 deny:
     cargo deny check
 
@@ -47,4 +50,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/justfile
+++ b/tools/shaka/justfile
@@ -16,6 +16,9 @@ fmt-check:
 lint:
     cargo clippy --all-targets -- -D warnings
 
+doc-check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
 deny:
     cargo deny check
 
@@ -47,4 +50,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -26,6 +26,9 @@ fmt-check:
 lint:
     cargo clippy --all-targets -- -D warnings
 
+doc-check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
 deny:
     cargo deny check
 
@@ -57,7 +60,7 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
 "#;
 
 const NIX_LIB_TEMPLATE: &str = r#"nix-fmt-check:
@@ -335,8 +338,15 @@ mod tests {
         assert!(RUST_TEMPLATE.contains("fmt-check"));
         assert!(RUST_TEMPLATE.contains("clippy"));
         assert!(RUST_TEMPLATE.contains(
-            "validate: fmt-check lint deny machete test coverage nix-fmt-check flake-check whitespace-check"
+            "validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check"
         ));
+    }
+
+    #[test]
+    fn rust_template_includes_doc_check_recipe() {
+        assert!(RUST_TEMPLATE.contains("doc-check:"));
+        assert!(RUST_TEMPLATE.contains(r#"RUSTDOCFLAGS="-D warnings""#));
+        assert!(RUST_TEMPLATE.contains("cargo doc --no-deps --document-private-items"));
     }
 
     #[test]

--- a/tools/shaka/src/workspace/mod.rs
+++ b/tools/shaka/src/workspace/mod.rs
@@ -16,13 +16,13 @@ use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 pub enum WorkspaceCommand {
     /// Create a new jj workspace as a sibling of the repo
     New {
-        /// Workspace name (slug). Directory will be ../<repo-basename>-<name>.
+        /// Workspace name (slug). Directory will be `../<repo-basename>-<name>`.
         /// Mutually exclusive with --issue.
         #[arg(conflicts_with = "issue")]
         name: Option<String>,
 
-        /// GitHub issue number. Derives name as i<N> and prints the issue title.
-        /// Mutually exclusive with <name>.
+        /// GitHub issue number. Derives name as `i<N>` and prints the issue title.
+        /// Mutually exclusive with `<name>`.
         #[arg(long, conflicts_with = "name")]
         issue: Option<u64>,
     },


### PR DESCRIPTION
Rustdoc parses bare <name>, <N>, and <repo-basename> in doc comments as
HTML tags and emits unclosed-tag warnings. Wrap the placeholders in
backticks so they render as inline code and rustdoc leaves them alone.

Sets up the rustdoc-warnings-as-errors preflight gate in #49.

Run `cargo doc --no-deps --document-private-items` with
`RUSTDOCFLAGS=-D warnings` as part of every rust project's `just
validate` recipe. Catches broken intra-doc links (`[Foo]` referencing
a removed type), malformed doc comments, and any future
`#![warn(missing_docs)]` opt-ins.

Cheap signal — `cargo doc` reuses the build cache from `cargo
check`/`cargo test`, so the marginal cost on top of `validate` is
small.

Lives in the per-project rust template rather than a top-level CHECKS
entry: `shaka preflight`'s per-project pass already gates this on
changed paths via `--since`, so the "scope to changed rust projects"
behavior the issue calls for is free.

Closes #49