### PR TITLE
refactor(shaka): delegate repo ship push to repo send

### DIFF
--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -1,10 +1,8 @@
 use crate::commit::{self, CommitCommand};
-use crate::gh;
 use crate::jj;
 use crate::preflight;
-use crate::repo::describe;
-use crate::repo::send::resolve_bookmark;
-use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+use crate::repo::send::{self, resolve_bookmark};
+use crate::term::{BOLD, DIM, RED, RESET, YELLOW};
 
 const SHIP_REVSET: &str = "main@origin..@";
 
@@ -36,16 +34,6 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
         },
     };
 
-    let synthesized = match describe::for_current_branch() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("{RED}{BOLD}error:{RESET} {e}");
-            std::process::exit(1);
-        }
-    };
-    let title = synthesized.title.as_str();
-    let body = synthesized.body.as_str();
-
     if dry_run {
         println!("would run: jj git fetch");
         println!("would run: jj rebase -b @ -d main@origin");
@@ -56,9 +44,7 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
         } else {
             println!("would run: shaka preflight");
         }
-        println!("would run: jj bookmark set {bookmark} -r @");
-        println!("would run: jj git push --allow-new --bookmark {bookmark}");
-        println!("would ensure PR exists for head {bookmark}");
+        send::run(Some(bookmark), false, true);
         return;
     }
 
@@ -106,37 +92,6 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
         preflight::run(false, None);
     }
 
-    println!("{BOLD}step 6/6: push and ensure PR{RESET}");
-    if let Err(e) = jj::set_bookmark(&bookmark) {
-        eprintln!("{RED}{BOLD}error:{RESET} {e}");
-        std::process::exit(1);
-    }
-    if let Err(e) = jj::push_bookmark(&bookmark) {
-        eprintln!("{RED}{BOLD}error:{RESET} {e}");
-        std::process::exit(1);
-    }
-
-    let repo = match gh::detect_repo() {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("{YELLOW}{BOLD}warn:{RESET} could not detect repo: {e}");
-            println!("{GREEN}{BOLD}pushed{RESET} (skipping PR)");
-            return;
-        }
-    };
-
-    match gh::pr_for_head(&repo, &bookmark) {
-        Ok(Some(pr)) => println!("{GREEN}{BOLD}shipped{RESET} (PR: {})", pr.url),
-        Ok(None) => match gh::pr_create(&repo, title, body, &bookmark) {
-            Ok(url) => println!("{GREEN}{BOLD}shipped{RESET} ({url})"),
-            Err(e) => {
-                eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");
-                std::process::exit(1);
-            }
-        },
-        Err(e) => {
-            eprintln!("{RED}{BOLD}error:{RESET} {e}");
-            std::process::exit(1);
-        }
-    }
+    println!("{BOLD}step 6/6: handing off to repo send{RESET}");
+    send::run(Some(bookmark), false, false);
 }

--- a/tools/shaka/tests/repo_ship_workspace.rs
+++ b/tools/shaka/tests/repo_ship_workspace.rs
@@ -1,0 +1,185 @@
+//! Integration tests for `shaka repo ship` from inside a jj workspace.
+//!
+//! Verifies that `repo ship --dry-run` resolves the correct bookmark when
+//! invoked from a non-default workspace and that its dry-run preview now
+//! delegates the push/PR steps to `repo send` (closing the race fixed by
+//! #287).
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+const SHAKA: &str = env!("CARGO_BIN_EXE_shaka");
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn jj(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("jj")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("failed to spawn jj")
+}
+
+fn jj_ok(cwd: &Path, args: &[&str]) {
+    let out = jj(cwd, args);
+    assert!(
+        out.status.success(),
+        "jj {} failed\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+fn shaka(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(SHAKA)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("failed to spawn shaka")
+}
+
+fn setup_repo(repo: &Path) {
+    jj_ok(repo, &["git", "init", "--colocate"]);
+    jj_ok(
+        repo,
+        &["config", "set", "--repo", "user.email", "test@test.test"],
+    );
+    jj_ok(repo, &["config", "set", "--repo", "user.name", "Test"]);
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// `shaka repo ship --dry-run --skip-preflight --bookmark <name>` invoked from
+/// a non-default workspace must (a) preview ship's own steps 1–5 and (b)
+/// delegate push/PR steps to `send::run`, whose dry-run includes the
+/// race-closing pre-push fetch + rebase + conditional preflight.
+#[test]
+fn dry_run_from_non_default_workspace() {
+    let parent = TempDir::new().expect("tempdir");
+
+    let default_repo = parent.path().join("repo");
+    std::fs::create_dir(&default_repo).unwrap();
+    setup_repo(&default_repo);
+
+    jj_ok(
+        &default_repo,
+        &["describe", "-m", "feat(shaka): default workspace work"],
+    );
+
+    let ws_path = parent.path().join("repo-extra");
+    jj_ok(
+        &default_repo,
+        &[
+            "workspace",
+            "add",
+            "--name",
+            "extra",
+            ws_path.to_str().unwrap(),
+        ],
+    );
+
+    jj_ok(
+        &ws_path,
+        &["describe", "-m", "refactor(shaka): repair from workspace"],
+    );
+
+    let bookmark = "refactor/shaka-repair-from-workspace";
+    let out = shaka(
+        &ws_path,
+        &[
+            "repo",
+            "ship",
+            "--dry-run",
+            "--skip-preflight",
+            "--bookmark",
+            bookmark,
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "shaka repo ship --dry-run failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Ship's own steps (initial fetch + rebase + lint + diff + preflight skip).
+    assert!(
+        stdout.contains("shaka commit lint -r main@origin..@"),
+        "expected ship commit-lint preview; got: {stdout}",
+    );
+    assert!(
+        stdout.contains("jj diff -r main@origin..@"),
+        "expected ship diff preview; got: {stdout}",
+    );
+    assert!(
+        stdout.contains("would skip: shaka preflight"),
+        "expected ship preflight-skip preview; got: {stdout}",
+    );
+
+    // Delegated send dry-run: bookmark set + push must reference the bookmark.
+    assert!(
+        stdout.contains(&format!("jj bookmark set {bookmark}")),
+        "expected delegated bookmark set; got: {stdout}",
+    );
+    assert!(
+        stdout.contains(&format!("jj git push --allow-new --bookmark {bookmark}")),
+        "expected delegated push; got: {stdout}",
+    );
+
+    // Ship's own pre-push race-closing rebase comes from send's dry-run, so
+    // the dry-run output should contain the fetch/rebase/preflight lines that
+    // `repo send --dry-run` emits — confirming the delegation.
+    assert!(
+        stdout.contains("shaka preflight --since origin/main"),
+        "expected delegated conditional preflight preview; got: {stdout}",
+    );
+}
+
+/// Shipping from inside a workspace without a description should fail with a
+/// clear error — same behaviour as `repo send`.
+#[test]
+fn ship_fails_without_description_in_workspace() {
+    let parent = TempDir::new().expect("tempdir");
+
+    let default_repo = parent.path().join("repo");
+    std::fs::create_dir(&default_repo).unwrap();
+    setup_repo(&default_repo);
+
+    let ws_path = parent.path().join("repo-nodesc");
+    jj_ok(
+        &default_repo,
+        &[
+            "workspace",
+            "add",
+            "--name",
+            "nodesc",
+            ws_path.to_str().unwrap(),
+        ],
+    );
+
+    let out = shaka(
+        &ws_path,
+        &[
+            "repo",
+            "ship",
+            "--dry-run",
+            "--skip-preflight",
+            "--bookmark",
+            "fix/whatever",
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "expected shaka repo ship to fail with no description",
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no description"),
+        "expected 'no description' error; got: {stderr}",
+    );
+}


### PR DESCRIPTION
Replace ship's step-6 push/PR logic with `send::run(Some(bookmark),
false, dry_run)` so ship inherits the race-closing pre-push fetch +
rebase + conditional preflight that #286 added to send. Without this,
between ship's preflight (step 5) and its own push (step 6),
`main@origin` could move and the PR would open behind — exactly the
race the issue calls out.

Ship's steps 1–5 (initial fetch, rebase, commit lint, self-review
diff, preflight) stay as-is; the second fetch+rebase inside send is
the cheap drift check immediately before push.

Cosmetic: success line on ship now prints `sent (<url>)` (from send)
instead of `shipped (PR: <url>)`. Threading a label flag through send
just to preserve the wording wasn't worth the plumbing.

Closes #287