### PR TITLE
ci: drop maximize-build-space from validate

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,26 +79,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      # `nix flake check` for infra/devbox evaluates the full NixOS system
-      # closure and exhausts the runner's ~14GB free /. Pruning preinstalled
-      # toolchains alone (jlumbroso/free-disk-space) reclaimed ~25GB but
-      # still wasn't enough — the closure pulled clang and OOMed. Instead,
-      # carve an LVM volume out of the runner's unallocated disk + the
-      # freed tool space and mount it at /nix before nix installs.
-      # Yields ~75GB at /nix.
-      - name: Maximize disk for /nix
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 1024
-          temp-reserve-mb: 100
-          swap-size-mb: 1024
-          overprovision-lvm: true
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
-          build-mount-path: /nix
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           determinate: true


### PR DESCRIPTION
The Maximize disk for /nix step was added in #169 to give nix flake check
./infra/devbox enough room for the NixOS system closure (~75 GB at /nix).
#170 dropped that flake check from infra projects' just validate
entirely; the remaining flake checks (rust crates, nix-lib) have small
closures and fit comfortably in the runner's stock disk.

Saves ~1-1.5 min from the validate baseline on every PR. If a future
per-project check reintroduces a large-closure flake check, re-add the
step then.

Closes #399