### PR TITLE
feat(blogctl): expose packages.default for downstream consumption

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,6 +35,7 @@ jobs:
       shaka: ${{ steps.filter.outputs.shaka }}
       image: ${{ steps.filter.outputs.image }}
       nix-lib: ${{ steps.filter.outputs.nix-lib }}
+      blogctl: ${{ steps.filter.outputs.blogctl }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -57,6 +58,8 @@ jobs:
               - 'infra/devbox/**'
             nix-lib:
               - 'nix/kolohelios-nix/**'
+            blogctl:
+              - 'apps/blogctl/**'
 
   # ── Single gate for branch protection ─────────────────────────
   # `shaka preflight` runs every validation check in one place. CI and
@@ -150,6 +153,29 @@ jobs:
           visibility: public
           rolling: true
 
+  build-blogctl:
+    name: Build blogctl
+    needs: [validate, changes]
+    if: needs.changes.outputs.blogctl == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - run: nix build ./apps/blogctl
+      - uses: DeterminateSystems/flakehub-push@main
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        with:
+          directory: apps/blogctl
+          name: kolohelios/blogctl
+          visibility: public
+          rolling: true
+
   build-nix-lib:
     name: Build kolohelios-nix
     needs: [validate, changes]
@@ -206,7 +232,7 @@ jobs:
   # new CI job must add itself to `gate.needs`.
   gate:
     name: Gate
-    needs: [changes, validate, build-shaka, build-nix-lib, build-image]
+    needs: [changes, validate, build-shaka, build-blogctl, build-nix-lib, build-image]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -87,6 +87,23 @@ OpenRouter calls, prompt loading, historical-consistency checks, and
 `Todoist` import are deliberately out of this slice; they slot in alongside
 the preceding modules without rewiring.
 
+## Consuming `blogctl`
+
+Published to FlakeHub as `kolohelios/blogctl` on every push to `main`
+that touches `apps/blogctl/**` (see `.github/workflows/main.yaml`'s
+`build-blogctl` job). Two ways to use it:
+
+- One-shot run:
+  ```
+  nix run https://flakehub.com/f/kolohelios/blogctl/*.tar.gz -- --help
+  ```
+- Pin as a flake input from another project:
+  ```nix
+  inputs.blogctl.url = "https://flakehub.com/f/kolohelios/blogctl/*.tar.gz";
+  # then in a devShell:
+  packages = [ blogctl.packages.${system}.default ];
+  ```
+
 ## Development
 
 This project lives in the kolohelios monorepo. Run validation with

--- a/apps/blogctl/flake.nix
+++ b/apps/blogctl/flake.nix
@@ -46,6 +46,28 @@
         };
     in
     {
+      packages = forEachSupportedSystem (
+        { pkgs, ... }:
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "blogctl";
+            version = "0.1.0";
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+          };
+        }
+      );
+
+      apps = forEachSupportedSystem (
+        { system, ... }:
+        {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/blogctl";
+          };
+        }
+      );
+
       devShells = forEachSupportedSystem (
         { pkgs, ... }:
         {


### PR DESCRIPTION
Add `packages.default` (rustPlatform.buildRustPackage) and
`apps.default` outputs to `apps/blogctl/flake.nix`, mirroring the
shape used by `tools/shaka/flake.nix`. Wire a `build-blogctl` job
into `.github/workflows/main.yaml` that builds the package and
publishes to FlakeHub as `kolohelios/blogctl` on every push to
main that touches `apps/blogctl/**`. Document the FlakeHub
consumer URL in the README.

This unblocks #284, where `kolohelios/blogs-and-posts` will pull
blogctl as a flake input from FlakeHub.

Closes #283