### PR TITLE
feat(shaka): audit allow_auto_merge in repo policy

### DIFF
--- a/tools/shaka/schema/repo-policy-schema.cue
+++ b/tools/shaka/schema/repo-policy-schema.cue
@@ -7,6 +7,10 @@ package repopolicy
 		merge:               bool
 		squash:              bool
 		deleteBranchOnMerge: bool
+		// `allow_auto_merge` on the repo. Required for
+		// `gh pr merge --auto` to queue (used by the lock-bump workflows
+		// and #57's `shaka repo send` follow-up).
+		autoMerge: bool
 	}
 	// Omit any optional field below to opt the audit out of that
 	// dimension — useful for personal repos that don't enable issues,

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -184,37 +184,41 @@ fn check_general(repo: &str, policy: &RepoPolicy) -> (Vec<Check>, Option<Value>)
         ));
     }
 
-    push_merge_check(
-        &mut checks,
-        "Rebase merge",
-        data["allow_rebase_merge"].as_bool() == Some(true),
-        policy.merge.rebase,
-    );
-    push_merge_check(
-        &mut checks,
-        "Merge commits",
-        data["allow_merge_commit"].as_bool() == Some(true),
-        policy.merge.merge,
-    );
-    push_merge_check(
-        &mut checks,
-        "Squash merge",
-        data["allow_squash_merge"].as_bool() == Some(true),
-        policy.merge.squash,
-    );
-    push_merge_check(
-        &mut checks,
-        "Delete branch on merge",
-        data["delete_branch_on_merge"].as_bool() == Some(true),
-        policy.merge.delete_branch_on_merge,
-    );
+    let observed_bool = |key: &str| data[key].as_bool() == Some(true);
+    checks.extend([
+        merge_check(
+            "Rebase merge",
+            observed_bool("allow_rebase_merge"),
+            policy.merge.rebase,
+        ),
+        merge_check(
+            "Merge commits",
+            observed_bool("allow_merge_commit"),
+            policy.merge.merge,
+        ),
+        merge_check(
+            "Squash merge",
+            observed_bool("allow_squash_merge"),
+            policy.merge.squash,
+        ),
+        merge_check(
+            "Delete branch on merge",
+            observed_bool("delete_branch_on_merge"),
+            policy.merge.delete_branch_on_merge,
+        ),
+        merge_check(
+            "Auto-merge",
+            observed_bool("allow_auto_merge"),
+            policy.merge.auto_merge,
+        ),
+    ]);
 
     (checks, Some(data))
 }
 
-fn push_merge_check(checks: &mut Vec<Check>, name: &'static str, observed: bool, want: bool) {
+fn merge_check(name: &'static str, observed: bool, want: bool) -> Check {
     let (pass_msg, fail_msg) = enabled_messages(want);
-    checks.push(bool_check(name, observed == want, pass_msg, fail_msg));
+    bool_check(name, observed == want, pass_msg, fail_msg)
 }
 
 fn enabled_messages(want: bool) -> (&'static str, &'static str) {
@@ -234,6 +238,7 @@ fn fix_general(repo: &str, checks: &[Check], policy: &RepoPolicy) {
                     | "Merge commits"
                     | "Squash merge"
                     | "Delete branch on merge"
+                    | "Auto-merge"
                     | "Issues enabled"
             )
     });
@@ -252,6 +257,7 @@ fn fix_general(repo: &str, checks: &[Check], policy: &RepoPolicy) {
         merge,
         squash,
         delete_branch_on_merge,
+        auto_merge,
     } = policy.merge;
     body.insert("allow_rebase_merge".into(), json!(rebase));
     body.insert("allow_merge_commit".into(), json!(merge));
@@ -260,6 +266,7 @@ fn fix_general(repo: &str, checks: &[Check], policy: &RepoPolicy) {
         "delete_branch_on_merge".into(),
         json!(delete_branch_on_merge),
     );
+    body.insert("allow_auto_merge".into(), json!(auto_merge));
 
     match gh::api_patch(&format!("/repos/{repo}"), &Value::Object(body)) {
         Ok(_) => println!("  {GREEN}Fixed{RESET}"),

--- a/tools/shaka/src/repo/policy.rs
+++ b/tools/shaka/src/repo/policy.rs
@@ -40,6 +40,7 @@ pub struct MergePolicy {
     pub merge: bool,
     pub squash: bool,
     pub delete_branch_on_merge: bool,
+    pub auto_merge: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tools/shaka/tests/fixtures/repo-policy/invalid/missing-auto-merge.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/invalid/missing-auto-merge.cue
@@ -7,9 +7,7 @@ package repopolicy
 		merge:               false
 		squash:              false
 		deleteBranchOnMerge: true
-		autoMerge:           true
 	}
-	issues: true
 	branchProtection: {
 		requiredChecks: ["Gate"]
 		strictStatusChecks: false

--- a/tools/shaka/tests/fixtures/repo-policy/valid/kolohelios.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/kolohelios.cue
@@ -7,6 +7,7 @@ package repopolicy
 		merge:               false
 		squash:              false
 		deleteBranchOnMerge: true
+		autoMerge:           true
 	}
 	issues: true
 	branchProtection: {

--- a/tools/shaka/tests/fixtures/repo-policy/valid/minimal.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/minimal.cue
@@ -7,5 +7,6 @@ package repopolicy
 		merge:               false
 		squash:              false
 		deleteBranchOnMerge: true
+		autoMerge:           true
 	}
 }

--- a/tools/shaka/tests/fixtures/repo-policy/valid/multiple-checks.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/multiple-checks.cue
@@ -7,6 +7,7 @@ package repopolicy
 		merge:               false
 		squash:              false
 		deleteBranchOnMerge: true
+		autoMerge:           true
 	}
 	branchProtection: {
 		requiredChecks: ["Gate", "Lint", "Test"]

--- a/tools/shaka/tests/fixtures/repo-policy/valid/permissive.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/permissive.cue
@@ -7,6 +7,7 @@ package repopolicy
 		merge:               true
 		squash:              true
 		deleteBranchOnMerge: false
+		autoMerge:           false
 	}
 	branchProtection: {
 		requiredChecks: []


### PR DESCRIPTION
Extend the repo-policy schema and `MergePolicy` with `autoMerge: bool`,
and add a corresponding `Auto-merge` check (plus `--fix` support) to
`shaka repo audit`. Set `autoMerge: true` in this repo's policy.

`allow_auto_merge` is the GitHub repo-level switch that lets
`gh pr merge --auto` queue. Without it, the bumper PRs from #385 (and
the `shaka repo send` work in #57) silently fail to enable auto-merge.
The audit now flags drift before that fails in production.

Surfaced `kolohelios/blogs-and-posts` having `allow_auto_merge: false`
— which is what motivated this issue. Flipping it is a separate one-off
(`gh api -X PATCH ...`), or will be covered when #387 lands and audit
runs against external repos.

Updated repo-policy fixtures: every `valid/` fixture now sets
`autoMerge`, and a new `invalid/missing-auto-merge.cue` proves the
field is required.

Closes #386