### PR TITLE
feat(shaka): wrap infra-TF plan/apply in op run, gate on .env

### DIFF
--- a/infra/cloudflare-deploy/justfile
+++ b/infra/cloudflare-deploy/justfile
@@ -12,8 +12,16 @@ whitespace-check:
 
 validate: tofu-validate nix-fmt-check whitespace-check
 
-plan:
-    cd terraform && tofu init -input=false && tofu plan
+# Secrets (CF token, S3 credentials) live in 1Password and reach TF
+# through `op://...` refs in `.env`, resolved by `op run`. Fail fast
+# with a clear message when `.env` is missing rather than letting the
+# AWS SDK report "no valid credential sources found" — that error
+# masks the actual cause and sends people down the wrong rabbit hole.
+_env-check:
+    @test -f .env || { echo "error: .env not found. Run: cp .env.example .env" >&2; exit 1; }
 
-apply:
-    cd terraform && tofu apply
+plan: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
+
+apply: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'

--- a/infra/cloudflare-dns/justfile
+++ b/infra/cloudflare-dns/justfile
@@ -12,8 +12,16 @@ whitespace-check:
 
 validate: tofu-validate nix-fmt-check whitespace-check
 
-plan:
-    cd terraform && tofu init -input=false && tofu plan
+# Secrets (CF token, S3 credentials) live in 1Password and reach TF
+# through `op://...` refs in `.env`, resolved by `op run`. Fail fast
+# with a clear message when `.env` is missing rather than letting the
+# AWS SDK report "no valid credential sources found" — that error
+# masks the actual cause and sends people down the wrong rabbit hole.
+_env-check:
+    @test -f .env || { echo "error: .env not found. Run: cp .env.example .env" >&2; exit 1; }
 
-apply:
-    cd terraform && tofu apply
+plan: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
+
+apply: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'

--- a/infra/cloudflare-tokens/justfile
+++ b/infra/cloudflare-tokens/justfile
@@ -12,8 +12,16 @@ whitespace-check:
 
 validate: tofu-validate nix-fmt-check whitespace-check
 
-plan:
-    cd terraform && tofu init -input=false && tofu plan
+# Secrets (CF token, S3 credentials) live in 1Password and reach TF
+# through `op://...` refs in `.env`, resolved by `op run`. Fail fast
+# with a clear message when `.env` is missing rather than letting the
+# AWS SDK report "no valid credential sources found" — that error
+# masks the actual cause and sends people down the wrong rabbit hole.
+_env-check:
+    @test -f .env || { echo "error: .env not found. Run: cp .env.example .env" >&2; exit 1; }
 
-apply:
-    cd terraform && tofu apply
+plan: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
+
+apply: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'

--- a/infra/devbox/justfile
+++ b/infra/devbox/justfile
@@ -16,4 +16,4 @@ plan:
     cd terraform && tofu init -input=false && tofu plan
 
 apply:
-    cd terraform && tofu apply
+    cd terraform && tofu init -input=false && tofu apply

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -157,11 +157,43 @@ whitespace-check:
 
 validate: tofu-validate nix-fmt-check whitespace-check
 
+# Secrets (CF token, S3 credentials) live in 1Password and reach TF
+# through `op://...` refs in `.env`, resolved by `op run`. Fail fast
+# with a clear message when `.env` is missing rather than letting the
+# AWS SDK report "no valid credential sources found" — that error
+# masks the actual cause and sends people down the wrong rabbit hole.
+_env-check:
+    @test -f .env || { echo "error: .env not found. Run: cp .env.example .env" >&2; exit 1; }
+
+plan: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
+
+apply: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'
+"#;
+
+// Infra-with-TF projects whose secrets aren't 1Password-resolved at
+// runtime — they use `terraform.tfvars` or hand-set env vars (e.g.
+// `infra/devbox`'s Linode token). Bare `tofu plan` / `apply`, no
+// `op run` wrapper. The discriminator is `.env.example` presence: the
+// 1Password projects carry one (it documents the `op://` references);
+// the tfvars-style projects don't.
+const INFRA_TEMPLATE_WITH_TF_BARE: &str = r#"tofu-validate:
+    cd terraform && tofu init -backend=false -input=false && tofu validate
+
+nix-fmt-check:
+    nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
+
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: tofu-validate nix-fmt-check whitespace-check
+
 plan:
     cd terraform && tofu init -input=false && tofu plan
 
 apply:
-    cd terraform && tofu apply
+    cd terraform && tofu init -input=false && tofu apply
 "#;
 
 // Infra projects without a `terraform/` directory (nix-only infra such
@@ -231,7 +263,14 @@ fn template_for(kind: &str, project_dir: &Path) -> Option<&'static str> {
         "rust" => Some(RUST_TEMPLATE),
         "rust-worker" => Some(RUST_WORKER_TEMPLATE),
         "infra" => Some(if project_dir.join("terraform").is_dir() {
-            INFRA_TEMPLATE_WITH_TF
+            // `.env.example` signals the project resolves secrets via
+            // `op run --env-file=.env`; absence means tfvars/env-set
+            // credentials (see `infra/devbox`).
+            if project_dir.join(".env.example").is_file() {
+                INFRA_TEMPLATE_WITH_TF
+            } else {
+                INFRA_TEMPLATE_WITH_TF_BARE
+            }
         } else {
             INFRA_TEMPLATE_NO_TF
         }),
@@ -364,12 +403,23 @@ mod tests {
     }
 
     #[test]
-    fn template_for_infra_with_terraform_dir_returns_with_tf_template() {
-        let dir = tmp_project("infra-tf");
+    fn template_for_infra_with_tf_and_env_example_returns_op_run_template() {
+        let dir = tmp_project("infra-tf-op");
         std::fs::create_dir(dir.path().join("terraform")).unwrap();
+        std::fs::write(dir.path().join(".env.example"), "").unwrap();
         assert_eq!(
             template_for("infra", dir.path()),
             Some(INFRA_TEMPLATE_WITH_TF)
+        );
+    }
+
+    #[test]
+    fn template_for_infra_with_tf_no_env_example_returns_bare_template() {
+        let dir = tmp_project("infra-tf-bare");
+        std::fs::create_dir(dir.path().join("terraform")).unwrap();
+        assert_eq!(
+            template_for("infra", dir.path()),
+            Some(INFRA_TEMPLATE_WITH_TF_BARE)
         );
     }
 
@@ -418,6 +468,7 @@ mod tests {
             RUST_WORKER_TEMPLATE,
             NIX_LIB_TEMPLATE,
             INFRA_TEMPLATE_WITH_TF,
+            INFRA_TEMPLATE_WITH_TF_BARE,
             INFRA_TEMPLATE_NO_TF,
         ] {
             assert!(tpl.contains("whitespace-check:"));
@@ -436,6 +487,7 @@ mod tests {
             RUST_WORKER_TEMPLATE,
             NIX_LIB_TEMPLATE,
             INFRA_TEMPLATE_WITH_TF,
+            INFRA_TEMPLATE_WITH_TF_BARE,
             INFRA_TEMPLATE_NO_TF,
         ] {
             assert!(tpl.contains("nix-fmt-check:"));
@@ -465,7 +517,11 @@ mod tests {
         // See #170: infra `nix flake check` pulls a NixOS closure that
         // exceeds GitHub runner disk; `Build Linode image` covers the
         // eval check via full `nix build`.
-        for tpl in [INFRA_TEMPLATE_WITH_TF, INFRA_TEMPLATE_NO_TF] {
+        for tpl in [
+            INFRA_TEMPLATE_WITH_TF,
+            INFRA_TEMPLATE_WITH_TF_BARE,
+            INFRA_TEMPLATE_NO_TF,
+        ] {
             assert!(!tpl.contains("flake-check"));
             assert!(!tpl.contains("nix flake check"));
         }
@@ -535,6 +591,23 @@ mod tests {
     fn infra_with_tf_template_validate_chain() {
         assert!(INFRA_TEMPLATE_WITH_TF
             .contains("validate: tofu-validate nix-fmt-check whitespace-check\n"));
+    }
+
+    #[test]
+    fn infra_with_tf_template_wraps_plan_and_apply_in_op_run() {
+        // Both deploy-side recipes need 1Password-resolved secrets;
+        // bare `tofu plan` / `apply` fail with an opaque AWS SDK error.
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("plan: _env-check\n"));
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("apply: _env-check\n"));
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("op run --env-file=.env -- bash -c"));
+    }
+
+    #[test]
+    fn infra_with_tf_template_apply_includes_init() {
+        // `tofu apply` previously skipped `init` (relied on the user
+        // having run `plan` first). Folding `init -input=false` in
+        // removes one more "did the recipe just work?" footgun.
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("tofu init -input=false && tofu apply"));
     }
 
     #[test]


### PR DESCRIPTION
Today the canonical apply flow for every `infra/cloudflare-*`
project is `op run --env-file=.env -- just apply`. Bare `just apply`
fails with `No valid credential sources found` from the AWS SDK,
because the `.env` is full of `op://...` references that only
`op run` resolves. The error is opaque enough to send people down
the wrong rabbit hole; the friction is constant.

`INFRA_TEMPLATE_WITH_TF` now generates:

  - A private `_env-check` recipe that fails fast with a clear
    "run `cp .env.example .env`" message when the file is missing.
  - `plan` and `apply` depending on `_env-check`, wrapped in
    `op run --env-file=.env -- bash -c '…'`.
  - `apply` gains `tofu init -input=false` ahead of the apply step
    (per the comment on #319) — the old recipe relied on a prior
    `plan` having seeded `.terraform/`, which is one more
    "recipe didn't just work" footgun.

Not every infra-with-TF project uses 1Password. `infra/devbox` uses
`terraform.tfvars` for its Linode token. Adding the `op run` wrap
unconditionally would break it. Discriminator: `.env.example`
presence at the project root. The new
`INFRA_TEMPLATE_WITH_TF_BARE` retains the legacy shape (bare
`tofu plan` / `apply`) for tfvars-style projects, also gaining
`init -input=false` in `apply` for the same reason. Selection
lives in `template_for`.

The issue body called for an additional `op signin` pre-check.
Skipped on this pass: with 1Password's desktop CLI integration now in
play, `op whoami` itself prompts biometric — pre-checking it adds
prompt-noise without clarifying anything. `op run` reports auth
failure clearly enough.

Closes #319.