### PR TITLE
chore(shaka): drop deprecated environment from generated worker TF

### DIFF
--- a/infra/cloudflare-deploy/terraform/generated/kolohelios-portfolio.tf
+++ b/infra/cloudflare-deploy/terraform/generated/kolohelios-portfolio.tf
@@ -3,9 +3,8 @@
 # The source of truth is each project's `deploy:` block in project.cue.
 
 resource "cloudflare_workers_custom_domain" "kolohelios_portfolio" {
-  account_id  = var.cloudflare_account_id
-  zone_id     = data.cloudflare_zone.kolohelios_com.zone_id
-  hostname    = "kolohelios.com"
-  service     = "kolohelios-portfolio"
-  environment = "production"
+  account_id = var.cloudflare_account_id
+  zone_id    = data.cloudflare_zone.kolohelios_com.zone_id
+  hostname   = "kolohelios.com"
+  service    = "kolohelios-portfolio"
 }

--- a/tools/shaka/src/deploy/generate_tf.rs
+++ b/tools/shaka/src/deploy/generate_tf.rs
@@ -151,11 +151,10 @@ fn render_project(name: &str, deploy: &Deploy) -> String {
             let zone_ident = tf_ident(zone);
             body.push_str(&format!(
                 "resource \"cloudflare_workers_custom_domain\" \"{resource_ident}\" {{\n\
-                 \x20\x20account_id  = var.cloudflare_account_id\n\
-                 \x20\x20zone_id     = data.cloudflare_zone.{zone_ident}.zone_id\n\
-                 \x20\x20hostname    = \"{custom_domain}\"\n\
-                 \x20\x20service     = \"{name}\"\n\
-                 \x20\x20environment = \"production\"\n\
+                 \x20\x20account_id = var.cloudflare_account_id\n\
+                 \x20\x20zone_id    = data.cloudflare_zone.{zone_ident}.zone_id\n\
+                 \x20\x20hostname   = \"{custom_domain}\"\n\
+                 \x20\x20service    = \"{name}\"\n\
                  }}\n"
             ));
         }

--- a/tools/shaka/tests/fixtures/deploy/multiple-same-zone/expected/portfolio-a.tf
+++ b/tools/shaka/tests/fixtures/deploy/multiple-same-zone/expected/portfolio-a.tf
@@ -3,9 +3,8 @@
 # The source of truth is each project's `deploy:` block in project.cue.
 
 resource "cloudflare_workers_custom_domain" "portfolio_a" {
-  account_id  = var.cloudflare_account_id
-  zone_id     = data.cloudflare_zone.kolohelios_com.zone_id
-  hostname    = "a.kolohelios.com"
-  service     = "portfolio-a"
-  environment = "production"
+  account_id = var.cloudflare_account_id
+  zone_id    = data.cloudflare_zone.kolohelios_com.zone_id
+  hostname   = "a.kolohelios.com"
+  service    = "portfolio-a"
 }

--- a/tools/shaka/tests/fixtures/deploy/multiple-same-zone/expected/portfolio-b.tf
+++ b/tools/shaka/tests/fixtures/deploy/multiple-same-zone/expected/portfolio-b.tf
@@ -3,9 +3,8 @@
 # The source of truth is each project's `deploy:` block in project.cue.
 
 resource "cloudflare_workers_custom_domain" "portfolio_b" {
-  account_id  = var.cloudflare_account_id
-  zone_id     = data.cloudflare_zone.kolohelios_com.zone_id
-  hostname    = "b.kolohelios.com"
-  service     = "portfolio-b"
-  environment = "production"
+  account_id = var.cloudflare_account_id
+  zone_id    = data.cloudflare_zone.kolohelios_com.zone_id
+  hostname   = "b.kolohelios.com"
+  service    = "portfolio-b"
 }

--- a/tools/shaka/tests/fixtures/deploy/single-worker/expected/kolohelios-portfolio.tf
+++ b/tools/shaka/tests/fixtures/deploy/single-worker/expected/kolohelios-portfolio.tf
@@ -3,9 +3,8 @@
 # The source of truth is each project's `deploy:` block in project.cue.
 
 resource "cloudflare_workers_custom_domain" "kolohelios_portfolio" {
-  account_id  = var.cloudflare_account_id
-  zone_id     = data.cloudflare_zone.kolohelios_com.zone_id
-  hostname    = "kolohelios.com"
-  service     = "kolohelios-portfolio"
-  environment = "production"
+  account_id = var.cloudflare_account_id
+  zone_id    = data.cloudflare_zone.kolohelios_com.zone_id
+  hostname   = "kolohelios.com"
+  service    = "kolohelios-portfolio"
 }


### PR DESCRIPTION
CF terraform-provider 5.x marks `environment` on
`cloudflare_workers_custom_domain` as `Computed: true, Optional:
true, DeprecationMessage: "This attribute is deprecated."`, with no
replacement. The provider populates it from the API when absent. Every
`tofu plan` and `apply` against `infra/cloudflare-deploy` was
throwing two deprecation warnings (one per resource on plan, one on
apply).

Generator and fixtures drop the line; live generated TF refreshes via
the same generator pass. State for the already-applied
`module.generated.cloudflare_workers_custom_domain.kolohelios_portfolio`
will reconcile silently — the `Computed` flag tells TF to accept the
existing state value without diff when no config override is supplied.

Closes #339.