### PR TITLE
ci: migrate kolohelios-bot workflows from app-id to client-id

### DIFF
--- a/.github/auto-rebase-app.md
+++ b/.github/auto-rebase-app.md
@@ -12,12 +12,12 @@ moves, or bumping flake inputs daily. They live across every repo the
 App is installed on. To list the current set:
 
 ```sh
-gh search code --owner kolohelios 'KOLOHELIOS_BOT_APP_ID' --extension yaml \
+gh search code --owner kolohelios 'KOLOHELIOS_BOT_CLIENT_ID' --extension yaml \
   --json repository,path \
   --jq '.[] | "\(.repository.nameWithOwner): \(.path)"' | sort -u
 ```
 
-Every match needs the same `KOLOHELIOS_BOT_APP_ID` variable and
+Every match needs the same `KOLOHELIOS_BOT_CLIENT_ID` variable and
 `KOLOHELIOS_BOT_APP_PRIVATE_KEY` secret on its repo — see
 [Repo configuration](#repo-configuration). The discovery query is the
 single source of truth: don't keep a hand-maintained list.
@@ -122,22 +122,22 @@ the kolohelios account.
 
 | Kind | Name | Value |
 | --- | --- | --- |
-| Variable | `KOLOHELIOS_BOT_APP_ID` | The numeric App ID (top of the App's settings page; not sensitive) |
+| Variable | `KOLOHELIOS_BOT_CLIENT_ID` | The Client ID from the App settings page (`Iv23…`; not sensitive) |
 | Secret | `KOLOHELIOS_BOT_APP_PRIVATE_KEY` | Full `.pem` contents — including the `-----BEGIN/END PRIVATE KEY-----` lines |
 
-Both are referenced as `${{ vars.KOLOHELIOS_BOT_APP_ID }}` and
+Both are referenced as `${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}` and
 `${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}` in the consuming
 workflows. The PEM is stored canonically in 1Password
 (`Kolohelios Monorepo` vault, id `vedq2v6cmtkglnonkenrjneepa`) as the
 document `kolohelios-bot GitHub App private key`.
 
 Concrete commands to wire a new consumer repo (replace `<repo>` and
-`<APP_ID>`; the App ID is the same number for every consumer repo,
-since they all share one App):
+`<CLIENT_ID>`; the Client ID is the same string for every consumer
+repo, since they all share one App):
 
 ```sh
-# Variable: the App ID is public, no secret handling needed.
-gh variable set KOLOHELIOS_BOT_APP_ID -R <repo> -b '<APP_ID>'
+# Variable: the Client ID is public, no secret handling needed.
+gh variable set KOLOHELIOS_BOT_CLIENT_ID -R <repo> -b '<CLIENT_ID>'
 
 # Secret: pipe the PEM straight from 1Password into the gh secret set.
 op document get 'kolohelios-bot GitHub App private key' \
@@ -198,7 +198,7 @@ author needs to resolve, but doesn't itself gate merge.
 3. **Update the secret on every consumer repo** in lockstep — same
    key, every repo, single source of truth:
    ```sh
-   gh search code --owner kolohelios 'KOLOHELIOS_BOT_APP_ID' --extension yaml \
+   gh search code --owner kolohelios 'KOLOHELIOS_BOT_CLIENT_ID' --extension yaml \
      --json repository --jq '.[].repository.nameWithOwner' | sort -u \
    | while read -r repo; do
        gh secret set KOLOHELIOS_BOT_APP_PRIVATE_KEY -R "$repo" < "$PEM"
@@ -221,7 +221,7 @@ author needs to resolve, but doesn't itself gate merge.
    any consumer without `workflow_dispatch:` skips here and verifies
    itself the next time its actual trigger fires:
    ```sh
-   gh search code --owner kolohelios 'KOLOHELIOS_BOT_APP_ID' --extension yaml \
+   gh search code --owner kolohelios 'KOLOHELIOS_BOT_CLIENT_ID' --extension yaml \
      --json repository,path \
      --jq '.[] | "\(.repository.nameWithOwner) \(.path | split("/") | last)"' \
    | sort -u \

--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.KOLOHELIOS_BOT_APP_ID }}
+          client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
@@ -49,9 +49,13 @@ jobs:
           determinate: true
           flakehub: true
       - name: Configure git identity for rebase commits
+        # The numeric App ID (3591292) is part of GitHub's noreply email
+        # format `<app-id>+<bot-name>[bot]@users.noreply.github.com`,
+        # which is what makes commits attributable to the App. The Client
+        # ID (used above for token minting) doesn't fit this slot.
         run: |
           git config --global user.name 'kolohelios-bot[bot]'
-          git config --global user.email '${{ vars.KOLOHELIOS_BOT_APP_ID }}+kolohelios-bot[bot]@users.noreply.github.com'
+          git config --global user.email '3591292+kolohelios-bot[bot]@users.noreply.github.com'
       - name: Rebase open PRs
         run: nix run ./tools/shaka -- repo rebase-open-prs
         env:

--- a/.github/workflows/bump-kolohelios-nix.yaml
+++ b/.github/workflows/bump-kolohelios-nix.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.KOLOHELIOS_BOT_APP_ID }}
+          client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
@@ -57,9 +57,13 @@ jobs:
           determinate: true
           flakehub: true
       - name: Configure git identity
+        # The numeric App ID (3591292) is part of GitHub's noreply email
+        # format `<app-id>+<bot-name>[bot]@users.noreply.github.com`,
+        # which is what makes commits attributable to the App. The Client
+        # ID (used above for token minting) doesn't fit this slot.
         run: |
           git config --global user.name 'kolohelios-bot[bot]'
-          git config --global user.email '${{ vars.KOLOHELIOS_BOT_APP_ID }}+kolohelios-bot[bot]@users.noreply.github.com'
+          git config --global user.email '3591292+kolohelios-bot[bot]@users.noreply.github.com'
       - name: Bump kolohelios-nix and open or update PR
         run: |
           nix run ./tools/shaka -- repo bump-locks \


### PR DESCRIPTION
\`actions/create-github-app-token@v3\` deprecated the \`app-id\` input
in favor of \`client-id\`. The 2026-05-09 rotation runs surfaced this
on every consumer:

  ! Input 'app-id' has been deprecated with message: Use 'client-id' instead.

Swap the two kolohelios-side workflows (\`auto-rebase-prs.yaml\` and
\`bump-kolohelios-nix.yaml\`) to read \`KOLOHELIOS_BOT_CLIENT_ID\`. The
git committer email keeps the numeric App ID — it's part of GitHub's
\`<app-id>+<bot-name>[bot]@users.noreply.github.com\` noreply format,
so inline \`3591292\` with a comment rather than keeping the variable
just for that. Refresh the runbook discovery query, credentials table,
and per-repo wiring snippet to match.

The matching change in \`kolohelios/blogs-and-posts\` is shipped
separately. Drop the \`KOLOHELIOS_BOT_APP_ID\` variable from both
repos after both PRs land.

Closes #303