### PR TITLE
fix(apps/kolohelios-portfolio): build worker outside wrangler

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -105,6 +105,28 @@ jobs:
           determinate: true
           flakehub: true
       - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: worker-build
+        working-directory: ${{ inputs.project_dir }}
+        # Build the worker upstream of `wrangler deploy` so the wasm
+        # build runs inside our devshell, not inside a subprocess
+        # wrangler spawns with a different `$PATH`. `wasm-pack`'s
+        # wasm-target probe does `which("rustc")` against `$PATH`;
+        # in CI a wrangler-spawned subprocess was somehow resolving
+        # a rustc outside our declared closure and failing the probe
+        # (#403). Pulling the build out of wrangler keeps everything
+        # in a `$PATH` we control. See `wrangler.toml`'s top-of-file
+        # comment + #423.
+        #
+        # Split into two `nix develop --command` invocations rather
+        # than one `bash -c`: each call applies the flake's
+        # `shellHook` (which puts `~/.cargo/bin` on `$PATH`), so the
+        # `worker-build` binary that `cargo install` drops there is
+        # visible to the second call. `--locked` pins `worker-build`
+        # to its published `Cargo.lock`; subsequent runs no-op when
+        # the binary is already cached.
+        run: |
+          nix develop . --command cargo install -q worker-build --locked
+          nix develop . --command worker-build --release
       - name: wrangler deploy${{ inputs.verify_only && ' (dry-run)' || '' }}
         id: wrangler
         working-directory: ${{ inputs.project_dir }}
@@ -113,10 +135,10 @@ jobs:
         # holds the `op://` refs the SA token will resolve.
         #
         # `--dry-run` (verify_only mode) runs everything `wrangler
-        # deploy` would do except the final upload: wasm build,
-        # `wrangler.toml` validation, CF API authentication, account
-        # and scope checks. Strictly stronger than a bare `op run
-        # -- true` credential probe.
+        # deploy` would do except the final upload: `wrangler.toml`
+        # validation, CF API authentication, account and scope
+        # checks, asset upload prep. The wasm build already ran in
+        # the previous step.
         #
         # `--name <override>` (script_name_override mode) deploys to
         # an alternate Worker name without touching `wrangler.toml`.

--- a/apps/kolohelios-portfolio/wrangler.toml
+++ b/apps/kolohelios-portfolio/wrangler.toml
@@ -1,14 +1,17 @@
 name = "kolohelios-portfolio"
+# `worker-build` produces `build/worker/shim.mjs` and the wasm module
+# wrangler uploads. The build runs upstream of `wrangler deploy` (in
+# CI: a dedicated step in `cf-deploy.yml`; locally: same command in
+# the devshell). Wrangler is invoked with the artifact already in
+# place — no `[build]` block, no custom build subprocess. See #403 /
+# #423: when `worker-build` runs inside a wrangler-spawned subprocess
+# (the documented workers-rs idiom), `wasm-pack`'s wasm-target probe
+# does `which("rustc")` against whatever `$PATH` wrangler hands it,
+# which in our CI ends up resolving to a rustc that isn't the one we
+# declared in the devshell. Pulling the build out of wrangler keeps
+# the probe inside a process whose `$PATH` we control.
 main = "build/worker/shim.mjs"
 compatibility_date = "2026-05-01"
-
-# `worker-build` compiles the crate to wasm32-unknown-unknown and emits
-# `build/worker/shim.mjs` + the WASM module that wrangler uploads. The
-# `cargo install` is a no-op on subsequent runs and matches the
-# workers-rs documented idiom; the devshell adds `~/.cargo/bin` to PATH
-# so the installed binary is visible to the build step.
-[build]
-command = "cargo install -q worker-build --locked && worker-build --release"
 
 # Workers Static Assets: CF serves files from `./dist/` directly at
 # the edge, bypassing the Worker for matched paths. Cache rules


### PR DESCRIPTION
Web research turned up the load-bearing mechanic in #403. `worker-build`
wraps `wasm-pack`, whose wasm-target probe
(https://docs.rs/wasm-pack/latest/src/wasm_pack/build/wasm_target.rs.html)
does `which("rustc")` against `$PATH` and runs `rustc --target
wasm32-unknown-unknown --print target-libdir`. In CI the `which`
resolved to a nightly-2026-04-29 toolchain that's not in our flake's
declared closure (the still-unexplained part — see #422 for the
diagnostic), and the probe failed.

Architectural fix: stop running `worker-build` through wrangler's
`[build]` subprocess. Build the worker in our devshell, where `$PATH`
is fully under flake control, and let wrangler just upload the
prebuilt artifact.

  - Drop `[build]` from `wrangler.toml`. The block ran inside a
    process whose `$PATH` was wrangler's, not the devshell's.
  - Add a `worker-build` step in `cf-deploy.yml` before
    `wrangler deploy`, invoked via `nix develop . --command bash -c
    '...'` with `~/.cargo/bin` explicitly on `$PATH` so the freshly
    installed `worker-build` is visible to the second command in the
    same shell.
  - `main = "build/worker/shim.mjs"` stays — wrangler picks up the
    prebuilt artifact untouched. `wrangler deploy --dry-run` still
    exercises the full credential chain + CF API + asset upload prep
    (just not the wasm build, which already ran).

Side benefit beyond the bug fix: the new shape eliminates the
local/CI parity seam that hid this failure. Same nix-develop+
worker-build command runs on darwin and linux, so any future drift
shows up in `just validate` rather than only after pushing. Broader
parity work tracked in #424.

Closes #403
Closes #423