### PR TITLE
feat(shaka): rebase before push in repo send

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -65,11 +65,15 @@ diagnose the failure.
 
 ### 5. Push and open PR
 
-Run `shaka repo send`. It sets a bookmark from the change description, pushes
-it, and creates a PR if one doesn't exist. Report the PR URL.
+Run `shaka repo send`. It fetches, rebases onto `main@origin` (re-running
+preflight if the rebase moved `@`, since new ancestors could conflict with
+our changes in ways `jj` doesn't flag), sets a bookmark from the change
+description, pushes, and creates a PR if one doesn't exist. Report the PR
+URL.
 
 If `shaka repo send` errors because the change has no description, stop and
-ask the user to run `jj describe`.
+ask the user to run `jj describe`. If the rebase hits a conflict, stop and
+let the user resolve it.
 
 ## Conventions
 
@@ -86,7 +90,9 @@ Halt the workflow and report to the user when:
 - `shaka repo sync` hits a merge conflict
 - `shaka commit lint` reports errors that aren't trivially auto-fixable
 - Self-review surfaces something unintentional
-- `shaka preflight` fails any check
+- `shaka preflight` fails any check (including the conditional re-run inside
+  `shaka repo send` when `main@origin` advanced during the work)
+- `shaka repo send`'s pre-push rebase hits a conflict — let the user resolve
 - The change has no description (push step needs one)
 
 A failed step is a stop — not a prompt to retry blindly. Diagnose first.

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -45,7 +45,15 @@ pub enum RepoCommand {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Set a bookmark on the current change, push it, and open a PR
+    /// Fetch, rebase onto main@origin, push, and open a PR
+    ///
+    /// Always fetches and rebases the bookmark onto the latest
+    /// `main@origin` immediately before push so the PR opens on a
+    /// current base. If the rebase pulls in new ancestors (i.e.,
+    /// `main` moved during the work), re-runs `shaka preflight --since
+    /// origin/main` first — new commits can break our changes in ways
+    /// `jj` doesn't flag with conflict markers. If the rebase is a
+    /// no-op, preflight is skipped.
     Send {
         /// Bookmark name (auto-derived from the change description if omitted)
         #[arg(long)]

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -1,7 +1,8 @@
 use crate::gh;
 use crate::jj;
+use crate::preflight;
 use crate::repo::describe;
-use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
     let description = match jj::current_description() {
@@ -42,12 +43,52 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
     let body = synthesized.body.as_str();
 
     if dry_run {
+        println!("would run: jj git fetch");
+        println!("would run: jj rebase -b @ -d main@origin");
+        println!(
+            "would run: shaka preflight --since origin/main {DIM}(only if rebase moved @){RESET}"
+        );
         println!("would run: jj bookmark set {bookmark} -r @");
         println!("would run: jj git push --allow-new --bookmark {bookmark}");
         if !no_pr {
             println!("would run: gh pr create --title {title:?} --head {bookmark}");
         }
         return;
+    }
+
+    println!("{BOLD}fetching from origin{RESET}");
+    if let Err(e) = jj::fetch() {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    let before = match jj::commit_id_of("@") {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("{BOLD}rebasing onto main@origin{RESET}");
+    if let Err(e) = jj::rebase_branch_onto("@", "main@origin") {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+
+    let after = match jj::commit_id_of("@") {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if before != after {
+        println!(
+            "{BOLD}main@origin advanced — re-running preflight{RESET} {DIM}(rebase pulled in new ancestors){RESET}"
+        );
+        preflight::run(false, Some("origin/main".to_string()));
     }
 
     println!("{BOLD}setting bookmark {bookmark}{RESET}");

--- a/tools/shaka/tests/repo_send_workspace.rs
+++ b/tools/shaka/tests/repo_send_workspace.rs
@@ -126,6 +126,20 @@ fn dry_run_from_non_default_workspace() {
         stdout.contains(&format!("jj git push --allow-new --bookmark {bookmark}")),
         "expected push line in dry-run output; got: {stdout}",
     );
+    // Send always rebases on main@origin before pushing so the PR opens on a
+    // current base; the dry-run output must reflect that.
+    assert!(
+        stdout.contains("jj git fetch"),
+        "expected pre-push fetch in dry-run output; got: {stdout}",
+    );
+    assert!(
+        stdout.contains("jj rebase -b @ -d main@origin"),
+        "expected pre-push rebase in dry-run output; got: {stdout}",
+    );
+    assert!(
+        stdout.contains("shaka preflight --since origin/main"),
+        "expected conditional preflight in dry-run output; got: {stdout}",
+    );
 }
 
 /// Sending from inside a workspace without a description should fail with a


### PR DESCRIPTION
Make `shaka repo send` always fetch and rebase onto `main@origin`
immediately before push so the PR opens on a current base. If the
rebase pulls in new ancestors (i.e., `main` advanced during the
work — typical when the daily `bump-kolohelios-nix` lock bump or
another PR landed), re-run `shaka preflight --since origin/main`
first: new commits can break our changes in ways `jj` doesn't flag
with conflict markers. When the rebase is a no-op, preflight is
skipped — cost is one fetch.

This makes `send` safe-by-default for any caller; the `/ship`
skill simply walks through to step 5 and trusts `send` to do the
right thing rather than orchestrating fetch + rebase + revalidate
in markdown.

`shaka repo ship` (Rust) still has the original race; folding it
into `send` is follow-up.

Closes #282