### PR TITLE
ci: add reusable tf-apply workflow_call workflow

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -1,0 +1,52 @@
+# Reusable `tofu apply` workflow for `infra/*` projects.
+#
+# Caller (per-project workflow under #343) passes the project directory
+# and the 1Password Service Account token. The SA token lets `op run`
+# resolve every `op://` reference in the project's `.env` (Cloudflare
+# token, Linode S3 creds for remote tfstate, etc.) so `just apply`
+# authenticates the same way it does locally.
+#
+# Apply runs non-interactively via `just apply -auto-approve
+# -input=false`; the generated recipe already wraps `tofu apply` in
+# `op run --env-file=.env -- bash -c '...'` and inits before applying,
+# so this workflow stays thin.
+name: tf-apply
+
+on:
+  workflow_call:
+    inputs:
+      project_dir:
+        description: "Path to the infra project (e.g. infra/cloudflare-deploy)"
+        required: true
+        type: string
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        description: "1Password Service Account token used by `op run` to resolve `.env` references"
+        required: true
+
+jobs:
+  apply:
+    name: tofu apply
+    runs-on: ubuntu-latest
+    permissions:
+      # nix-installer-action mints an OIDC token to authenticate with
+      # FlakeHub for the `kolohelios-nix` private input.
+      id-token: write
+      contents: read
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: tofu apply
+        working-directory: ${{ inputs.project_dir }}
+        # `.env` is gitignored; copy from the in-repo example so the
+        # recipe's `_env-check` precondition passes. `.env.example`
+        # already holds the `op://` refs the SA token will resolve.
+        run: |
+          cp .env.example .env
+          nix develop . --command just apply -auto-approve -input=false

--- a/infra/cloudflare-deploy/justfile
+++ b/infra/cloudflare-deploy/justfile
@@ -23,5 +23,7 @@ _env-check:
 plan: _env-check
     op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
 
-apply: _env-check
-    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'
+# `*ARGS` lets CI pass `-auto-approve -input=false` while local
+# `just apply` stays interactive (see `.github/workflows/tf-apply.yml`).
+apply *ARGS: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply {{ARGS}}'

--- a/infra/cloudflare-dns/justfile
+++ b/infra/cloudflare-dns/justfile
@@ -23,5 +23,7 @@ _env-check:
 plan: _env-check
     op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
 
-apply: _env-check
-    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'
+# `*ARGS` lets CI pass `-auto-approve -input=false` while local
+# `just apply` stays interactive (see `.github/workflows/tf-apply.yml`).
+apply *ARGS: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply {{ARGS}}'

--- a/infra/cloudflare-tokens/justfile
+++ b/infra/cloudflare-tokens/justfile
@@ -23,5 +23,7 @@ _env-check:
 plan: _env-check
     op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
 
-apply: _env-check
-    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'
+# `*ARGS` lets CI pass `-auto-approve -input=false` while local
+# `just apply` stays interactive (see `.github/workflows/tf-apply.yml`).
+apply *ARGS: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply {{ARGS}}'

--- a/infra/devbox/justfile
+++ b/infra/devbox/justfile
@@ -15,5 +15,5 @@ validate: tofu-validate nix-fmt-check whitespace-check
 plan:
     cd terraform && tofu init -input=false && tofu plan
 
-apply:
-    cd terraform && tofu init -input=false && tofu apply
+apply *ARGS:
+    cd terraform && tofu init -input=false && tofu apply {{ARGS}}

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -168,8 +168,10 @@ _env-check:
 plan: _env-check
     op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu plan'
 
-apply: _env-check
-    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply'
+# `*ARGS` lets CI pass `-auto-approve -input=false` while local
+# `just apply` stays interactive (see `.github/workflows/tf-apply.yml`).
+apply *ARGS: _env-check
+    op run --env-file=.env -- bash -c 'cd terraform && tofu init -input=false && tofu apply {{ARGS}}'
 "#;
 
 // Infra-with-TF projects whose secrets aren't 1Password-resolved at
@@ -192,8 +194,8 @@ validate: tofu-validate nix-fmt-check whitespace-check
 plan:
     cd terraform && tofu init -input=false && tofu plan
 
-apply:
-    cd terraform && tofu init -input=false && tofu apply
+apply *ARGS:
+    cd terraform && tofu init -input=false && tofu apply {{ARGS}}
 "#;
 
 // Infra projects without a `terraform/` directory (nix-only infra such
@@ -598,7 +600,7 @@ mod tests {
         // Both deploy-side recipes need 1Password-resolved secrets;
         // bare `tofu plan` / `apply` fail with an opaque AWS SDK error.
         assert!(INFRA_TEMPLATE_WITH_TF.contains("plan: _env-check\n"));
-        assert!(INFRA_TEMPLATE_WITH_TF.contains("apply: _env-check\n"));
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("apply *ARGS: _env-check\n"));
         assert!(INFRA_TEMPLATE_WITH_TF.contains("op run --env-file=.env -- bash -c"));
     }
 
@@ -608,6 +610,17 @@ mod tests {
         // having run `plan` first). Folding `init -input=false` in
         // removes one more "did the recipe just work?" footgun.
         assert!(INFRA_TEMPLATE_WITH_TF.contains("tofu init -input=false && tofu apply"));
+    }
+
+    #[test]
+    fn infra_apply_recipes_forward_args() {
+        // Same recipe drives local (interactive) and CI (`-auto-approve
+        // -input=false`); the `*ARGS` shape avoids the alternative of
+        // duplicating recipes per environment.
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("apply *ARGS:"));
+        assert!(INFRA_TEMPLATE_WITH_TF.contains("tofu apply {{ARGS}}"));
+        assert!(INFRA_TEMPLATE_WITH_TF_BARE.contains("apply *ARGS:"));
+        assert!(INFRA_TEMPLATE_WITH_TF_BARE.contains("tofu apply {{ARGS}}"));
     }
 
     #[test]


### PR DESCRIPTION
Make the generated infra `apply` recipe take `*ARGS` (both the
1Password-wrapped `INFRA_TEMPLATE_WITH_TF` and the bare
`INFRA_TEMPLATE_WITH_TF_BARE`). The same recipe now drives local
interactive applies (`just apply`) and non-interactive CI applies
(`just apply -auto-approve -input=false`), which #342's reusable
`tf-apply.yml` workflow needs.

Add `.github/workflows/tf-apply.yml` so per-project workflows for
the `cloudflare-dns`, `cloudflare-deploy`, and `cloudflare-tokens`
infra projects (sibling #343) can share one applier.

The reusable workflow takes `project_dir` as input and
`OP_SERVICE_ACCOUNT_TOKEN` as a secret. The SA token authenticates
the `op run` already inside the generated `apply` recipe, which
resolves every other credential (Cloudflare API token, S3 creds for
remote tfstate) from the project's `.env` — matching how local
applies work.

`.env` is gitignored, so the workflow seeds it from `.env.example`
(the in-repo file already carries the right `op://` refs) before
calling `just apply -auto-approve -input=false`. The `*ARGS` shape
landed in the previous commit lets the same recipe drive local and
CI without divergence.

Closes #342.