### PR TITLE
feat(shaka): justfile template + audit for rust-worker

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -43,6 +43,22 @@ package project
 			fail: number & >=0 & <=100
 		}
 	}
+} | {
+	// Rust crate that compiles to wasm32-unknown-unknown and ships
+	// as a Cloudflare Worker. Coverage is optional because cargo-llvm-cov
+	// can't measure the wasm-target code paths that actually serve
+	// requests; native-only coverage would gate the wrong thing.
+	// Deploy lives here (not on `rust`) since `cloudflare-worker` only
+	// makes sense for wasm builds.
+	kind: "rust-worker"
+	coverage?: {
+		line: {
+			fail: number & >=0 & <=100
+		}
+		branch: {
+			fail: number & >=0 & <=100
+		}
+	}
 	deploy?: #Deploy
 } | {
 	kind: "infra"

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -38,8 +38,17 @@ struct AuditConfig {
 #[serde(rename_all = "kebab-case")]
 pub enum ProjectKind {
     Rust,
+    RustWorker,
     Infra,
     NixLib,
+}
+
+impl ProjectKind {
+    /// Rust-flavored kinds share the cargo/clippy/license rules even
+    /// when coverage requirements diverge.
+    fn is_rust_flavored(self) -> bool {
+        matches!(self, ProjectKind::Rust | ProjectKind::RustWorker)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -133,7 +142,7 @@ impl Rule for RustHasTests {
         "rust-has-tests"
     }
     fn applies(&self, meta: &ProjectMeta) -> bool {
-        meta.kind == ProjectKind::Rust
+        meta.kind.is_rust_flavored()
     }
     fn check(&self, project_dir: &Path, _meta: &ProjectMeta) -> RuleResult {
         if has_rust_tests(project_dir) {
@@ -149,11 +158,18 @@ impl Rule for RustCoverageThresholdNonzero {
         "rust-coverage-threshold-nonzero"
     }
     fn applies(&self, meta: &ProjectMeta) -> bool {
-        meta.kind == ProjectKind::Rust
+        meta.kind.is_rust_flavored()
     }
     fn check(&self, _project_dir: &Path, meta: &ProjectMeta) -> RuleResult {
         let Some(cov) = &meta.coverage else {
-            return RuleResult::Fail("rust project missing coverage block".into());
+            // Rust requires coverage; rust-worker treats it as opt-in
+            // (cargo-llvm-cov can't see the wasm-target code, so
+            // gating on native-only coverage is misleading).
+            return match meta.kind {
+                ProjectKind::Rust => RuleResult::Fail("rust project missing coverage block".into()),
+                ProjectKind::RustWorker => RuleResult::Pass,
+                _ => RuleResult::Pass,
+            };
         };
         if cov.line.fail == 0 || cov.branch.fail == 0 {
             return RuleResult::Fail(format!(
@@ -170,7 +186,7 @@ impl Rule for RustLicenseDual {
         "rust-license-dual"
     }
     fn applies(&self, meta: &ProjectMeta) -> bool {
-        meta.kind == ProjectKind::Rust
+        meta.kind.is_rust_flavored()
     }
     fn check(&self, project_dir: &Path, _meta: &ProjectMeta) -> RuleResult {
         let cargo = project_dir.join("Cargo.toml");
@@ -664,6 +680,15 @@ mod tests {
         }
     }
 
+    fn rust_worker_meta() -> ProjectMeta {
+        ProjectMeta {
+            name: "demo".into(),
+            kind: ProjectKind::RustWorker,
+            coverage: None,
+            audit: None,
+        }
+    }
+
     #[test]
     fn readme_present_passes_when_readme_exists() {
         let tmp = TempDir::new().unwrap();
@@ -713,8 +738,9 @@ mod tests {
     }
 
     #[test]
-    fn rust_has_tests_only_applies_to_rust() {
+    fn rust_has_tests_applies_to_rust_and_rust_worker_only() {
         assert!(RustHasTests.applies(&rust_meta()));
+        assert!(RustHasTests.applies(&rust_worker_meta()));
         assert!(!RustHasTests.applies(&infra_meta()));
     }
 
@@ -800,8 +826,9 @@ mod tests {
     }
 
     #[test]
-    fn coverage_threshold_only_applies_to_rust() {
+    fn coverage_threshold_applies_to_rust_and_rust_worker_only() {
         assert!(RustCoverageThresholdNonzero.applies(&rust_meta()));
+        assert!(RustCoverageThresholdNonzero.applies(&rust_worker_meta()));
         assert!(!RustCoverageThresholdNonzero.applies(&infra_meta()));
     }
 
@@ -847,7 +874,7 @@ mod tests {
     }
 
     #[test]
-    fn coverage_threshold_fails_when_block_missing() {
+    fn coverage_threshold_fails_when_block_missing_on_rust() {
         let tmp = TempDir::new().unwrap();
         let meta = ProjectMeta {
             coverage: None,
@@ -860,8 +887,36 @@ mod tests {
     }
 
     #[test]
-    fn rust_license_dual_only_applies_to_rust() {
+    fn coverage_threshold_passes_when_block_missing_on_rust_worker() {
+        // Coverage is opt-in on rust-worker; absence must not fail.
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(
+            RustCoverageThresholdNonzero.check(tmp.path(), &rust_worker_meta()),
+            RuleResult::Pass
+        );
+    }
+
+    #[test]
+    fn coverage_threshold_fails_for_zero_threshold_on_rust_worker() {
+        // When a rust-worker app opts in, zero values are still rejected.
+        let tmp = TempDir::new().unwrap();
+        let meta = ProjectMeta {
+            coverage: Some(Coverage {
+                line: CoverageThreshold { fail: 0 },
+                branch: CoverageThreshold { fail: 50 },
+            }),
+            ..rust_worker_meta()
+        };
+        assert!(matches!(
+            RustCoverageThresholdNonzero.check(tmp.path(), &meta),
+            RuleResult::Fail(_)
+        ));
+    }
+
+    #[test]
+    fn rust_license_dual_applies_to_rust_and_rust_worker_only() {
         assert!(RustLicenseDual.applies(&rust_meta()));
+        assert!(RustLicenseDual.applies(&rust_worker_meta()));
         assert!(!RustLicenseDual.applies(&infra_meta()));
     }
 

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -75,6 +75,70 @@ whitespace-check:
 validate: nix-fmt-check flake-check whitespace-check
 "#;
 
+// Rust crate that ships as a Cloudflare Worker (wasm32-unknown-unknown).
+// Coverage is optional (cargo-llvm-cov can't measure the wasm-target
+// code that handles requests; native-only would gate the wrong thing).
+// `build`/`--release` is intentionally absent — workers ship via
+// wrangler/worker-build, not a native release binary; the
+// wasm-target sanity check lives in `wasm-check`. The validate recipe
+// composes the wasm check so wasm-incompat deps surface here, not
+// later when wrangler tries to compile.
+const RUST_WORKER_TEMPLATE: &str = r#"wasm-check:
+    cargo check --target wasm32-unknown-unknown
+
+test:
+    cargo test
+
+fmt:
+    cargo fmt
+
+fmt-check:
+    cargo fmt --check
+
+lint:
+    cargo clippy --all-targets -- -D warnings
+
+doc-check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
+deny:
+    cargo deny check
+
+# Macro-only deps can register as false positives — allowlist via
+# `package.metadata.cargo-machete.ignored` in the offending Cargo.toml.
+machete:
+    cargo machete
+
+coverage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
+        echo "coverage: not declared (optional on rust-worker); skipping"
+        exit 0
+    fi
+    fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
+    fail_branch=$(jq <<<"$thresholds" '.coverage.branch.fail')
+    measured=$(cargo llvm-cov --json --summary-only --branch)
+    line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
+    branch=$(jq <<<"$measured" '.data[0].totals.branches.percent')
+    printf 'coverage: line=%.1f%% branch=%.1f%% (gates: line>=%s%% branch>=%s%%)\n' \
+        "$line" "$branch" "$fail_line" "$fail_branch"
+    awk -v l="$line" -v b="$branch" -v fl="$fail_line" -v fb="$fail_branch" \
+        'BEGIN { exit (l < fl || b < fb) ? 1 : 0 }'
+
+nix-fmt-check:
+    nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
+
+flake-check:
+    nix flake check
+
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: fmt-check lint doc-check deny machete test coverage wasm-check nix-fmt-check flake-check whitespace-check
+"#;
+
 // Infra projects intentionally do NOT run `nix flake check` in `validate`.
 // The devbox eval-check forces `system.build.toplevel.drvPath` evaluation,
 // which pulls a NixOS closure larger than a stock GitHub runner's disk
@@ -165,6 +229,7 @@ pub fn run(check: bool) {
 fn template_for(kind: &str, project_dir: &Path) -> Option<&'static str> {
     match kind {
         "rust" => Some(RUST_TEMPLATE),
+        "rust-worker" => Some(RUST_WORKER_TEMPLATE),
         "infra" => Some(if project_dir.join("terraform").is_dir() {
             INFRA_TEMPLATE_WITH_TF
         } else {
@@ -324,6 +389,15 @@ mod tests {
     }
 
     #[test]
+    fn template_for_rust_worker_returns_rust_worker_template() {
+        let dir = tmp_project("rust-worker");
+        assert_eq!(
+            template_for("rust-worker", dir.path()),
+            Some(RUST_WORKER_TEMPLATE)
+        );
+    }
+
+    #[test]
     fn template_for_unknown_kind_returns_none() {
         let dir = tmp_project("unknown");
         assert!(template_for("python", dir.path()).is_none());
@@ -341,6 +415,7 @@ mod tests {
     fn all_templates_run_whitespace_check() {
         for tpl in [
             RUST_TEMPLATE,
+            RUST_WORKER_TEMPLATE,
             NIX_LIB_TEMPLATE,
             INFRA_TEMPLATE_WITH_TF,
             INFRA_TEMPLATE_NO_TF,
@@ -358,6 +433,7 @@ mod tests {
     fn all_templates_run_nix_fmt_check() {
         for tpl in [
             RUST_TEMPLATE,
+            RUST_WORKER_TEMPLATE,
             NIX_LIB_TEMPLATE,
             INFRA_TEMPLATE_WITH_TF,
             INFRA_TEMPLATE_NO_TF,
@@ -366,6 +442,22 @@ mod tests {
             assert!(tpl.contains("nix fmt -- --check"));
             assert!(tpl.contains("nix-fmt-check"));
         }
+    }
+
+    #[test]
+    fn rust_worker_template_runs_wasm_check_in_validate() {
+        assert!(RUST_WORKER_TEMPLATE.contains("wasm-check:"));
+        assert!(RUST_WORKER_TEMPLATE.contains("cargo check --target wasm32-unknown-unknown"));
+        assert!(RUST_WORKER_TEMPLATE
+            .lines()
+            .any(|l| l.starts_with("validate:") && l.contains("wasm-check")));
+    }
+
+    #[test]
+    fn rust_worker_coverage_skips_when_block_absent() {
+        // The recipe must early-exit when the project.cue has no coverage
+        // block; otherwise it'd fail on a missing .coverage in `cue export`.
+        assert!(RUST_WORKER_TEMPLATE.contains(r#"jq -r '.coverage // "absent"'"#));
     }
 
     #[test]

--- a/tools/shaka/tests/fixtures/deploy/multiple-same-zone/inputs/apps/portfolio-a/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/deploy/multiple-same-zone/inputs/apps/portfolio-a/project.cue.fixture
@@ -2,15 +2,7 @@ package project
 
 #Project & {
 	name: "portfolio-a"
-	kind: "rust"
-	coverage: {
-		line: {
-			fail: 0
-		}
-		branch: {
-			fail: 0
-		}
-	}
+	kind: "rust-worker"
 	deploy: {
 		target:       "cloudflare-worker"
 		customDomain: "a.kolohelios.com"

--- a/tools/shaka/tests/fixtures/deploy/multiple-same-zone/inputs/apps/portfolio-b/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/deploy/multiple-same-zone/inputs/apps/portfolio-b/project.cue.fixture
@@ -2,15 +2,7 @@ package project
 
 #Project & {
 	name: "portfolio-b"
-	kind: "rust"
-	coverage: {
-		line: {
-			fail: 0
-		}
-		branch: {
-			fail: 0
-		}
-	}
+	kind: "rust-worker"
 	deploy: {
 		target:       "cloudflare-worker"
 		customDomain: "b.kolohelios.com"

--- a/tools/shaka/tests/fixtures/deploy/single-worker/inputs/apps/kolohelios-portfolio/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/deploy/single-worker/inputs/apps/kolohelios-portfolio/project.cue.fixture
@@ -2,15 +2,7 @@ package project
 
 #Project & {
 	name: "kolohelios-portfolio"
-	kind: "rust"
-	coverage: {
-		line: {
-			fail: 30
-		}
-		branch: {
-			fail: 50
-		}
-	}
+	kind: "rust-worker"
 	deploy: {
 		target:       "cloudflare-worker"
 		customDomain: "kolohelios.com"

--- a/tools/shaka/tests/fixtures/schema/invalid/deploy-bad-target.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/deploy-bad-target.cue
@@ -2,15 +2,7 @@ package project
 
 #Project & {
 	name: "kolohelios-portfolio"
-	kind: "rust"
-	coverage: {
-		line: {
-			fail: 30
-		}
-		branch: {
-			fail: 50
-		}
-	}
+	kind: "rust-worker"
 	deploy: {
 		target:       "fly"
 		customDomain: "kolohelios.com"

--- a/tools/shaka/tests/fixtures/schema/invalid/deploy-missing-zone.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/deploy-missing-zone.cue
@@ -2,15 +2,7 @@ package project
 
 #Project & {
 	name: "kolohelios-portfolio"
-	kind: "rust"
-	coverage: {
-		line: {
-			fail: 30
-		}
-		branch: {
-			fail: 50
-		}
-	}
+	kind: "rust-worker"
 	deploy: {
 		target:       "cloudflare-worker"
 		customDomain: "kolohelios.com"

--- a/tools/shaka/tests/fixtures/schema/invalid/deploy-on-rust.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/deploy-on-rust.cue
@@ -1,0 +1,21 @@
+package project
+
+// deploy lives on rust-worker, not rust — the only target today is
+// cloudflare-worker, which only makes sense for wasm builds.
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust"
+	coverage: {
+		line: {
+			fail: 30
+		}
+		branch: {
+			fail: 50
+		}
+	}
+	deploy: {
+		target:       "cloudflare-worker"
+		customDomain: "kolohelios.com"
+		zone:         "kolohelios.com"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/rust-worker-bad-coverage.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/rust-worker-bad-coverage.cue
@@ -1,0 +1,16 @@
+package project
+
+// Coverage is optional on rust-worker, but if declared, the values
+// must still be in [0, 100].
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust-worker"
+	coverage: {
+		line: {
+			fail: 150
+		}
+		branch: {
+			fail: 50
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-minimal.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-minimal.cue
@@ -1,0 +1,10 @@
+package project
+
+// Worker app with no opt-in coverage block and no deploy block yet.
+// Coverage is optional on rust-worker since cargo-llvm-cov can't
+// measure the wasm-target code; deploy is optional until the app is
+// ready to be attached.
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust-worker"
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-coverage.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-coverage.cue
@@ -1,0 +1,15 @@
+package project
+
+// Worker app that opts in to coverage on its native unit tests.
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust-worker"
+	coverage: {
+		line: {
+			fail: 30
+		}
+		branch: {
+			fail: 50
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-deploy.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-deploy.cue
@@ -1,16 +1,10 @@
 package project
 
+// Worker app with a Cloudflare Worker deploy block. Coverage stays
+// optional even when deploy is declared.
 #Project & {
 	name: "kolohelios-portfolio"
-	kind: "rust"
-	coverage: {
-		line: {
-			fail: 30
-		}
-		branch: {
-			fail: 50
-		}
-	}
+	kind: "rust-worker"
 	deploy: {
 		target:       "cloudflare-worker"
 		customDomain: "kolohelios.com"


### PR DESCRIPTION
Apps that compile to wasm32-unknown-unknown and ship as Cloudflare
Workers don't fit the existing rust kind's gates: cargo-llvm-cov
can't measure the wasm-target code (so coverage on native unit
tests would gate the wrong thing) and the native cargo build doesn't
catch wasm-incompatible deps. A separate rust-worker kind keeps the
schema honest about what's actually being measured.

In rust-worker, coverage is optional. Apps with enough pure-logic
surface to make native unit-test coverage meaningful can opt in by
declaring the same coverage block rust mandates; absence is allowed.

`deploy:` moves off rust onto rust-worker — the only target today
(cloudflare-worker) only makes sense for wasm builds. No real
consumers use deploy yet, so this is a safe relocation; when future
targets like fly or hetzner arrive they'll be added wherever they
make sense.

Fixtures cover: rust-worker with no coverage and no deploy, with
opt-in coverage, with deploy; out-of-range coverage when declared;
and a rust kind with deploy (rejected, since deploy moved away).
The existing deploy-bad-target and deploy-missing-zone invalid
fixtures move to rust-worker so they exercise the intended failure
mode (bad target / missing zone) rather than the new "deploy not
allowed on rust" rejection. Deploy generator fixtures (which
exercise apps with deploy blocks) move to rust-worker too.

Wire the rust-worker kind from #329 end-to-end: justfile template,
audit rules, and template_for dispatch. With this, scaffolding a
worker app (e.g. for #189) produces the right validate gate without
hand-edits.

The new template carries a wasm-target sanity check
(`cargo check --target wasm32-unknown-unknown`) in validate so
wasm-incompat deps surface at preflight rather than at wrangler
deploy. `build`/`--release` is intentionally absent — a native
release binary isn't the deployed artifact. The coverage recipe
mirrors rust's but early-exits when the project.cue has no coverage
block (opt-in on rust-worker).

Audit changes:

- `ProjectKind::RustWorker` variant added. A tiny `is_rust_flavored`
  helper centralizes the "rust or rust-worker" membership check used
  by the three Rust-family rules.
- `rust-has-tests` and `rust-license-dual` extend to rust-worker —
  pure-logic tests are still valuable, and any Rust code in the repo
  needs the MIT OR Apache-2.0 dual license.
- `rust-coverage-threshold-nonzero` applies to rust-worker but treats
  missing coverage as Pass (matching the schema's opt-in). Zero
  thresholds on a present block still fail, on either kind.

Closes #329.