### PR TITLE
feat(ci): reusable cf-deploy workflow_call workflow

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -1,0 +1,75 @@
+# Reusable `wrangler deploy` workflow for `rust-worker` apps.
+#
+# Caller (per-project workflow, e.g. `kolohelios-portfolio-deploy.yml`
+# under #341) passes the project directory and the 1Password Service
+# Account token. The SA token lets `op run` resolve every `op://`
+# reference in the project's `.env` (CF deploy token, account id,
+# etc.) so `wrangler deploy` authenticates the same way it does
+# locally. Mirrors `tf-apply.yml`'s shape — one input, one secret,
+# the project's `.env.example` is the source of truth for what
+# resolves.
+#
+# Threat-model assumptions (worth revisiting if any of these change):
+#
+#   - This workflow is invoked only via `workflow_call` from callers
+#     triggered by `push: main` (no fork PR triggers). Fork PRs can't
+#     reach `main`, so the SA token never flows into untrusted YAML.
+#   - Third-party actions below are tag-pinned; SHA pinning is a
+#     known gap tracked in #377.
+#   - Child secrets resolved by `op run` (e.g. CLOUDFLARE_API_TOKEN)
+#     are not auto-masked by GH Actions — only the SA token itself is.
+#     #378 tracks the wrapper that closes that gap.
+#
+# `wrangler secret put` for declared Worker runtime secrets is not
+# implemented in v1 — portfolio has none today, and the idempotence
+# story belongs in a separate issue when there's a real consumer.
+name: cf-deploy
+
+on:
+  workflow_call:
+    inputs:
+      project_dir:
+        description: "Path to the rust-worker app (e.g. apps/kolohelios-portfolio)"
+        required: true
+        type: string
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN:
+        description: "1Password Service Account token used by `op run` to resolve `.env` references"
+        required: true
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    permissions:
+      # nix-installer-action mints an OIDC token to authenticate with
+      # FlakeHub for the `kolohelios-nix` private input.
+      id-token: write
+      contents: read
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - name: verify OP_SERVICE_ACCOUNT_TOKEN
+        # `required: true` above catches "caller didn't pass it";
+        # this catches "caller passed an empty value" (e.g. the org
+        # secret is unset). Fail fast with a clear annotation so the
+        # downstream `op run` doesn't surface a cryptic error.
+        run: |
+          if [[ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]]; then
+            echo "::error::OP_SERVICE_ACCOUNT_TOKEN is empty; check the caller workflow and repo/org secret"
+            exit 1
+          fi
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: wrangler deploy
+        working-directory: ${{ inputs.project_dir }}
+        # `.env` is gitignored; copy from the in-repo example so the
+        # `op run` invocation finds the file. `.env.example` already
+        # holds the `op://` refs the SA token will resolve.
+        run: |
+          cp .env.example .env
+          nix develop . --command op run --env-file=.env -- wrangler deploy


### PR DESCRIPTION
Adds `.github/workflows/cf-deploy.yml` as a workflow_call entry
point for `wrangler deploy` of any `rust-worker` app in the
repo. Mirrors the `tf-apply.yml` shape: single `project_dir`
input, single `OP_SERVICE_ACCOUNT_TOKEN` secret, `op run`
resolves the project's `.env.example` so child tooling
authenticates the same way it does locally.

Differs from the original #114 scope on two points, both adopting
conventions established after the issue was filed:

  - SA-token model (#291) replaces the separate
    `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets the
    issue prescribed. Same `op run` indirection the infra
    workflows already use.
  - `wrangler_version` input dropped; wrangler is pinned by the
    project's flake, which is the source of truth.

`wrangler secret put` idempotence for declared Worker runtime
secrets is intentionally deferred — portfolio has none today,
and the right surface for that is a separate issue when there's
a real consumer.

The workflow header documents the threat-model assumptions
(workflow_call only, push-to-main triggers, no fork PR triggers)
and cross-links the two security follow-ups filed alongside this
PR: #377 (SHA-pin third-party actions across all workflows) and
#378 (mask op-resolved child secrets via shaka wrapper). Both
exist to keep this PR's scope tight while the broader hygiene
work happens in dedicated PRs.

Integration verification lands with #341 (portfolio consumer).
There is no meaningful smoke test of a workflow_call workflow in
isolation; the consumer is the test.

Closes #114