### PR TITLE
docs(shaka): document repo audit external-consumer flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ tfplan
 *.key
 .env
 
-# Shaka local state (e.g. workspace ↔ issue links — see tools/shaka/src/workspace/issue_link.rs)
-.shaka/
+# Shaka local state — workspace ↔ issue links (tools/shaka/src/workspace/issue_link.rs).
+# Tracked shaka configs (e.g. `.shaka/repo.cue`) live alongside in the same directory.
+.shaka/workspaces/

--- a/.shaka/repo.cue
+++ b/.shaka/repo.cue
@@ -1,0 +1,26 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	issues: true
+	branchProtection: {
+		requiredChecks: ["Gate"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/README.md
+++ b/tools/shaka/README.md
@@ -46,6 +46,32 @@ changed) and exec's the debug binary.
 
 See `shaka <subcommand> --help` for full options.
 
+## Auditing other repositories
+
+`shaka repo audit` is a generic GitHub repo-settings auditor: any repo
+that wants to use it authors a `.shaka/repo.cue` describing its desired
+GitHub configuration (default branch, merge modes, branch protection
+status checks, `ruleset` rules, `Dependabot` toggle), and the command
+reports drift between the policy and the live repo. `--fix` PATCHes the
+divergent settings back to policy values. The schema lives at
+`tools/shaka/schema/repo-policy-schema.cue` in this repo; optional
+groups (`branchProtection`, `rulesets`, `security`, `issues`) can be
+omitted entirely to opt out of audit dimensions a particular repo
+doesn't enforce — typical for personal repos without branch protection.
+
+Outside the kolohelios devshell, run `shaka` directly from FlakeHub:
+
+```
+nix run https://flakehub.com/f/kolohelios/shaka/*.tar.gz -- repo audit
+```
+
+Run from anywhere inside the target repo's working copy; the loader
+walks upward looking for `.shaka/repo.cue`. The wrapped binary already
+ships `cue`, `jj`, `git`, and `gh` on its `PATH`, so external consumers
+don't need a devshell. Pass `--repo owner/name` if `jj git remote list`
+can't auto-detect the GitHub repo (for example, plain-git checkouts
+without a colocated `.jj`).
+
 ## Development
 
 ```

--- a/tools/shaka/schema/repo-policy-schema.cue
+++ b/tools/shaka/schema/repo-policy-schema.cue
@@ -1,0 +1,29 @@
+package repopolicy
+
+#RepoPolicy: {
+	defaultBranch: string & !=""
+	merge: {
+		rebase:              bool
+		merge:               bool
+		squash:              bool
+		deleteBranchOnMerge: bool
+	}
+	// Omit any optional field below to opt the audit out of that
+	// dimension — useful for personal repos that don't enable issues,
+	// branch protection, or rulesets.
+	issues?: bool
+	branchProtection?: {
+		requiredChecks: [...string]
+		strictStatusChecks: bool
+		allowForcePush:     bool
+		allowDeletion:      bool
+	}
+	rulesets?: {
+		requireDeletion:       bool
+		requireNonFastForward: bool
+		requireStatusChecks:   bool
+	}
+	security?: {
+		dependabotAlerts: bool
+	}
+}

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -1,6 +1,11 @@
-use serde_json::{json, Value};
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
 
 use crate::gh;
+use crate::repo::policy::{
+    self, BranchProtectionPolicy, MergePolicy, RepoPolicy, RulesetsPolicy, SecurityPolicy,
+};
 use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
 #[derive(Clone, Copy, PartialEq)]
@@ -77,40 +82,54 @@ pub fn run(repo_arg: Option<String>, fix: bool) {
         },
     };
 
+    let policy = match policy::load(Path::new(".")) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            eprintln!(
+                "Hint: create `.shaka/repo.cue` at the repo root \
+                describing your desired GitHub settings"
+            );
+            std::process::exit(1);
+        }
+    };
+
     println!("{BOLD}Auditing {repo}{RESET}\n");
 
     let mut has_failure = false;
 
-    // General settings
-    let (checks, repo_data) = check_general(&repo);
+    let (checks, _repo_data) = check_general(&repo, &policy);
     print_group("Repository Settings", &checks);
     has_failure |= checks.iter().any(|c| c.status == Status::Fail);
 
     if fix {
-        fix_general(&repo, &checks, &repo_data);
+        fix_general(&repo, &checks, &policy);
     }
 
-    // Branch protection
-    let checks = check_branch_protection(&repo);
-    print_group("Branch Protection (main)", &checks);
-    has_failure |= checks.iter().any(|c| c.status == Status::Fail);
+    if let Some(bp) = &policy.branch_protection {
+        let checks = check_branch_protection(&repo, bp);
+        print_group("Branch Protection (main)", &checks);
+        has_failure |= checks.iter().any(|c| c.status == Status::Fail);
 
-    if fix {
-        fix_branch_protection(&repo, &checks);
+        if fix {
+            fix_branch_protection(&repo, &checks, bp);
+        }
     }
 
-    // Rulesets
-    let checks = check_rulesets(&repo);
-    print_group("Rulesets", &checks);
-    has_failure |= checks.iter().any(|c| c.status == Status::Fail);
+    if let Some(rs) = &policy.rulesets {
+        let checks = check_rulesets(&repo, rs);
+        print_group("Rulesets", &checks);
+        has_failure |= checks.iter().any(|c| c.status == Status::Fail);
+    }
 
-    // Security
-    let checks = check_security(&repo);
-    print_group("Security", &checks);
-    has_failure |= checks.iter().any(|c| c.status == Status::Fail);
+    if let Some(sec) = &policy.security {
+        let checks = check_security(&repo, sec);
+        print_group("Security", &checks);
+        has_failure |= checks.iter().any(|c| c.status == Status::Fail);
 
-    if fix {
-        fix_security(&repo, &checks);
+        if fix {
+            fix_security(&repo, &checks);
+        }
     }
 
     println!();
@@ -134,7 +153,7 @@ fn print_group(title: &str, checks: &[Check]) {
 
 // ── General settings ───────────────────────────────────────────
 
-fn check_general(repo: &str) -> (Vec<Check>, Option<Value>) {
+fn check_general(repo: &str, policy: &RepoPolicy) -> (Vec<Check>, Option<Value>) {
     let data = match gh::api_get(&format!("/repos/{repo}")) {
         Ok(v) => v,
         Err(e) => {
@@ -145,49 +164,68 @@ fn check_general(repo: &str) -> (Vec<Check>, Option<Value>) {
         }
     };
 
-    let checks = vec![
-        bool_check(
-            "Default branch",
-            data["default_branch"].as_str() == Some("main"),
-            "main",
-            data["default_branch"].as_str().unwrap_or("unknown"),
-        ),
-        bool_check(
+    let mut checks = Vec::with_capacity(8);
+    let observed_branch = data["default_branch"].as_str().unwrap_or("unknown");
+    checks.push(bool_check(
+        "Default branch",
+        observed_branch == policy.default_branch,
+        &policy.default_branch,
+        observed_branch,
+    ));
+
+    if let Some(want_issues) = policy.issues {
+        let observed = data["has_issues"].as_bool() == Some(true);
+        let (pass_msg, fail_msg) = enabled_messages(want_issues);
+        checks.push(bool_check(
             "Issues enabled",
-            data["has_issues"].as_bool() == Some(true),
-            "enabled",
-            "disabled",
-        ),
-        bool_check(
-            "Rebase merge",
-            data["allow_rebase_merge"].as_bool() == Some(true),
-            "enabled",
-            "disabled",
-        ),
-        bool_check(
-            "Merge commits",
-            data["allow_merge_commit"].as_bool() == Some(false),
-            "disabled",
-            "enabled (should be disabled)",
-        ),
-        bool_check(
-            "Squash merge",
-            data["allow_squash_merge"].as_bool() == Some(false),
-            "disabled",
-            "enabled (should be disabled)",
-        ),
-        bool_check(
-            "Delete branch on merge",
-            data["delete_branch_on_merge"].as_bool() == Some(true),
-            "enabled",
-            "disabled",
-        ),
-    ];
+            observed == want_issues,
+            pass_msg,
+            fail_msg,
+        ));
+    }
+
+    push_merge_check(
+        &mut checks,
+        "Rebase merge",
+        data["allow_rebase_merge"].as_bool() == Some(true),
+        policy.merge.rebase,
+    );
+    push_merge_check(
+        &mut checks,
+        "Merge commits",
+        data["allow_merge_commit"].as_bool() == Some(true),
+        policy.merge.merge,
+    );
+    push_merge_check(
+        &mut checks,
+        "Squash merge",
+        data["allow_squash_merge"].as_bool() == Some(true),
+        policy.merge.squash,
+    );
+    push_merge_check(
+        &mut checks,
+        "Delete branch on merge",
+        data["delete_branch_on_merge"].as_bool() == Some(true),
+        policy.merge.delete_branch_on_merge,
+    );
 
     (checks, Some(data))
 }
 
-fn fix_general(repo: &str, checks: &[Check], _repo_data: &Option<Value>) {
+fn push_merge_check(checks: &mut Vec<Check>, name: &'static str, observed: bool, want: bool) {
+    let (pass_msg, fail_msg) = enabled_messages(want);
+    checks.push(bool_check(name, observed == want, pass_msg, fail_msg));
+}
+
+fn enabled_messages(want: bool) -> (&'static str, &'static str) {
+    if want {
+        ("enabled", "disabled (should be enabled)")
+    } else {
+        ("disabled", "enabled (should be disabled)")
+    }
+}
+
+fn fix_general(repo: &str, checks: &[Check], policy: &RepoPolicy) {
     let needs_fix = checks.iter().any(|c| {
         c.status == Status::Fail
             && matches!(
@@ -205,15 +243,25 @@ fn fix_general(repo: &str, checks: &[Check], _repo_data: &Option<Value>) {
     }
 
     println!("  {YELLOW}Fixing repository settings...{RESET}");
-    let body = json!({
-        "has_issues": true,
-        "allow_rebase_merge": true,
-        "allow_merge_commit": false,
-        "allow_squash_merge": false,
-        "delete_branch_on_merge": true,
-    });
+    let mut body = Map::new();
+    if let Some(want_issues) = policy.issues {
+        body.insert("has_issues".into(), json!(want_issues));
+    }
+    let MergePolicy {
+        rebase,
+        merge,
+        squash,
+        delete_branch_on_merge,
+    } = policy.merge;
+    body.insert("allow_rebase_merge".into(), json!(rebase));
+    body.insert("allow_merge_commit".into(), json!(merge));
+    body.insert("allow_squash_merge".into(), json!(squash));
+    body.insert(
+        "delete_branch_on_merge".into(),
+        json!(delete_branch_on_merge),
+    );
 
-    match gh::api_patch(&format!("/repos/{repo}"), &body) {
+    match gh::api_patch(&format!("/repos/{repo}"), &Value::Object(body)) {
         Ok(_) => println!("  {GREEN}Fixed{RESET}"),
         Err(e) => eprintln!("  {RED}Fix failed: {e}{RESET}"),
     }
@@ -221,7 +269,7 @@ fn fix_general(repo: &str, checks: &[Check], _repo_data: &Option<Value>) {
 
 // ── Branch protection ──────────────────────────────────────────
 
-fn check_branch_protection(repo: &str) -> Vec<Check> {
+fn check_branch_protection(repo: &str, bp: &BranchProtectionPolicy) -> Vec<Check> {
     let data = match gh::api_get(&format!("/repos/{repo}/branches/main/protection")) {
         Ok(v) => v,
         Err(e) => {
@@ -233,36 +281,89 @@ fn check_branch_protection(repo: &str) -> Vec<Check> {
         }
     };
 
+    let observed_strict = data["required_status_checks"]["strict"].as_bool() == Some(true);
+    let observed_force = data["allow_force_pushes"]["enabled"].as_bool() == Some(true);
+    let observed_delete = data["allow_deletions"]["enabled"].as_bool() == Some(true);
+
+    let observed_checks: Vec<String> = data["required_status_checks"]["contexts"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let want_set: std::collections::BTreeSet<&str> =
+        bp.required_checks.iter().map(String::as_str).collect();
+    let observed_set: std::collections::BTreeSet<&str> =
+        observed_checks.iter().map(String::as_str).collect();
+    let checks_match = want_set == observed_set;
+
     vec![
         Check::pass("Branch protection", "enabled"),
         bool_check(
             "Required status checks",
-            !data["required_status_checks"].is_null(),
-            "configured",
-            "not configured",
+            checks_match,
+            &checks_summary(&bp.required_checks),
+            &format!(
+                "expected {:?}, got {:?}",
+                bp.required_checks, observed_checks
+            ),
         ),
         bool_check(
             "Strict status checks",
-            data["required_status_checks"]["strict"].as_bool() != Some(true),
-            "off (stale-but-mergeable allowed)",
-            "on (forces rebase before merge)",
+            observed_strict == bp.strict_status_checks,
+            if bp.strict_status_checks {
+                "on (forces rebase before merge)"
+            } else {
+                "off (stale-but-mergeable allowed)"
+            },
+            if bp.strict_status_checks {
+                "off (should be on)"
+            } else {
+                "on (should be off — forces rebase before merge)"
+            },
         ),
         bool_check(
             "Force push",
-            data["allow_force_pushes"]["enabled"].as_bool() == Some(false),
-            "blocked",
-            "allowed (should be blocked)",
+            observed_force == bp.allow_force_push,
+            if bp.allow_force_push {
+                "allowed"
+            } else {
+                "blocked"
+            },
+            if bp.allow_force_push {
+                "blocked (should be allowed)"
+            } else {
+                "allowed (should be blocked)"
+            },
         ),
         bool_check(
             "Branch deletion",
-            data["allow_deletions"]["enabled"].as_bool() == Some(false),
-            "blocked",
-            "allowed (should be blocked)",
+            observed_delete == bp.allow_deletion,
+            if bp.allow_deletion {
+                "allowed"
+            } else {
+                "blocked"
+            },
+            if bp.allow_deletion {
+                "blocked (should be allowed)"
+            } else {
+                "allowed (should be blocked)"
+            },
         ),
     ]
 }
 
-fn fix_branch_protection(repo: &str, checks: &[Check]) {
+fn checks_summary(want: &[String]) -> String {
+    if want.is_empty() {
+        "no required checks (configured)".into()
+    } else {
+        format!("{:?}", want)
+    }
+}
+
+fn fix_branch_protection(repo: &str, checks: &[Check], bp: &BranchProtectionPolicy) {
     let protection_missing = checks
         .iter()
         .any(|c| c.name == "Branch protection" && c.status == Status::Fail);
@@ -286,14 +387,14 @@ fn fix_branch_protection(repo: &str, checks: &[Check]) {
     println!("  {YELLOW}Fixing branch protection...{RESET}");
     let body = json!({
         "required_status_checks": {
-            "strict": false,
-            "contexts": ["Gate"]
+            "strict": bp.strict_status_checks,
+            "contexts": bp.required_checks,
         },
         "enforce_admins": true,
         "required_pull_request_reviews": null,
         "restrictions": null,
-        "allow_force_pushes": false,
-        "allow_deletions": false,
+        "allow_force_pushes": bp.allow_force_push,
+        "allow_deletions": bp.allow_deletion,
     });
 
     match gh::api_put(&format!("/repos/{repo}/branches/main/protection"), &body) {
@@ -304,7 +405,7 @@ fn fix_branch_protection(repo: &str, checks: &[Check]) {
 
 // ── Rulesets ───────────────────────────────────────────────────
 
-fn check_rulesets(repo: &str) -> Vec<Check> {
+fn check_rulesets(repo: &str, policy: &RulesetsPolicy) -> Vec<Check> {
     let rulesets = match gh::api_get(&format!("/repos/{repo}/rulesets")) {
         Ok(Value::Array(arr)) => arr,
         Ok(_) => return vec![Check::warn("Rulesets", "unexpected response format")],
@@ -331,7 +432,6 @@ fn check_rulesets(repo: &str) -> Vec<Check> {
         "none active",
     ));
 
-    // Check each active ruleset for key rules
     let mut has_deletion = false;
     let mut has_non_ff = false;
     let mut has_status_checks = false;
@@ -352,37 +452,55 @@ fn check_rulesets(repo: &str) -> Vec<Check> {
         }
     }
 
-    checks.push(bool_check(
-        "Deletion rule",
-        has_deletion,
-        "present",
-        "missing",
-    ));
-    checks.push(bool_check(
-        "Non-fast-forward rule",
-        has_non_ff,
-        "present",
-        "missing",
-    ));
-    checks.push(bool_check(
-        "Required status checks rule",
-        has_status_checks,
-        "present",
-        "missing",
-    ));
+    if policy.require_deletion {
+        checks.push(bool_check(
+            "Deletion rule",
+            has_deletion,
+            "present",
+            "missing",
+        ));
+    }
+    if policy.require_non_fast_forward {
+        checks.push(bool_check(
+            "Non-fast-forward rule",
+            has_non_ff,
+            "present",
+            "missing",
+        ));
+    }
+    if policy.require_status_checks {
+        checks.push(bool_check(
+            "Required status checks rule",
+            has_status_checks,
+            "present",
+            "missing",
+        ));
+    }
 
     checks
 }
 
 // ── Security ───────────────────────────────────────────────────
 
-fn check_security(repo: &str) -> Vec<Check> {
+fn check_security(repo: &str, policy: &SecurityPolicy) -> Vec<Check> {
     let mut checks = Vec::new();
 
-    // Vulnerability alerts (Dependabot) — uses status code
+    let want = policy.dependabot_alerts;
     match gh::api_get_status(&format!("/repos/{repo}/vulnerability-alerts")) {
-        Ok(204) => checks.push(Check::pass("Dependabot alerts", "enabled")),
-        Ok(404) => checks.push(Check::fail("Dependabot alerts", "disabled")),
+        Ok(204) => {
+            checks.push(if want {
+                Check::pass("Dependabot alerts", "enabled")
+            } else {
+                Check::fail("Dependabot alerts", "enabled (should be disabled)")
+            });
+        }
+        Ok(404) => {
+            checks.push(if !want {
+                Check::pass("Dependabot alerts", "disabled")
+            } else {
+                Check::fail("Dependabot alerts", "disabled (should be enabled)")
+            });
+        }
         Ok(code) => checks.push(Check::warn(
             "Dependabot alerts",
             format!("unexpected status {code}"),
@@ -394,7 +512,6 @@ fn check_security(repo: &str) -> Vec<Check> {
 }
 
 fn fix_security(repo: &str, checks: &[Check]) {
-    // Enable Dependabot alerts
     if checks
         .iter()
         .any(|c| c.name == "Dependabot alerts" && c.status == Status::Fail)

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -2,6 +2,7 @@ mod audit;
 mod bump;
 mod bump_locks;
 pub mod describe;
+mod policy;
 mod pr;
 mod rebase_open_prs;
 pub mod send;

--- a/tools/shaka/src/repo/policy.rs
+++ b/tools/shaka/src/repo/policy.rs
@@ -1,0 +1,159 @@
+//! Loader for `.shaka/repo.cue` — the per-repo policy file that drives
+//! `shaka repo audit`.
+//!
+//! `load(start)` walks upward from `start` looking for `.shaka/repo.cue`,
+//! validates and exports it via `cue export` against the embedded
+//! `repo-policy-schema.cue`, and returns a typed `RepoPolicy`. Optional
+//! groups (`branchProtection`, `rulesets`, `security`, `issues`) come back
+//! as `None` when omitted, so consumers can opt out of audit dimensions
+//! they don't care about.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+
+pub const SCHEMA: &str = include_str!("../../schema/repo-policy-schema.cue");
+
+const POLICY_FILE_REL: &str = ".shaka/repo.cue";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RepoPolicy {
+    pub default_branch: String,
+    pub merge: MergePolicy,
+    #[serde(default)]
+    pub issues: Option<bool>,
+    #[serde(default)]
+    pub branch_protection: Option<BranchProtectionPolicy>,
+    #[serde(default)]
+    pub rulesets: Option<RulesetsPolicy>,
+    #[serde(default)]
+    pub security: Option<SecurityPolicy>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MergePolicy {
+    pub rebase: bool,
+    pub merge: bool,
+    pub squash: bool,
+    pub delete_branch_on_merge: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct BranchProtectionPolicy {
+    pub required_checks: Vec<String>,
+    pub strict_status_checks: bool,
+    pub allow_force_push: bool,
+    pub allow_deletion: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RulesetsPolicy {
+    pub require_deletion: bool,
+    pub require_non_fast_forward: bool,
+    pub require_status_checks: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SecurityPolicy {
+    pub dependabot_alerts: bool,
+}
+
+pub fn find_policy_file(start: &Path) -> Option<PathBuf> {
+    let mut current: PathBuf = start.canonicalize().ok()?;
+    loop {
+        let candidate = current.join(POLICY_FILE_REL);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        let parent = current.parent()?;
+        current = parent.to_path_buf();
+    }
+}
+
+pub fn load(start: &Path) -> Result<RepoPolicy, String> {
+    let policy_path = find_policy_file(start).ok_or_else(|| {
+        format!(
+            "no {POLICY_FILE_REL} found in {} or any ancestor",
+            start.display()
+        )
+    })?;
+
+    // Per-process schema temp file — same pattern as project::schema_check.
+    let schema_path =
+        write_schema().map_err(|e| format!("could not write repo-policy schema: {e}"))?;
+
+    let output = Command::new("cue")
+        .arg("export")
+        .arg("--out")
+        .arg("json")
+        .arg(&schema_path)
+        .arg(&policy_path)
+        .output()
+        .map_err(|e| format!("failed to spawn cue: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(format!(
+            "cue export failed for {}: {detail}",
+            policy_path.display()
+        ));
+    }
+
+    serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("could not parse {}: {e}", policy_path.display()))
+}
+
+fn write_schema() -> std::io::Result<PathBuf> {
+    let path = std::env::temp_dir().join(format!(
+        "shaka-repo-policy-schema-{}.cue",
+        std::process::id()
+    ));
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(SCHEMA.as_bytes())?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn find_policy_file_finds_at_start() {
+        let tmp = TempDir::new().unwrap();
+        write(&tmp.path().join(".shaka/repo.cue"), "");
+        let found = find_policy_file(tmp.path()).unwrap();
+        assert!(found.ends_with(".shaka/repo.cue"));
+    }
+
+    #[test]
+    fn find_policy_file_walks_up() {
+        let tmp = TempDir::new().unwrap();
+        write(&tmp.path().join(".shaka/repo.cue"), "");
+        let nested = tmp.path().join("a/b/c");
+        fs::create_dir_all(&nested).unwrap();
+        let found = find_policy_file(&nested).unwrap();
+        assert!(found.ends_with(".shaka/repo.cue"));
+    }
+
+    #[test]
+    fn find_policy_file_returns_none_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        assert!(find_policy_file(tmp.path()).is_none());
+    }
+}

--- a/tools/shaka/tests/fixtures/repo-policy/invalid/empty-default-branch.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/invalid/empty-default-branch.cue
@@ -1,0 +1,25 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: ""
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	branchProtection: {
+		requiredChecks: ["Gate"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/invalid/missing-merge.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/invalid/missing-merge.cue
@@ -1,0 +1,19 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	branchProtection: {
+		requiredChecks: ["Gate"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/invalid/unknown-field.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/invalid/unknown-field.cue
@@ -1,0 +1,26 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	branchProtection: {
+		requiredChecks: ["Gate"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+	unknownField: "should-be-rejected"
+}

--- a/tools/shaka/tests/fixtures/repo-policy/invalid/wrong-checks-element-type.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/invalid/wrong-checks-element-type.cue
@@ -1,0 +1,25 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	branchProtection: {
+		requiredChecks: [123]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/invalid/wrong-merge-type.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/invalid/wrong-merge-type.cue
@@ -1,0 +1,25 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              "yes"
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	branchProtection: {
+		requiredChecks: ["Gate"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/valid/kolohelios.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/kolohelios.cue
@@ -1,0 +1,26 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	issues: true
+	branchProtection: {
+		requiredChecks: ["Gate"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/valid/minimal.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/minimal.cue
@@ -1,0 +1,11 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/valid/multiple-checks.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/multiple-checks.cue
@@ -1,0 +1,25 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               false
+		squash:              false
+		deleteBranchOnMerge: true
+	}
+	branchProtection: {
+		requiredChecks: ["Gate", "Lint", "Test"]
+		strictStatusChecks: false
+		allowForcePush:     false
+		allowDeletion:      false
+	}
+	rulesets: {
+		requireDeletion:       true
+		requireNonFastForward: true
+		requireStatusChecks:   true
+	}
+	security: {
+		dependabotAlerts: true
+	}
+}

--- a/tools/shaka/tests/fixtures/repo-policy/valid/permissive.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/permissive.cue
@@ -1,0 +1,25 @@
+package repopolicy
+
+#RepoPolicy & {
+	defaultBranch: "main"
+	merge: {
+		rebase:              true
+		merge:               true
+		squash:              true
+		deleteBranchOnMerge: false
+	}
+	branchProtection: {
+		requiredChecks: []
+		strictStatusChecks: false
+		allowForcePush:     true
+		allowDeletion:      true
+	}
+	rulesets: {
+		requireDeletion:       false
+		requireNonFastForward: false
+		requireStatusChecks:   false
+	}
+	security: {
+		dependabotAlerts: false
+	}
+}

--- a/tools/shaka/tests/repo_policy_schema.rs
+++ b/tools/shaka/tests/repo_policy_schema.rs
@@ -1,0 +1,66 @@
+//! Integration tests for the repo-policy.cue schema.
+//!
+//! Runs `cue vet -c` against fixtures in `tests/fixtures/repo-policy/{valid,invalid}/`.
+//! Each fixture is a complete `repo.cue` that should be accepted or rejected
+//! by the shipped schema. The test walks both directories and asserts every
+//! fixture in `valid/` passes and every fixture in `invalid/` fails — adding a
+//! new fixture is enough to extend coverage.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SCHEMA_PATH: &str = "schema/repo-policy-schema.cue";
+
+fn cue_vet(schema: &Path, policy: &Path) -> bool {
+    Command::new("cue")
+        .arg("vet")
+        .arg("-c")
+        .arg(schema)
+        .arg(policy)
+        .output()
+        .expect("failed to spawn cue (is it on PATH?)")
+        .status
+        .success()
+}
+
+fn fixtures_in(subdir: &str) -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/repo-policy")
+        .join(subdir);
+    let mut out: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|_| panic!("missing fixture dir: {}", dir.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "cue").unwrap_or(false))
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn every_valid_fixture_is_accepted() {
+    let schema = Path::new(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_PATH);
+    let fixtures = fixtures_in("valid");
+    assert!(!fixtures.is_empty(), "no valid fixtures found");
+    for fixture in fixtures {
+        assert!(
+            cue_vet(&schema, &fixture),
+            "expected {} to pass cue vet but it failed",
+            fixture.display()
+        );
+    }
+}
+
+#[test]
+fn every_invalid_fixture_is_rejected() {
+    let schema = Path::new(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_PATH);
+    let fixtures = fixtures_in("invalid");
+    assert!(!fixtures.is_empty(), "no invalid fixtures found");
+    for fixture in fixtures {
+        assert!(
+            !cue_vet(&schema, &fixture),
+            "expected {} to fail cue vet but it passed",
+            fixture.display()
+        );
+    }
+}


### PR DESCRIPTION
`shaka repo audit` today encodes the kolohelios convention (rebase-only
merging, `Gate` required check, etc.) as constants in
`tools/shaka/src/repo/audit.rs`. To make the audit reusable across
repos — kolohelios itself, and external consumers like
blogs-and-posts — the policy needs to live as data, not Rust code.

Add `tools/shaka/schema/repo-policy-schema.cue` describing the surface:
default branch, merge modes, branch protection (with a multi-element
required-checks list), ruleset requirements, and Dependabot toggle.
Walk fixtures in `tests/fixtures/repo-policy/{valid,invalid}/` from a
new `tests/repo_policy_schema.rs`, mirroring the existing
`tests/schema.rs` pattern — adding coverage means dropping a fixture
file, not editing Rust.

Loader and audit refactor land in the next commit; this commit is
schema-only so the policy shape can be reviewed in isolation.

`shaka repo audit` previously hard-coded the kolohelios convention
(rebase-only merging, `Gate` required check, Dependabot enabled, etc.)
as constants in the audit module. That made the command useful for
exactly one repo. To support kolohelios itself plus external
consumers like blogs-and-posts, every check needs to read from a
declared policy.

Add a `repo::policy` module that walks upward from the working
directory looking for `.shaka/repo.cue`, exports it through the
schema added in the previous commit (so all type/shape errors surface
as cue-vet failures, not Rust panics), and deserializes into a
`RepoPolicy`. Optional groups (`branchProtection`, `rulesets`,
`security`, `issues`) become `Option<...>` so consumers can opt out
of audit dimensions they don't enforce — typical for personal repos
without branch protection.

Refactor `repo::audit` to take the loaded policy and parameterize
each check + `--fix` PATCH body off it. Optional groups are skipped
entirely when the policy omits them. The loader exits early with a
clear hint if no `.shaka/repo.cue` is found, so external consumers
that haven't authored one yet get an actionable error rather than a
crash mid-audit.

Closes #293

Now that `shaka repo audit` reads its policy from `.shaka/repo.cue`,
kolohelios needs to author one — otherwise the audit refuses to run
in this repo. Capture exactly the values that the pre-refactor audit
hard-coded as Rust constants: rebase-only merging, `Gate` as the
single required status check, no force-push or branch-deletion on
`main`, the three ruleset rules (`deletion`, `non_fast_forward`,
`required_status_checks`), and Dependabot alerts enabled.

Behavior unchanged: running `shaka repo audit` against
`kolohelios/kolohelios` produces the same pass/fail set as before,
including the pre-existing drift between the audit's required check
name (`Gate`) and the live branch protection (`Validate`) — that's a
real GitHub-side inconsistency this refactor neither introduces nor
masks.

Narrow `.gitignore`'s `.shaka/` rule to just `.shaka/workspaces/` so
the directory can host both shaka's ephemeral workspace ↔ issue
links (which the rule was originally written for) and tracked
configs like `repo.cue`. The new file lives at `.shaka/repo.cue`
rather than the repo root so future shaka-owned root configs share a
namespace; `shaka project schema-check`'s slot-rooted discovery
ignores it.

The audit refactor in the previous commits made `shaka repo audit`
useful in any GitHub repo, not just kolohelios — but the README still
described it only in passing as a kolohelios-internal helper.

Add an `Auditing other repositories` section that names the policy
file (`.shaka/repo.cue`), points at the schema, calls out that
optional groups can be omitted (so personal repos without branch
protection still have a clean opt-out), and documents the canonical
external invocation:

    nix run https://flakehub.com/f/kolohelios/shaka/*.tar.gz \\
        -- repo audit

shaka is already published on every push to main by the build-shaka
job, so the FlakeHub URL is stable. The wrapped binary carries cue,
jj, git, and gh on its PATH, so external consumers don't need a
devshell — only the policy file at the target repo's root.