### PR TITLE
feat(infra/cloudflare-tokens): grant Cache Rules:Edit to deploy token

### DIFF
--- a/infra/cloudflare-tokens/terraform/main.tf
+++ b/infra/cloudflare-tokens/terraform/main.tf
@@ -54,6 +54,10 @@ data "cloudflare_api_token_permission_groups_list" "workers_scripts_write" {
   name = "Workers Scripts Write"
 }
 
+data "cloudflare_api_token_permission_groups_list" "cache_rules_write" {
+  name = "Cache Rules Write"
+}
+
 locals {
   account_id = var.cloudflare_account_id
 }
@@ -107,11 +111,14 @@ resource "onepassword_item" "dns_management" {
 # ── deploy ────────────────────────────────────────────────────────────
 #
 # Mirrors `tokens/deploy.cue`. Consumed by `infra/cloudflare-deploy`
-# (TF custom-domain attach) and by `wrangler deploy` from `rust-worker`
-# apps (code uploads). The two flows share one token because both need
-# `Workers Scripts:Edit`; if their rotation cadences diverge, split.
-# Zone-scoped DNS comes along because `cloudflare_workers_custom_domain`
-# installs a CF-managed routing record alongside the attach.
+# (TF custom-domain attach + per-project cache rulesets) and by
+# `wrangler deploy` from `rust-worker` apps (code uploads). The three
+# flows share one token because all three converge on the same zones;
+# if their rotation cadences diverge, split. Zone-scoped DNS comes
+# along because `cloudflare_workers_custom_domain` installs a
+# CF-managed routing record alongside the attach. Zone-scoped
+# Cache Rules gates the `/zones/{id}/rulesets` API used by the
+# `http_request_cache_settings` ruleset.
 resource "cloudflare_api_token" "deploy" {
   name = "Deploy (TF-managed)"
 
@@ -129,6 +136,7 @@ resource "cloudflare_api_token" "deploy" {
       effect = "allow"
       permission_groups = [
         { id = data.cloudflare_api_token_permission_groups_list.dns_write.result[0].id },
+        { id = data.cloudflare_api_token_permission_groups_list.cache_rules_write.result[0].id },
       ]
       resources = jsonencode({
         # All current and future zones in the account.

--- a/infra/cloudflare-tokens/tokens/deploy.cue
+++ b/infra/cloudflare-tokens/tokens/deploy.cue
@@ -1,6 +1,6 @@
 package cloudflare_token
 
-// CF Worker-deploy token. Used for two flows:
+// CF Worker-deploy token. Used for three flows:
 //
 //   - `infra/cloudflare-deploy` `tofu apply` that attaches Worker
 //     custom domains (`cloudflare_workers_custom_domain` needs
@@ -9,9 +9,14 @@ package cloudflare_token
 //   - `wrangler deploy` from a `rust-worker` app (e.g.
 //     `apps/kolohelios-portfolio`) that uploads compiled WASM —
 //     also `Workers Scripts:Edit`, account-scoped.
+//   - `infra/cloudflare-deploy` `tofu apply` that materializes
+//     per-project cache rules (`cloudflare_ruleset`, phase
+//     `http_request_cache_settings`) for the zones the Workers
+//     attach to. The rulesets endpoint is gated by
+//     `Cache Rules:Edit`, separate from `DNS:Edit`.
 //
-// Sharing one token for both flows keeps the credential surface tight;
-// if the two grow divergent rotation cadences, split later.
+// Sharing one token for all three flows keeps the credential surface
+// tight; if rotation cadences diverge, split later.
 //
 // 90-day expiry, mirroring `dns-management`; rotate via
 // `tofu apply -replace=cloudflare_api_token.deploy` until #290 lands
@@ -19,9 +24,10 @@ package cloudflare_token
 
 #Token & {
 	name:    "deploy"
-	purpose: "Worker deploys (TF custom-domain attach + wrangler code uploads)"
+	purpose: "Worker deploys (TF custom-domain attach + wrangler code uploads + cache rules)"
 	permission_groups: [
 		"Account:Workers Scripts:Edit",
+		"Zone:Cache Rules:Edit",
 		"Zone:DNS:Edit",
 	]
 	scope: {

--- a/tools/shaka/schema/cloudflare-token.cue
+++ b/tools/shaka/schema/cloudflare-token.cue
@@ -56,6 +56,7 @@ package cloudflare_token
 	"Account Settings:Read" |
 	"Account:Cloudflare Pages:Edit" |
 	"Account:Workers Scripts:Edit" |
+	"Zone:Cache Rules:Edit" |
 	"Zone:Zone:Edit" |
 	"Zone:DNS:Edit" |
 	"User:API Tokens:Edit"

--- a/tools/shaka/tests/fixtures/cloudflare-token/valid/deploy-account-all-zones.cue
+++ b/tools/shaka/tests/fixtures/cloudflare-token/valid/deploy-account-all-zones.cue
@@ -5,6 +5,7 @@ package cloudflare_token
 	purpose: "Worker deploys (TF custom-domain attach + wrangler code uploads)"
 	permission_groups: [
 		"Account:Workers Scripts:Edit",
+		"Zone:Cache Rules:Edit",
 		"Zone:DNS:Edit",
 	]
 	scope: {


### PR DESCRIPTION
Extends the closed `#PermissionGroup` enum with the
`Zone:Cache Rules:Edit` permission group. Matches the precedent
established by `feat(shaka): allow Workers Scripts:Edit in
cloudflare-token schema` — schema move first, consumer move next.

Refreshes the `deploy-account-all-zones` snapshot fixture (which
exists to mirror the real `deploy` token) so it picks up the same
grant in the same order; the fixture's job is to stay an honest
snapshot, not to enumerate every legal combination.

#190's `cloudflare_ruleset` resource fails apply with 403 — the
`/zones/{id}/rulesets` endpoint is gated by `Cache Rules:Edit`, not
covered by the deploy token's existing `Workers Scripts:Edit` +
`DNS:Edit` grants.

Appends the permission to `tokens/deploy.cue` and mirrors the
CUE→TF sync into the `cloudflare_api_token.deploy` zone-scoped
policy (manual until #292). No new resource — the existing token
is rotated in place by the same recipe the comment already
documents.

Closes #368