### PR TITLE
ci: enable FlakeHub Cache in nix-using jobs

### DIFF
--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -48,6 +48,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       - name: Configure git identity for rebase commits
         # The numeric App ID (3591292) is part of GitHub's noreply email
         # format `<app-id>+<bot-name>[bot]@users.noreply.github.com`,

--- a/.github/workflows/bump-kolohelios-nix.yaml
+++ b/.github/workflows/bump-kolohelios-nix.yaml
@@ -56,6 +56,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       - name: Configure git identity
         # The numeric App ID (3591292) is part of GitHub's noreply email
         # format `<app-id>+<bot-name>[bot]@users.noreply.github.com`,

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,6 +103,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       # Skip cargo dependency rebuilds when Cargo.lock is unchanged. Only
       # covers the host-side `cargo` invocations from `just validate`; the
       # `nix flake check` path runs in a sandbox actions/cache can't reach.
@@ -144,6 +145,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       - run: nix build ./tools/shaka
       - uses: DeterminateSystems/flakehub-push@main
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -167,6 +169,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       - run: nix build ./apps/blogctl
       - uses: DeterminateSystems/flakehub-push@main
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -190,6 +193,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       # `nix flake check` forces evaluation of the lib's outputs (lib,
       # formatter, devShells), which seeds the closure that flakehub-push
       # then uploads.
@@ -216,6 +220,7 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       - run: nix build ./infra/devbox#linodeImage
       - uses: actions/upload-artifact@v7
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -244,4 +249,5 @@ jobs:
         with:
           determinate: true
           flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
       - run: nix run ./tools/shaka -- ci gate --needs '${{ toJson(needs) }}'


### PR DESCRIPTION
Add `DeterminateSystems/flakehub-cache-action@v3` after every
`nix-installer-action` step so CI substitutes (and writes back) via
`cache.flakehub.com` instead of rebuilding nix derivations from
source.

`nix-installer-action` with `flakehub: true` only authenticates OIDC
for resolving private flake inputs; it does not enable the FlakeHub
Cache as a substituter. That ships as a separate action. PR #321's
validate run (id 25638894277) cold-built `wrangler-pnpm-deps.drv`
and `wrangler-4.62.0.drv` from source — no `cache.flakehub.com`
substitution attempts in the run — making the gap visible.

Wired into all eight call sites: the six jobs in `main.yaml`
(`validate`, `build-shaka`, `build-blogctl`, `build-nix-lib`,
`build-image`, `gate`) plus `auto-rebase-prs.yaml` and
`bump-kolohelios-nix.yaml`. Every job already has `id-token: write`,
so no permission changes.

Closes #323