### PR TITLE
fix(ci): make auto-rebase-app.md rotation portable across bash and zsh

### DIFF
--- a/.github/auto-rebase-app.md
+++ b/.github/auto-rebase-app.md
@@ -198,13 +198,11 @@ author needs to resolve, but doesn't itself gate merge.
 3. **Update the secret on every consumer repo** in lockstep — same
    key, every repo, single source of truth:
    ```sh
-   mapfile -t REPOS < <(
-     gh search code --owner kolohelios 'KOLOHELIOS_BOT_APP_ID' --extension yaml \
-       --json repository --jq '.[].repository.nameWithOwner' | sort -u
-   )
-   for repo in "${REPOS[@]}"; do
-     gh secret set KOLOHELIOS_BOT_APP_PRIVATE_KEY -R "$repo" < "$PEM"
-   done
+   gh search code --owner kolohelios 'KOLOHELIOS_BOT_APP_ID' --extension yaml \
+     --json repository --jq '.[].repository.nameWithOwner' | sort -u \
+   | while read -r repo; do
+       gh secret set KOLOHELIOS_BOT_APP_PRIVATE_KEY -R "$repo" < "$PEM"
+     done
    ```
 
 4. **Revoke the old key** on the App settings page. Workflow runs in
@@ -220,9 +218,8 @@ author needs to resolve, but doesn't itself gate merge.
 
 6. **Verify each consumer is healthy.** Trigger every
    `workflow_dispatch`-able workflow found by the discovery query;
-   non-dispatchable ones (for example, `auto-rebase-prs.yaml`, which
-   only fires on `push: main`) verify themselves the next time their
-   trigger fires:
+   any consumer without `workflow_dispatch:` skips here and verifies
+   itself the next time its actual trigger fires:
    ```sh
    gh search code --owner kolohelios 'KOLOHELIOS_BOT_APP_ID' --extension yaml \
      --json repository,path \


### PR DESCRIPTION
Two corrections, both surfaced during the 2026-05-09 rotation:

- Step 3 used \`mapfile -t REPOS < <(...)\` + a \`for\` loop, both
  bash builtins. zsh — the user's interactive shell — doesn't have
  \`mapfile\`, so running the snippet straight out of the runbook
  errored with \`command not found: mapfile\`. Replaced with the
  same \`while read\` pipe shape step 6 already uses; works in
  bash and zsh, no array intermediate needed.

- Step 6 named \`auto-rebase-prs.yaml\` as a non-dispatchable
  example, but it does have \`workflow_dispatch\` (added so the
  rotation runbook can verify it directly). Genericized the
  parenthetical — anything without \`workflow_dispatch:\` skips
  the loop and verifies on its real trigger.

Closes #300