### PR TITLE
feat(shaka): --auto-merge for repo bump-locks

### DIFF
--- a/.github/workflows/bump-kolohelios-nix.yaml
+++ b/.github/workflows/bump-kolohelios-nix.yaml
@@ -4,7 +4,12 @@ name: Bump kolohelios-nix locks
 # (`apps/blogctl`, `infra/devbox`, `tools/shaka`). When at least one
 # consumer's lock changes, opens a single lockstep PR (`bot/bump-kolohelios-nix`).
 # If a PR is already open for that branch, force-pushes fresher locks
-# onto it instead of opening a duplicate. No auto-merge.
+# onto it instead of opening a duplicate.
+#
+# `--auto-merge` queues GitHub auto-merge (rebase strategy) on the PR.
+# The `Gate` required status check gates the merge; if a consumer breaks
+# under the new lock, auto-merge waits for the fix — same one-place fix
+# as a manual review would land.
 #
 # All branch / commit / push / PR-or-update logic lives in
 # `shaka repo bump-locks --pr-branch <name>`. This workflow is the thin
@@ -69,6 +74,7 @@ jobs:
         run: |
           nix run ./tools/shaka -- repo bump-locks \
             --input kolohelios-nix \
-            --pr-branch bot/bump-kolohelios-nix
+            --pr-branch bot/bump-kolohelios-nix \
+            --auto-merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,10 +217,13 @@ bot/bump-kolohelios-nix`, which:
 3. Opens a single lockstep PR; if one is already open for that branch,
    the force-push updates it in place instead of creating a duplicate.
 
-No auto-merge — the PR is reviewed and merged manually after CI is
-green. The `kolohelios-nix-via-flakehub` audit rule guarantees that
-every consumer pins via the FlakeHub URL, so the bumper's grep-based
-discovery is safe.
+Auto-merge is queued automatically (`--auto-merge` passes
+`gh pr merge --auto --rebase` to GitHub). The PR merges as soon as
+the `Gate` check passes; if any consumer's CI breaks, the merge
+waits until the lock is fixed — same one-place fix a manual review
+would land. The `kolohelios-nix-via-flakehub` audit rule guarantees
+that every consumer pins via the FlakeHub URL, so the bumper's
+grep-based discovery is safe.
 
 The workflow authenticates as the `kolohelios-bot` GitHub App (same
 secret/variable as `auto-rebase-prs.yaml`) so the post-bump push

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -353,6 +353,30 @@ pub fn pr_create(repo: &str, title: &str, body: &str, head: &str) -> Result<Stri
     Ok(url)
 }
 
+/// Enable GitHub auto-merge on a PR with the rebase strategy.
+///
+/// Calls `gh pr merge --auto --rebase <pr-url>`. The PR will merge as soon
+/// as the repo's required checks pass. Idempotent — safe to call on a PR
+/// that already has auto-merge enabled.
+///
+/// Fails if the target repo has `allow_auto_merge: false`. The caller is
+/// expected to enforce that via repo policy (`shaka repo audit`).
+pub fn pr_merge_auto_rebase(pr_url: &str) -> Result<(), GhError> {
+    let output = Command::new("gh")
+        .args(["pr", "merge", "--auto", "--rebase", pr_url])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: format!("gh pr merge --auto --rebase {pr_url}"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
 /// Fetch the title of a GitHub issue by number.
 ///
 /// Shells out to `gh issue view <n> --json title --jq .title`.

--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -13,7 +13,7 @@ enum BumpResult {
     Failed(String),
 }
 
-pub fn run(input: String, pr_branch: Option<String>, repo: Option<String>) {
+pub fn run(input: String, pr_branch: Option<String>, repo: Option<String>, auto_merge: bool) {
     match repo {
         Some(slug) => {
             let Some(branch) = pr_branch else {
@@ -23,16 +23,16 @@ pub fn run(input: String, pr_branch: Option<String>, repo: Option<String>) {
                 );
                 std::process::exit(2);
             };
-            if let Err(e) = run_remote(&input, &branch, &slug) {
+            if let Err(e) = run_remote(&input, &branch, &slug, auto_merge) {
                 eprintln!("{RED}{BOLD}bump-locks failed:{RESET} {e}");
                 std::process::exit(1);
             }
         }
-        None => run_monorepo(input, pr_branch),
+        None => run_monorepo(input, pr_branch, auto_merge),
     }
 }
 
-fn run_monorepo(input: String, pr_branch: Option<String>) {
+fn run_monorepo(input: String, pr_branch: Option<String>, auto_merge: bool) {
     let projects = schema_check::discover(Path::new("."));
     if projects.is_empty() {
         println!("{YELLOW}no projects found{RESET}");
@@ -80,14 +80,14 @@ fn run_monorepo(input: String, pr_branch: Option<String>) {
     }
 
     if let Some(branch) = pr_branch {
-        if let Err(e) = publish_pr(&input, &branch, &updated_paths) {
+        if let Err(e) = publish_pr(&input, &branch, &updated_paths, auto_merge) {
             eprintln!("{RED}{BOLD}publish failed:{RESET} {e}");
             std::process::exit(1);
         }
     }
 }
 
-fn run_remote(input: &str, branch: &str, slug: &str) -> Result<(), String> {
+fn run_remote(input: &str, branch: &str, slug: &str, auto_merge: bool) -> Result<(), String> {
     println!("{BOLD}bump-locks:{RESET} input `{input}` in remote `{slug}`");
 
     let temp = tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {e}"))?;
@@ -134,13 +134,25 @@ fn run_remote(input: &str, branch: &str, slug: &str) -> Result<(), String> {
     if let Some(pr) = gh::pr_for_head(slug, branch).map_err(|e| e.to_string())? {
         if pr.state == PrState::Open {
             println!("{GREEN}{BOLD}updated existing PR:{RESET} {}", pr.url);
+            if auto_merge {
+                enable_auto_merge(&pr.url)?;
+            }
             return Ok(());
         }
     }
 
-    let body = format_remote_pr_body(input);
+    let body = format_remote_pr_body(input, auto_merge);
     let url = gh::pr_create(slug, &title, &body, branch).map_err(|e| e.to_string())?;
     println!("{GREEN}{BOLD}created PR:{RESET} {url}");
+    if auto_merge {
+        enable_auto_merge(&url)?;
+    }
+    Ok(())
+}
+
+fn enable_auto_merge(pr_url: &str) -> Result<(), String> {
+    gh::pr_merge_auto_rebase(pr_url).map_err(|e| e.to_string())?;
+    println!("  {DIM}auto-merge queued{RESET}");
     Ok(())
 }
 
@@ -157,11 +169,19 @@ fn git_in(work: &Path, args: &[&str]) -> Result<(), String> {
     Ok(())
 }
 
-fn format_remote_pr_body(input: &str) -> String {
+fn format_remote_pr_body(input: &str, auto_merge: bool) -> String {
     format!(
-        "Automated bump of `{input}` flake input.\n\n\
-         No auto-merge. Review the lockfile diff and merge when CI is green.\n"
+        "Automated bump of `{input}` flake input.\n\n{}\n",
+        merge_footer(auto_merge)
     )
+}
+
+fn merge_footer(auto_merge: bool) -> &'static str {
+    if auto_merge {
+        "Auto-merge queued — GitHub will rebase-merge once required checks pass."
+    } else {
+        "No auto-merge. Review the lockfile diff and merge when CI is green."
+    }
 }
 
 fn bump_one(project: &Path, input: &str) -> BumpResult {
@@ -200,7 +220,12 @@ fn bump_one(project: &Path, input: &str) -> BumpResult {
     }
 }
 
-fn publish_pr(input: &str, branch: &str, updated: &[PathBuf]) -> Result<(), String> {
+fn publish_pr(
+    input: &str,
+    branch: &str,
+    updated: &[PathBuf],
+    auto_merge: bool,
+) -> Result<(), String> {
     if updated.is_empty() {
         println!("{DIM}no changes to publish{RESET}");
         return Ok(());
@@ -216,13 +241,19 @@ fn publish_pr(input: &str, branch: &str, updated: &[PathBuf]) -> Result<(), Stri
     if let Some(pr) = gh::pr_for_head(&repo, branch).map_err(|e| e.to_string())? {
         if pr.state == PrState::Open {
             println!("{GREEN}{BOLD}updated existing PR:{RESET} {}", pr.url);
+            if auto_merge {
+                enable_auto_merge(&pr.url)?;
+            }
             return Ok(());
         }
     }
 
-    let body = format_pr_body(input, updated);
+    let body = format_pr_body(input, updated, auto_merge);
     let url = gh::pr_create(&repo, &title, &body, branch).map_err(|e| e.to_string())?;
     println!("{GREEN}{BOLD}created PR:{RESET} {url}");
+    if auto_merge {
+        enable_auto_merge(&url)?;
+    }
     Ok(())
 }
 
@@ -238,14 +269,16 @@ fn git(args: &[&str]) -> Result<(), String> {
     Ok(())
 }
 
-fn format_pr_body(input: &str, updated: &[PathBuf]) -> String {
+fn format_pr_body(input: &str, updated: &[PathBuf], auto_merge: bool) -> String {
     let mut body =
         format!("Automated daily bump of `{input}` across all FlakeHub-pinned consumers.\n\n");
     body.push_str("Updated `flake.lock` in:\n");
     for project in updated {
         body.push_str(&format!("- `{}`\n", project.display()));
     }
-    body.push_str("\nNo auto-merge. Review the lockfile diff and merge when CI is green.\n");
+    body.push('\n');
+    body.push_str(merge_footer(auto_merge));
+    body.push('\n');
     body
 }
 
@@ -320,12 +353,20 @@ mod tests {
 
     #[test]
     fn remote_pr_body_is_terse_and_names_input() {
-        let body = format_remote_pr_body("blogctl");
+        let body = format_remote_pr_body("blogctl", false);
         assert!(body.contains("`blogctl`"));
         assert!(body.contains("No auto-merge"));
         // The remote case has only one flake by construction; the body
         // should not list project paths the way the monorepo version does.
         assert!(!body.contains("Updated `flake.lock` in:"));
+    }
+
+    #[test]
+    fn remote_pr_body_advertises_auto_merge_when_set() {
+        let body = format_remote_pr_body("blogctl", true);
+        assert!(body.contains("`blogctl`"));
+        assert!(body.contains("Auto-merge queued"));
+        assert!(!body.contains("No auto-merge"));
     }
 
     #[test]
@@ -336,10 +377,18 @@ mod tests {
                 PathBuf::from("./apps/blogctl"),
                 PathBuf::from("./infra/devbox"),
             ],
+            false,
         );
         assert!(body.contains("`kolohelios-nix`"));
         assert!(body.contains("./apps/blogctl"));
         assert!(body.contains("./infra/devbox"));
         assert!(body.contains("No auto-merge"));
+    }
+
+    #[test]
+    fn pr_body_advertises_auto_merge_when_set() {
+        let body = format_pr_body("kolohelios-nix", &[PathBuf::from("./apps/blogctl")], true);
+        assert!(body.contains("Auto-merge queued"));
+        assert!(!body.contains("No auto-merge"));
     }
 }

--- a/tools/shaka/src/repo/mod.rs
+++ b/tools/shaka/src/repo/mod.rs
@@ -155,6 +155,13 @@ pub enum RepoCommand {
         /// helper (`gh auth setup-git`) before invoking shaka.
         #[arg(long)]
         repo: Option<String>,
+        /// After creating or updating the PR, queue GitHub auto-merge
+        /// (`gh pr merge --auto --rebase`). The PR merges as soon as the
+        /// repo's required checks pass. Requires `allow_auto_merge: true`
+        /// on the target repo; merge strategy is fixed to rebase to match
+        /// repo policy.
+        #[arg(long)]
+        auto_merge: bool,
     },
 }
 
@@ -181,6 +188,7 @@ pub fn run(cmd: RepoCommand) {
             input,
             pr_branch,
             repo,
-        } => bump_locks::run(input, pr_branch, repo),
+            auto_merge,
+        } => bump_locks::run(input, pr_branch, repo, auto_merge),
     }
 }


### PR DESCRIPTION
Add an `--auto-merge` flag to `shaka repo bump-locks` that queues GitHub
auto-merge (rebase strategy) on the PR right after creating or updating
it. Plumbed through both code paths (monorepo and `--repo <slug>`
remote bumps); the PR body footer flips from "No auto-merge" to
"Auto-merge queued" when the flag is set.

Wire the new flag into `.github/workflows/bump-kolohelios-nix.yaml`.
The blogs-and-posts side needs a separate PR over there to pass
`--auto-merge` once that repo has `allow_auto_merge: true` (currently
disabled — flip alongside that PR).

Auto-merge for these PRs is the right default: scope is a single
mechanical `flake.lock` change, gating is identical (`Gate` required
check on this repo, `Validate` on blogs-and-posts), and if a consumer
breaks under the new lock the fix is one place either way.

Follow-ups surfaced while doing this:
- #386: audit `allow_auto_merge` in repo policy (caught `blogs-and-posts`
  drift)
- #387: audit external kolohelios-* repos from this repo

Closes #385