### PR TITLE
feat(blogctl): per-target publish status in frontmatter

### DIFF
--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -66,6 +66,13 @@ updated_at: 2026-05-03T00:00:00Z
 tags: []
 todoist_task_id: null
 history_checked: false
+targets:
+  - name: linkedin
+    status: published
+    url: https://www.linkedin.com/posts/example
+    published_at: 2026-05-08T14:32:00Z
+  - name: blog
+    status: planned
 ---
 
 Draft text here.
@@ -75,6 +82,14 @@ Timestamps are RFC 3339 UTC. `kind` is one of `post` or `article`;
 `theme` is any name declared in `.blog-os.toml`'s `[themes.*]` table
 (the binary seeds `standard` and `parable`). The Markdown file is the
 source of truth.
+
+`status` tracks the editorial pipeline (where the post sits in
+`concept→ideation→editing→final-editing→published`); the directory the
+file lives in must agree with it. `targets` is orthogonal: a list of
+distribution venues and per-venue state (`planned`, `published`,
+`retracted`). `targets` defaults to `[]` and is optional. When a
+target's `status` is `published`, both `url` and `published_at` are
+required; each venue may appear at most once per post.
 
 ## Extension points
 

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -244,6 +244,7 @@ mod tests {
                 tags: vec![],
                 todoist_task_id: None,
                 history_checked: false,
+                targets: vec![],
             },
             "body\n",
         )

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -303,6 +303,7 @@ mod tests {
                 tags: vec![],
                 todoist_task_id: None,
                 history_checked: false,
+                targets: vec![],
             },
             "body\n",
         )

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -47,6 +47,7 @@ pub fn run(
         tags: vec![],
         todoist_task_id: None,
         history_checked: false,
+        targets: vec![],
     };
     let post = Post::new(metadata, "");
     let path = repo.create_post(&post)?;

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -42,6 +42,12 @@ pub enum Error {
     #[error("invalid kind {0:?}: expected `post` or `article`")]
     InvalidKind(String),
 
+    #[error("invalid target {0:?}: expected `linkedin` or `blog`")]
+    InvalidTarget(String),
+
+    #[error("invalid target status {0:?}: expected `planned`, `published`, or `retracted`")]
+    InvalidTargetStatus(String),
+
     #[error("unknown theme {theme:?}: known themes are {}", known.join(", "))]
     UnknownTheme { theme: String, known: Vec<String> },
 

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -48,6 +48,24 @@ pub enum Error {
     #[error("invalid target status {0:?}: expected `planned`, `published`, or `retracted`")]
     InvalidTargetStatus(String),
 
+    #[error("duplicate target {name} in {path} (each target may appear at most once)")]
+    DuplicateTarget {
+        path: PathBuf,
+        name: crate::target::Target,
+    },
+
+    #[error("target {name} in {path} has status `published` but `url` is not set")]
+    PublishedTargetMissingUrl {
+        path: PathBuf,
+        name: crate::target::Target,
+    },
+
+    #[error("target {name} in {path} has status `published` but `published_at` is not set")]
+    PublishedTargetMissingPublishedAt {
+        path: PathBuf,
+        name: crate::target::Target,
+    },
+
     #[error("unknown theme {theme:?}: known themes are {}", known.join(", "))]
     UnknownTheme { theme: String, known: Vec<String> },
 

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -6,9 +6,11 @@ pub mod post;
 pub mod slug;
 pub mod stage;
 pub mod storage;
+pub mod target;
 
 pub use error::{Error, Result};
 pub use kind::Kind;
 pub use post::{Post, PostMetadata};
 pub use stage::Stage;
 pub use storage::{Repository, Workdir};
+pub use target::{Target, TargetEntry, TargetStatus};

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -7,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::kind::Kind;
 use crate::stage::Stage;
 use crate::storage::DEFAULT_THEME;
+use crate::target::{TargetEntry, TargetStatus};
 
 /// Frontmatter metadata. Mirrors the YAML block at the top of every post
 /// file. Fields stay required so a round-trip preserves shape; clients
@@ -32,6 +34,11 @@ pub struct PostMetadata {
     pub todoist_task_id: Option<String>,
     #[serde(default)]
     pub history_checked: bool,
+    /// Distribution targets. Orthogonal to `status` (editorial pipeline):
+    /// records *where* this post has been pushed and the per-venue state.
+    /// Default `[]` keeps existing files parsing unchanged.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<TargetEntry>,
 }
 
 fn default_theme() -> String {
@@ -64,6 +71,7 @@ impl Post {
                 path: path.to_path_buf(),
                 source,
             })?;
+        validate_targets(path, &metadata.targets)?;
         Ok(Self {
             metadata,
             body: body.to_string(),
@@ -91,6 +99,36 @@ impl Post {
         }
         Ok(out)
     }
+}
+
+/// Enforce the cross-field invariants the type system can't carry:
+/// each `Target` appears at most once, and a `Published` entry has
+/// both `url` and `published_at`.
+fn validate_targets(path: &Path, targets: &[TargetEntry]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(targets.len());
+    for entry in targets {
+        if !seen.insert(entry.name) {
+            return Err(Error::DuplicateTarget {
+                path: path.to_path_buf(),
+                name: entry.name,
+            });
+        }
+        if entry.status == TargetStatus::Published {
+            if entry.url.is_none() {
+                return Err(Error::PublishedTargetMissingUrl {
+                    path: path.to_path_buf(),
+                    name: entry.name,
+                });
+            }
+            if entry.published_at.is_none() {
+                return Err(Error::PublishedTargetMissingPublishedAt {
+                    path: path.to_path_buf(),
+                    name: entry.name,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 fn split_frontmatter<'a>(path: &Path, contents: &'a str) -> Result<(&'a str, &'a str)> {
@@ -156,6 +194,7 @@ mod tests {
             tags: vec!["rust".into(), "tooling".into()],
             todoist_task_id: None,
             history_checked: false,
+            targets: vec![],
         }
     }
 
@@ -301,5 +340,161 @@ Body.
         let raw = "---\ntitle: T\nslug: t\nkind: post\nstatus: concept\ncreated_at: 2026-05-03T00:00:00Z\nupdated_at: 2026-05-03T00:00:00Z\ntags: []\n---\n\n--- not a delimiter ---\n";
         let post = parse(raw).unwrap();
         assert!(post.body.contains("--- not a delimiter ---"));
+    }
+
+    #[test]
+    fn parse_defaults_targets_to_empty_when_field_missing() {
+        let raw = r#"---
+title: "T"
+slug: t
+kind: post
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+---
+
+Body.
+"#;
+        let post = parse(raw).unwrap();
+        assert!(post.metadata.targets.is_empty());
+    }
+
+    #[test]
+    fn parse_accepts_post_with_targets() {
+        let raw = r#"---
+title: "T"
+slug: t
+kind: post
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    url: https://www.linkedin.com/posts/example
+    published_at: 2026-05-08T14:32:00Z
+  - name: blog
+    status: planned
+---
+
+Body.
+"#;
+        let post = parse(raw).unwrap();
+        assert_eq!(post.metadata.targets.len(), 2);
+        assert_eq!(
+            post.metadata.targets[0].name,
+            crate::target::Target::Linkedin
+        );
+        assert_eq!(
+            post.metadata.targets[0].status,
+            crate::target::TargetStatus::Published
+        );
+        assert_eq!(post.metadata.targets[1].name, crate::target::Target::Blog);
+        assert_eq!(
+            post.metadata.targets[1].status,
+            crate::target::TargetStatus::Planned
+        );
+        assert!(post.metadata.targets[1].url.is_none());
+    }
+
+    #[test]
+    fn parse_rejects_duplicate_targets() {
+        let raw = r#"---
+title: "T"
+slug: t
+kind: post
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+targets:
+  - name: blog
+    status: planned
+  - name: blog
+    status: planned
+---
+
+Body.
+"#;
+        assert!(matches!(
+            parse(raw),
+            Err(Error::DuplicateTarget { name, .. }) if name == crate::target::Target::Blog
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_published_target_missing_url() {
+        let raw = r#"---
+title: "T"
+slug: t
+kind: post
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    published_at: 2026-05-08T14:32:00Z
+---
+
+Body.
+"#;
+        assert!(matches!(
+            parse(raw),
+            Err(Error::PublishedTargetMissingUrl { name, .. })
+                if name == crate::target::Target::Linkedin
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_published_target_missing_published_at() {
+        let raw = r#"---
+title: "T"
+slug: t
+kind: post
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    url: https://www.linkedin.com/posts/example
+---
+
+Body.
+"#;
+        assert!(matches!(
+            parse(raw),
+            Err(Error::PublishedTargetMissingPublishedAt { name, .. })
+                if name == crate::target::Target::Linkedin
+        ));
+    }
+
+    #[test]
+    fn render_round_trips_post_with_targets() {
+        use crate::target::{Target, TargetEntry, TargetStatus};
+        let mut metadata = fixture_metadata();
+        metadata.targets = vec![
+            TargetEntry {
+                name: Target::Linkedin,
+                status: TargetStatus::Published,
+                url: Some("https://www.linkedin.com/posts/example".into()),
+                published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+            },
+            TargetEntry {
+                name: Target::Blog,
+                status: TargetStatus::Planned,
+                url: None,
+                published_at: None,
+            },
+        ];
+        let original = Post::new(metadata, "Body.\n");
+        let rendered = original.render().unwrap();
+        let reparsed = parse(&rendered).unwrap();
+        assert_eq!(reparsed.metadata, original.metadata);
     }
 }

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -512,6 +512,7 @@ mod tests {
                 tags: vec![],
                 todoist_task_id: None,
                 history_checked: false,
+                targets: vec![],
             },
             "body\n",
         )

--- a/apps/blogctl/src/target.rs
+++ b/apps/blogctl/src/target.rs
@@ -1,0 +1,189 @@
+//! Distribution targets and their per-target state. Orthogonal to the
+//! editorial `Stage` pipeline: a post is editorially in one stage
+//! (concept→…→published) but may end up distributed to zero, one, or
+//! more venues, each with its own small state machine.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+
+/// A venue a post can be distributed to. Closed enum — adding a new
+/// venue is a deliberate code change, not a frontmatter typo away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Target {
+    Linkedin,
+    Blog,
+}
+
+impl Target {
+    pub const ALL: &'static [Target] = &[Target::Linkedin, Target::Blog];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Target::Linkedin => "linkedin",
+            Target::Blog => "blog",
+        }
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Target {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "linkedin" => Ok(Target::Linkedin),
+            "blog" => Ok(Target::Blog),
+            other => Err(Error::InvalidTarget(other.to_string())),
+        }
+    }
+}
+
+/// Per-target state. Deliberately smaller than editorial `Stage` —
+/// distribution is "have I posted this here, and where can I find it?"
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TargetStatus {
+    Planned,
+    Published,
+    Retracted,
+}
+
+impl TargetStatus {
+    pub const ALL: &'static [TargetStatus] = &[
+        TargetStatus::Planned,
+        TargetStatus::Published,
+        TargetStatus::Retracted,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TargetStatus::Planned => "planned",
+            TargetStatus::Published => "published",
+            TargetStatus::Retracted => "retracted",
+        }
+    }
+}
+
+impl fmt::Display for TargetStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TargetStatus {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "planned" => Ok(TargetStatus::Planned),
+            "published" => Ok(TargetStatus::Published),
+            "retracted" => Ok(TargetStatus::Retracted),
+            other => Err(Error::InvalidTargetStatus(other.to_string())),
+        }
+    }
+}
+
+/// One entry in a post's `targets:` list. `url` and `published_at` are
+/// required when `status == Published` and optional otherwise; the
+/// invariant is enforced at parse time, not by the type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TargetEntry {
+    pub name: Target,
+    pub status: TargetStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(
+        default,
+        with = "time::serde::rfc3339::option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub published_at: Option<OffsetDateTime>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn target_parse_round_trips() {
+        for &t in Target::ALL {
+            assert_eq!(t.as_str().parse::<Target>().unwrap(), t);
+        }
+    }
+
+    #[test]
+    fn target_parse_rejects_unknown() {
+        let err = "mastodon".parse::<Target>().unwrap_err();
+        assert!(matches!(err, Error::InvalidTarget(_)));
+    }
+
+    #[test]
+    fn target_status_parse_round_trips() {
+        for &s in TargetStatus::ALL {
+            assert_eq!(s.as_str().parse::<TargetStatus>().unwrap(), s);
+        }
+    }
+
+    #[test]
+    fn target_status_parse_rejects_unknown() {
+        let err = "draft".parse::<TargetStatus>().unwrap_err();
+        assert!(matches!(err, Error::InvalidTargetStatus(_)));
+    }
+
+    #[test]
+    fn target_serde_uses_kebab_case() {
+        let yaml = serde_yaml_ng::to_string(&Target::Linkedin).unwrap();
+        assert_eq!(yaml.trim(), "linkedin");
+        let parsed: Target = serde_yaml_ng::from_str("linkedin").unwrap();
+        assert_eq!(parsed, Target::Linkedin);
+    }
+
+    #[test]
+    fn target_status_serde_uses_kebab_case() {
+        let yaml = serde_yaml_ng::to_string(&TargetStatus::Published).unwrap();
+        assert_eq!(yaml.trim(), "published");
+        let parsed: TargetStatus = serde_yaml_ng::from_str("planned").unwrap();
+        assert_eq!(parsed, TargetStatus::Planned);
+    }
+
+    #[test]
+    fn target_entry_round_trips_published() {
+        let raw = "name: linkedin\nstatus: published\nurl: https://www.linkedin.com/posts/x\npublished_at: 2026-05-08T14:32:00Z\n";
+        let parsed: TargetEntry = serde_yaml_ng::from_str(raw).unwrap();
+        assert_eq!(parsed.name, Target::Linkedin);
+        assert_eq!(parsed.status, TargetStatus::Published);
+        assert_eq!(
+            parsed.url.as_deref(),
+            Some("https://www.linkedin.com/posts/x")
+        );
+        assert!(parsed.published_at.is_some());
+
+        let rendered = serde_yaml_ng::to_string(&parsed).unwrap();
+        let reparsed: TargetEntry = serde_yaml_ng::from_str(&rendered).unwrap();
+        assert_eq!(reparsed, parsed);
+    }
+
+    #[test]
+    fn target_entry_round_trips_planned_without_url_or_timestamp() {
+        let raw = "name: blog\nstatus: planned\n";
+        let parsed: TargetEntry = serde_yaml_ng::from_str(raw).unwrap();
+        assert_eq!(parsed.name, Target::Blog);
+        assert_eq!(parsed.status, TargetStatus::Planned);
+        assert!(parsed.url.is_none());
+        assert!(parsed.published_at.is_none());
+
+        let rendered = serde_yaml_ng::to_string(&parsed).unwrap();
+        // skip_serializing_if drops the empty optional fields entirely
+        assert!(!rendered.contains("url"));
+        assert!(!rendered.contains("published_at"));
+    }
+}

--- a/apps/blogctl/tests/fixtures/frontmatter/invalid/duplicate-target.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/invalid/duplicate-target.md
@@ -1,0 +1,16 @@
+---
+title: "Duplicate target"
+slug: duplicate-target
+kind: post
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+targets:
+  - name: blog
+    status: planned
+  - name: blog
+    status: planned
+---
+
+Body.

--- a/apps/blogctl/tests/fixtures/frontmatter/invalid/published-target-missing-published-at.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/invalid/published-target-missing-published-at.md
@@ -1,0 +1,15 @@
+---
+title: "Published target without published_at"
+slug: published-target-missing-published-at
+kind: post
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-08T14:32:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    url: https://www.linkedin.com/posts/example
+---
+
+Body.

--- a/apps/blogctl/tests/fixtures/frontmatter/invalid/published-target-missing-url.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/invalid/published-target-missing-url.md
@@ -1,0 +1,15 @@
+---
+title: "Published target without url"
+slug: published-target-missing-url
+kind: post
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-08T14:32:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    published_at: 2026-05-08T14:32:00Z
+---
+
+Body.

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/with-targets.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/with-targets.md
@@ -1,0 +1,18 @@
+---
+title: "Post with distribution targets"
+slug: post-with-distribution-targets
+kind: post
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-08T14:32:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    url: https://www.linkedin.com/posts/example
+    published_at: 2026-05-08T14:32:00Z
+  - name: blog
+    status: planned
+---
+
+Body.


### PR DESCRIPTION
Introduces the typed vocabulary for tracking where a post is
distributed, separately from the editorial `Stage` pipeline.

- `Target`: closed enum of venues (`linkedin`, `blog`). Adding
  a new venue is a deliberate code change, not a frontmatter typo
  away.
- `TargetStatus`: small state machine per target (`planned`,
  `published`, `retracted`). Distinct from `Stage` because
  distribution is a different concern than editorial readiness.
- `TargetEntry`: one row in a post's eventual `targets:` list,
  carrying `name`, `status`, optional `url`, optional
  `published_at`.

No wiring into `PostMetadata` yet — that lands in a follow-up
commit alongside parse-time validation and fixtures.

Refs #318

Wires the new `Target` / `TargetStatus` / `TargetEntry` vocabulary
into `PostMetadata` as an optional `targets:` field (default `[]`,
so existing files parse unchanged). `targets` is orthogonal to the
editorial `status` pipeline: `status` says where in
concept→…→published the post sits, `targets` records *where* the
finished post has been distributed and the per-venue state.

Parse-time validation in `Post::parse` enforces the cross-field
invariants the type system can't carry:

- Each `Target` may appear at most once.
- A `Published` target requires both `url` and `published_at`.

Fixture-driven coverage extends naturally — three new `invalid/` and
one new `valid/` markdown file under
`tests/fixtures/frontmatter/`. Existing `PostMetadata` call sites
(production `blogctl new` plus four test helpers) gain a
`targets: vec![]` field; the README's frontmatter example shows the
new shape with both a `published` linkedin entry and a `planned`
blog entry.

CLI helpers for editing `targets` (e.g. `blogctl target add`)
are deliberately deferred — hand-edit frontmatter for now, revisit
if it becomes painful.

Closes #318