### PR TITLE
feat(shaka): add repo bump to refresh PR onto latest main

### DIFF
--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -73,8 +73,12 @@ pub fn fetch() -> Result<(), JjError> {
     run_streaming(&["git", "fetch"])
 }
 
-pub fn rebase_onto(dest: &str) -> Result<(), JjError> {
-    run_streaming(&["rebase", "-d", dest])
+/// Rebase the whole "branch" containing `branch` onto `dest`
+/// (`jj rebase -b <branch> -d <dest>`). For an in-flight PR refresh, pass
+/// `branch = "@"` so the entire stack of described commits ahead of base
+/// moves with the working copy, not just `@` itself.
+pub fn rebase_branch_onto(branch: &str, dest: &str) -> Result<(), JjError> {
+    run_streaming(&["rebase", "-b", branch, "-d", dest])
 }
 
 /// Description of the current change (`@`).

--- a/tools/shaka/src/repo/bump.rs
+++ b/tools/shaka/src/repo/bump.rs
@@ -1,0 +1,89 @@
+use crate::gh;
+use crate::jj;
+use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
+
+/// Refresh an in-flight PR: fetch, rebase the stack onto `main@origin`,
+/// push, and report the PR url.
+///
+/// Resolves the bookmark to refresh in this order:
+///
+/// 1. `--bookmark <name>` (explicit override).
+/// 2. The unique bookmark in `main@origin..@` (inclusive of `@`). Errors
+///    if zero or more than one bookmark is found and no `--bookmark` was
+///    supplied — multi-bookmark stacks (stack-of-PRs) are out of scope.
+pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
+    let bookmark = match bookmark_arg {
+        Some(b) => b,
+        None => match resolve_bookmark() {
+            Ok(b) => b,
+            Err(msg) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {msg}");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    if dry_run {
+        println!("would run: jj git fetch");
+        println!("would run: jj rebase -b @ -d main@origin");
+        println!("would run: jj git push --bookmark {bookmark}");
+        println!("would print PR url for head {bookmark}");
+        return;
+    }
+
+    println!("{BOLD}fetching from origin{RESET}");
+    if let Err(e) = jj::fetch() {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    println!("{BOLD}rebasing onto main@origin{RESET}");
+    if let Err(e) = jj::rebase_branch_onto("@", "main@origin") {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    println!("{BOLD}pushing {bookmark}{RESET}");
+    if let Err(e) = jj::push_bookmark(&bookmark) {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    let repo = match gh::detect_repo() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{YELLOW}{BOLD}warn:{RESET} could not detect repo: {e}");
+            println!("{GREEN}{BOLD}bumped{RESET} (skipping PR lookup)");
+            return;
+        }
+    };
+
+    match gh::pr_for_head(&repo, &bookmark) {
+        Ok(Some(pr)) => println!("{GREEN}{BOLD}bumped{RESET} ({})", pr.url),
+        Ok(None) => println!("{GREEN}{BOLD}bumped{RESET} (no PR found for {bookmark})"),
+        Err(e) => {
+            eprintln!("{YELLOW}{BOLD}warn:{RESET} could not look up PR: {e}");
+            println!("{GREEN}{BOLD}bumped{RESET}");
+        }
+    }
+}
+
+/// Find the unique bookmark in the in-flight stack (`main@origin..@`).
+///
+/// Returns an error message when zero or more than one bookmark is found.
+/// Multi-bookmark stacks (stack-of-PRs) are out of scope; the caller can
+/// pass `--bookmark` to disambiguate.
+fn resolve_bookmark() -> Result<String, String> {
+    let bookmarks = jj::bookmarks_on("main@origin..@").map_err(|e| e.to_string())?;
+    match bookmarks.len() {
+        1 => Ok(bookmarks.into_iter().next().unwrap()),
+        0 => Err(
+            "no bookmark found in main@origin..@; pass --bookmark or set one with `jj bookmark`"
+                .to_string(),
+        ),
+        _ => Err(format!(
+            "multiple bookmarks in main@origin..@ ({}); pass --bookmark to pick one",
+            bookmarks.join(", ")
+        )),
+    }
+}

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -1,4 +1,5 @@
 mod audit;
+mod bump;
 mod bump_locks;
 pub mod describe;
 mod pr;
@@ -24,6 +25,22 @@ pub enum RepoCommand {
     },
     /// Fetch from origin and rebase the current change onto main@origin
     Sync {
+        /// Print the commands that would run without executing them
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Refresh an in-flight PR's bookmark onto the latest main@origin
+    ///
+    /// Fetches, rebases the whole stack rooted at the bookmark onto
+    /// `main@origin`, force-pushes the bookmark, and prints the PR url
+    /// (if one exists). The bookmark is auto-detected as the unique
+    /// bookmark in `main@origin..@`; pass `--bookmark` to disambiguate
+    /// or override.
+    Bump {
+        /// Bookmark to refresh (auto-detected from main@origin..@ if omitted)
+        #[arg(long)]
+        bookmark: Option<String>,
+
         /// Print the commands that would run without executing them
         #[arg(long)]
         dry_run: bool,
@@ -127,6 +144,7 @@ pub fn run(cmd: RepoCommand) {
     match cmd {
         RepoCommand::Audit { repo, fix } => audit::run(repo, fix),
         RepoCommand::Sync { dry_run } => sync::run(dry_run),
+        RepoCommand::Bump { bookmark, dry_run } => bump::run(bookmark, dry_run),
         RepoCommand::Send {
             bookmark,
             no_pr,

--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -48,7 +48,7 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
 
     if dry_run {
         println!("would run: jj git fetch");
-        println!("would run: jj rebase -d main@origin");
+        println!("would run: jj rebase -b @ -d main@origin");
         println!("would run: shaka commit lint -r {SHIP_REVSET}");
         println!("would run: jj diff -r {SHIP_REVSET}");
         if skip_preflight {
@@ -69,7 +69,7 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
     }
 
     println!("{BOLD}step 2/6: rebasing onto main@origin{RESET}");
-    if let Err(e) = jj::rebase_onto("main@origin") {
+    if let Err(e) = jj::rebase_branch_onto("@", "main@origin") {
         eprintln!("{RED}{BOLD}error:{RESET} {e}");
         std::process::exit(1);
     }

--- a/tools/shaka/src/repo/sync.rs
+++ b/tools/shaka/src/repo/sync.rs
@@ -4,7 +4,7 @@ use crate::term::{BOLD, GREEN, RED, RESET};
 pub fn run(dry_run: bool) {
     if dry_run {
         println!("would run: jj git fetch");
-        println!("would run: jj rebase -d main@origin");
+        println!("would run: jj rebase -b @ -d main@origin");
         return;
     }
 
@@ -15,7 +15,7 @@ pub fn run(dry_run: bool) {
     }
 
     println!("{BOLD}rebasing onto main@origin{RESET}");
-    if let Err(e) = jj::rebase_onto("main@origin") {
+    if let Err(e) = jj::rebase_branch_onto("@", "main@origin") {
         eprintln!("{RED}{BOLD}error:{RESET} {e}");
         std::process::exit(1);
     }


### PR DESCRIPTION
Both subcommands ran `jj rebase -d main@origin`, which only moves the
working-copy commit and leaves any earlier described commits in the
stack stranded on the old base. Switch to `jj rebase -b @ -d main@origin`
so the entire branch containing `@` rides forward.

Replace the bare `rebase_onto` helper with `rebase_branch_onto(branch,
dest)` so call sites are explicit about the rebase shape, and so the
upcoming `repo bump` can reuse the same primitive.

After landing one PR, refreshing a sibling in-flight PR onto the new
main was a three-step ritual: fetch, rebase the stack, push. Wrap that
into a single command.

bump auto-detects the bookmark to refresh as the unique bookmark in
main@origin..@, errors out for empty or multi-bookmark stacks (with a
hint to pass --bookmark), and prints the existing PR url so the next
click goes straight to the freshly-rebased PR. Reuses the
rebase_branch_onto primitive so sync, ship, and bump all rebase the
whole stack rather than just @.

Closes #75