### PR TITLE
feat(infra/home): enable nix-darwin linux-builder

### DIFF
--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -11,6 +11,10 @@
     "flakes"
   ];
 
+  nix.linux-builder.enable = true;
+  # Required so non-root users can dispatch to the linux-builder VM.
+  nix.settings.trusted-users = [ "@admin" ];
+
   users.users.jedwards = {
     name = "jedwards";
     home = "/Users/jedwards";


### PR DESCRIPTION
Without a Linux builder, `shaka preflight` on aarch64-darwin fails on
flake outputs like `checks.x86_64-linux.devbox-eval`: darwin can
evaluate them but not build them, and `nix flake check` falls back to
a local build it can't satisfy. `nix.linux-builder` exposes an Apple
Virtualization VM as `ssh-ng://`, so cross-arch outputs realize via
the VM instead. With FlakeHub Cache substitution already wired up,
unchanged inputs hit the cache; only changed inputs need the VM.

`trusted-users = [ "@admin" ]` is required so the invoking user can
dispatch builds to the remote builder.

End-to-end verification on this Mac is blocked on first-time
nix-darwin bootstrap, tracked in #279.

Closes #64