### PR TITLE
fix(infra/cloudflare-tokens): drop cloudflare_accounts data source

### DIFF
--- a/infra/cloudflare-tokens/.env.example
+++ b/infra/cloudflare-tokens/.env.example
@@ -11,10 +11,11 @@
 # Password item with the token value in the `password` field.
 CLOUDFLARE_API_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/Cloudflare Meta Token/password"
 
-# CF account name. Not a secret; literal value or 1Password reference,
-# either works. The TF `cloudflare_accounts` data source resolves this
-# to an account ID at plan time.
-TF_VAR_cloudflare_account_name="kolohelios"
+# CF account ID for account-scoped token resources. Stable and not
+# secret; copy from the dashboard URL (`dash.cloudflare.com/<id>/...`).
+# Passed literally rather than looked up because the meta-token's
+# `User:API Tokens:Edit` scope can't list accounts.
+TF_VAR_cloudflare_account_id="cc625b188f1219ec7ff2e9d19d1a1a7e"
 
 # 1Password vault UUID where provisioned token values land. This is the
 # canonical "Kolohelios Monorepo" vault.

--- a/infra/cloudflare-tokens/README.md
+++ b/infra/cloudflare-tokens/README.md
@@ -14,9 +14,11 @@ reads CUE registries directly).
 
 - `tokens/` — per-token CUE registry, one `#Token` instance per file.
   Validated against `tools/shaka/schema/cloudflare-token.cue`.
-- `terraform/main.tf` — Cloudflare and 1Password providers, account data
-  source, token resources.
-- `terraform/variables.tf` — `cloudflare_account_name` and
+- `terraform/main.tf` — Cloudflare and 1Password providers,
+  permission-group data sources, token resources.
+- `terraform/variables.tf` — `cloudflare_account_id` (literal, copied
+  from the dashboard URL — the meta-token's `User:API Tokens:Edit`
+  scope can't list accounts, so we don't look it up by name) and
   `onepassword_vault_id` (the canonical "Kolohelios Monorepo" vault,
   UUID `vedq2v6cmtkglnonkenrjneepa`).
 - `terraform/outputs.tf` — token metadata (IDs, expiry); never values.

--- a/infra/cloudflare-tokens/terraform/main.tf
+++ b/infra/cloudflare-tokens/terraform/main.tf
@@ -26,18 +26,18 @@ provider "cloudflare" {}
 # README.md.
 provider "onepassword" {}
 
-# ── Account / permission-group lookups ─────────────────────────────────
+# ── Permission-group lookups ──────────────────────────────────────────
 #
-# The CF account is referenced by name (provided via
-# `var.cloudflare_account_name`) so account IDs don't appear in version
-# control. Permission groups are looked up by API name and resolved to
-# opaque CF group IDs at plan time — this lets the per-token CUE
-# registry under `tokens/` declare permissions in human-readable form
-# without hardcoding IDs in TF.
-data "cloudflare_accounts" "primary" {
-  name = var.cloudflare_account_name
-}
-
+# Permission groups are looked up by API name and resolved to opaque CF
+# group IDs at plan time — this lets the per-token CUE registry under
+# `tokens/` declare permissions in human-readable form without
+# hardcoding IDs in TF.
+#
+# Account ID is passed literally via `var.cloudflare_account_id` rather
+# than looked up via `data "cloudflare_accounts"` (which the
+# `cloudflare-dns` project uses), because the bootstrap meta-token has
+# only `User:API Tokens:Edit` scope and can't list accounts. The
+# account ID is stable and not secret.
 data "cloudflare_api_token_permission_groups_list" "dns_write" {
   name = "DNS Write"
 }
@@ -51,7 +51,7 @@ data "cloudflare_api_token_permission_groups_list" "account_settings_read" {
 }
 
 locals {
-  account_id = data.cloudflare_accounts.primary.result[0].id
+  account_id = var.cloudflare_account_id
 }
 
 # ── dns-management ────────────────────────────────────────────────────

--- a/infra/cloudflare-tokens/terraform/variables.tf
+++ b/infra/cloudflare-tokens/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "cloudflare_account_name" {
-  description = "The name of the Cloudflare account that owns these tokens (used to look up the account ID for account-scoped tokens)"
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for account-scoped token resources. Stable and not secret; visible in the dashboard URL. Passed literally rather than looked up because the bootstrap meta-token has only `User:API Tokens:Edit` and can't list accounts."
   type        = string
 }
 


### PR DESCRIPTION
The bootstrap meta-token's permissions are User:API Tokens:Edit only,
which authenticates but grants no account memberships in scope. The
cloudflare_accounts data source returns an empty result list under
that token, so TF would crash on result[0].id during the first plan.
Verified directly against /accounts: success: true with result: [].

Replaces the data-source lookup with a literal cloudflare_account_id
variable (stable, not secret, copy from the dashboard URL). Drops
cloudflare_account_name. infra/cloudflare-dns is unchanged: its
consumer-token (DNS Management) has Account Settings:Read, so the
data-source pattern there will work once the token is provisioned.

Closes #311