### PR TITLE
chore(shaka): silence tofu fmt stdout noise in terraform check

### DIFF
--- a/tools/shaka/src/terraform/emit.rs
+++ b/tools/shaka/src/terraform/emit.rs
@@ -3,7 +3,7 @@
 //! `tofu fmt` to canonicalize.
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use hcl_edit::expr::{
     Array, Expression, FuncArgs, FuncCall, FuncName, Object, ObjectKey, ObjectValue, Traversal,
@@ -66,8 +66,19 @@ pub fn format_string(s: &str) -> Result<String, String> {
 /// Spawn `tofu fmt <path>` (which rewrites the file in place).
 /// Public so callers that emit-then-fmt-in-place don't have to duplicate
 /// the spawn dance and its error handling.
+///
+/// `tofu fmt` echoes the formatted file path to stdout on every
+/// invocation, which is noise for every caller in this codebase — the
+/// emit-side wrapper already announces what it wrote, and the
+/// check-side caller is operating on a tempfile the user never sees.
+/// stdout is suppressed unconditionally; stderr stays inherited so
+/// genuine errors still surface.
 pub fn tofu_fmt(path: &Path) -> Result<(), String> {
-    let status = Command::new("tofu").arg("fmt").arg(path).status();
+    let status = Command::new("tofu")
+        .arg("fmt")
+        .arg(path)
+        .stdout(Stdio::null())
+        .status();
     match status {
         Ok(s) if s.success() => Ok(()),
         Ok(s) => Err(format!(


### PR DESCRIPTION
`shaka terraform check` shells out to `tofu fmt <tempfile>` to
canonicalize rendered HCL before drift comparison. `tofu fmt` echoes
the formatted file path to stdout on every invocation, leaking the
tempfile path into check output and contaminating structured-log
parsers.

Suppress `tofu fmt`'s stdout in `emit::tofu_fmt` for all callers, not
just the check path: the emit wrapper already prints what it wrote,
so `tofu fmt`'s path-echo is redundant there too, and `format_string`
operates on a tempfile the user never sees. stderr is inherited so
genuine errors still surface. New callers inherit the quiet behavior
automatically.

Closes #364.