### PR TITLE
ci: route cf-deploy and tf-apply through shaka ci mask-and-run

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -40,7 +40,9 @@
 #     known gap tracked in #377.
 #   - Child secrets resolved by `op run` (e.g. CLOUDFLARE_API_TOKEN)
 #     are not auto-masked by GH Actions — only the SA token itself is.
-#     #378 tracks the wrapper that closes that gap.
+#     `shaka ci mask-and-run` registers them with `::add-mask::` before
+#     execing the consumer, so any value op resolves shows as `***` in
+#     the log even if a consumer prints it.
 #
 # `wrangler secret put` for declared Worker runtime secrets is not
 # implemented in v1 — portfolio has none today, and the idempotence
@@ -122,7 +124,7 @@ jobs:
         # next step can grep it without re-running wrangler.
         run: |
           cp .env.example .env
-          nix develop . --command op run --env-file=.env -- \
+          nix develop . --command shaka ci mask-and-run --env-file=.env -- \
             wrangler deploy \
             ${{ inputs.verify_only && '--dry-run' || '' }} \
             ${{ inputs.script_name_override && format('--name {0}', inputs.script_name_override) || '' }} \

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -10,6 +10,13 @@
 # -input=false`; the generated recipe already wraps `tofu apply` in
 # `op run --env-file=.env -- bash -c '...'` and inits before applying,
 # so this workflow stays thin.
+#
+# Wrapped in `shaka ci mask-and-run` so each op-resolved value
+# (CLOUDFLARE_API_TOKEN, the S3 creds for tfstate, etc.) is registered
+# with GH Actions log masking before any consumer runs — `tofu apply`
+# error context that echoes a sensitive value still shows as `***`.
+# The recipe's own inner `op run` is harmless redundancy; keeping the
+# wrapper at the outermost layer leaves local `just apply` unchanged.
 name: tf-apply
 
 on:
@@ -49,4 +56,5 @@ jobs:
         # already holds the `op://` refs the SA token will resolve.
         run: |
           cp .env.example .env
-          nix develop . --command just apply -auto-approve -input=false
+          nix develop . --command shaka ci mask-and-run --env-file=.env -- \
+            just apply -auto-approve -input=false

--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+use std::io::Write;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::Command;
+
 use clap::Subcommand;
 use serde_json::Value;
 
@@ -11,11 +17,35 @@ pub enum CiCommand {
         #[arg(long)]
         needs: String,
     },
+    /// Run a command under `op run`, registering each resolved-secret value
+    /// with GitHub Actions log masking first (`::add-mask::<value>`).
+    ///
+    /// GH auto-masks the literal `secrets.*` values it injects, but not
+    /// values `op run` resolves from them (CLOUDFLARE_API_TOKEN,
+    /// AWS_SECRET_ACCESS_KEY, etc.). This wrapper enumerates the resolved
+    /// env first, emits a mask command for each non-empty new/changed
+    /// value, then execs `op run --env-file=<file> -- <args...>`.
+    #[command(name = "mask-and-run")]
+    MaskAndRun {
+        /// Path passed through to `op run --env-file=<path>`.
+        #[arg(long)]
+        env_file: PathBuf,
+        /// Command and args to run under `op run` (separated by `--`).
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+        args: Vec<String>,
+    },
 }
 
 pub fn run(cmd: CiCommand) {
     match cmd {
         CiCommand::Gate { needs } => match gate(&needs) {
+            Ok(()) => {}
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                std::process::exit(1);
+            }
+        },
+        CiCommand::MaskAndRun { env_file, args } => match mask_and_run(&env_file, &args) {
             Ok(()) => {}
             Err(e) => {
                 eprintln!("{RED}{BOLD}error:{RESET} {e}");
@@ -89,6 +119,89 @@ fn gate(needs_json: &str) -> Result<(), String> {
     }
 }
 
+fn mask_and_run(env_file: &PathBuf, args: &[String]) -> Result<(), String> {
+    // Phase 1: enumerate the resolved env without running the consumer.
+    // `env -0` separates entries with NUL so values containing newlines or
+    // `=` survive parsing.
+    let output = Command::new("op")
+        .arg("run")
+        .arg("--env-file")
+        .arg(env_file)
+        .arg("--")
+        .arg("env")
+        .arg("-0")
+        .output()
+        .map_err(|e| format!("could not spawn `op run -- env -0`: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "`op run --env-file={} -- env -0` exited with status {}: {}",
+            env_file.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let child_env = parse_env_z(&output.stdout)?;
+    let parent_env: HashMap<String, String> = std::env::vars().collect();
+    let secrets = resolved_secrets(&parent_env, &child_env);
+
+    // Phase 2: register each resolved value with GH Actions log masking.
+    // The worker reads workflow commands from any stdout line, so plain
+    // `println!` is sufficient. Flush before exec so the masks land before
+    // the child writes a single byte.
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for value in &secrets {
+        writeln!(out, "::add-mask::{value}").map_err(|e| format!("write add-mask: {e}"))?;
+    }
+    out.flush().map_err(|e| format!("flush stdout: {e}"))?;
+    drop(out);
+
+    // Phase 3: replace this process with the real `op run`. On failure,
+    // `exec` returns; on success, it does not.
+    let mut cmd = Command::new("op");
+    cmd.arg("run").arg("--env-file").arg(env_file).arg("--");
+    cmd.args(args);
+    Err(format!("exec `op run`: {}", cmd.exec()))
+}
+
+/// Parse the NUL-separated output of `env -0` into a map of `KEY -> VALUE`.
+/// Entries without an `=` are dropped (env never produces them, but be
+/// defensive). The trailing empty entry produced by the final NUL is
+/// dropped naturally by the `is_empty` filter.
+fn parse_env_z(bytes: &[u8]) -> Result<HashMap<String, String>, String> {
+    let text =
+        std::str::from_utf8(bytes).map_err(|e| format!("`env -0` output is not utf-8: {e}"))?;
+    let mut map = HashMap::new();
+    for entry in text.split('\0') {
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((k, v)) = entry.split_once('=') {
+            map.insert(k.to_string(), v.to_string());
+        }
+    }
+    Ok(map)
+}
+
+/// Return the values present in `child` that are non-empty and either
+/// absent from `parent` or differ from the parent value. Sorted and
+/// deduplicated for deterministic output.
+fn resolved_secrets(
+    parent: &HashMap<String, String>,
+    child: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut values: Vec<String> = child
+        .iter()
+        .filter(|(k, v)| !v.is_empty() && parent.get(*k).map(|p| p != *v).unwrap_or(true))
+        .map(|(_, v)| v.clone())
+        .collect();
+    values.sort();
+    values.dedup();
+    values
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +245,60 @@ mod tests {
     #[test]
     fn gate_rejects_empty_object() {
         assert!(gate("{}").is_err());
+    }
+
+    fn map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parse_env_z_handles_trailing_nul_and_multiline_values() {
+        let bytes = b"A=1\0B=two\nlines\0C=\0";
+        let got = parse_env_z(bytes).unwrap();
+        assert_eq!(got.get("A"), Some(&"1".to_string()));
+        assert_eq!(got.get("B"), Some(&"two\nlines".to_string()));
+        assert_eq!(got.get("C"), Some(&"".to_string()));
+        assert_eq!(got.len(), 3);
+    }
+
+    #[test]
+    fn resolved_secrets_picks_new_vars() {
+        let parent = map(&[("PATH", "/usr/bin")]);
+        let child = map(&[("PATH", "/usr/bin"), ("SECRET", "abc")]);
+        assert_eq!(resolved_secrets(&parent, &child), vec!["abc".to_string()]);
+    }
+
+    #[test]
+    fn resolved_secrets_skips_parent_equal_values() {
+        let parent = map(&[("FOO", "same")]);
+        let child = map(&[("FOO", "same")]);
+        assert!(resolved_secrets(&parent, &child).is_empty());
+    }
+
+    #[test]
+    fn resolved_secrets_skips_empty_values() {
+        let parent = map(&[]);
+        let child = map(&[("EMPTY", ""), ("SET", "value")]);
+        assert_eq!(resolved_secrets(&parent, &child), vec!["value".to_string()]);
+    }
+
+    #[test]
+    fn resolved_secrets_includes_overridden_values() {
+        let parent = map(&[("TOKEN", "placeholder")]);
+        let child = map(&[("TOKEN", "real")]);
+        assert_eq!(resolved_secrets(&parent, &child), vec!["real".to_string()]);
+    }
+
+    #[test]
+    fn resolved_secrets_deduplicates_repeated_values() {
+        let parent = map(&[]);
+        let child = map(&[("A", "shared"), ("B", "shared"), ("C", "unique")]);
+        assert_eq!(
+            resolved_secrets(&parent, &child),
+            vec!["shared".to_string(), "unique".to_string()]
+        );
     }
 }


### PR DESCRIPTION
GitHub Actions auto-masks the literal `secrets.*` values it injects,
but not the values `op run` resolves from them (CLOUDFLARE_API_TOKEN,
AWS_SECRET_ACCESS_KEY for tfstate, etc.). A misbehaving consumer
(`tofu apply` on error, `wrangler --verbose`, future tools added to
a deploy recipe) could echo a resolved value into the log unmasked.

`shaka ci mask-and-run --env-file=<f> -- <cmd> [args...]` closes the
gap. It runs `op run --env-file=<f> -- env -0` once to enumerate the
resolved env, diffs against the parent env to find newly-set or
overridden non-empty values, emits `::add-mask::<value>` for each,
then execs `op run --env-file=<f> -- <cmd> [args...]`. The exec
replaces the process so the consumer's exit status propagates
naturally.

`env -0` (NUL-separated) is used so resolved values containing
newlines survive parsing intact.

Replaces the bare `op run --env-file=.env -- <consumer>` invocation
in both reusable apply workflows with `shaka ci mask-and-run`, so
every op-resolved value (CLOUDFLARE_API_TOKEN, the S3 creds for
tfstate, etc.) is registered with GH Actions log masking before
the consumer runs.

`cf-deploy.yml`'s threat-model header is updated to note that the
gap is now closed by the wrapper rather than tracked open in #378.
`tf-apply.yml` gains a parallel note plus a one-liner on why
wrapping at the workflow layer (instead of inside the generated
`just apply` recipe) is the right cut — the recipe's own inner
`op run` is harmless redundancy in CI and keeps local `just apply`
unchanged.

Closes #378