### PR TITLE
feat(ci): trigger blogs-and-posts bumper on blogctl publish

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -185,6 +185,27 @@ jobs:
           name: kolohelios/blogctl
           visibility: public
           rolling: true
+      # Fire a repository_dispatch at kolohelios/blogs-and-posts so its
+      # bump-blogctl workflow runs immediately rather than waiting up
+      # to 24h for its daily cron. The kolohelios-bot App already has
+      # contents:write on both repos (it's the same identity used by
+      # auto-rebase-prs and bump-blogctl in blogs-and-posts), so no
+      # new secrets are required.
+      - uses: actions/create-github-app-token@v3
+        id: bot-token
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        with:
+          client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
+          owner: kolohelios
+          repositories: blogs-and-posts
+      - name: Notify blogs-and-posts of new blogctl publish
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+        run: |
+          gh api -X POST repos/kolohelios/blogs-and-posts/dispatches \
+            -f event_type=blogctl-published
 
   build-nix-lib:
     name: Build kolohelios-nix


### PR DESCRIPTION
After `build-blogctl`'s `flakehub-push` step succeeds on push or
workflow_dispatch, mint a kolohelios-bot App token scoped to
`kolohelios/blogs-and-posts` and POST a `repository_dispatch` with
`event_type=blogctl-published`. The `bump-blogctl.yaml` workflow on
that side listens for the same event type (separate PR in the
blogs-and-posts repo) and runs the bump immediately.

Collapses the existing ≤24h cron lag to ~2 min: a blogctl change
merged in kolohelios produces a bumper PR in blogs-and-posts within
minutes, not the next morning. The daily cron stays as a backstop.

No new secrets: the kolohelios-bot App already has contents:write
on blogs-and-posts (same identity that auto-rebase-prs and
bump-blogctl already use there).

The dispatch step is gated on `push || workflow_dispatch` so PR
builds don't fire spurious bumper runs.

Closes #374.