### PR TITLE
fix(infra/cloudflare-dns): drop cloudflare_accounts data source

### DIFF
--- a/infra/cloudflare-dns/.env.example
+++ b/infra/cloudflare-dns/.env.example
@@ -10,8 +10,11 @@
 # zones in the kolohelios account.
 CLOUDFLARE_API_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/Cloudflare DNS Management Token/password"
 
-# CF account name. Not a secret; literal string is fine.
-TF_VAR_cloudflare_account_name="kolohelios"
+# CF account ID. Stable and not secret; copy from the dashboard URL
+# (`dash.cloudflare.com/<id>/...`). Passed literally rather than looked
+# up because the DNS Management token can't list accounts via /accounts
+# (same pattern as `infra/cloudflare-tokens`; see #311/#313).
+TF_VAR_cloudflare_account_id="cc625b188f1219ec7ff2e9d19d1a1a7e"
 
 # S3-compatible credentials for the Linode Object Storage bucket that
 # holds remote `tofu` state — minted by `shaka object-store init`.

--- a/infra/cloudflare-dns/terraform/main.tf
+++ b/infra/cloudflare-dns/terraform/main.tf
@@ -16,14 +16,10 @@ terraform {
 # Source it via 1Password: see README.md.
 provider "cloudflare" {}
 
-data "cloudflare_accounts" "primary" {
-  name = var.cloudflare_account_name
-}
-
 # ── kolohelios.com ─────────────────────────────────────────────
 resource "cloudflare_zone" "kolohelios_com" {
   account = {
-    id = data.cloudflare_accounts.primary.result[0].id
+    id = var.cloudflare_account_id
   }
   name = "kolohelios.com"
   type = "full"

--- a/infra/cloudflare-dns/terraform/variables.tf
+++ b/infra/cloudflare-dns/terraform/variables.tf
@@ -1,4 +1,4 @@
-variable "cloudflare_account_name" {
-  description = "The name of the Cloudflare account that owns these zones (used to look up the account ID)"
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID for the zones managed here. Stable and not secret; visible in the dashboard URL. Passed literally rather than looked up because the consumer-token can't list accounts (matches the pattern in infra/cloudflare-tokens; see #311/#313)."
   type        = string
 }


### PR DESCRIPTION
Mirror of #311/PR #312. The DNS Management token (provisioned by
infra/cloudflare-tokens) has Account Settings:Read scoped to the
kolohelios account, but /accounts returns an empty list under that
token — TF crashes on data.cloudflare_accounts.primary.result[0].id.
The prediction in #311's body (\"the data source there will work once
the token is provisioned\") was empirically wrong; account listing
needs a User-level permission the token deliberately doesn't have.

Same pattern as #312: drop the data source, take the account ID as
TF_VAR_cloudflare_account_id (literal value, not secret).

Closes #313