### PR TITLE
ci(apps/kolohelios-portfolio): deploy Worker on push to main

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -1,19 +1,32 @@
 # Reusable `wrangler deploy` workflow for `rust-worker` apps.
 #
-# Caller (per-project workflow, e.g. `kolohelios-portfolio-deploy.yml`
-# under #341) passes the project directory and the 1Password Service
-# Account token. The SA token lets `op run` resolve every `op://`
-# reference in the project's `.env` (CF deploy token, account id,
-# etc.) so `wrangler deploy` authenticates the same way it does
-# locally. Mirrors `tf-apply.yml`'s shape — one input, one secret,
-# the project's `.env.example` is the source of truth for what
-# resolves.
+# Caller (per-project workflow, e.g. `kolohelios-portfolio-deploy.yml`)
+# passes the project directory and the 1Password Service Account
+# token. The SA token lets `op run` resolve every `op://` reference
+# in the project's `.env` (CF deploy token, account id, etc.) so
+# `wrangler deploy` authenticates the same way it does locally.
+# Mirrors `tf-apply.yml`'s shape — one input, one secret, the
+# project's `.env.example` is the source of truth for what resolves.
+#
+# `verify_only: true` toggles dry-run mode: `wrangler deploy
+# --dry-run` exercises the full credential chain (SA token, vault
+# permissions, `op://` resolution, CF API auth, account/scope
+# checks) plus the build (wasm compile, `wrangler.toml`
+# validation), but skips the actual upload. Use this from PR
+# triggers so credential rot, stale `op://` refs, expired tokens,
+# or misconfigured Worker scripts fail pre-merge instead of
+# surfacing after the first real `push: main` deploy. The only
+# failure modes that slip past dry-run are apply-time CF API
+# outages and the literal upload itself.
 #
 # Threat-model assumptions (worth revisiting if any of these change):
 #
 #   - This workflow is invoked only via `workflow_call` from callers
-#     triggered by `push: main` (no fork PR triggers). Fork PRs can't
-#     reach `main`, so the SA token never flows into untrusted YAML.
+#     triggered by `push: main` (real deploys) or `pull_request`
+#     with `verify_only: true` (dry-run preflights). Fork PRs can't
+#     reach `main`; same-repo PRs receive secrets by default. If
+#     callers ever trigger from fork PRs without secret gating, the
+#     SA token's blast radius is the whole 1Password vault.
 #   - Third-party actions below are tag-pinned; SHA pinning is a
 #     known gap tracked in #377.
 #   - Child secrets resolved by `op run` (e.g. CLOUDFLARE_API_TOKEN)
@@ -32,6 +45,11 @@ on:
         description: "Path to the rust-worker app (e.g. apps/kolohelios-portfolio)"
         required: true
         type: string
+      verify_only:
+        description: "If true, run `wrangler deploy --dry-run` instead of the real deploy. Use from PR triggers as a pre-merge credential and config check."
+        required: false
+        type: boolean
+        default: false
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         description: "1Password Service Account token used by `op run` to resolve `.env` references"
@@ -39,7 +57,7 @@ on:
 
 jobs:
   deploy:
-    name: wrangler deploy
+    name: ${{ inputs.verify_only && 'wrangler deploy (dry-run)' || 'wrangler deploy' }}
     runs-on: ubuntu-latest
     permissions:
       # nix-installer-action mints an OIDC token to authenticate with
@@ -65,11 +83,18 @@ jobs:
           determinate: true
           flakehub: true
       - uses: DeterminateSystems/flakehub-cache-action@v3
-      - name: wrangler deploy
+      - name: wrangler deploy${{ inputs.verify_only && ' (dry-run)' || '' }}
         working-directory: ${{ inputs.project_dir }}
         # `.env` is gitignored; copy from the in-repo example so the
         # `op run` invocation finds the file. `.env.example` already
         # holds the `op://` refs the SA token will resolve.
+        #
+        # `--dry-run` (verify_only mode) runs everything `wrangler
+        # deploy` would do except the final upload: wasm build,
+        # `wrangler.toml` validation, CF API authentication, account
+        # and scope checks. Strictly stronger than a bare `op run
+        # -- true` credential probe.
         run: |
           cp .env.example .env
-          nix develop . --command op run --env-file=.env -- wrangler deploy
+          nix develop . --command op run --env-file=.env -- \
+            wrangler deploy ${{ inputs.verify_only && '--dry-run' || '' }}

--- a/.github/workflows/kolohelios-portfolio-deploy.yml
+++ b/.github/workflows/kolohelios-portfolio-deploy.yml
@@ -1,0 +1,67 @@
+# `wrangler deploy` for `apps/kolohelios-portfolio`.
+#
+# Two triggers, two jobs:
+#
+#   - `pull_request` → `verify` job calls cf-deploy.yml with
+#     `verify_only: true`. Runs `wrangler deploy --dry-run` so
+#     credential rot, stale `op://` refs, malformed
+#     `wrangler.toml`, and CF account/scope mismatches fail
+#     pre-merge.
+#   - `push: main` → `deploy` job calls cf-deploy.yml with the
+#     default `verify_only: false`, performing the real upload.
+#
+# Path filter scopes the trigger to changes in this project plus
+# the two workflow files involved — a workflow refactor should
+# also re-deploy on the next main-merge, not lie dormant until an
+# unrelated app change lands.
+name: kolohelios-portfolio deploy
+
+on:
+  pull_request:
+    paths:
+      - apps/kolohelios-portfolio/**
+      - .github/workflows/kolohelios-portfolio-deploy.yml
+      - .github/workflows/cf-deploy.yml
+  push:
+    branches: [main]
+    paths:
+      - apps/kolohelios-portfolio/**
+      - .github/workflows/kolohelios-portfolio-deploy.yml
+      - .github/workflows/cf-deploy.yml
+  workflow_dispatch:
+
+# Caller permissions are the ceiling for the called workflow's
+# permissions; `id-token: write` is needed so the called
+# workflow's nix-installer can authenticate with FlakeHub.
+permissions:
+  id-token: write
+  contents: read
+
+# Serialize real deploys to this Worker. Two rapid merges would
+# otherwise race two `wrangler deploy`s; whichever lands second
+# wins, but the ordering should be visible in the Actions UI.
+# `cancel-in-progress` is `false` — canceling mid-deploy can
+# leave the script half-uploaded. Verify jobs use a per-PR group
+# so an updated PR cancels its previous verify run.
+concurrency:
+  group: kolohelios-portfolio-deploy-${{ github.event_name == 'pull_request' && github.ref || 'main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  verify:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/cf-deploy.yml
+    with:
+      project_dir: apps/kolohelios-portfolio
+      verify_only: true
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  deploy:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/cf-deploy.yml
+    with:
+      project_dir: apps/kolohelios-portfolio
+      verify_only: false
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/apps/kolohelios-portfolio/.env.example
+++ b/apps/kolohelios-portfolio/.env.example
@@ -1,0 +1,18 @@
+# Copy to `.env` (gitignored) and run commands via:
+#   op run --env-file=.env -- wrangler deploy
+#
+# All secrets live in 1Password; `op run` resolves references at
+# runtime. CI uses the same `.env.example` via the SA token —
+# see `.github/workflows/cf-deploy.yml`.
+
+# Cloudflare API token. Needs Workers Scripts:Edit (account-scoped)
+# + Zone:DNS:Edit + Zone:Cache Settings:Edit (all zones the Worker
+# attaches to). Provisioned by `infra/cloudflare-tokens` —
+# `tokens/deploy.cue` is the source of truth for the permission set.
+CLOUDFLARE_API_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/Cloudflare Deploy Token/password"
+
+# CF account ID. Stable and not secret; copy from the dashboard URL
+# (`dash.cloudflare.com/<id>/...`). Passed literally rather than
+# looked up because the deploy-scoped token can't list accounts via
+# /accounts (same pattern as `infra/cloudflare-deploy/.env.example`).
+CLOUDFLARE_ACCOUNT_ID="cc625b188f1219ec7ff2e9d19d1a1a7e"

--- a/apps/kolohelios-portfolio/flake.nix
+++ b/apps/kolohelios-portfolio/flake.nix
@@ -57,6 +57,17 @@
             packages = [
               (rustToolchain pkgs)
               pkgs.wrangler
+              # `cargo install worker-build` (lazily invoked by
+              # wrangler.toml's `[build]` command) pulls in
+              # `openssl-sys`, which needs system openssl headers +
+              # pkg-config to compile natively. Locally invisible
+              # because the prebuilt `worker-build` is cached in
+              # `~/.cargo/bin/`; CI starts fresh, so the install
+              # actually runs and the missing headers fail the build.
+              # #333 tracks packaging `worker-build` as a nix
+              # derivation, which would let us drop both of these.
+              pkgs.pkg-config
+              pkgs.openssl
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;


### PR DESCRIPTION
Adds a `verify_only: bool = false` input to `.github/workflows/
cf-deploy.yml`. When true, the workflow runs `wrangler deploy
--dry-run` instead of the real deploy — same setup, same
authentication path, same wasm build, same CF API auth and
account/scope checks, but no upload.

The intended use is PR triggers: callers wire a `verify` job on
`pull_request` (passing `verify_only: true`) alongside the
existing `deploy` job on `push: main`. Credential rot, stale
`op://` references, expired tokens, malformed `wrangler.toml`,
and account/scope mismatches then fail pre-merge instead of
breaking the first real deploy.

Tradeoff: dry-run rebuilds the wasm, which `nix flake check` in
the main validate job also does — a redundant build per PR.
Acceptable for the safety it buys; if the duplication ever
matters, the right fix is caching, not weakening the check.

Implements #381.

Adds `kolohelios-portfolio-deploy.yml` as the per-project
consumer of the reusable `cf-deploy.yml` workflow. Two jobs:

  - `verify` (PR trigger) calls cf-deploy with `verify_only:
    true` — `wrangler deploy --dry-run` runs the full credential
    chain and build but skips the upload. Catches credential rot
    and config breakage before merge.
  - `deploy` (push: main + workflow_dispatch) calls cf-deploy
    with `verify_only: false` — the real upload.

Path filter scopes triggers to changes under
`apps/kolohelios-portfolio/`, the consumer workflow itself, or
the reusable cf-deploy workflow — so a refactor of either YAML
re-runs against this project on the next main-merge instead of
lying dormant.

Concurrency groups split by event: PR runs scope the group by
`github.ref` and cancel-on-update so a force-push abandons the
in-flight verify; main pushes share one group and never cancel
mid-deploy.

The portfolio's `.env.example` ships the two env vars wrangler
needs — `CLOUDFLARE_API_TOKEN` (1Password reference) and
`CLOUDFLARE_ACCOUNT_ID` (literal, same value as the infra
side). Root `.gitignore` already covers `.env`, so no
per-project gitignore is needed.

The original issue body referenced `TF_VAR_cloudflare_account_id`,
which is the Terraform-prefixed name — wrangler reads
`CLOUDFLARE_ACCOUNT_ID`. The value is identical; the env var
name reflects the consumer tool.

Required-status-check wiring (the issue's third scope bullet) is
intentionally not in this PR — `main.yaml`'s gate is a single
`validate` job that can't `needs:` across workflows. Marking the
verify job blocking is a branch-protection config done in the GH
UI / API post-merge.

Closes #341