### PR TITLE
feat(blogctl): fix command for auto-correctable findings

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -75,6 +75,16 @@ pub enum Command {
         #[arg(long, value_name = "PATH")]
         workdir: PathBuf,
     },
+    /// Apply doctor's auto-correctable repairs. Skipped findings
+    /// remain non-zero so `fix` followed by `doctor` is a useful
+    /// idempotency check.
+    Fix {
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        /// Print the plan without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -111,6 +121,7 @@ pub fn dispatch(cmd: Command) -> Result<()> {
             ReadmeAction::Regenerate { workdir } => commands::readme::regenerate(workdir),
         },
         Command::Doctor { workdir } => commands::doctor::run(workdir),
+        Command::Fix { workdir, dry_run } => commands::fix::run(workdir, dry_run),
     }
 }
 
@@ -157,6 +168,8 @@ mod tests {
             vec!["blogctl", "demote", "hello", "--workdir", "/tmp/wd"],
             vec!["blogctl", "readme", "regenerate", "--workdir", "/tmp/wd"],
             vec!["blogctl", "doctor", "--workdir", "/tmp/wd"],
+            vec!["blogctl", "fix", "--workdir", "/tmp/wd"],
+            vec!["blogctl", "fix", "--workdir", "/tmp/wd", "--dry-run"],
         ] {
             assert!(Cli::try_parse_from(args.clone()).is_ok(), "{args:?}");
         }

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -69,6 +69,12 @@ pub enum Command {
         #[command(subcommand)]
         action: ReadmeAction,
     },
+    /// Audit a workdir for layout, frontmatter, and config problems.
+    /// Exits non-zero if any finding is surfaced.
+    Doctor {
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -104,6 +110,7 @@ pub fn dispatch(cmd: Command) -> Result<()> {
         Command::Readme { action } => match action {
             ReadmeAction::Regenerate { workdir } => commands::readme::regenerate(workdir),
         },
+        Command::Doctor { workdir } => commands::doctor::run(workdir),
     }
 }
 
@@ -149,6 +156,7 @@ mod tests {
             vec!["blogctl", "promote", "hello", "--workdir", "/tmp/wd"],
             vec!["blogctl", "demote", "hello", "--workdir", "/tmp/wd"],
             vec!["blogctl", "readme", "regenerate", "--workdir", "/tmp/wd"],
+            vec!["blogctl", "doctor", "--workdir", "/tmp/wd"],
         ] {
             assert!(Cli::try_parse_from(args.clone()).is_ok(), "{args:?}");
         }
@@ -180,6 +188,7 @@ mod tests {
             vec!["blogctl", "new", "Hello"],
             vec!["blogctl", "list"],
             vec!["blogctl", "show", "hello"],
+            vec!["blogctl", "doctor"],
         ] {
             assert!(Cli::try_parse_from(args.clone()).is_err(), "{args:?}");
         }

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -1,0 +1,454 @@
+//! Read-only audit of a workdir's health. `audit()` returns the full
+//! list of `Finding`s; `run()` prints them and returns
+//! `Error::WorkdirUnhealthy` when the list is non-empty so the binary
+//! exits non-zero. `fix` (next slice) calls `audit()` directly.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::stage::Stage;
+use crate::storage::{AuditedPost, Config, ConfigStatus, Repository, StrayEntry, Workdir};
+
+#[derive(Debug)]
+pub enum Finding {
+    ConfigMissing,
+    ConfigUnparsable {
+        error: Error,
+    },
+    StageDirMissing {
+        stage: Stage,
+    },
+    FrontmatterParseError {
+        path: PathBuf,
+        error: Error,
+    },
+    StageMismatch {
+        path: PathBuf,
+        dir_stage: Stage,
+        fm_stage: Stage,
+    },
+    FilenameSlugMismatch {
+        path: PathBuf,
+        slug: String,
+    },
+    DuplicateSlug {
+        slug: String,
+        paths: Vec<PathBuf>,
+    },
+    UnknownTheme {
+        path: PathBuf,
+        theme: String,
+        known: Vec<String>,
+    },
+    TimestampInversion {
+        path: PathBuf,
+        created_at: OffsetDateTime,
+        updated_at: OffsetDateTime,
+    },
+    StrayEntry {
+        dir_stage: Stage,
+        path: PathBuf,
+    },
+}
+
+impl fmt::Display for Finding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConfigMissing => write!(f, "config missing: .blog-os.toml does not exist"),
+            Self::ConfigUnparsable { error } => write!(f, "config unparsable: {error}"),
+            Self::StageDirMissing { stage } => {
+                write!(f, "stage directory missing: {}/", stage.dirname())
+            },
+            Self::FrontmatterParseError { path, error } => {
+                write!(f, "frontmatter unreadable in {}: {error}", path.display())
+            },
+            Self::StageMismatch {
+                path,
+                dir_stage,
+                fm_stage,
+            } => write!(
+                f,
+                "stage mismatch in {}: directory says {dir_stage}, frontmatter says {fm_stage}",
+                path.display()
+            ),
+            Self::FilenameSlugMismatch { path, slug } => write!(
+                f,
+                "filename does not match slug in {}: frontmatter slug is {slug:?}",
+                path.display()
+            ),
+            Self::DuplicateSlug { slug, paths } => {
+                let joined = paths
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "duplicate slug {slug:?}: {joined}")
+            },
+            Self::UnknownTheme { path, theme, known } => write!(
+                f,
+                "unknown theme {theme:?} in {}: known themes are {}",
+                path.display(),
+                known.join(", ")
+            ),
+            Self::TimestampInversion {
+                path,
+                created_at,
+                updated_at,
+            } => write!(
+                f,
+                "timestamp inversion in {}: updated_at {updated_at} predates created_at {created_at}",
+                path.display()
+            ),
+            Self::StrayEntry { dir_stage, path } => write!(
+                f,
+                "stray entry in {}/: {}",
+                dir_stage.dirname(),
+                path.display()
+            ),
+        }
+    }
+}
+
+/// Walk the workdir and collect every health finding. Never short-
+/// circuits — the caller decides whether to print, repair, or both.
+///
+/// Returns `Err` only for unrecoverable IO (e.g. a stage directory
+/// that exists but can't be read). Every recoverable problem comes
+/// back as a `Finding`.
+pub fn audit(workdir: &Workdir) -> Result<Vec<Finding>> {
+    let repo = Repository::unchecked(workdir.clone());
+    let mut findings = Vec::new();
+
+    let cfg = match repo.audit_config() {
+        ConfigStatus::Ok(cfg) => Some(cfg),
+        ConfigStatus::Missing => {
+            findings.push(Finding::ConfigMissing);
+            None
+        }
+        ConfigStatus::Unparsable(error) => {
+            findings.push(Finding::ConfigUnparsable { error });
+            None
+        }
+    };
+
+    for stage in repo.missing_stage_dirs() {
+        findings.push(Finding::StageDirMissing { stage });
+    }
+
+    // Per-post checks. `slug_index` collects parsed slugs so we can
+    // surface duplicates after the loop.
+    let mut slug_index: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+    for post in repo.audit_posts()? {
+        match post {
+            AuditedPost::ParseFailed { path, error, .. } => {
+                findings.push(Finding::FrontmatterParseError { path, error });
+            }
+            AuditedPost::Parsed {
+                dir_stage,
+                path,
+                post,
+            } => {
+                let meta = post.metadata;
+                if meta.status != dir_stage {
+                    findings.push(Finding::StageMismatch {
+                        path: path.clone(),
+                        dir_stage,
+                        fm_stage: meta.status,
+                    });
+                }
+                if filename_stem(&path) != Some(meta.slug.as_str()) {
+                    findings.push(Finding::FilenameSlugMismatch {
+                        path: path.clone(),
+                        slug: meta.slug.clone(),
+                    });
+                }
+                if meta.updated_at < meta.created_at {
+                    findings.push(Finding::TimestampInversion {
+                        path: path.clone(),
+                        created_at: meta.created_at,
+                        updated_at: meta.updated_at,
+                    });
+                }
+                if let Some(cfg) = &cfg {
+                    if !theme_known(cfg, &meta.theme) {
+                        findings.push(Finding::UnknownTheme {
+                            path: path.clone(),
+                            theme: meta.theme.clone(),
+                            known: cfg.themes.keys().cloned().collect(),
+                        });
+                    }
+                }
+                slug_index.entry(meta.slug).or_default().push(path);
+            }
+        }
+    }
+    for (slug, paths) in slug_index {
+        if paths.len() > 1 {
+            findings.push(Finding::DuplicateSlug { slug, paths });
+        }
+    }
+
+    for StrayEntry { dir_stage, path } in repo.stray_entries()? {
+        findings.push(Finding::StrayEntry { dir_stage, path });
+    }
+
+    Ok(findings)
+}
+
+pub fn run(workdir: PathBuf) -> Result<()> {
+    let findings = audit(&Workdir::new(&workdir))?;
+    if findings.is_empty() {
+        println!("workdir healthy: {}", workdir.display());
+        return Ok(());
+    }
+    for finding in &findings {
+        println!("{finding}");
+    }
+    Err(Error::WorkdirUnhealthy(findings.len()))
+}
+
+fn theme_known(cfg: &Config, theme: &str) -> bool {
+    cfg.themes.contains_key(theme)
+}
+
+fn filename_stem(path: &Path) -> Option<&str> {
+    path.file_stem().and_then(|s| s.to_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use tempfile::TempDir;
+    use time::macros::datetime;
+
+    use crate::kind::Kind;
+    use crate::post::{Post, PostMetadata};
+    use crate::storage::DEFAULT_THEME;
+
+    fn fixture_post(slug: &str, stage: Stage) -> Post {
+        Post::new(
+            PostMetadata {
+                title: format!("Title {slug}"),
+                slug: slug.to_string(),
+                kind: Kind::Post,
+                theme: DEFAULT_THEME.to_string(),
+                status: stage,
+                created_at: datetime!(2026-05-03 00:00:00 UTC),
+                updated_at: datetime!(2026-05-03 00:00:00 UTC),
+                tags: vec![],
+                todoist_task_id: None,
+                history_checked: false,
+            },
+            "body\n",
+        )
+    }
+
+    fn fresh_workdir() -> (TempDir, Workdir) {
+        let tmp = TempDir::new().unwrap();
+        let workdir = Workdir::new(tmp.path());
+        Repository::unchecked(workdir.clone()).init().unwrap();
+        (tmp, workdir)
+    }
+
+    #[test]
+    fn audit_returns_empty_for_freshly_initialized_workdir() {
+        let (_tmp, workdir) = fresh_workdir();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings.is_empty(), "got findings: {findings:?}");
+    }
+
+    #[test]
+    fn audit_flags_missing_config() {
+        let tmp = TempDir::new().unwrap();
+        for &stage in Stage::ALL {
+            fs::create_dir_all(tmp.path().join(stage.dirname())).unwrap();
+        }
+        let findings = audit(&Workdir::new(tmp.path())).unwrap();
+        assert!(findings.iter().any(|f| matches!(f, Finding::ConfigMissing)));
+    }
+
+    #[test]
+    fn audit_flags_unparsable_config() {
+        let tmp = TempDir::new().unwrap();
+        for &stage in Stage::ALL {
+            fs::create_dir_all(tmp.path().join(stage.dirname())).unwrap();
+        }
+        fs::write(tmp.path().join(".blog-os.toml"), "this = is not = valid").unwrap();
+        let findings = audit(&Workdir::new(tmp.path())).unwrap();
+        assert!(findings
+            .iter()
+            .any(|f| matches!(f, Finding::ConfigUnparsable { .. })));
+    }
+
+    #[test]
+    fn audit_flags_each_missing_stage_directory() {
+        let tmp = TempDir::new().unwrap();
+        // Only create concepts/ and the config; everything else is
+        // missing.
+        fs::create_dir_all(tmp.path().join("concepts")).unwrap();
+        fs::write(tmp.path().join(".blog-os.toml"), "version = 1\n").unwrap();
+        let findings = audit(&Workdir::new(tmp.path())).unwrap();
+        let missing: Vec<Stage> = findings
+            .iter()
+            .filter_map(|f| match f {
+                Finding::StageDirMissing { stage } => Some(*stage),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(missing.len(), 5);
+        assert!(!missing.contains(&Stage::Concept));
+    }
+
+    #[test]
+    fn audit_flags_stage_mismatch() {
+        let (tmp, workdir) = fresh_workdir();
+        let mismatched = fixture_post("oops", Stage::Editing);
+        fs::write(
+            tmp.path().join("concepts/oops.md"),
+            mismatched.render().unwrap(),
+        )
+        .unwrap();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings.iter().any(|f| matches!(
+            f,
+            Finding::StageMismatch {
+                dir_stage: Stage::Concept,
+                fm_stage: Stage::Editing,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn audit_flags_filename_slug_mismatch() {
+        let (tmp, workdir) = fresh_workdir();
+        let post = fixture_post("real-slug", Stage::Concept);
+        // Write the post under a wrong filename — slug stays "real-slug"
+        // but the file is named otherwise.md.
+        fs::write(
+            tmp.path().join("concepts/otherwise.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings
+            .iter()
+            .any(|f| matches!(f, Finding::FilenameSlugMismatch { .. })));
+    }
+
+    #[test]
+    fn audit_flags_frontmatter_parse_errors() {
+        let (tmp, workdir) = fresh_workdir();
+        // Missing closing delimiter.
+        fs::write(tmp.path().join("concepts/broken.md"), "---\ntitle: X\n").unwrap();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings
+            .iter()
+            .any(|f| matches!(f, Finding::FrontmatterParseError { .. })));
+    }
+
+    #[test]
+    fn audit_flags_duplicate_slug_across_stages() {
+        let (tmp, workdir) = fresh_workdir();
+        let p1 = fixture_post("dup", Stage::Concept);
+        fs::write(tmp.path().join("concepts/dup.md"), p1.render().unwrap()).unwrap();
+        let p2 = fixture_post("dup", Stage::Editing);
+        // Frontmatter says editing, file lives in editing — both valid in
+        // isolation, but they share a slug.
+        fs::write(tmp.path().join("editing/dup.md"), p2.render().unwrap()).unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        let dups: Vec<_> = findings
+            .iter()
+            .filter(|f| matches!(f, Finding::DuplicateSlug { .. }))
+            .collect();
+        assert_eq!(dups.len(), 1);
+    }
+
+    #[test]
+    fn audit_flags_unknown_theme() {
+        let (tmp, workdir) = fresh_workdir();
+        let mut post = fixture_post("themed", Stage::Concept);
+        post.metadata.theme = "wat".to_string();
+        fs::write(
+            tmp.path().join("concepts/themed.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings.iter().any(|f| matches!(
+            f,
+            Finding::UnknownTheme { theme, .. } if theme == "wat"
+        )));
+    }
+
+    #[test]
+    fn audit_skips_theme_check_when_config_unparsable() {
+        // Without a parseable config we have no list of valid themes,
+        // so the theme check would be noise. The config error itself
+        // is the actionable finding.
+        let tmp = TempDir::new().unwrap();
+        for &stage in Stage::ALL {
+            fs::create_dir_all(tmp.path().join(stage.dirname())).unwrap();
+        }
+        fs::write(tmp.path().join(".blog-os.toml"), "garbage = = =").unwrap();
+        let mut post = fixture_post("p", Stage::Concept);
+        post.metadata.theme = "anything".into();
+        fs::write(tmp.path().join("concepts/p.md"), post.render().unwrap()).unwrap();
+
+        let findings = audit(&Workdir::new(tmp.path())).unwrap();
+        assert!(!findings
+            .iter()
+            .any(|f| matches!(f, Finding::UnknownTheme { .. })));
+        assert!(findings
+            .iter()
+            .any(|f| matches!(f, Finding::ConfigUnparsable { .. })));
+    }
+
+    #[test]
+    fn audit_flags_timestamp_inversion() {
+        let (tmp, workdir) = fresh_workdir();
+        let mut post = fixture_post("inverted", Stage::Concept);
+        post.metadata.created_at = datetime!(2026-05-05 00:00:00 UTC);
+        post.metadata.updated_at = datetime!(2026-05-03 00:00:00 UTC);
+        fs::write(
+            tmp.path().join("concepts/inverted.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings
+            .iter()
+            .any(|f| matches!(f, Finding::TimestampInversion { .. })));
+    }
+
+    #[test]
+    fn audit_flags_stray_entries() {
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(tmp.path().join("concepts/.DS_Store"), "noise").unwrap();
+        let findings = audit(&workdir).unwrap();
+        assert!(findings
+            .iter()
+            .any(|f| matches!(f, Finding::StrayEntry { .. })));
+    }
+
+    #[test]
+    fn run_returns_workdir_unhealthy_on_findings() {
+        let (tmp, _workdir) = fresh_workdir();
+        fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
+        let err = run(tmp.path().to_path_buf()).unwrap_err();
+        assert!(matches!(err, Error::WorkdirUnhealthy(n) if n >= 1));
+    }
+
+    #[test]
+    fn run_returns_ok_on_clean_workdir() {
+        let (tmp, _workdir) = fresh_workdir();
+        run(tmp.path().to_path_buf()).unwrap();
+    }
+}

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -1,0 +1,544 @@
+//! Apply auto-correctable repairs surfaced by `doctor`. The
+//! classifier in `plan` decides per-finding whether to apply or skip
+//! (with a reason); `apply` executes the applies in an order that
+//! avoids in-flight conflicts (e.g. stage rewrite before filename
+//! rename, so the rename works against the post's final shape).
+//!
+//! Exits non-zero whenever any finding remains after the run — `fix`
+//! followed by `doctor` is therefore a useful idempotency check.
+
+use std::fmt;
+use std::fs;
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::commands::doctor::{self, Finding};
+use crate::error::{Error, Result};
+use crate::post::Post;
+use crate::stage::Stage;
+use crate::storage::Workdir;
+
+/// Per-finding plan entry — either we'll attempt a repair or we'll
+/// skip with a reason. The order in `plan()` doubles as the apply
+/// order: directory creation precedes content rewrites, content
+/// rewrites precede file renames.
+#[derive(Debug)]
+pub enum Repair {
+    CreateStageDir(Stage),
+    RewriteStage {
+        path: PathBuf,
+        new_status: Stage,
+    },
+    BumpUpdatedAt {
+        path: PathBuf,
+    },
+    RenameToSlug {
+        path: PathBuf,
+        slug: String,
+    },
+    Skip {
+        finding: Finding,
+        reason: SkipReason,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SkipReason {
+    DuplicateSlug,
+    FrontmatterUnreadable,
+    UnknownTheme,
+    StrayEntry,
+    ConfigMissing,
+    ConfigUnparsable,
+}
+
+impl fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::DuplicateSlug => "manual: choose which file keeps the slug",
+            Self::FrontmatterUnreadable => "manual: frontmatter must be repaired by hand",
+            Self::UnknownTheme => "manual: typo or missing [themes.*] entry",
+            Self::StrayEntry => "manual: review the file and remove or relocate it",
+            Self::ConfigMissing => "manual: run `blogctl init` or restore .blog-os.toml",
+            Self::ConfigUnparsable => "manual: edit .blog-os.toml by hand",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Classify every finding. Auto-correctable findings become specific
+/// `Repair` variants in apply order; the rest become `Skip` with a
+/// reason. Order matters at apply time: directory creation precedes
+/// content rewrites, content rewrites precede renames.
+pub fn plan(findings: Vec<Finding>) -> Vec<Repair> {
+    let mut creates = Vec::new();
+    let mut rewrites = Vec::new();
+    let mut bumps = Vec::new();
+    let mut renames = Vec::new();
+    let mut skips = Vec::new();
+
+    for finding in findings {
+        match finding {
+            Finding::StageDirMissing { stage } => creates.push(Repair::CreateStageDir(stage)),
+            Finding::StageMismatch {
+                path, dir_stage, ..
+            } => rewrites.push(Repair::RewriteStage {
+                path,
+                new_status: dir_stage,
+            }),
+            Finding::TimestampInversion { path, .. } => bumps.push(Repair::BumpUpdatedAt { path }),
+            Finding::FilenameSlugMismatch { path, slug } => {
+                renames.push(Repair::RenameToSlug { path, slug })
+            }
+            f @ Finding::DuplicateSlug { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::DuplicateSlug,
+            }),
+            f @ Finding::FrontmatterParseError { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::FrontmatterUnreadable,
+            }),
+            f @ Finding::UnknownTheme { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::UnknownTheme,
+            }),
+            f @ Finding::StrayEntry { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::StrayEntry,
+            }),
+            f @ Finding::ConfigMissing => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::ConfigMissing,
+            }),
+            f @ Finding::ConfigUnparsable { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::ConfigUnparsable,
+            }),
+        }
+    }
+
+    let mut out = Vec::with_capacity(
+        creates.len() + rewrites.len() + bumps.len() + renames.len() + skips.len(),
+    );
+    out.extend(creates);
+    out.extend(rewrites);
+    out.extend(bumps);
+    out.extend(renames);
+    out.extend(skips);
+    out
+}
+
+/// Outcome line for a single planned `Repair`. `Failed` carries the
+/// finding-equivalent diagnosis so the post-run summary can re-count
+/// it as a remaining problem.
+#[derive(Debug)]
+pub enum Outcome {
+    Fixed(String),
+    Skipped(String, SkipReason),
+    Failed(String, Error),
+}
+
+impl fmt::Display for Outcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fixed(diag) => write!(f, "fixed: {diag}"),
+            Self::Skipped(diag, reason) => write!(f, "skipped: {diag} ({reason})"),
+            Self::Failed(diag, err) => write!(f, "failed: {diag} ({err})"),
+        }
+    }
+}
+
+/// Apply (or simulate) every planned repair against the workdir.
+/// `dry_run = true` performs no IO but produces the same diagnostic
+/// stream so users can preview the fix.
+pub fn apply(
+    workdir: &Workdir,
+    plan: Vec<Repair>,
+    now: OffsetDateTime,
+    dry_run: bool,
+) -> Vec<Outcome> {
+    plan.into_iter()
+        .map(|r| apply_one(workdir, r, now, dry_run))
+        .collect()
+}
+
+fn apply_one(workdir: &Workdir, repair: Repair, now: OffsetDateTime, dry_run: bool) -> Outcome {
+    match repair {
+        Repair::CreateStageDir(stage) => {
+            let dir = workdir.stage_dir(stage);
+            let diag = format!("create stage directory {}/", stage.dirname());
+            if dry_run {
+                return Outcome::Fixed(diag);
+            }
+            match fs::create_dir_all(&dir) {
+                Ok(()) => Outcome::Fixed(diag),
+                Err(err) => Outcome::Failed(diag, Error::io(&dir, err)),
+            }
+        }
+        Repair::RewriteStage { path, new_status } => {
+            let diag = format!(
+                "rewrite frontmatter status to {} in {}",
+                new_status,
+                path.display()
+            );
+            if dry_run {
+                return Outcome::Fixed(diag);
+            }
+            match rewrite_metadata(&path, |post| {
+                post.metadata.status = new_status;
+                post.metadata.updated_at = now;
+            }) {
+                Ok(()) => Outcome::Fixed(diag),
+                Err(e) => Outcome::Failed(diag, e),
+            }
+        }
+        Repair::BumpUpdatedAt { path } => {
+            let diag = format!("bump updated_at in {}", path.display());
+            if dry_run {
+                return Outcome::Fixed(diag);
+            }
+            match rewrite_metadata(&path, |post| {
+                post.metadata.updated_at = now;
+            }) {
+                Ok(()) => Outcome::Fixed(diag),
+                Err(e) => Outcome::Failed(diag, e),
+            }
+        }
+        Repair::RenameToSlug { path, slug } => {
+            let parent = match path.parent() {
+                Some(p) => p,
+                None => {
+                    return Outcome::Failed(
+                        format!("rename {} to {slug}.md", path.display()),
+                        Error::io(&path, std::io::Error::other("path has no parent")),
+                    )
+                }
+            };
+            let new_path = parent.join(format!("{slug}.md"));
+            let diag = format!("rename {} to {}", path.display(), new_path.display());
+            if new_path.exists() {
+                return Outcome::Failed(
+                    diag,
+                    Error::io(
+                        &new_path,
+                        std::io::Error::new(
+                            std::io::ErrorKind::AlreadyExists,
+                            "target file already exists",
+                        ),
+                    ),
+                );
+            }
+            if dry_run {
+                return Outcome::Fixed(diag);
+            }
+            match fs::rename(&path, &new_path) {
+                Ok(()) => Outcome::Fixed(diag),
+                Err(err) => Outcome::Failed(diag, Error::io(&new_path, err)),
+            }
+        }
+        Repair::Skip { finding, reason } => Outcome::Skipped(finding.to_string(), reason),
+    }
+}
+
+fn rewrite_metadata<F>(path: &PathBuf, mutate: F) -> Result<()>
+where
+    F: FnOnce(&mut Post),
+{
+    let raw = fs::read_to_string(path).map_err(|e| Error::io(path, e))?;
+    let mut post = Post::parse(path, &raw)?;
+    mutate(&mut post);
+    let rendered = post.render()?;
+    fs::write(path, rendered).map_err(|e| Error::io(path, e))?;
+    Ok(())
+}
+
+pub fn run(workdir: PathBuf, dry_run: bool) -> Result<()> {
+    let wd = Workdir::new(&workdir);
+    let findings = doctor::audit(&wd)?;
+    if findings.is_empty() {
+        println!("workdir healthy: {}", workdir.display());
+        return Ok(());
+    }
+
+    let plan = plan(findings);
+    let outcomes = apply(&wd, plan, OffsetDateTime::now_utc(), dry_run);
+    for outcome in &outcomes {
+        println!("{outcome}");
+    }
+
+    let remaining = outcomes
+        .iter()
+        .filter(|o| !matches!(o, Outcome::Fixed(_)))
+        .count();
+    if remaining == 0 {
+        Ok(())
+    } else {
+        Err(Error::WorkdirUnhealthy(remaining))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use tempfile::TempDir;
+    use time::macros::datetime;
+
+    use crate::kind::Kind;
+    use crate::post::PostMetadata;
+    use crate::storage::{Repository, DEFAULT_THEME};
+
+    fn fixture_post(slug: &str, stage: Stage) -> Post {
+        Post::new(
+            PostMetadata {
+                title: format!("Title {slug}"),
+                slug: slug.to_string(),
+                kind: Kind::Post,
+                theme: DEFAULT_THEME.to_string(),
+                status: stage,
+                created_at: datetime!(2026-05-03 00:00:00 UTC),
+                updated_at: datetime!(2026-05-03 00:00:00 UTC),
+                tags: vec![],
+                todoist_task_id: None,
+                history_checked: false,
+            },
+            "body\n",
+        )
+    }
+
+    fn fresh_workdir() -> (TempDir, Workdir) {
+        let tmp = TempDir::new().unwrap();
+        let workdir = Workdir::new(tmp.path());
+        Repository::unchecked(workdir.clone()).init().unwrap();
+        (tmp, workdir)
+    }
+
+    fn now() -> OffsetDateTime {
+        datetime!(2026-05-09 12:00:00 UTC)
+    }
+
+    #[test]
+    fn apply_creates_missing_stage_directories() {
+        let tmp = TempDir::new().unwrap();
+        let workdir = Workdir::new(tmp.path());
+        // Skip init so all stage dirs are missing, but plant a config so
+        // we don't trip the config-missing skip path.
+        fs::write(tmp.path().join(".blog-os.toml"), "version = 1\n").unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+
+        for &stage in Stage::ALL {
+            assert!(tmp.path().join(stage.dirname()).is_dir(), "{}", stage);
+        }
+        assert!(outcomes.iter().all(|o| matches!(o, Outcome::Fixed(_))));
+    }
+
+    #[test]
+    fn apply_rewrites_stage_to_match_directory() {
+        let (tmp, workdir) = fresh_workdir();
+        let mismatched = fixture_post("oops", Stage::Editing);
+        fs::write(
+            tmp.path().join("concepts/oops.md"),
+            mismatched.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes.iter().all(|o| matches!(o, Outcome::Fixed(_))));
+
+        // After fix, doctor should see no findings.
+        let after = doctor::audit(&workdir).unwrap();
+        assert!(after.is_empty(), "remaining findings: {after:?}");
+    }
+
+    #[test]
+    fn apply_renames_file_to_match_slug() {
+        let (tmp, workdir) = fresh_workdir();
+        let post = fixture_post("real-slug", Stage::Concept);
+        fs::write(
+            tmp.path().join("concepts/wrong-name.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes.iter().all(|o| matches!(o, Outcome::Fixed(_))));
+        assert!(tmp.path().join("concepts/real-slug.md").is_file());
+        assert!(!tmp.path().join("concepts/wrong-name.md").exists());
+    }
+
+    #[test]
+    fn apply_bumps_updated_at_on_inversion() {
+        let (tmp, workdir) = fresh_workdir();
+        let mut post = fixture_post("inverted", Stage::Concept);
+        post.metadata.created_at = datetime!(2026-05-05 00:00:00 UTC);
+        post.metadata.updated_at = datetime!(2026-05-03 00:00:00 UTC);
+        fs::write(
+            tmp.path().join("concepts/inverted.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes.iter().all(|o| matches!(o, Outcome::Fixed(_))));
+
+        let raw = fs::read_to_string(tmp.path().join("concepts/inverted.md")).unwrap();
+        assert!(raw.contains("updated_at: 2026-05-09T12:00:00Z"));
+    }
+
+    #[test]
+    fn apply_combined_stage_and_filename_repairs_in_correct_order() {
+        // Both stage mismatch and filename mismatch on the same file.
+        // Stage rewrite must run first, otherwise the rename moves the
+        // file out from under the rewrite. The plan() helper enforces
+        // this ordering.
+        let (tmp, workdir) = fresh_workdir();
+        let mut post = fixture_post("right-slug", Stage::Editing);
+        post.metadata.status = Stage::Editing; // explicit
+        let path = tmp.path().join("concepts/wrong-name.md");
+        fs::write(&path, post.render().unwrap()).unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(
+            outcomes.iter().all(|o| matches!(o, Outcome::Fixed(_))),
+            "got: {outcomes:?}"
+        );
+
+        let final_path = tmp.path().join("concepts/right-slug.md");
+        assert!(final_path.is_file());
+        let raw = fs::read_to_string(final_path).unwrap();
+        assert!(raw.contains("status: concept"));
+        assert!(!tmp.path().join("concepts/wrong-name.md").exists());
+    }
+
+    #[test]
+    fn apply_skips_duplicate_slug() {
+        let (tmp, workdir) = fresh_workdir();
+        let p1 = fixture_post("dup", Stage::Concept);
+        let p2 = fixture_post("dup", Stage::Editing);
+        fs::write(tmp.path().join("concepts/dup.md"), p1.render().unwrap()).unwrap();
+        fs::write(tmp.path().join("editing/dup.md"), p2.render().unwrap()).unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes
+            .iter()
+            .any(|o| matches!(o, Outcome::Skipped(_, SkipReason::DuplicateSlug))));
+    }
+
+    #[test]
+    fn apply_skips_frontmatter_parse_errors() {
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(tmp.path().join("concepts/bad.md"), "---\nbroken").unwrap();
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes
+            .iter()
+            .any(|o| matches!(o, Outcome::Skipped(_, SkipReason::FrontmatterUnreadable))));
+    }
+
+    #[test]
+    fn apply_skips_unknown_theme() {
+        let (tmp, workdir) = fresh_workdir();
+        let mut post = fixture_post("themed", Stage::Concept);
+        post.metadata.theme = "nope".into();
+        fs::write(
+            tmp.path().join("concepts/themed.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes
+            .iter()
+            .any(|o| matches!(o, Outcome::Skipped(_, SkipReason::UnknownTheme))));
+    }
+
+    #[test]
+    fn apply_skips_stray_entries() {
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        assert!(outcomes
+            .iter()
+            .any(|o| matches!(o, Outcome::Skipped(_, SkipReason::StrayEntry))));
+        // Confirm the stray file was left in place.
+        assert!(tmp.path().join("concepts/.DS_Store").is_file());
+    }
+
+    #[test]
+    fn dry_run_makes_no_changes() {
+        let (tmp, workdir) = fresh_workdir();
+        let mismatched = fixture_post("oops", Stage::Editing);
+        let path = tmp.path().join("concepts/oops.md");
+        fs::write(&path, mismatched.render().unwrap()).unwrap();
+        let raw_before = fs::read_to_string(&path).unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), true);
+        assert!(outcomes.iter().any(|o| matches!(o, Outcome::Fixed(_))));
+
+        let raw_after = fs::read_to_string(&path).unwrap();
+        assert_eq!(raw_before, raw_after, "dry-run must not modify files");
+    }
+
+    #[test]
+    fn rename_refuses_to_clobber_existing_file() {
+        // Plant two files: concepts/a.md (slug=a) and concepts/b.md
+        // (slug=b). Then rewrite a.md's frontmatter so its slug claims
+        // to be "b" — fix should refuse the rename rather than clobber.
+        let (tmp, workdir) = fresh_workdir();
+        let a = fixture_post("a", Stage::Concept);
+        let b = fixture_post("b", Stage::Concept);
+        fs::write(tmp.path().join("concepts/a.md"), a.render().unwrap()).unwrap();
+        fs::write(tmp.path().join("concepts/b.md"), b.render().unwrap()).unwrap();
+
+        // Write a file at concepts/a.md whose frontmatter says slug=b.
+        let mut wrong = fixture_post("b", Stage::Concept);
+        wrong.metadata.title = "claims b".into();
+        fs::write(tmp.path().join("concepts/a.md"), wrong.render().unwrap()).unwrap();
+
+        let findings = doctor::audit(&workdir).unwrap();
+        let outcomes = apply(&workdir, plan(findings), now(), false);
+        // The rename for concepts/a.md -> concepts/b.md must fail.
+        assert!(
+            outcomes.iter().any(|o| matches!(o, Outcome::Failed(_, _))),
+            "expected a Failed outcome, got: {outcomes:?}"
+        );
+        // Both files still exist.
+        assert!(tmp.path().join("concepts/a.md").is_file());
+        assert!(tmp.path().join("concepts/b.md").is_file());
+    }
+
+    #[test]
+    fn run_returns_ok_when_every_repair_applies() {
+        let (tmp, workdir) = fresh_workdir();
+        let mismatched = fixture_post("oops", Stage::Editing);
+        fs::write(
+            tmp.path().join("concepts/oops.md"),
+            mismatched.render().unwrap(),
+        )
+        .unwrap();
+
+        run(tmp.path().to_path_buf(), false).unwrap();
+        // doctor should now be clean.
+        assert!(doctor::audit(&workdir).unwrap().is_empty());
+    }
+
+    #[test]
+    fn run_returns_unhealthy_when_findings_remain() {
+        let (tmp, _workdir) = fresh_workdir();
+        // A skipped-only finding: stray entry.
+        fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
+        let err = run(tmp.path().to_path_buf(), false).unwrap_err();
+        assert!(matches!(err, Error::WorkdirUnhealthy(_)));
+    }
+}

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod demote;
+pub mod doctor;
 pub mod init;
 pub mod list;
 pub mod new;

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod demote;
 pub mod doctor;
+pub mod fix;
 pub mod init;
 pub mod list;
 pub mod new;

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -86,6 +86,11 @@ pub enum Error {
         #[source]
         source: std::io::Error,
     },
+
+    #[error(
+        "workdir unhealthy: {0} finding(s); run `blogctl fix` to repair the auto-correctable subset"
+    )]
+    WorkdirUnhealthy(usize),
 }
 
 impl Error {

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -129,6 +129,56 @@ pub struct PostHandle {
     pub metadata: PostMetadata,
 }
 
+/// A single Markdown file discovered by the audit walk. Either the
+/// frontmatter parsed cleanly or it didn't — `doctor` surfaces both
+/// shapes, so the audit refuses to fail-fast the way `list()` does.
+#[derive(Debug)]
+pub enum AuditedPost {
+    Parsed {
+        dir_stage: Stage,
+        path: PathBuf,
+        post: Post,
+    },
+    ParseFailed {
+        dir_stage: Stage,
+        path: PathBuf,
+        error: Error,
+    },
+}
+
+impl AuditedPost {
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Parsed { path, .. } | Self::ParseFailed { path, .. } => path,
+        }
+    }
+
+    pub fn dir_stage(&self) -> Stage {
+        match self {
+            Self::Parsed { dir_stage, .. } | Self::ParseFailed { dir_stage, .. } => *dir_stage,
+        }
+    }
+}
+
+/// Result of looking at `<workdir>/.blog-os.toml` without committing
+/// to "this workdir is initialized." Used by `doctor` to diagnose
+/// half-built or corrupted workdirs.
+#[derive(Debug)]
+pub enum ConfigStatus {
+    Ok(Config),
+    Missing,
+    Unparsable(Error),
+}
+
+/// A non-Markdown entry found inside a stage directory. The path is
+/// kept verbatim so callers can print it; `dir_stage` lets them say
+/// which stage the clutter is polluting.
+#[derive(Debug, Clone)]
+pub struct StrayEntry {
+    pub dir_stage: Stage,
+    pub path: PathBuf,
+}
+
 #[derive(Debug)]
 pub struct Repository {
     workdir: Workdir,
@@ -302,6 +352,114 @@ impl Repository {
             path: new_path,
             metadata: post.metadata,
         })
+    }
+
+    /// Read `.blog-os.toml` and report whether it's present, missing,
+    /// or unparsable. Unlike `read_config`, this never returns an
+    /// `Err` — `doctor` needs to inspect every variant.
+    pub fn audit_config(&self) -> ConfigStatus {
+        let path = self.workdir.config_path();
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return ConfigStatus::Missing,
+            Err(err) => return ConfigStatus::Unparsable(Error::io(&path, err)),
+        };
+        match toml::from_str::<Config>(&raw) {
+            Ok(cfg) => ConfigStatus::Ok(cfg),
+            Err(source) => ConfigStatus::Unparsable(Error::ConfigParse { path, source }),
+        }
+    }
+
+    /// Stage directories that the workdir layout demands but that
+    /// don't currently exist on disk. Files at the path (rather than
+    /// directories) also count as missing — the layout is broken.
+    pub fn missing_stage_dirs(&self) -> Vec<Stage> {
+        Stage::ALL
+            .iter()
+            .copied()
+            .filter(|s| !self.workdir.stage_dir(*s).is_dir())
+            .collect()
+    }
+
+    /// Walk every stage directory and parse each `.md` file. Unlike
+    /// `list()`, this never short-circuits on parse failure or stage
+    /// mismatch — the audit needs to enumerate problems, not stop at
+    /// the first one.
+    ///
+    /// Outer `Result` is reserved for unrecoverable IO (e.g. a stage
+    /// directory that exists but can't be read). Missing stage
+    /// directories are skipped silently and surfaced separately by
+    /// `missing_stage_dirs()`.
+    pub fn audit_posts(&self) -> Result<Vec<AuditedPost>> {
+        let mut out = Vec::new();
+        for &stage in Stage::ALL {
+            let dir = self.workdir.stage_dir(stage);
+            let entries = match fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(Error::io(&dir, err)),
+            };
+            for entry in entries {
+                let entry = entry.map_err(|e| Error::io(&dir, e))?;
+                let path = entry.path();
+                if !is_markdown(&path) {
+                    continue;
+                }
+                let raw = match fs::read_to_string(&path) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        out.push(AuditedPost::ParseFailed {
+                            dir_stage: stage,
+                            path: path.clone(),
+                            error: Error::io(&path, err),
+                        });
+                        continue;
+                    }
+                };
+                match Post::parse(&path, &raw) {
+                    Ok(post) => out.push(AuditedPost::Parsed {
+                        dir_stage: stage,
+                        path,
+                        post,
+                    }),
+                    Err(error) => out.push(AuditedPost::ParseFailed {
+                        dir_stage: stage,
+                        path,
+                        error,
+                    }),
+                }
+            }
+        }
+        out.sort_by(|a, b| a.path().cmp(b.path()));
+        Ok(out)
+    }
+
+    /// Non-Markdown entries living inside any stage directory.
+    /// Captures both files (`.DS_Store`, stray drafts in other
+    /// formats) and subdirectories (which the layout never expects).
+    pub fn stray_entries(&self) -> Result<Vec<StrayEntry>> {
+        let mut out = Vec::new();
+        for &stage in Stage::ALL {
+            let dir = self.workdir.stage_dir(stage);
+            let entries = match fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(Error::io(&dir, err)),
+            };
+            for entry in entries {
+                let entry = entry.map_err(|e| Error::io(&dir, e))?;
+                let path = entry.path();
+                if path.is_file() && is_markdown(&path) {
+                    continue;
+                }
+                out.push(StrayEntry {
+                    dir_stage: stage,
+                    path,
+                });
+            }
+        }
+        out.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(out)
     }
 
     fn locate(&self, slug: &str) -> Result<Option<(Stage, PathBuf)>> {
@@ -558,5 +716,151 @@ mod tests {
             .relocate("same", Stage::Concept, datetime!(2026-05-04 0:00 UTC))
             .unwrap();
         assert_eq!(handle.stage, Stage::Concept);
+    }
+
+    #[test]
+    fn audit_config_returns_missing_when_no_config_file() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        assert!(matches!(repo.audit_config(), ConfigStatus::Missing));
+    }
+
+    #[test]
+    fn audit_config_returns_unparsable_for_garbage_toml() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".blog-os.toml"), "this = is not = valid").unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        assert!(matches!(repo.audit_config(), ConfigStatus::Unparsable(_)));
+    }
+
+    #[test]
+    fn audit_config_returns_ok_for_freshly_initialized_workdir() {
+        let (_tmp, repo) = fresh_repo();
+        match repo.audit_config() {
+            ConfigStatus::Ok(cfg) => assert_eq!(cfg.version, Config::CURRENT_VERSION),
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_stage_dirs_is_empty_after_init() {
+        let (_tmp, repo) = fresh_repo();
+        assert!(repo.missing_stage_dirs().is_empty());
+    }
+
+    #[test]
+    fn missing_stage_dirs_lists_every_absent_stage() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        // Only create two of the six.
+        fs::create_dir_all(tmp.path().join("concepts")).unwrap();
+        fs::create_dir_all(tmp.path().join("ideation")).unwrap();
+
+        let missing = repo.missing_stage_dirs();
+        assert!(!missing.contains(&Stage::Concept));
+        assert!(!missing.contains(&Stage::Ideation));
+        assert!(missing.contains(&Stage::Editing));
+        assert!(missing.contains(&Stage::FinalEditing));
+        assert!(missing.contains(&Stage::Published));
+        assert!(missing.contains(&Stage::Abandoned));
+    }
+
+    #[test]
+    fn missing_stage_dirs_treats_a_file_at_the_path_as_missing() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        // A regular file where the directory belongs.
+        fs::write(tmp.path().join("concepts"), "oops").unwrap();
+        assert!(repo.missing_stage_dirs().contains(&Stage::Concept));
+    }
+
+    #[test]
+    fn audit_posts_returns_empty_for_fresh_workdir() {
+        let (_tmp, repo) = fresh_repo();
+        assert!(repo.audit_posts().unwrap().is_empty());
+    }
+
+    #[test]
+    fn audit_posts_surfaces_parse_failures_alongside_parsed_posts() {
+        let (tmp, repo) = fresh_repo();
+        // Healthy post in concepts/.
+        repo.create_post(&fixture_post("good", Stage::Concept))
+            .unwrap();
+        // Malformed post in ideation/ — no closing delimiter.
+        fs::write(tmp.path().join("ideation/broken.md"), "---\ntitle: X\n").unwrap();
+
+        let audited = repo.audit_posts().unwrap();
+        assert_eq!(audited.len(), 2);
+        let parsed = audited
+            .iter()
+            .filter(|a| matches!(a, AuditedPost::Parsed { .. }))
+            .count();
+        let failed = audited
+            .iter()
+            .filter(|a| matches!(a, AuditedPost::ParseFailed { .. }))
+            .count();
+        assert_eq!(parsed, 1);
+        assert_eq!(failed, 1);
+    }
+
+    #[test]
+    fn audit_posts_does_not_fail_on_stage_mismatch() {
+        // `list()` errors on stage mismatch; `audit_posts()` keeps walking
+        // so doctor can collect every problem in one pass.
+        let (tmp, repo) = fresh_repo();
+        let mismatched = fixture_post("miss", Stage::Editing);
+        fs::write(
+            tmp.path().join("concepts/miss.md"),
+            mismatched.render().unwrap(),
+        )
+        .unwrap();
+
+        let audited = repo.audit_posts().unwrap();
+        assert_eq!(audited.len(), 1);
+        match &audited[0] {
+            AuditedPost::Parsed {
+                dir_stage, post, ..
+            } => {
+                assert_eq!(*dir_stage, Stage::Concept);
+                assert_eq!(post.metadata.status, Stage::Editing);
+            }
+            other => panic!("expected Parsed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_posts_skips_missing_stage_directories() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        // No stage directories exist at all.
+        assert!(repo.audit_posts().unwrap().is_empty());
+    }
+
+    #[test]
+    fn stray_entries_flags_non_markdown_files_in_stage_dirs() {
+        let (tmp, repo) = fresh_repo();
+        fs::write(tmp.path().join("concepts/.DS_Store"), "noise").unwrap();
+        fs::write(tmp.path().join("editing/notes.txt"), "stray").unwrap();
+        // A real markdown file should not show up as stray.
+        repo.create_post(&fixture_post("real", Stage::Concept))
+            .unwrap();
+
+        let stray = repo.stray_entries().unwrap();
+        assert_eq!(stray.len(), 2);
+        let paths: Vec<&Path> = stray.iter().map(|s| s.path.as_path()).collect();
+        assert!(paths.iter().any(|p| p.ends_with(".DS_Store")));
+        assert!(paths.iter().any(|p| p.ends_with("notes.txt")));
+    }
+
+    #[test]
+    fn stray_entries_flags_subdirectories_inside_stage_dirs() {
+        let (tmp, _repo) = fresh_repo();
+        fs::create_dir_all(tmp.path().join("concepts/archive")).unwrap();
+
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        let stray = repo.stray_entries().unwrap();
+        assert_eq!(stray.len(), 1);
+        assert!(stray[0].path.ends_with("archive"));
+        assert_eq!(stray[0].dir_stage, Stage::Concept);
     }
 }

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -288,6 +288,66 @@ fn doctor_reports_clean_workdir_with_zero_exit() {
 }
 
 #[test]
+fn fix_repairs_stage_mismatch_and_leaves_workdir_clean() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+    // Move the file from concepts/ to editing/ without rewriting
+    // frontmatter — that's a stage mismatch fix can repair.
+    let from = tmp.path().join("concepts/hello.md");
+    let to = tmp.path().join("editing/hello.md");
+    std::fs::rename(&from, &to).unwrap();
+
+    let fix_out = run(&["fix", "--workdir", &wd]);
+    assert_success(&fix_out, "fix");
+    assert!(
+        stdout(&fix_out).contains("fixed"),
+        "got: {}",
+        stdout(&fix_out)
+    );
+
+    // Doctor exits zero now.
+    assert_success(&run(&["doctor", "--workdir", &wd]), "doctor after fix");
+    let body = std::fs::read_to_string(&to).unwrap();
+    assert!(
+        body.contains("status: editing"),
+        "frontmatter was not rewritten: {body}"
+    );
+}
+
+#[test]
+fn fix_dry_run_makes_no_changes() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+    let from = tmp.path().join("concepts/hello.md");
+    let to = tmp.path().join("editing/hello.md");
+    std::fs::rename(&from, &to).unwrap();
+    let raw_before = std::fs::read_to_string(&to).unwrap();
+
+    let out = run(&["fix", "--workdir", &wd, "--dry-run"]);
+    assert_success(&out, "fix --dry-run");
+    let raw_after = std::fs::read_to_string(&to).unwrap();
+    assert_eq!(raw_before, raw_after, "dry-run modified the file");
+}
+
+#[test]
+fn fix_exits_nonzero_when_skipped_findings_remain() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    std::fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
+
+    let out = run(&["fix", "--workdir", &wd]);
+    assert!(!out.status.success(), "expected non-zero exit");
+    assert!(stdout(&out).contains("skipped"), "got: {}", stdout(&out));
+}
+
+#[test]
 fn doctor_reports_findings_with_nonzero_exit() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -273,3 +273,37 @@ fn new_rejects_unknown_theme_with_known_list() {
     assert!(err.contains("standard"), "stderr was: {err}");
     assert!(err.contains("parable"), "stderr was: {err}");
 }
+
+#[test]
+fn doctor_reports_clean_workdir_with_zero_exit() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+
+    let out = run(&["doctor", "--workdir", &wd]);
+    assert_success(&out, "doctor (clean)");
+    assert!(stdout(&out).contains("workdir healthy"));
+}
+
+#[test]
+fn doctor_reports_findings_with_nonzero_exit() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    // Plant several distinct findings: stray file, removed stage dir.
+    std::fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
+    std::fs::remove_dir_all(tmp.path().join("editing")).unwrap();
+
+    let out = run(&["doctor", "--workdir", &wd]);
+    assert!(!out.status.success(), "doctor should exit non-zero");
+    let combined = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(combined.contains("stray entry"), "got: {combined}");
+    assert!(
+        combined.contains("stage directory missing"),
+        "got: {combined}"
+    );
+    assert!(combined.contains("workdir unhealthy"), "got: {combined}");
+}


### PR DESCRIPTION
Add types and methods on `Repository` that surface workdir health
without short-circuiting on the first failure. `audit_posts` keeps
walking past parse errors and stage mismatches; `audit_config` reports
present/missing/unparseable as data; `missing_stage_dirs` and
`stray_entries` enumerate layout violations. Existing commands keep
using the fail-fast `list()` and `read_config()` paths — these are new
surfaces, intended for the upcoming `doctor` and `fix` commands.

Refs #280.

`blogctl doctor --workdir <path>` walks the workdir, collects every
health finding (stage mismatch, duplicate slug, filename-slug drift,
frontmatter parse errors, unknown theme, timestamp inversion, stray
entries, missing stage dirs, missing/unparseable config), prints them
to stdout, and exits non-zero when the list is non-empty.

`audit()` and `run()` are split so the upcoming `fix` command can
reuse the audit logic without the print/exit side effects.

Refs #280.

`blogctl fix --workdir <path>` runs the doctor audit, classifies each
finding into a `Repair::Apply` or `Repair::Skip(reason)`, executes
the applies, and prints an annotated outcome stream.

Auto-correctable: missing stage directories, stage mismatch (rewrite
frontmatter to match the directory), filename ≠ slug (rename file to
<slug>.md, refusing to clobber), timestamp inversion (bump
updated_at to now). The directory is treated as the source of truth
for stage mismatch — the file's location is the user's intent.

Skipped: duplicate slugs, frontmatter parse errors, unknown themes,
stray entries, missing or unparseable config. Each carries a one-line
reason explaining what manual step is needed.

`--dry-run` prints the same plan without writing. The exit code is
non-zero whenever any finding remains after the run, so the pair
`blogctl fix && blogctl doctor` is a clean idempotency check.

Closes #280.