### PR TITLE
feat(shaka): teach repo bump-locks to bump external repos

### DIFF
--- a/tools/shaka/Cargo.toml
+++ b/tools/shaka/Cargo.toml
@@ -14,6 +14,4 @@ clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.9"
-
-[dev-dependencies]
 tempfile = "3"

--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -13,7 +13,26 @@ enum BumpResult {
     Failed(String),
 }
 
-pub fn run(input: String, pr_branch: Option<String>) {
+pub fn run(input: String, pr_branch: Option<String>, repo: Option<String>) {
+    match repo {
+        Some(slug) => {
+            let Some(branch) = pr_branch else {
+                eprintln!(
+                    "{RED}{BOLD}--repo requires --pr-branch{RESET} \
+                     (remote bumps always open or update a PR)"
+                );
+                std::process::exit(2);
+            };
+            if let Err(e) = run_remote(&input, &branch, &slug) {
+                eprintln!("{RED}{BOLD}bump-locks failed:{RESET} {e}");
+                std::process::exit(1);
+            }
+        }
+        None => run_monorepo(input, pr_branch),
+    }
+}
+
+fn run_monorepo(input: String, pr_branch: Option<String>) {
     let projects = schema_check::discover(Path::new("."));
     if projects.is_empty() {
         println!("{YELLOW}no projects found{RESET}");
@@ -66,6 +85,83 @@ pub fn run(input: String, pr_branch: Option<String>) {
             std::process::exit(1);
         }
     }
+}
+
+fn run_remote(input: &str, branch: &str, slug: &str) -> Result<(), String> {
+    println!("{BOLD}bump-locks:{RESET} input `{input}` in remote `{slug}`");
+
+    let temp = tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {e}"))?;
+    let work = temp.path().join("repo");
+
+    let work_str = work
+        .to_str()
+        .ok_or_else(|| "temp dir path is not valid UTF-8".to_string())?;
+    let output = Command::new("gh")
+        .args(["repo", "clone", slug, work_str, "--", "--depth", "1"])
+        .output()
+        .map_err(|e| format!("failed to spawn gh: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh repo clone {slug}: {}", stderr.trim()));
+    }
+
+    match bump_one(&work, input) {
+        BumpResult::Updated => {
+            println!("  {GREEN}{BOLD}updated{RESET}   {slug}");
+        }
+        BumpResult::Unchanged => {
+            println!("  {DIM}unchanged{RESET} {slug}");
+            println!("{DIM}no changes to publish{RESET}");
+            return Ok(());
+        }
+        BumpResult::Skipped => {
+            return Err(format!(
+                "remote {slug} does not declare `{input}` as a flake input \
+                 (checked root flake.nix)"
+            ));
+        }
+        BumpResult::Failed(msg) => {
+            return Err(format!("nix flake update failed: {msg}"));
+        }
+    }
+
+    git_in(&work, &["checkout", "-B", branch])?;
+    git_in(&work, &["add", "flake.lock"])?;
+    let title = format!("chore(deps): bump {input} flake input");
+    git_in(&work, &["commit", "-m", &title])?;
+    git_in(&work, &["push", "--force", "origin", branch])?;
+
+    if let Some(pr) = gh::pr_for_head(slug, branch).map_err(|e| e.to_string())? {
+        if pr.state == PrState::Open {
+            println!("{GREEN}{BOLD}updated existing PR:{RESET} {}", pr.url);
+            return Ok(());
+        }
+    }
+
+    let body = format_remote_pr_body(input);
+    let url = gh::pr_create(slug, &title, &body, branch).map_err(|e| e.to_string())?;
+    println!("{GREEN}{BOLD}created PR:{RESET} {url}");
+    Ok(())
+}
+
+fn git_in(work: &Path, args: &[&str]) -> Result<(), String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(work)
+        .output()
+        .map_err(|e| format!("failed to spawn git {}: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git {}: {}", args.join(" "), stderr.trim()));
+    }
+    Ok(())
+}
+
+fn format_remote_pr_body(input: &str) -> String {
+    format!(
+        "Automated bump of `{input}` flake input.\n\n\
+         No auto-merge. Review the lockfile diff and merge when CI is green.\n"
+    )
 }
 
 fn bump_one(project: &Path, input: &str) -> BumpResult {
@@ -220,6 +316,16 @@ mod tests {
         // `foo-bar.url` is not the `foo` input even though it starts with `foo`.
         let nix = "{\n  inputs.foo-bar.url = \"x\";\n}\n";
         assert!(!references_flake_input(nix, "foo"));
+    }
+
+    #[test]
+    fn remote_pr_body_is_terse_and_names_input() {
+        let body = format_remote_pr_body("blogctl");
+        assert!(body.contains("`blogctl`"));
+        assert!(body.contains("No auto-merge"));
+        // The remote case has only one flake by construction; the body
+        // should not list project paths the way the monorepo version does.
+        assert!(!body.contains("Updated `flake.lock` in:"));
     }
 
     #[test]

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -143,9 +143,18 @@ pub enum RepoCommand {
         input: String,
         /// If set, after bumping, switch to this branch, commit the changes,
         /// force-push, and open or update a PR. Requires GH_TOKEN with PR
-        /// write scope and a clean working copy on entry.
+        /// write scope and a clean working copy on entry. Required when
+        /// `--repo` is set.
         #[arg(long)]
         pr_branch: Option<String>,
+        /// If set, operate on the named remote repo (`<owner>/<slug>`)
+        /// instead of the current monorepo. Clones into a temp directory,
+        /// bumps the input in the root flake, and opens/updates a PR via
+        /// `--pr-branch` (which is required in this mode). The workflow
+        /// must set `GH_TOKEN` and pre-configure git identity + credential
+        /// helper (`gh auth setup-git`) before invoking shaka.
+        #[arg(long)]
+        repo: Option<String>,
     },
 }
 
@@ -168,6 +177,10 @@ pub fn run(cmd: RepoCommand) {
         RepoCommand::Status { json } => status::run(json),
         RepoCommand::Describe { json } => describe::run(json),
         RepoCommand::RebaseOpenPrs { dry_run } => rebase_open_prs::run(dry_run),
-        RepoCommand::BumpLocks { input, pr_branch } => bump_locks::run(input, pr_branch),
+        RepoCommand::BumpLocks {
+            input,
+            pr_branch,
+            repo,
+        } => bump_locks::run(input, pr_branch, repo),
     }
 }


### PR DESCRIPTION
Adds a `--repo <owner/slug>` flag to `shaka repo bump-locks`. When set, shaka clones the named repo into a temp dir, runs `nix flake update <input>` against the root flake, and if the lock changed, commits, force-pushes to `--pr-branch`, and opens or updates a PR via `gh`. The existing monorepo path is unchanged; `--repo` requires `--pr-branch` (remote bumps always publish).

This unblocks consolidating bumpers: `bump-blogctl.yaml` in `kolohelios/blogs-and-posts` currently uses `DeterminateSystems/update-flake-lock` because shaka's `schema_check::discover` is monorepo-only. With `--repo`, the single-flake repo's bumper can use shaka too, matching `bump-kolohelios-nix.yaml`'s shape. Workflow swap ships separately.

Closes #304