### PR TITLE
perf(ci): wrap shaka package and skip dev-shell in non-preflight runs

### DIFF
--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -28,8 +28,9 @@ jobs:
   rebase:
     runs-on: ubuntu-latest
     # `id-token: write` lets DeterminateSystems/nix-installer-action mint an
-    # OIDC token for FlakeHub — `nix develop ./tools/shaka` resolves the
-    # `kolohelios-nix` private flake input via FlakeHub and fails without it.
+    # OIDC token for FlakeHub — `nix run ./tools/shaka` substitutes the
+    # wrapped shaka closure from FlakeHub Cache (published by the
+    # `build-shaka` job in `main.yaml`) and fails without the token.
     permissions:
       id-token: write
       contents: read
@@ -47,19 +48,11 @@ jobs:
         with:
           determinate: true
           flakehub: true
-      - uses: actions/cache@v5
-        with:
-          path: |
-            tools/shaka/target/
-            ~/.cargo/registry/
-            ~/.cargo/git/
-          key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
       - name: Configure git identity for rebase commits
         run: |
           git config --global user.name 'kolohelios-bot[bot]'
           git config --global user.email '${{ vars.KOLOHELIOS_BOT_APP_ID }}+kolohelios-bot[bot]@users.noreply.github.com'
       - name: Rebase open PRs
-        run: nix develop ./tools/shaka --command tools/shaka/bin/shaka repo rebase-open-prs
+        run: nix run ./tools/shaka -- repo rebase-open-prs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/bump-kolohelios-nix.yaml
+++ b/.github/workflows/bump-kolohelios-nix.yaml
@@ -33,8 +33,10 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     # `id-token: write` lets DeterminateSystems/nix-installer-action mint
-    # an OIDC token for FlakeHub, which `nix develop ./tools/shaka` and
-    # `nix flake update kolohelios-nix` both need to fetch the private
+    # an OIDC token for FlakeHub. `nix run ./tools/shaka` substitutes the
+    # wrapped shaka closure from FlakeHub Cache (published by the
+    # `build-shaka` job in `main.yaml`); `nix flake update kolohelios-nix`
+    # called by shaka itself also needs the token to fetch the private
     # `kolohelios-nix` flake.
     permissions:
       id-token: write
@@ -54,23 +56,14 @@ jobs:
         with:
           determinate: true
           flakehub: true
-      - uses: actions/cache@v5
-        with:
-          path: |
-            tools/shaka/target/
-            ~/.cargo/registry/
-            ~/.cargo/git/
-          key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
       - name: Configure git identity
         run: |
           git config --global user.name 'kolohelios-bot[bot]'
           git config --global user.email '${{ vars.KOLOHELIOS_BOT_APP_ID }}+kolohelios-bot[bot]@users.noreply.github.com'
       - name: Bump kolohelios-nix and open or update PR
         run: |
-          nix develop ./tools/shaka --command \
-            tools/shaka/bin/shaka repo bump-locks \
-              --input kolohelios-nix \
-              --pr-branch bot/bump-kolohelios-nix
+          nix run ./tools/shaka -- repo bump-locks \
+            --input kolohelios-nix \
+            --pr-branch bot/bump-kolohelios-nix
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -64,6 +64,28 @@
               pkgs.jujutsu
               pkgs.git
             ];
+            # Bake shaka's runtime deps onto the wrapped binary's PATH so
+            # `nix run ./tools/shaka -- <subcmd>` works without a dev shell
+            # — that's how non-preflight CI workflows (auto-rebase,
+            # kolohelios-nix bump) skip the heavy Rust toolchain fetch.
+            # Set deliberately to the everyday subset; less-common shaka
+            # subcommands (object-store, preflight) still want the dev
+            # shell, which carries awscli2/tofu/actionlint/vale/typos.
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+            postFixup = ''
+              wrapProgram $out/bin/shaka \
+                --prefix PATH : ${
+                  pkgs.lib.makeBinPath [
+                    pkgs.jujutsu
+                    pkgs.git
+                    pkgs.gh
+                    pkgs.nix
+                    pkgs.cue
+                    pkgs.just
+                    pkgs.jq
+                  ]
+                }
+            '';
           };
         }
       );


### PR DESCRIPTION
The auto-rebase and kolohelios-nix bump workflows used to enter
`nix develop ./tools/shaka` so the local `bin/shaka` wrapper could find
its runtime deps. That dev shell pulls the entire Rust toolchain
(cargo-nightly, clippy, rustfmt, rust-analyzer, rust-src, rust-std,
rust-docs, llvm-tools), plus actionlint, shellcheck, awscli2, and the
workflowPackages set — wasted closure for jobs that just want to run a
prebuilt shaka.

Wrap `packages.default` of `tools/shaka` with `makeWrapper`, prefixing
PATH with the everyday runtime deps (jujutsu, git, gh, nix, cue, just,
jq) so the wrapped binary works without a dev shell. Less-common
subcommands (object-store, preflight) still want the dev shell, which
carries awscli2/tofu/actionlint/vale/typos.

Switch both workflows to `nix run ./tools/shaka -- <subcmd>` and drop
their cargo caches. The build-shaka job already publishes shaka to
FlakeHub Cache on every push to main, so subsequent runs substitute
the closure instead of building. The first auto-rebase after this lands
races build-shaka and may build from source once; after that, cache hits.

Closes #271