### PR TITLE
fix(apps/kolohelios-portfolio): unblock Worker deploy from devshell

### DIFF
--- a/apps/kolohelios-portfolio/Cargo.lock
+++ b/apps/kolohelios-portfolio/Cargo.lock
@@ -179,6 +179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,17 +481,6 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
@@ -559,6 +554,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,26 +590,6 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -706,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -729,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.5.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727789ca7eff9733efbea9d0e97779edc1cf1926e98aee7d7d8afe32805458aa"
+checksum = "2d3c60a70414db58e1890f3675d02692adace736657cb66994f220ae3780c90d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -744,44 +740,30 @@ dependencies = [
  "matchit",
  "pin-project",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_urlencoded",
+ "strum",
  "tokio",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "worker-kv",
  "worker-macros",
  "worker-sys",
 ]
 
 [[package]]
-name = "worker-kv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f06d4d1416a9f8346ee9123b0d9a11b3cfa38e6cfb5a139698017d1597c4d41"
-dependencies = [
- "js-sys",
- "serde",
- "serde-wasm-bindgen 0.5.0",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "worker-macros"
-version = "0.5.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d625c24570ba9207a2617476013335f28a95cbe513e59bb814ffba092a18058"
+checksum = "60bcb459a67977fcb79698a3123ae58a928b1b24cc3035eaec033dbdfc139438"
 dependencies = [
  "async-trait",
  "proc-macro2",
  "quote",
+ "strum",
  "syn",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -791,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.5.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34563340d41016b4381257c5a16b0d2bc590dbe00500ecfbebcaa16f5f85ce90"
+checksum = "c0e59a8504685d87649b8fda877d95fcc48f8c8177dbd77a4dc8e67f8fc80240"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/apps/kolohelios-portfolio/Cargo.toml
+++ b/apps/kolohelios-portfolio/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 askama = { version = "0.12", default-features = false, features = ["config"] }
-worker = "0.5"
+worker = "0.8"
 
 [profile.release]
 opt-level = "s"

--- a/apps/kolohelios-portfolio/flake.nix
+++ b/apps/kolohelios-portfolio/flake.nix
@@ -56,9 +56,23 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
+              pkgs.wrangler
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
+
+            # `worker-build` is installed lazily via `cargo install` in
+            # `wrangler.toml`'s build command (the workers-rs documented
+            # idiom — see #333 for whether to package it as a nix
+            # derivation instead). Append `~/.cargo/bin` to PATH so the
+            # resulting binary is visible to wrangler. Append (not
+            # prepend) because GitHub Actions runners ship a
+            # rustup-managed `cargo` in `~/.cargo/bin` that would
+            # otherwise shadow nix's cargo and bypass the project
+            # toolchain entirely.
+            shellHook = ''
+              export PATH="$PATH:$HOME/.cargo/bin"
+            '';
           };
         }
       );

--- a/apps/kolohelios-portfolio/wrangler.toml
+++ b/apps/kolohelios-portfolio/wrangler.toml
@@ -3,6 +3,9 @@ main = "build/worker/shim.mjs"
 compatibility_date = "2026-05-01"
 
 # `worker-build` compiles the crate to wasm32-unknown-unknown and emits
-# `build/worker/shim.mjs` + the WASM module that wrangler uploads.
+# `build/worker/shim.mjs` + the WASM module that wrangler uploads. The
+# `cargo install` is a no-op on subsequent runs and matches the
+# workers-rs documented idiom; the devshell adds `~/.cargo/bin` to PATH
+# so the installed binary is visible to the build step.
 [build]
-command = "worker-build --release"
+command = "cargo install -q worker-build --locked && worker-build --release"


### PR DESCRIPTION
PR #331 landed the worker scaffold but didn't exercise the deploy
path; `wrangler deploy` failed three ways from a clean shell:

1. `worker = "0.5"` is older than worker-build 0.8.3 will accept.
   Bumped to ^0.8 (latest is 0.8.3); the `#[event(fetch)]` signature
   is unchanged, so src/lib.rs needs no edit.
2. `wrangler` wasn't in the devshell, so `npx wrangler@latest` was
   the fallback. Added `pkgs.wrangler`.
3. Even after `cargo install worker-build`, the nix devshell didn't
   add `~/.cargo/bin` to PATH, so wrangler's build step couldn't find
   the binary. Two parts: a `shellHook` puts `~/.cargo/bin` on PATH,
   and `wrangler.toml`'s build command now does
   `cargo install -q worker-build --locked && worker-build --release`
   — the workers-rs documented idiom. The install is a no-op on
   subsequent runs.

#333 tracks the broader "should worker-build be a nix derivation /
should rust-worker template carry this tooling" question.

Closes #332.