### PR TITLE
chore(repo): require strict status checks on main

### DIFF
--- a/.shaka/repo.cue
+++ b/.shaka/repo.cue
@@ -12,7 +12,7 @@ package repopolicy
 	issues: true
 	branchProtection: {
 		requiredChecks: ["Gate"]
-		strictStatusChecks: false
+		strictStatusChecks: true
 		allowForcePush:     false
 		allowDeletion:      false
 	}

--- a/tools/shaka/tests/fixtures/repo-policy/valid/kolohelios.cue
+++ b/tools/shaka/tests/fixtures/repo-policy/valid/kolohelios.cue
@@ -12,7 +12,7 @@ package repopolicy
 	issues: true
 	branchProtection: {
 		requiredChecks: ["Gate"]
-		strictStatusChecks: false
+		strictStatusChecks: true
 		allowForcePush:     false
 		allowDeletion:      false
 	}


### PR DESCRIPTION
Flip `strictStatusChecks` from false to true in `.shaka/repo.cue`
(and the matching fixture). With `auto-rebase-prs.yaml` handling the
rebase mechanically and auto-merge (#385) queueing the post-rebase
green-status merge, requiring a fresh base before merge costs nothing
and closes the window where a stale-base PR could merge before the bot
rebases it.

Live-side PATCH for `kolohelios/kolohelios` and `kolohelios/blogs-and-posts`
follows in a manual step once this merges. The rename in #400 will fold in
the kolohelios required-checks reconciliation at the same time.