### PR TITLE
fix(infra/cloudflare-tokens): use Cache Settings, not Cache Rules

### DIFF
--- a/infra/cloudflare-tokens/terraform/main.tf
+++ b/infra/cloudflare-tokens/terraform/main.tf
@@ -54,8 +54,8 @@ data "cloudflare_api_token_permission_groups_list" "workers_scripts_write" {
   name = "Workers Scripts Write"
 }
 
-data "cloudflare_api_token_permission_groups_list" "cache_rules_write" {
-  name = "Cache Rules Write"
+data "cloudflare_api_token_permission_groups_list" "cache_settings_write" {
+  name = "Cache Settings Write"
 }
 
 locals {
@@ -117,8 +117,9 @@ resource "onepassword_item" "dns_management" {
 # if their rotation cadences diverge, split. Zone-scoped DNS comes
 # along because `cloudflare_workers_custom_domain` installs a
 # CF-managed routing record alongside the attach. Zone-scoped
-# Cache Rules gates the `/zones/{id}/rulesets` API used by the
-# `http_request_cache_settings` ruleset.
+# Cache Settings gates the `/zones/{id}/rulesets` API used by the
+# `http_request_cache_settings` ruleset (covers all cache settings
+# on the zone, not just rules — smallest CF-exposed scope).
 resource "cloudflare_api_token" "deploy" {
   name = "Deploy (TF-managed)"
 
@@ -136,7 +137,7 @@ resource "cloudflare_api_token" "deploy" {
       effect = "allow"
       permission_groups = [
         { id = data.cloudflare_api_token_permission_groups_list.dns_write.result[0].id },
-        { id = data.cloudflare_api_token_permission_groups_list.cache_rules_write.result[0].id },
+        { id = data.cloudflare_api_token_permission_groups_list.cache_settings_write.result[0].id },
       ]
       resources = jsonencode({
         # All current and future zones in the account.

--- a/infra/cloudflare-tokens/tokens/deploy.cue
+++ b/infra/cloudflare-tokens/tokens/deploy.cue
@@ -13,7 +13,9 @@ package cloudflare_token
 //     per-project cache rules (`cloudflare_ruleset`, phase
 //     `http_request_cache_settings`) for the zones the Workers
 //     attach to. The rulesets endpoint is gated by
-//     `Cache Rules:Edit`, separate from `DNS:Edit`.
+//     `Cache Settings:Edit`, separate from `DNS:Edit`. The grant
+//     is broader than "cache rules" — it covers all cache settings
+//     on the zone, which is the smallest scope CF exposes.
 //
 // Sharing one token for all three flows keeps the credential surface
 // tight; if rotation cadences diverge, split later.
@@ -27,7 +29,7 @@ package cloudflare_token
 	purpose: "Worker deploys (TF custom-domain attach + wrangler code uploads + cache rules)"
 	permission_groups: [
 		"Account:Workers Scripts:Edit",
-		"Zone:Cache Rules:Edit",
+		"Zone:Cache Settings:Edit",
 		"Zone:DNS:Edit",
 	]
 	scope: {

--- a/tools/shaka/schema/cloudflare-token.cue
+++ b/tools/shaka/schema/cloudflare-token.cue
@@ -56,7 +56,7 @@ package cloudflare_token
 	"Account Settings:Read" |
 	"Account:Cloudflare Pages:Edit" |
 	"Account:Workers Scripts:Edit" |
-	"Zone:Cache Rules:Edit" |
+	"Zone:Cache Settings:Edit" |
 	"Zone:Zone:Edit" |
 	"Zone:DNS:Edit" |
 	"User:API Tokens:Edit"

--- a/tools/shaka/tests/fixtures/cloudflare-token/valid/deploy-account-all-zones.cue
+++ b/tools/shaka/tests/fixtures/cloudflare-token/valid/deploy-account-all-zones.cue
@@ -5,7 +5,7 @@ package cloudflare_token
 	purpose: "Worker deploys (TF custom-domain attach + wrangler code uploads)"
 	permission_groups: [
 		"Account:Workers Scripts:Edit",
-		"Zone:Cache Rules:Edit",
+		"Zone:Cache Settings:Edit",
 		"Zone:DNS:Edit",
 	]
 	scope: {


### PR DESCRIPTION
The CUE label `Zone:Cache Rules:Edit` introduced in #369's schema
move was wishful — CF's actual permission group covers all cache
settings on a zone, not just rules. Renaming the label to
`Zone:Cache Settings:Edit` so the schema reflects what's actually
granted, and updating the `deploy-account-all-zones` snapshot
fixture to mirror.

Token mint can't succeed until the consumer's `main.tf` data
source is also corrected — that move ships in the follow-up commit.

#368 added the wrong CF permission-group name —
`"Cache Rules Write"` doesn't exist, so the data source returned
empty and `tofu apply` failed with `Invalid index ... empty list
of object`. The right name is `"Cache Settings Write"`, which is
the broader permission CF actually gates the cache-rules ruleset
endpoint with.

Renames the data source from `cache_rules_write` to
`cache_settings_write`, updates the literal `name = ...`, and
swaps the reference in the deploy token's zone-scoped policy.
`deploy.cue` picks up the matching schema label
(`Zone:Cache Settings:Edit`) and its comment block explains the
broader-than-just-rules scope.

Closes #371