### PR TITLE
docs(infra/cloudflare-tokens): 1Password SA setup for local + CI

### DIFF
--- a/infra/cloudflare-tokens/.env.example
+++ b/infra/cloudflare-tokens/.env.example
@@ -24,7 +24,9 @@ TF_VAR_onepassword_vault_id="vedq2v6cmtkglnonkenrjneepa"
 # 1Password Service Account token, read-write scoped to the Kolohelios
 # Monorepo vault. Stored as a 1Password Password item with the SA token
 # in the `password` field. The TF `onepassword` provider reads this
-# from the environment automatically.
+# from the environment automatically. CI exports the same value via
+# the `OP_SERVICE_ACCOUNT_TOKEN` GitHub repo secret — see README
+# section "2. Provision the 1Password Service Account".
 OP_SERVICE_ACCOUNT_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/1Password Service Account/password"
 
 # S3-compatible credentials for the Linode Object Storage bucket that

--- a/infra/cloudflare-tokens/README.md
+++ b/infra/cloudflare-tokens/README.md
@@ -62,8 +62,11 @@ Service Account**:
 - **Name**: `kolohelios-monorepo-tf`
 - **Vault access**: read-write, scoped to the *Kolohelios Monorepo*
   vault only.
-- **Token expiration**: 90 days (or longer if local applies dominate;
-  CI applies move to a separate SA per #291).
+- **Token expiration**: 90 days.
+
+One service account covers both local and CI applies — the token is
+stored in two places so each context can read it without needing the
+other.
 
 Store the SA token in the same vault as a new *Password* item:
 
@@ -71,6 +74,38 @@ Store the SA token in the same vault as a new *Password* item:
 - Store the SA token in the `password` field.
 
 Reference path: `op://vedq2v6cmtkglnonkenrjneepa/1Password Service Account/password`.
+
+This is what `.env`'s `OP_SERVICE_ACCOUNT_TOKEN` resolves to under
+`op run` — the TF `onepassword` provider reads it from the
+environment to authenticate against the vault.
+
+For CI applies, store the same token as a GitHub repository secret so
+workflows can export it directly (no interactive `op` session exists
+in CI to resolve the `op://` reference):
+
+- GitHub repo **Settings → Secrets and variables → Actions → New
+  repository secret**.
+- **Name**: `OP_SERVICE_ACCOUNT_TOKEN`.
+- **Value**: the SA token (same value as the 1Password item's
+  `password` field).
+
+CI workflows then declare:
+
+```yaml
+env:
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+```
+
+and `op run --env-file=.env -- just apply` works without an
+interactive `op` session: the CLI authenticates against the vault
+using the SA token already in the environment, resolves the
+remaining `op://` references (CF tokens, S3 credentials) from the
+vault, and exports them for the wrapped command.
+
+**Rotation**: when the SA token is regenerated (every 90 days, or
+ad-hoc if compromised), update both stores — the 1Password vault item
+and the GitHub secret. The two stores aren't auto-synced; #290 will
+automate the rotation.
 
 ### 3. Author `.env`
 


### PR DESCRIPTION
The 1Password Service Account is the bootstrap credential that both
local applies and CI applies use to authenticate the
`onepassword` TF provider. Locally, `.env`'s
`OP_SERVICE_ACCOUNT_TOKEN` resolves the SA token from the vault via
`op run` (which uses the user's interactive session for that single
fetch, then exports the value). In CI, no interactive session exists
— the same token has to be in the environment directly, sourced from
a GitHub repository secret of the same name.

README section 2 already covered the SA provisioning shape but
listed CI as a deferred concern ("CI applies move to a separate SA
per #291"). With the CI-deploy track (#345) starting and the deploy
token + 1Password SA both in place, the same SA covers both contexts
— two stores of the same token rather than two service accounts.
Section 2 now documents the GitHub-secret half and the rotation
implication (regenerate → update both stores; #290 will automate).

The `.env.example` comment for `OP_SERVICE_ACCOUNT_TOKEN` points
at the README for the CI-side story so a fresh checkout sees both
halves.

No workflow YAML lands here — that's #342 (the reusable tf-apply
workflow) and its per-project consumers (#343). This PR provisions
the credential and writes down the contract; consumers wire it up.

Closes #291.