### PR TITLE
docs(shaka): prefer in-shell shaka over wrapper invocation

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,6 +1,6 @@
 ---
 description: Start working on a GitHub issue — create workspace, read, bookmark, and plan
-allowed-tools: Bash(shaka repo sync), Bash(shaka repo status:*), Bash(shaka workspace new:*), Bash(tools/shaka/bin/shaka issue brief:*), Bash(jj *), Read, Glob, Grep
+allowed-tools: Bash(shaka repo sync), Bash(shaka repo status:*), Bash(shaka workspace new:*), Bash(shaka issue brief:*), Bash(jj *), Read, Glob, Grep
 argument-hint: <issue-number>
 ---
 
@@ -24,7 +24,7 @@ explicitly confirms it's fine to continue.
 Fetch the issue body and any comments in one shot:
 
 ```
-tools/shaka/bin/shaka issue brief $1
+shaka issue brief $1
 ```
 
 This runs `jj git fetch` (so the next step's workspace parents on the
@@ -49,7 +49,7 @@ the primary tree clean for sync, audit, and cross-cutting reads, and it
 means the user's WIP elsewhere is undisturbed.
 
 ```
-tools/shaka/bin/shaka workspace new --issue $1
+shaka workspace new --issue $1
 ```
 
 This creates a sibling working copy at `../kolohelios-i$1` parented on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,19 @@ the current change set. Two things to remember when adding one:
 
 ### Running `shaka`
 
-`shaka` is **not** on `$PATH` globally. Always invoke it via the wrapper:
+Inside any project's devshell (the common case via `direnv` or
+`nix develop`), `shaka` is on `$PATH` and resolves from any `cwd`:
+
+```
+shaka <subcommand>
+```
+
+That comes from a tiny shim in `kolohelios-nix.lib.workflowPackages`
+that walks up from `cwd` to find the canonical wrapper at
+`tools/shaka/bin/shaka` and exec's it.
+
+Outside a devshell (cold-start scripts), invoke the wrapper directly
+from the repo root:
 
 ```
 tools/shaka/bin/shaka <subcommand>
@@ -263,7 +275,7 @@ into the repo.
 For rust projects, run:
 
 ```
-tools/shaka/bin/shaka project new --name <name> --slot <slot>
+shaka project new --name <name> --slot <slot>
 ```
 
 `<slot>` is one of `apps`, `packages`, `projects`, `tools`. The command

--- a/README.md
+++ b/README.md
@@ -33,10 +33,14 @@ just <recipe>      # build, test, lint, validate, ...
 To run validation across the whole repo (the same command CI runs):
 
 ```sh
-tools/shaka/bin/shaka preflight
+shaka preflight
 # or, scoped to changes since a ref:
-tools/shaka/bin/shaka preflight --since main@origin
+shaka preflight --since main@origin
 ```
+
+`shaka` is on `$PATH` inside any project's devshell (via a shim in
+`kolohelios-nix.lib.workflowPackages`); from outside a devshell, the
+wrapper at `tools/shaka/bin/shaka` is the cold-start escape hatch.
 
 ## Build system
 

--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -90,5 +90,5 @@ the preceding modules without rewiring.
 ## Development
 
 This project lives in the kolohelios monorepo. Run validation with
-`just validate` from inside the project's nix devshell, or
-`tools/shaka/bin/shaka preflight` from the repo root.
+`just validate` from inside the project's nix devshell, or `shaka
+preflight` from any `cwd` inside one.

--- a/tools/shaka/README.md
+++ b/tools/shaka/README.md
@@ -8,7 +8,16 @@ management, and the single CI gate (`shaka preflight`).
 
 ## Running
 
-`shaka` is not on `$PATH` globally. Always invoke it via the wrapper:
+Inside any project's devshell (`direnv` / `nix develop`), `shaka` is
+on `$PATH` and resolves from any `cwd`:
+
+```
+shaka <subcommand>
+```
+
+The shim ships from `kolohelios-nix.lib.workflowPackages`. For
+cold-start invocations (outside any devshell), call the wrapper
+directly from the repo root:
 
 ```
 tools/shaka/bin/shaka <subcommand>
@@ -35,7 +44,7 @@ changed) and exec's the debug binary.
 - `workspace new|list|forget|status|cleanup` — `jj` workspace management
   for parallel work.
 
-See `tools/shaka/bin/shaka <subcommand> --help` for full options.
+See `shaka <subcommand> --help` for full options.
 
 ## Development
 


### PR DESCRIPTION
With the shim landed in kolohelios-nix.lib.workflowPackages, every
project's dev shell has `shaka` on $PATH and resolves from any cwd.
Recommend it first across CLAUDE.md, root README, tools/shaka README,
blogctl README, and the /start slash command. Keep tools/shaka/bin/shaka
documented as the cold-start escape hatch from the repo root.

Closes #81