### PR TITLE
feat(kolohelios-nix): add op (1Password CLI) to workflowPackages

### DIFF
--- a/nix/kolohelios-nix/README.md
+++ b/nix/kolohelios-nix/README.md
@@ -11,9 +11,10 @@ together.
 - `lib.forEachSupportedSystem` — helper that maps a function over every
   supported system, providing a system-specific `pkgs`.
 - `lib.workflowPackages` — the workflow-tool list (`jujutsu`, `git`,
-  `just`, `jq`, `cue`, `nixfmt-rfc-style`, `nil`, `typos`, `vale`) that
-  every project's devshell wants; consumers spread it and add
-  project-specific tools on top.
+  `just`, `jq`, `cue`, `nixfmt-rfc-style`, `nil`, `typos`, `cargo-deny`,
+  `cargo-machete`, `vale`, `_1password-cli`) that every project's
+  devshell wants; consumers spread it and add project-specific tools on
+  top.
 - `formatter` — `nixfmt-rfc-style` per system, used by `nix fmt`.
 
 ## Usage from a consumer flake

--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -76,6 +76,7 @@
           cargo-deny
           cargo-machete
           vale
+          _1password-cli
         ])
         ++ [ (shakaShim pkgs) ];
     in


### PR DESCRIPTION
The auto-rebase-app.md rotation runbook calls `op document get | gh
secret set` to push the kolohelios-bot PEM into Actions secrets, and
`op document edit` to refresh the canonical 1Password copy. Without
`op` in the shared devshell, every consumer of the runbook needs a
separate Homebrew install. Per the global guidance that 1Password is
the canonical secret store via the `op` CLI, it belongs alongside
\`jj\`/\`git\`/\`just\` in the shared workflow toolset.

Also refreshes README's workflowPackages list (was missing
\`cargo-deny\` and \`cargo-machete\` from earlier additions).

Closes #298