### PR TITLE
fix(shaka): make registry/schema tests work in nix-build sandbox

### DIFF
--- a/tools/shaka/src/object_store/registry.rs
+++ b/tools/shaka/src/object_store/registry.rs
@@ -103,10 +103,21 @@ fn read_project(schema: &Path, file: &Path) -> Result<ProjectFile, RegistryError
     // `cue export` needs both the schema (for #Project) and the project
     // file unified together. Schema-check has already enforced structure,
     // so any export failure here is a real problem and bubbles up.
+    //
+    // `current_dir(file.parent())` anchors cue's module-resolution walk
+    // at the project dir. The project schema imports the domain
+    // registry, so cue needs to find `cue.mod/module.cue` somewhere
+    // up the tree. Inheriting the caller's cwd works in
+    // `cargo test`/`cargo run` (cwd = repo root) but breaks under
+    // `nix build`'s sandbox (cwd = `/build/.tmpXXX/`, no cue.mod). The
+    // file's parent always sits inside the project tree containing
+    // `cue.mod`, so the walk succeeds in both worlds.
+    let project_dir = file.parent().expect("project file has a parent dir");
     let output = Command::new("cue")
         .args(["export", "--out", "json"])
         .arg(schema)
         .arg(file)
+        .current_dir(project_dir)
         .output()
         .with_context(|_| SpawnCueExportSnafu {
             file: file.display().to_string(),
@@ -263,9 +274,36 @@ mod tests {
         assert_eq!(ns("tfstate", "devbox").prefix(), "tfstate/devbox");
     }
 
+    /// Plant a minimal CUE module + stubbed domain registry into
+    /// `root` so the project schema's
+    /// `import "kolohelios.com/infra/cloudflare-dns/domains:domain"`
+    /// resolves when `cue export` runs against a fixture project.cue
+    /// here. The tests below don't reference `#KnownHostnames` (no
+    /// `serving:` / `deploy:` blocks), so the stub is sufficient.
+    /// Local `cargo test` happens to work because cwd is the repo
+    /// root (real `cue.mod` is found one walk-up away), but `nix
+    /// build`'s sandbox has no enclosing module — this setup makes
+    /// the tests pass in both.
+    fn plant_test_module(root: &Path) {
+        fs::create_dir_all(root.join("cue.mod")).unwrap();
+        fs::write(
+            root.join("cue.mod/module.cue"),
+            "module: \"kolohelios.com\"\nlanguage: version: \"v0.15.1\"\n",
+        )
+        .unwrap();
+        let registry = root.join("infra/cloudflare-dns/domains");
+        fs::create_dir_all(&registry).unwrap();
+        fs::write(
+            registry.join("registry.cue"),
+            "package domain\n\n#KnownHostnames: _\n",
+        )
+        .unwrap();
+    }
+
     #[test]
     fn collect_skips_projects_without_object_storage() {
         let tmp = TempDir::new().unwrap();
+        plant_test_module(tmp.path());
         fs::create_dir_all(tmp.path().join("apps/foo")).unwrap();
         fs::write(
             tmp.path().join("apps/foo/project.cue"),
@@ -280,6 +318,7 @@ mod tests {
     #[test]
     fn collect_reads_namespaces_from_project_cue() {
         let tmp = TempDir::new().unwrap();
+        plant_test_module(tmp.path());
         fs::create_dir_all(tmp.path().join("infra/devbox")).unwrap();
         fs::write(
             tmp.path().join("infra/devbox/project.cue"),

--- a/tools/shaka/tests/common/mod.rs
+++ b/tools/shaka/tests/common/mod.rs
@@ -1,13 +1,24 @@
 //! Shared helpers for integration tests that spawn shaka against a
 //! temp dir.
 //!
+//! Not every test binary that `mod common;`-includes this file uses
+//! every helper, which trips clippy under `-D warnings`. The
+//! `#[allow(dead_code)]` attribute below covers all helpers — any
+//! genuine drift (a removed helper still referenced) shows up as a
+//! compile error at the call site.
+
+#![allow(dead_code)]
+//!
 //! The project schema imports
 //! `kolohelios.com/infra/cloudflare-dns/domains:domain` to constrain
 //! hostname fields against the registry. CUE resolves that import by
 //! walking up from `cue`'s cwd to find `cue.mod/module.cue`, so any
 //! test that runs shaka in a temp dir has to plant a `cue.mod` plus a
 //! registry there — otherwise `cue vet` fails with "imports are
-//! unavailable." Tests opt into this via [`write_test_module`].
+//! unavailable." Tests opt into this via [`write_test_module`] (stub
+//! registry, accepts any hostname — fine for fixtures that don't use
+//! `serving:` / `deploy:`) or [`write_test_module_with_registry`]
+//! (concrete zone list — the constraint actually fires).
 
 use std::path::Path;
 
@@ -15,13 +26,12 @@ use std::path::Path;
 /// the project schema's `import "kolohelios.com/...domains:domain"`
 /// resolves when `cue` is invoked with `current_dir(root)`.
 ///
-/// Most tests don't reference `#KnownHostnames` (no `serving:` /
-/// `deploy:` blocks in their project.cue fixtures), so the registry
-/// can stub the definition out — CUE's lazy evaluation keeps the stub
-/// from blowing up. An infra-side stub project is also planted so
-/// shaka's `audit` / `schema-check` passes over
-/// `tmp/infra/cloudflare-dns/` don't trip on a missing project.cue
-/// or audit-rule violations.
+/// The registry stubs `#KnownHostnames: _` so any hostname passes —
+/// fine for fixtures that don't exercise the constraint. Tests that
+/// *do* exercise it want [`write_test_module_with_registry`] instead.
+/// An infra-side stub project is also planted so shaka's `audit` /
+/// `schema-check` passes over `tmp/infra/cloudflare-dns/` don't trip
+/// on a missing project.cue or audit-rule violations.
 pub fn write_test_module(root: &Path) {
     std::fs::create_dir_all(root.join("cue.mod")).unwrap();
     std::fs::write(
@@ -72,4 +82,33 @@ pub fn write_test_module(root: &Path) {
         }\n",
     )
     .unwrap();
+}
+
+/// Like [`write_test_module`] but the registry actually enumerates
+/// `zones` (with the same regex-disjunction shape as the real
+/// `aggregate.cue`) so the project schema's hostname constraint
+/// fires. Use for tests where a `serving:` / `deploy:` fixture must
+/// be accepted (hostname matches the regex) or rejected (doesn't).
+pub fn write_test_module_with_registry(root: &Path, zones: &[&str]) {
+    write_test_module(root);
+    let registry_dir = root.join("infra/cloudflare-dns/domains");
+    let mut entries = String::new();
+    for z in zones {
+        entries.push_str(&format!("domains: \"{z}\": {{}}\n"));
+    }
+    let content = format!(
+        "package domain\n\
+        \n\
+        import \"strings\"\n\
+        \n\
+        domains: [string]: {{}}\n\
+        \n\
+        {entries}\n\
+        #KnownHostnames: or([\n\
+        \tfor k, _ in domains {{\n\
+        \t\t=~\"(^|\\\\.)\\(strings.Replace(k, \".\", \"\\\\.\", -1))$\"\n\
+        \t}},\n\
+        ])\n"
+    );
+    std::fs::write(registry_dir.join("registry.cue"), content).unwrap();
 }

--- a/tools/shaka/tests/schema.rs
+++ b/tools/shaka/tests/schema.rs
@@ -9,14 +9,28 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+mod common;
+
 const SCHEMA_PATH: &str = "schema/project-schema.cue";
 
+/// Vet `project` against `schema`, with cue's cwd set to a temp dir
+/// that carries a `cue.mod` and a real-ish domain registry. The
+/// schema imports the registry to constrain hostname fields, so cue
+/// needs both the module root (found by walking up from cwd) and a
+/// registry whose `#KnownHostnames` actually enumerates known zones
+/// — a wildcard stub would let invalid fixtures (intentionally using
+/// unregistered hostnames) slip through. Local `cargo test` happens
+/// to be inside the real module, but `nix build`'s sandbox is not —
+/// this setup makes the constraint fire in both environments.
 fn cue_vet(schema: &Path, project: &Path) -> bool {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    common::write_test_module_with_registry(tmp.path(), &["kolohelios.com"]);
     Command::new("cue")
         .arg("vet")
         .arg("-c")
         .arg(schema)
         .arg(project)
+        .current_dir(tmp.path())
         .output()
         .expect("failed to spawn cue (is it on PATH?)")
         .status


### PR DESCRIPTION
After #349 merged, `nix build ./tools/shaka` on main fails: the
project schema imports the domain registry, and CUE walks up from its
cwd to find `cue.mod/module.cue` for import resolution. Local
`cargo test` happens to be inside the real module, but `nix
build`'s sandbox is not — cue walks up to `/build/.tmpXXX/`, finds
no module, errors.

Two test surfaces broke:

- `src/object_store/registry.rs` unit tests build temp dirs and
  call `collect()`, which spawns `cue export` against fixture
  project.cue files.
- `tests/schema.rs` integration tests vet fixtures against the
  in-tree schema, with cue inheriting cargo's cwd.

Two changes:

1. `read_project` in `object_store/registry.rs` now sets
   `current_dir(file.parent())` on the cue spawn. CUE then walks up
   from the project dir, which always sits inside the test's tmp
   tree (where a stub `cue.mod` lives) or the real repo tree (where
   the live `cue.mod` lives). Prod behavior is unchanged — the walk
   still terminates at the repo root.

2. `tests/common/mod.rs` gains
   `write_test_module_with_registry(root, zones)` that plants a
   concrete registry (regex disjunction over zones) rather than the
   wildcard stub. `tests/schema.rs` uses it so the hostname
   constraint actually fires for fixtures that exercise it. The two
   failing unit tests plant their own minimal `cue.mod` + wildcard
   registry inline (they don't need the constraint to fire).

Closes #351.