### PR TITLE
fix(shaka): use main@origin in preflight --since callers

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -56,8 +56,9 @@ decide whether to fix before shipping.
 
 ### 4. Run preflight
 
-Run `shaka preflight --since origin/main` to scope checks to changed paths
-(`--since` takes a git ref, not a `jj` revset).
+Run `shaka preflight --since main@origin` to scope checks to changed paths.
+The argument is shelled to `jj diff --from`, so it takes a `jj` revision
+(use `main@origin`, not git-style `origin/main`).
 This is the same gate CI runs, so passing here means CI passes too.
 
 If preflight fails, stop. Do not push a known-broken change. Help the user

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -51,7 +51,7 @@ pub enum RepoCommand {
     /// `main@origin` immediately before push so the PR opens on a
     /// current base. If the rebase pulls in new ancestors (i.e.,
     /// `main` moved during the work), re-runs `shaka preflight --since
-    /// origin/main` first — new commits can break our changes in ways
+    /// main@origin` first — new commits can break our changes in ways
     /// `jj` doesn't flag with conflict markers. If the rebase is a
     /// no-op, preflight is skipped.
     Send {

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -46,7 +46,7 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         println!("would run: jj git fetch");
         println!("would run: jj rebase -b @ -d main@origin");
         println!(
-            "would run: shaka preflight --since origin/main {DIM}(only if rebase moved @){RESET}"
+            "would run: shaka preflight --since main@origin {DIM}(only if rebase moved @){RESET}"
         );
         println!("would run: jj bookmark set {bookmark} -r @");
         println!("would run: jj git push --allow-new --bookmark {bookmark}");
@@ -88,7 +88,7 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         println!(
             "{BOLD}main@origin advanced — re-running preflight{RESET} {DIM}(rebase pulled in new ancestors){RESET}"
         );
-        preflight::run(false, Some("origin/main".to_string()));
+        preflight::run(false, Some("main@origin".to_string()));
     }
 
     println!("{BOLD}setting bookmark {bookmark}{RESET}");

--- a/tools/shaka/tests/repo_send_workspace.rs
+++ b/tools/shaka/tests/repo_send_workspace.rs
@@ -137,7 +137,7 @@ fn dry_run_from_non_default_workspace() {
         "expected pre-push rebase in dry-run output; got: {stdout}",
     );
     assert!(
-        stdout.contains("shaka preflight --since origin/main"),
+        stdout.contains("shaka preflight --since main@origin"),
         "expected conditional preflight in dry-run output; got: {stdout}",
     );
 }

--- a/tools/shaka/tests/repo_ship_workspace.rs
+++ b/tools/shaka/tests/repo_ship_workspace.rs
@@ -135,7 +135,7 @@ fn dry_run_from_non_default_workspace() {
     // the dry-run output should contain the fetch/rebase/preflight lines that
     // `repo send --dry-run` emits — confirming the delegation.
     assert!(
-        stdout.contains("shaka preflight --since origin/main"),
+        stdout.contains("shaka preflight --since main@origin"),
         "expected delegated conditional preflight preview; got: {stdout}",
     );
 }


### PR DESCRIPTION
`jj` doesn't resolve git-style `origin/main` — only `main@origin`. The
arg to `shaka preflight --since` is shelled straight to `jj diff
--from`, so the git form errors out:

    error: ... Error: Revision `origin/main` doesn't exist

Replace `origin/main` → `main@origin` at every call site in this repo:
the conditional preflight inside `repo send`, its dry-run preview, the
matching doc comment on the `Send` clap subcommand, and the `/ship`
skill instructions. Test assertions follow the new string. Real-git
invocations in `repo/rebase_open_prs.rs` keep `origin/main` — those
shell to `git`, which does resolve it.

Closes #295