### PR TITLE
ci(apps/kolohelios-portfolio): PR preview deploys via *.workers.dev

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -19,6 +19,15 @@
 # failure modes that slip past dry-run are apply-time CF API
 # outages and the literal upload itself.
 #
+# `script_name_override: <name>` deploys to that Worker script
+# name instead of the one in `wrangler.toml`. Use for PR preview
+# deploys — pair with a name like `<project>-pr-${{ pr.number }}`
+# so each PR gets its own ephemeral Worker (cleanup is the
+# caller's responsibility, typically a `pull_request: closed`
+# job that runs `wrangler delete`). Output `worker_url` exposes
+# the `*.workers.dev` URL so the caller can post / update a PR
+# comment without re-parsing wrangler output itself.
+#
 # Threat-model assumptions (worth revisiting if any of these change):
 #
 #   - This workflow is invoked only via `workflow_call` from callers
@@ -50,10 +59,19 @@ on:
         required: false
         type: boolean
         default: false
+      script_name_override:
+        description: "If non-empty, deploys to this Worker script name instead of the one in wrangler.toml (via wrangler --name). Use for PR preview deploys; caller is responsible for cleanup."
+        required: false
+        type: string
+        default: ""
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         description: "1Password Service Account token used by `op run` to resolve `.env` references"
         required: true
+    outputs:
+      worker_url:
+        description: "The *.workers.dev URL the Worker was deployed to. Empty in verify_only mode."
+        value: ${{ jobs.deploy.outputs.worker_url }}
 
 jobs:
   deploy:
@@ -66,6 +84,8 @@ jobs:
       contents: read
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    outputs:
+      worker_url: ${{ steps.parse-url.outputs.worker_url }}
     steps:
       - name: verify OP_SERVICE_ACCOUNT_TOKEN
         # `required: true` above catches "caller didn't pass it";
@@ -84,6 +104,7 @@ jobs:
           flakehub: true
       - uses: DeterminateSystems/flakehub-cache-action@v3
       - name: wrangler deploy${{ inputs.verify_only && ' (dry-run)' || '' }}
+        id: wrangler
         working-directory: ${{ inputs.project_dir }}
         # `.env` is gitignored; copy from the in-repo example so the
         # `op run` invocation finds the file. `.env.example` already
@@ -94,7 +115,32 @@ jobs:
         # `wrangler.toml` validation, CF API authentication, account
         # and scope checks. Strictly stronger than a bare `op run
         # -- true` credential probe.
+        #
+        # `--name <override>` (script_name_override mode) deploys to
+        # an alternate Worker name without touching `wrangler.toml`.
+        # `tee` mirrors stdout to a file so the URL parser in the
+        # next step can grep it without re-running wrangler.
         run: |
           cp .env.example .env
           nix develop . --command op run --env-file=.env -- \
-            wrangler deploy ${{ inputs.verify_only && '--dry-run' || '' }}
+            wrangler deploy \
+            ${{ inputs.verify_only && '--dry-run' || '' }} \
+            ${{ inputs.script_name_override && format('--name {0}', inputs.script_name_override) || '' }} \
+            2>&1 | tee /tmp/wrangler-output.log
+          # `tee` masks the inner exit code; restore it explicitly.
+          exit "${PIPESTATUS[0]}"
+      - name: parse worker URL
+        id: parse-url
+        # Skipped in verify-only mode; nothing was deployed, no URL
+        # to extract. Grep the first `https://*.workers.dev` line
+        # from wrangler stdout — stable across recent wrangler
+        # versions; if the format ever shifts, this step fails the
+        # job rather than silently emitting an empty URL.
+        if: ${{ ! inputs.verify_only }}
+        run: |
+          url=$(grep -oE 'https://[^[:space:]]+\.workers\.dev' /tmp/wrangler-output.log | head -1)
+          if [[ -z "$url" ]]; then
+            echo "::error::could not parse worker URL from wrangler output (format change?)"
+            exit 1
+          fi
+          echo "worker_url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/kolohelios-portfolio-deploy.yml
+++ b/.github/workflows/kolohelios-portfolio-deploy.yml
@@ -1,14 +1,25 @@
 # `wrangler deploy` for `apps/kolohelios-portfolio`.
 #
-# Two triggers, two jobs:
+# Four jobs across two triggers:
 #
-#   - `pull_request` → `verify` job calls cf-deploy.yml with
-#     `verify_only: true`. Runs `wrangler deploy --dry-run` so
-#     credential rot, stale `op://` refs, malformed
-#     `wrangler.toml`, and CF account/scope mismatches fail
-#     pre-merge.
-#   - `push: main` → `deploy` job calls cf-deploy.yml with the
-#     default `verify_only: false`, performing the real upload.
+#   - `pull_request` → `verify` (dry-run against the prod script
+#     name, fast credential gate) followed by `preview` (real
+#     deploy to `kolohelios-portfolio-pr-${pr.number}`) followed
+#     by `comment` (sticky bot comment with the *.workers.dev
+#     URL). `preview` needs `verify` so broken credentials don't
+#     burn a real deploy run.
+#   - `pull_request: closed` (merged or abandoned) → `cleanup`
+#     deletes the ephemeral preview Worker so dead scripts don't
+#     accumulate.
+#   - `push: main` (+ workflow_dispatch) → `deploy` does the real
+#     prod upload.
+#
+# Verify and preview both run on every qualifying PR push:
+# verify catches issues specific to the prod script name and
+# config (`wrangler.toml` routes, token rotation timing, etc.)
+# that a `--name`-overridden preview deploy would bypass. Cheap
+# insurance; sequencing avoids paying for a wasted preview when
+# the credential chain is broken.
 #
 # Path filter scopes the trigger to changes in this project plus
 # the two workflow files involved — a workflow refactor should
@@ -18,6 +29,7 @@ name: kolohelios-portfolio deploy
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - apps/kolohelios-portfolio/**
       - .github/workflows/kolohelios-portfolio-deploy.yml
@@ -33,29 +45,116 @@ on:
 # Caller permissions are the ceiling for the called workflow's
 # permissions; `id-token: write` is needed so the called
 # workflow's nix-installer can authenticate with FlakeHub.
+# `pull-requests: write` lets the `comment` job post / edit the
+# sticky preview comment.
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
 
 # Serialize real deploys to this Worker. Two rapid merges would
 # otherwise race two `wrangler deploy`s; whichever lands second
 # wins, but the ordering should be visible in the Actions UI.
-# `cancel-in-progress` is `false` — canceling mid-deploy can
-# leave the script half-uploaded. Verify jobs use a per-PR group
-# so an updated PR cancels its previous verify run.
+# `cancel-in-progress` is `false` for push:main — canceling
+# mid-deploy can leave the script half-uploaded. PR-triggered
+# jobs use a per-PR group and cancel on update so a force-push
+# abandons the in-flight verify / preview.
 concurrency:
   group: kolohelios-portfolio-deploy-${{ github.event_name == 'pull_request' && github.ref || 'main' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   verify:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     uses: ./.github/workflows/cf-deploy.yml
     with:
       project_dir: apps/kolohelios-portfolio
       verify_only: true
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  preview:
+    needs: verify
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    uses: ./.github/workflows/cf-deploy.yml
+    with:
+      project_dir: apps/kolohelios-portfolio
+      script_name_override: kolohelios-portfolio-pr-${{ github.event.pull_request.number }}
+    secrets:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+  comment:
+    needs: preview
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # Sticky comment: an HTML marker in the body lets subsequent
+      # runs find and edit the existing comment instead of posting
+      # a new one on every push. Both list and edit go through the
+      # REST API (`/repos/{repo}/issues/{n}/comments` and
+      # `/repos/{repo}/issues/comments/{id}`) so the integer
+      # comment IDs round-trip cleanly — `gh pr view --json
+      # comments` would return GraphQL node IDs that the REST
+      # PATCH endpoint doesn't accept.
+      - name: post preview URL comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          WORKER_URL: ${{ needs.preview.outputs.worker_url }}
+        run: |
+          body="<!-- preview-deploy:portfolio -->
+          📦 **Preview deploy** for this PR is live at:
+
+          ${WORKER_URL}
+
+          Updates on every push; deleted when the PR closes."
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq 'map(select(.body | contains("<!-- preview-deploy:portfolio -->"))) | .[0].id // empty')
+          if [[ -n "$existing" ]]; then
+            gh api "repos/$REPO/issues/comments/$existing" -X PATCH -f body="$body"
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" -X POST -f body="$body"
+          fi
+
+  cleanup:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - name: verify OP_SERVICE_ACCOUNT_TOKEN
+        run: |
+          if [[ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]]; then
+            echo "::error::OP_SERVICE_ACCOUNT_TOKEN is empty; check repo/org secret"
+            exit 1
+          fi
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: wrangler delete preview Worker
+        working-directory: apps/kolohelios-portfolio
+        # `--force` skips interactive confirmation; safe because the
+        # script name is deterministically derived from the PR
+        # number. `|| true` tolerates "not found" — a cleanup
+        # running against a PR that never produced a preview
+        # (closed before first preview deploy succeeded) shouldn't
+        # fail the workflow.
+        run: |
+          cp .env.example .env
+          nix develop . --command op run --env-file=.env -- \
+            wrangler delete \
+            --name kolohelios-portfolio-pr-${{ github.event.pull_request.number }} \
+            --force \
+            || true
 
   deploy:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Adds two seams to the reusable `cf-deploy.yml` workflow needed
for PR preview deploys:

  - `script_name_override: string` — when non-empty, passes
    `--name <override>` to `wrangler deploy`, deploying to that
    Worker script name instead of the one in `wrangler.toml`.
    Use case: per-PR ephemeral Workers like
    `kolohelios-portfolio-pr-${pr.number}`. Caller is responsible
    for cleanup (typically a `pull_request: closed` job).
  - `worker_url: string` (output) — the `*.workers.dev` URL the
    Worker was deployed to, parsed from wrangler stdout. Empty in
    `verify_only` mode (nothing deployed). Caller uses this to
    post / update a sticky PR comment without having to re-parse
    wrangler output itself.

The parser greps the first `https://*.workers.dev` line from
wrangler stdout. Wrangler's deploy summary format has been stable
across recent versions; if it ever changes, the parser fails the
job rather than silently emitting an empty URL. URL parsing is
trivial inline bash — below the "non-trivial logic → shaka"
threshold.

Both inputs orthogonal: `verify_only` (dry-run) and
`script_name_override` compose freely, though verify+override in
the same call is mostly pointless (dry-run never produces a URL).

Implements the producer half of #376.

Restructures the per-project consumer workflow to give every PR
a live preview URL while keeping the existing prod deploy path
unchanged. Four jobs across two triggers replace the previous
two-job shape:

  - `verify` (PR push, fast credential gate, unchanged) — runs
    `wrangler deploy --dry-run` against the prod script name.
    Cheap; catches credential rot or `wrangler.toml` issues
    specific to the prod target before any real deploy spins up.
  - `preview` (PR push, `needs: verify`) — calls cf-deploy with
    `script_name_override: kolohelios-portfolio-pr-${pr.number}`.
    Real upload to an ephemeral Worker; the `worker_url` output
    flows downstream.
  - `comment` (PR push, `needs: preview`) — sticky bot comment
    with the preview URL. HTML marker scopes future edits to the
    same comment so PRs don't accumulate one per push.
  - `cleanup` (`pull_request: closed`, both merge and abandon) —
    `wrangler delete --force --name kolohelios-portfolio-pr-${N}`,
    tolerating "not found" so PRs closed before a successful
    preview don't fail the workflow.
  - `deploy` (push: main + workflow_dispatch, unchanged) — real
    prod upload.

Keeping `verify` alongside `preview` rather than replacing it:
verify hits the prod script name (and any `wrangler.toml` config
keyed to it), preview overrides the name so prod-specific
issues — current or future routes, token-rotation timing, name
collisions — wouldn't surface there. Sequencing avoids the cost
when credentials are broken.

Triggers add the `closed` action so the same workflow handles
cleanup; the per-PR concurrency group still cancels in-flight
verify / preview on force-push.

`permissions: pull-requests: write` lets the `comment` job
post / edit the sticky comment via the workflow's `GITHUB_TOKEN`.

Closes #376