### PR TITLE
fix(ci): always publish build jobs on push to main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -130,11 +130,18 @@ jobs:
           nix develop ./tools/shaka --command tools/shaka/bin/shaka preflight \
             --since "${{ needs.changes.outputs.base_ref }}"
 
-  # ── Build jobs (run after validation, only when inputs change) ─
+  # ── Build jobs ─
+  # On pushes (including merges to main) and workflow_dispatch, build
+  # jobs always run so FlakeHub publishes never silently skip — the
+  # path filter on `changes.outputs.*` is only reliable on PR events,
+  # where the base is well-defined. On a rebase-merged push to main,
+  # `github.event.before` can resolve to the merge commit itself and
+  # the diff comes up empty (see #370). Builds with nothing new are
+  # cheap (FlakeHub + nix store cache hit), so the safety is free.
   build-shaka:
     name: Build shaka
     needs: [validate, changes]
-    if: needs.changes.outputs.shaka == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.shaka == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -158,7 +165,7 @@ jobs:
   build-blogctl:
     name: Build blogctl
     needs: [validate, changes]
-    if: needs.changes.outputs.blogctl == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.blogctl == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -182,7 +189,7 @@ jobs:
   build-nix-lib:
     name: Build kolohelios-nix
     needs: [validate, changes]
-    if: needs.changes.outputs.nix-lib == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.nix-lib == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -209,7 +216,7 @@ jobs:
   build-image:
     name: Build Linode image
     needs: [validate, changes]
-    if: needs.changes.outputs.image == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.image == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Switch the four build jobs (`build-shaka`, `build-blogctl`,
`build-nix-lib`, `build-image`) to always run on push and
workflow_dispatch, keeping the path-filter optimization only for PR
events:

    if: github.event_name != 'pull_request'
        || needs.changes.outputs.<name> == 'true'

The prior gate (`changes.outputs.<name> == 'true'
|| github.event_name == 'workflow_dispatch'`) silently skipped on
rebase-merged push-to-main events because the `Detect changes` job
resolved `BASE` to the same SHA as the new tip — the path filter
then saw zero diff and every build job skipped. #366's merge hit
exactly this: blogctl never republished to FlakeHub until the
manual workflow_dispatch.

Builds with nothing to rebuild remain cheap (FlakeHub + nix store
cache hit), so the cost of always running on push is a quick
cache-replay job, not a full rebuild.

The deeper question — why `github.event.before` is unreliable on
rebase-merged pushes (likely an interaction with the auto-rebase
bot's force-push) — is left for a follow-up if this guard turns
out to miss a variant.

Closes #370.