### PR TITLE
fix(infra/cloudflare-portfolio): attach kolohelios.com to Pages

### DIFF
--- a/infra/cloudflare-portfolio/terraform/main.tf
+++ b/infra/cloudflare-portfolio/terraform/main.tf
@@ -35,3 +35,16 @@ resource "cloudflare_pages_project" "kolohelios_portfolio" {
   name              = "kolohelios-portfolio"
   production_branch = "main"
 }
+
+# Custom-domain attachment so CF's edge knows to route requests for
+# kolohelios.com to this Pages project. The apex CNAME in
+# `infra/cloudflare-dns` is necessary but not sufficient — without
+# this resource, requests follow the CNAME but Pages returns "not
+# found" because no project owns the hostname. CF validates against
+# the existing CNAME on apply and provisions the TLS cert
+# automatically.
+resource "cloudflare_pages_domain" "kolohelios_com" {
+  account_id   = var.cloudflare_account_id
+  project_name = cloudflare_pages_project.kolohelios_portfolio.name
+  name         = "kolohelios.com"
+}


### PR DESCRIPTION
Slice #2 of #186 (PR #317) provisioned the Pages project and the
apex CNAME but missed the custom-domain attachment on the project
itself. Without it, CF's edge follows the CNAME but doesn't know
which Pages project owns kolohelios.com, so requests return a
Pages "not found" page instead of the placeholder content.

The Pages-management token already has Account:Cloudflare
Pages:Edit, so no token change is needed. CF validates against
the existing apex CNAME at apply time and provisions the TLS
cert automatically.

Closes #320.