### PR TITLE
fix(apps/kolohelios-portfolio): use selectLatestNightlyWith for wasm

### DIFF
--- a/apps/kolohelios-portfolio/flake.nix
+++ b/apps/kolohelios-portfolio/flake.nix
@@ -35,19 +35,31 @@
           }
         );
 
-      # wasm32-unknown-unknown is added explicitly so `cargo check
-      # --target wasm32-unknown-unknown` (the wasm-check recipe) and any
-      # local `worker-build --release` invocation both find the stdlib.
+      # `selectLatestNightlyWith` picks the latest nightly date for which
+      # *every* requested component is available — base profile,
+      # extensions, AND the `wasm32-unknown-unknown` rust-std. The
+      # naive `rust-bin.nightly.latest.default.override` resolves each
+      # component's "latest" independently, so when upstream lands a
+      # newer wasm rust-std before a newer default profile (or vice
+      # versa), the combined toolchain ends up with `rustc` from one
+      # date and the wasm stdlib from another. `rustc --print sysroot`
+      # then points at the base toolchain (no wasm), and worker-build's
+      # fresh-install probe fails with "wasm32-unknown-unknown target
+      # not found in sysroot". See #403 and run
+      # https://github.com/kolohelios/kolohelios/actions/runs/25882388549.
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.nightly.latest.default.override {
-          extensions = [
-            "rust-src"
-            "rust-analyzer"
-            "llvm-tools-preview"
-          ];
-          targets = [ "wasm32-unknown-unknown" ];
-        };
+        pkgs.rust-bin.selectLatestNightlyWith (
+          toolchain:
+          toolchain.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analyzer"
+              "llvm-tools-preview"
+            ];
+            targets = [ "wasm32-unknown-unknown" ];
+          }
+        );
     in
     {
       devShells = forEachSupportedSystem (


### PR DESCRIPTION
The first `push: main` `wrangler deploy` after #392 merged failed
because rust-overlay's `nightly.latest.default.override { targets =
[...] }` resolves "latest" independently per component. Nix copied
`rust-default-1.97.0-nightly-2026-04-29` (which became rustc's
sysroot) alongside `rust-std-1.97.0-nightly-2026-05-11-wasm32-...`,
so `wasm32-unknown-unknown` wasn't in the sysroot rustc reported.
`worker-build`'s fresh-install probe failed; locally this stayed
masked because `worker-build` was already cached in `~/.cargo/bin`.

`selectLatestNightlyWith` picks the latest nightly date for which
*every* requested component (base profile + extensions + wasm
rust-std) exists, so the combined toolchain is internally consistent
by construction. Verified locally: `rustc --print sysroot` now lands
on `rust-default-1.97.0-nightly-2026-05-11`, `lib/rustlib/` contains
`wasm32-unknown-unknown`, and a fresh `cargo install worker-build &&
worker-build --release` builds the worker end-to-end.

Same pattern lives in `jobs/pollen-alert/flake.nix` and will hit this
once that project deploys; #333 already tracks consolidating the
workers-rs toolchain story, so the broader fix lives there.

Closes #403