### PR TITLE
ci(infra): apply workflows for cloudflare-{dns,deploy,tokens}

### DIFF
--- a/.github/workflows/cloudflare-deploy-apply.yml
+++ b/.github/workflows/cloudflare-deploy-apply.yml
@@ -1,0 +1,41 @@
+# `tofu apply` for `infra/cloudflare-deploy` on push to main.
+#
+# Calls the shared `tf-apply.yml` reusable workflow. Path filter
+# scopes the trigger to changes in this project plus the two
+# workflow files involved — a workflow refactor should also
+# re-apply on the next main-merge, not lie dormant until an
+# unrelated infra change lands.
+name: cloudflare-deploy apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infra/cloudflare-deploy/**
+      - .github/workflows/cloudflare-deploy-apply.yml
+      - .github/workflows/tf-apply.yml
+  workflow_dispatch:
+
+# Caller permissions are the ceiling for the called workflow's
+# permissions; `id-token: write` is needed so the called workflow's
+# nix-installer can authenticate with FlakeHub.
+permissions:
+  id-token: write
+  contents: read
+
+# Serialize applies to this project's TF state. Two rapid merges
+# would otherwise race two `tofu apply`s; the remote backend's
+# state lock would queue them implicitly, but an explicit group
+# makes the ordering visible in the Actions UI. `cancel-in-progress`
+# is `false` — canceling mid-apply leaves partial state.
+concurrency:
+  group: cloudflare-deploy-apply
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    uses: ./.github/workflows/tf-apply.yml
+    with:
+      project_dir: infra/cloudflare-deploy
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/cloudflare-dns-apply.yml
+++ b/.github/workflows/cloudflare-dns-apply.yml
@@ -1,0 +1,41 @@
+# `tofu apply` for `infra/cloudflare-dns` on push to main.
+#
+# Calls the shared `tf-apply.yml` reusable workflow. Path filter
+# scopes the trigger to changes in this project plus the two
+# workflow files involved — a workflow refactor should also
+# re-apply on the next main-merge, not lie dormant until an
+# unrelated infra change lands.
+name: cloudflare-dns apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infra/cloudflare-dns/**
+      - .github/workflows/cloudflare-dns-apply.yml
+      - .github/workflows/tf-apply.yml
+  workflow_dispatch:
+
+# Caller permissions are the ceiling for the called workflow's
+# permissions; `id-token: write` is needed so the called workflow's
+# nix-installer can authenticate with FlakeHub.
+permissions:
+  id-token: write
+  contents: read
+
+# Serialize applies to this project's TF state. Two rapid merges
+# would otherwise race two `tofu apply`s; the remote backend's
+# state lock would queue them implicitly, but an explicit group
+# makes the ordering visible in the Actions UI. `cancel-in-progress`
+# is `false` — canceling mid-apply leaves partial state.
+concurrency:
+  group: cloudflare-dns-apply
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    uses: ./.github/workflows/tf-apply.yml
+    with:
+      project_dir: infra/cloudflare-dns
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/cloudflare-tokens-apply.yml
+++ b/.github/workflows/cloudflare-tokens-apply.yml
@@ -1,0 +1,41 @@
+# `tofu apply` for `infra/cloudflare-tokens` on push to main.
+#
+# Calls the shared `tf-apply.yml` reusable workflow. Path filter
+# scopes the trigger to changes in this project plus the two
+# workflow files involved — a workflow refactor should also
+# re-apply on the next main-merge, not lie dormant until an
+# unrelated infra change lands.
+name: cloudflare-tokens apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infra/cloudflare-tokens/**
+      - .github/workflows/cloudflare-tokens-apply.yml
+      - .github/workflows/tf-apply.yml
+  workflow_dispatch:
+
+# Caller permissions are the ceiling for the called workflow's
+# permissions; `id-token: write` is needed so the called workflow's
+# nix-installer can authenticate with FlakeHub.
+permissions:
+  id-token: write
+  contents: read
+
+# Serialize applies to this project's TF state. Two rapid merges
+# would otherwise race two `tofu apply`s; the remote backend's
+# state lock would queue them implicitly, but an explicit group
+# makes the ordering visible in the Actions UI. `cancel-in-progress`
+# is `false` — canceling mid-apply leaves partial state.
+concurrency:
+  group: cloudflare-tokens-apply
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    uses: ./.github/workflows/tf-apply.yml
+    with:
+      project_dir: infra/cloudflare-tokens
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
Add three workflow files, one per infra TF project, that call the
shared `tf-apply.yml` reusable workflow (landed in #342). Each
triggers on push to `main` with a `paths:` filter scoped to its
own project (plus the two workflow files involved, so a workflow
refactor re-applies on the next main-merge).

Three explicit workflows instead of a matrix: each gets its own
status-check name, which is clearer in the Actions UI and for
branch protection. The ~10 lines of duplication per file are
worth the legibility.

`concurrency:` serializes applies per project, with
`cancel-in-progress: false` — canceling mid-apply leaves
partial state. `workflow_dispatch:` is included so a state-drift
remediation can force-apply without needing an empty commit.

Closes #343.