### PR TITLE
feat(blogctl): doctor finding for stale unpushed commits

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -8,6 +8,7 @@ use crate::commands;
 use crate::error::Result;
 use crate::kind::Kind;
 use crate::openrouter;
+use crate::sync::{Jj, RealJj};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -25,6 +26,9 @@ pub enum Command {
     Init {
         #[arg(long, value_name = "PATH")]
         workdir: PathBuf,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
     },
     /// Create a new post in the `concept` stage.
     New {
@@ -43,6 +47,9 @@ pub enum Command {
         /// `defaults.theme`; must be declared in `[themes.*]`.
         #[arg(long)]
         theme: Option<String>,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
     },
     /// List every post in the workdir, grouped by stage.
     List {
@@ -60,12 +67,18 @@ pub enum Command {
         slug: String,
         #[arg(long, value_name = "PATH")]
         workdir: PathBuf,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
     },
     /// Move a post one stage back.
     Demote {
         slug: String,
         #[arg(long, value_name = "PATH")]
         workdir: PathBuf,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
     },
     /// Manage the generated workdir `README.md`.
     Readme {
@@ -87,6 +100,9 @@ pub enum Command {
         /// Print the plan without writing anything.
         #[arg(long)]
         dry_run: bool,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
     },
     /// LLM interaction subcommands.
     Ai {
@@ -120,33 +136,55 @@ pub enum ReadmeAction {
     Regenerate {
         #[arg(long, value_name = "PATH")]
         workdir: PathBuf,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
     },
 }
 
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
-    dispatch(cli.command)
+    let jj = RealJj;
+    dispatch_with_jj(cli.command, &jj)
 }
 
-pub fn dispatch(cmd: Command) -> Result<()> {
+/// Dispatch with a caller-provided `Jj` impl. Tests use this entry
+/// point with a `FakeJj` to assert on the sync call sequence without
+/// shelling out to a real `jj` binary.
+pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
     match cmd {
-        Command::Init { workdir } => commands::init::run(workdir),
+        Command::Init { workdir, no_sync } => commands::init::run(jj, workdir, no_sync),
         Command::New {
             title,
             workdir,
             slug,
             kind,
             theme,
-        } => commands::new::run(title, workdir, slug, kind, theme),
+            no_sync,
+        } => commands::new::run(jj, title, workdir, slug, kind, theme, no_sync),
         Command::List { workdir } => commands::list::run(workdir),
         Command::Show { slug, workdir } => commands::show::run(slug, workdir),
-        Command::Promote { slug, workdir } => commands::promote::run(slug, workdir),
-        Command::Demote { slug, workdir } => commands::demote::run(slug, workdir),
+        Command::Promote {
+            slug,
+            workdir,
+            no_sync,
+        } => commands::promote::run(jj, slug, workdir, no_sync),
+        Command::Demote {
+            slug,
+            workdir,
+            no_sync,
+        } => commands::demote::run(jj, slug, workdir, no_sync),
         Command::Readme { action } => match action {
-            ReadmeAction::Regenerate { workdir } => commands::readme::regenerate(workdir),
+            ReadmeAction::Regenerate { workdir, no_sync } => {
+                commands::readme::regenerate(jj, workdir, no_sync)
+            }
         },
         Command::Doctor { workdir } => commands::doctor::run(workdir),
-        Command::Fix { workdir, dry_run } => commands::fix::run(workdir, dry_run),
+        Command::Fix {
+            workdir,
+            dry_run,
+            no_sync,
+        } => commands::fix::run(jj, workdir, dry_run, no_sync),
         Command::Ai { action } => match action {
             AiAction::Ping { prompt, model } => commands::ai::ping(prompt, model),
         },
@@ -168,6 +206,7 @@ mod tests {
     fn cli_parses_each_subcommand() {
         for args in [
             vec!["blogctl", "init", "--workdir", "/tmp/wd"],
+            vec!["blogctl", "init", "--workdir", "/tmp/wd", "--no-sync"],
             vec!["blogctl", "new", "Hello", "--workdir", "/tmp/wd"],
             vec![
                 "blogctl",
@@ -196,14 +235,47 @@ mod tests {
                 "--theme",
                 "parable",
             ],
+            vec![
+                "blogctl",
+                "new",
+                "Hello",
+                "--workdir",
+                "/tmp/wd",
+                "--no-sync",
+            ],
             vec!["blogctl", "list", "--workdir", "/tmp/wd"],
             vec!["blogctl", "show", "hello", "--workdir", "/tmp/wd"],
             vec!["blogctl", "promote", "hello", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "promote",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--no-sync",
+            ],
             vec!["blogctl", "demote", "hello", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "demote",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--no-sync",
+            ],
             vec!["blogctl", "readme", "regenerate", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "readme",
+                "regenerate",
+                "--workdir",
+                "/tmp/wd",
+                "--no-sync",
+            ],
             vec!["blogctl", "doctor", "--workdir", "/tmp/wd"],
             vec!["blogctl", "fix", "--workdir", "/tmp/wd"],
             vec!["blogctl", "fix", "--workdir", "/tmp/wd", "--dry-run"],
+            vec!["blogctl", "fix", "--workdir", "/tmp/wd", "--no-sync"],
             vec!["blogctl", "ai", "ping", "hello"],
             vec![
                 "blogctl",

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -179,7 +179,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 commands::readme::regenerate(jj, workdir, no_sync)
             }
         },
-        Command::Doctor { workdir } => commands::doctor::run(workdir),
+        Command::Doctor { workdir } => commands::doctor::run(jj, workdir),
         Command::Fix {
             workdir,
             dry_run,

--- a/apps/blogctl/src/commands/demote.rs
+++ b/apps/blogctl/src/commands/demote.rs
@@ -4,12 +4,19 @@ use time::OffsetDateTime;
 
 use crate::error::Result;
 use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 
-pub fn run(slug: String, workdir: PathBuf) -> Result<()> {
+pub fn run(jj: &dyn Jj, slug: String, workdir: PathBuf, no_sync: bool) -> Result<()> {
     let repo = Repository::open(Workdir::new(&workdir))?;
     let (handle, _post) = repo.load(&slug)?;
     let prev = handle.stage.demote()?;
-    let new_handle = repo.relocate(&slug, prev, OffsetDateTime::now_utc())?;
+    let message = format!("post({slug}): {} \u{2190} {prev}", handle.stage);
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+
+    let new_handle = sync::commit_and_push(jj, &workdir, &opts, &message, || {
+        repo.relocate(&slug, prev, OffsetDateTime::now_utc())
+    })?;
     println!(
         "{slug}: {} -> {} ({})",
         handle.stage,

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -12,6 +12,13 @@ use time::OffsetDateTime;
 use crate::error::{Error, Result};
 use crate::stage::Stage;
 use crate::storage::{AuditedPost, Config, ConfigStatus, Repository, StrayEntry, Workdir};
+use crate::sync::{Jj, Status};
+
+/// Threshold for flagging unpushed commits as stale. Past this age,
+/// the auto-push is probably failing silently (network gone bad,
+/// remote ref renamed, auth expired). `doctor` surfaces it; the
+/// user is expected to investigate (no auto-fix).
+pub const STALE_UNPUSHED_THRESHOLD_HOURS: i64 = 24;
 
 #[derive(Debug)]
 pub enum Finding {
@@ -52,6 +59,15 @@ pub enum Finding {
     StrayEntry {
         dir_stage: Stage,
         path: PathBuf,
+    },
+    /// Local commits on `<bookmark>` have not been pushed to
+    /// `<bookmark>@<remote>` for `oldest_age_hours`+, suggesting
+    /// auto-push has been silently failing.
+    UnpushedCommitsStale {
+        count: usize,
+        oldest_age_hours: i64,
+        bookmark: String,
+        remote: String,
     },
 }
 
@@ -108,6 +124,15 @@ impl fmt::Display for Finding {
                 "stray entry in {}/: {}",
                 dir_stage.dirname(),
                 path.display()
+            ),
+            Self::UnpushedCommitsStale {
+                count,
+                oldest_age_hours,
+                bookmark,
+                remote,
+            } => write!(
+                f,
+                "{count} unpushed commit(s) on {bookmark}; oldest is {oldest_age_hours}h old (auto-push to {remote} may be failing silently)",
             ),
         }
     }
@@ -199,8 +224,42 @@ pub fn audit(workdir: &Workdir) -> Result<Vec<Finding>> {
     Ok(findings)
 }
 
-pub fn run(workdir: PathBuf) -> Result<()> {
-    let findings = audit(&Workdir::new(&workdir))?;
+/// Sync-state audit. Separate from `audit()` so the filesystem pass
+/// stays pure and `fix` (which only reads filesystem findings)
+/// continues to know nothing about VCS state. Returns an empty list
+/// when `jj` is unavailable or the workdir isn't a `jj` repo — those
+/// are not "findings" worth blocking on.
+pub fn sync_audit(workdir: &Workdir, jj: &dyn Jj, now: OffsetDateTime) -> Result<Vec<Finding>> {
+    let mut findings = Vec::new();
+    if !matches!(jj.status(workdir.root())?, Status::Ok) {
+        return Ok(findings);
+    }
+    let cfg = match Repository::unchecked(workdir.clone()).audit_config() {
+        ConfigStatus::Ok(cfg) => cfg,
+        // The config layer's own findings (Missing / Unparsable) are
+        // surfaced by `audit()` already; we can't read sync settings
+        // without a config, so nothing more to do here.
+        _ => return Ok(findings),
+    };
+    if let Some(summary) =
+        jj.unpushed_summary(workdir.root(), &cfg.sync.bookmark, &cfg.sync.remote, now)?
+    {
+        if summary.oldest_age_hours >= STALE_UNPUSHED_THRESHOLD_HOURS {
+            findings.push(Finding::UnpushedCommitsStale {
+                count: summary.count,
+                oldest_age_hours: summary.oldest_age_hours,
+                bookmark: cfg.sync.bookmark,
+                remote: cfg.sync.remote,
+            });
+        }
+    }
+    Ok(findings)
+}
+
+pub fn run(jj: &dyn Jj, workdir: PathBuf) -> Result<()> {
+    let wd = Workdir::new(&workdir);
+    let mut findings = audit(&wd)?;
+    findings.extend(sync_audit(&wd, jj, OffsetDateTime::now_utc())?);
     if findings.is_empty() {
         println!("workdir healthy: {}", workdir.display());
         return Ok(());
@@ -443,13 +502,91 @@ mod tests {
     fn run_returns_workdir_unhealthy_on_findings() {
         let (tmp, _workdir) = fresh_workdir();
         fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
-        let err = run(tmp.path().to_path_buf()).unwrap_err();
+        // FakeJj with NotAJjRepo: sync_audit is a no-op, so we only
+        // see the filesystem finding (the stray entry).
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        let err = run(&jj, tmp.path().to_path_buf()).unwrap_err();
         assert!(matches!(err, Error::WorkdirUnhealthy(n) if n >= 1));
     }
 
     #[test]
     fn run_returns_ok_on_clean_workdir() {
         let (tmp, _workdir) = fresh_workdir();
-        run(tmp.path().to_path_buf()).unwrap();
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        run(&jj, tmp.path().to_path_buf()).unwrap();
+    }
+
+    #[test]
+    fn sync_audit_returns_empty_when_jj_not_installed() {
+        let (_tmp, workdir) = fresh_workdir();
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::JjNotInstalled);
+        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn sync_audit_returns_empty_when_not_a_jj_repo() {
+        let (_tmp, workdir) = fresh_workdir();
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn sync_audit_returns_empty_when_no_unpushed_commits() {
+        let (_tmp, workdir) = fresh_workdir();
+        let jj = crate::sync::FakeJj::new().with_unpushed_summary(None);
+        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn sync_audit_returns_empty_when_unpushed_below_threshold() {
+        let (_tmp, workdir) = fresh_workdir();
+        let jj =
+            crate::sync::FakeJj::new().with_unpushed_summary(Some(crate::sync::UnpushedSummary {
+                count: 2,
+                oldest_age_hours: STALE_UNPUSHED_THRESHOLD_HOURS - 1,
+            }));
+        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert!(
+            findings.is_empty(),
+            "below-threshold age must not produce a finding"
+        );
+    }
+
+    #[test]
+    fn sync_audit_surfaces_unpushed_stale_at_threshold() {
+        let (_tmp, workdir) = fresh_workdir();
+        let jj =
+            crate::sync::FakeJj::new().with_unpushed_summary(Some(crate::sync::UnpushedSummary {
+                count: 3,
+                oldest_age_hours: STALE_UNPUSHED_THRESHOLD_HOURS,
+            }));
+        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert!(matches!(
+            findings[0],
+            Finding::UnpushedCommitsStale {
+                count: 3,
+                oldest_age_hours: h,
+                ..
+            } if h == STALE_UNPUSHED_THRESHOLD_HOURS
+        ));
+    }
+
+    #[test]
+    fn unpushed_stale_finding_displays_useful_message() {
+        let f = Finding::UnpushedCommitsStale {
+            count: 4,
+            oldest_age_hours: 72,
+            bookmark: "main".into(),
+            remote: "origin".into(),
+        };
+        let rendered = format!("{f}");
+        assert!(rendered.contains("4 unpushed commit"));
+        assert!(rendered.contains("72h"));
+        assert!(rendered.contains("main"));
+        assert!(rendered.contains("origin"));
     }
 }

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -17,7 +17,8 @@ use crate::commands::doctor::{self, Finding};
 use crate::error::{Error, Result};
 use crate::post::Post;
 use crate::stage::Stage;
-use crate::storage::Workdir;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 
 /// Per-finding plan entry — either we'll attempt a repair or we'll
 /// skip with a reason. The order in `plan()` doubles as the apply
@@ -253,7 +254,7 @@ where
     Ok(())
 }
 
-pub fn run(workdir: PathBuf, dry_run: bool) -> Result<()> {
+pub fn run(jj: &dyn Jj, workdir: PathBuf, dry_run: bool, no_sync: bool) -> Result<()> {
     let wd = Workdir::new(&workdir);
     let findings = doctor::audit(&wd)?;
     if findings.is_empty() {
@@ -262,11 +263,42 @@ pub fn run(workdir: PathBuf, dry_run: bool) -> Result<()> {
     }
 
     let plan = plan(findings);
-    let outcomes = apply(&wd, plan, OffsetDateTime::now_utc(), dry_run);
+    // Count repairs that will actually touch the workdir — skips
+    // never write anything, so a plan of all-Skip needs no sync wrap.
+    let attempted = plan
+        .iter()
+        .filter(|r| !matches!(r, Repair::Skip { .. }))
+        .count();
+
+    if dry_run || attempted == 0 {
+        // Dry-run or skip-only plan: no file changes happen, so no
+        // sync. Print outcomes and return.
+        let outcomes = apply(&wd, plan, OffsetDateTime::now_utc(), dry_run);
+        for outcome in &outcomes {
+            println!("{outcome}");
+        }
+        let remaining = outcomes
+            .iter()
+            .filter(|o| !matches!(o, Outcome::Fixed(_)))
+            .count();
+        return if remaining == 0 {
+            Ok(())
+        } else {
+            Err(Error::WorkdirUnhealthy(remaining))
+        };
+    }
+
+    let repo = Repository::open(wd.clone())?;
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+    let message = format!("chore: fix workdir ({attempted} findings)");
+
+    let outcomes = sync::commit_and_push(jj, &workdir, &opts, &message, || {
+        Ok(apply(&wd, plan, OffsetDateTime::now_utc(), false))
+    })?;
     for outcome in &outcomes {
         println!("{outcome}");
     }
-
     let remaining = outcomes
         .iter()
         .filter(|o| !matches!(o, Outcome::Fixed(_)))
@@ -289,6 +321,7 @@ mod tests {
     use crate::kind::Kind;
     use crate::post::PostMetadata;
     use crate::storage::{Repository, DEFAULT_THEME};
+    use crate::sync::FakeJj;
 
     fn fixture_post(slug: &str, stage: Stage) -> Post {
         Post::new(
@@ -529,7 +562,9 @@ mod tests {
         )
         .unwrap();
 
-        run(tmp.path().to_path_buf(), false).unwrap();
+        // Disable sync via --no-sync (workdir isn't a jj repo).
+        let jj = FakeJj::new();
+        run(&jj, tmp.path().to_path_buf(), false, true).unwrap();
         // doctor should now be clean.
         assert!(doctor::audit(&workdir).unwrap().is_empty());
     }
@@ -539,7 +574,8 @@ mod tests {
         let (tmp, _workdir) = fresh_workdir();
         // A skipped-only finding: stray entry.
         fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
-        let err = run(tmp.path().to_path_buf(), false).unwrap_err();
+        let jj = FakeJj::new();
+        let err = run(&jj, tmp.path().to_path_buf(), false, true).unwrap_err();
         assert!(matches!(err, Error::WorkdirUnhealthy(_)));
     }
 }

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -52,6 +52,7 @@ pub enum SkipReason {
     StrayEntry,
     ConfigMissing,
     ConfigUnparsable,
+    UnpushedCommits,
 }
 
 impl fmt::Display for SkipReason {
@@ -63,6 +64,9 @@ impl fmt::Display for SkipReason {
             Self::StrayEntry => "manual: review the file and remove or relocate it",
             Self::ConfigMissing => "manual: run `blogctl init` or restore .blog-os.toml",
             Self::ConfigUnparsable => "manual: edit .blog-os.toml by hand",
+            Self::UnpushedCommits => {
+                "manual: investigate auto-push (network? auth? wrong bookmark name?)"
+            }
         };
         f.write_str(s)
     }
@@ -115,6 +119,10 @@ pub fn plan(findings: Vec<Finding>) -> Vec<Repair> {
             f @ Finding::ConfigUnparsable { .. } => skips.push(Repair::Skip {
                 finding: f,
                 reason: SkipReason::ConfigUnparsable,
+            }),
+            f @ Finding::UnpushedCommitsStale { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::UnpushedCommits,
             }),
         }
     }

--- a/apps/blogctl/src/commands/init.rs
+++ b/apps/blogctl/src/commands/init.rs
@@ -2,10 +2,17 @@ use std::path::PathBuf;
 
 use crate::error::Result;
 use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 
-pub fn run(workdir: PathBuf) -> Result<()> {
-    let repo = Repository::unchecked(Workdir::new(&workdir));
-    repo.init()?;
+pub fn run(jj: &dyn Jj, workdir: PathBuf, no_sync: bool) -> Result<()> {
+    // `init` creates `.blog-os.toml`, so we have no config to read
+    // SyncConfig from yet. Use the built-in defaults; if the user
+    // wants different sync settings they can edit the file after.
+    let opts = SyncOptions::with_defaults(no_sync);
+    sync::commit_and_push(jj, &workdir, &opts, "chore: scaffold workdir", || {
+        let repo = Repository::unchecked(Workdir::new(&workdir));
+        repo.init()
+    })?;
     println!("initialized blogctl workdir at {}", workdir.display());
     Ok(())
 }

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -7,14 +7,17 @@ use crate::kind::Kind;
 use crate::post::{Post, PostMetadata};
 use crate::stage::Stage;
 use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 use crate::{slug, Error};
 
 pub fn run(
+    jj: &dyn Jj,
     title: String,
     workdir: PathBuf,
     slug_override: Option<String>,
     kind: Kind,
     theme: Option<String>,
+    no_sync: bool,
 ) -> Result<()> {
     if title.trim().is_empty() {
         return Err(Error::EmptyTitle(title));
@@ -35,22 +38,31 @@ pub fn run(
         });
     }
 
-    let now = OffsetDateTime::now_utc();
-    let metadata = PostMetadata {
-        title,
-        slug: resolved_slug.clone(),
-        kind,
-        theme: resolved_theme,
-        status: Stage::Concept,
-        created_at: now,
-        updated_at: now,
-        tags: vec![],
-        todoist_task_id: None,
-        history_checked: false,
-        targets: vec![],
-    };
-    let post = Post::new(metadata, "");
-    let path = repo.create_post(&post)?;
+    let message = format!(
+        "post({}): draft \"{}\"",
+        resolved_slug,
+        title.replace('"', "\\\"")
+    );
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+
+    let path = sync::commit_and_push(jj, &workdir, &opts, &message, || {
+        let now = OffsetDateTime::now_utc();
+        let metadata = PostMetadata {
+            title,
+            slug: resolved_slug.clone(),
+            kind,
+            theme: resolved_theme,
+            status: Stage::Concept,
+            created_at: now,
+            updated_at: now,
+            tags: vec![],
+            todoist_task_id: None,
+            history_checked: false,
+            targets: vec![],
+        };
+        let post = Post::new(metadata, "");
+        repo.create_post(&post)
+    })?;
     println!("created {}", path.display());
     Ok(())
 }

--- a/apps/blogctl/src/commands/promote.rs
+++ b/apps/blogctl/src/commands/promote.rs
@@ -4,12 +4,19 @@ use time::OffsetDateTime;
 
 use crate::error::Result;
 use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 
-pub fn run(slug: String, workdir: PathBuf) -> Result<()> {
+pub fn run(jj: &dyn Jj, slug: String, workdir: PathBuf, no_sync: bool) -> Result<()> {
     let repo = Repository::open(Workdir::new(&workdir))?;
     let (handle, _post) = repo.load(&slug)?;
     let next = handle.stage.promote()?;
-    let new_handle = repo.relocate(&slug, next, OffsetDateTime::now_utc())?;
+    let message = format!("post({slug}): {} \u{2192} {next}", handle.stage);
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+
+    let new_handle = sync::commit_and_push(jj, &workdir, &opts, &message, || {
+        repo.relocate(&slug, next, OffsetDateTime::now_utc())
+    })?;
     println!(
         "{slug}: {} -> {} ({})",
         handle.stage,

--- a/apps/blogctl/src/commands/readme.rs
+++ b/apps/blogctl/src/commands/readme.rs
@@ -2,10 +2,24 @@ use std::path::PathBuf;
 
 use crate::error::Result;
 use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 
-pub fn regenerate(workdir: PathBuf) -> Result<()> {
+pub fn regenerate(jj: &dyn Jj, workdir: PathBuf, no_sync: bool) -> Result<()> {
     let repo = Repository::open(Workdir::new(&workdir))?;
-    repo.write_readme(true)?;
-    println!("regenerated {}", repo.workdir().readme_path().display());
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+    let readme_path = repo.workdir().readme_path();
+
+    sync::commit_and_push(
+        jj,
+        &workdir,
+        &opts,
+        "docs: regenerate workdir README",
+        || {
+            repo.write_readme(true)?;
+            Ok(())
+        },
+    )?;
+    println!("regenerated {}", readme_path.display());
     Ok(())
 }

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -126,6 +126,20 @@ pub enum Error {
 
     #[error("OpenRouter response contained no choices")]
     OpenrouterEmptyResponse,
+
+    #[error("could not invoke `{command}`: {source}")]
+    JjInvoke {
+        command: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("`{command}` failed (exit {status}): {stderr}")]
+    JjCommandFailed {
+        command: String,
+        status: i32,
+        stderr: String,
+    },
 }
 
 impl Error {

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -140,6 +140,11 @@ pub enum Error {
         status: i32,
         stderr: String,
     },
+
+    #[error(
+        "rebase of @ onto {bookmark}@{remote} produced conflicts — resolve via `jj` before re-running blogctl"
+    )]
+    SyncRebaseConflict { bookmark: String, remote: String },
 }
 
 impl Error {

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -7,6 +7,7 @@ pub mod post;
 pub mod slug;
 pub mod stage;
 pub mod storage;
+pub mod sync;
 pub mod target;
 
 pub use error::{Error, Result};

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -35,6 +35,8 @@ pub struct Config {
     pub defaults: Defaults,
     #[serde(default)]
     pub themes: BTreeMap<String, ThemeConfig>,
+    #[serde(default)]
+    pub sync: SyncConfig,
 }
 
 /// Workdir-wide defaults. Currently just the theme `blogctl new` selects
@@ -66,6 +68,44 @@ pub struct ThemeConfig {
     pub prompts: BTreeMap<String, String>,
 }
 
+/// VCS auto-sync settings. Controls whether write-shaped blogctl
+/// commands commit-and-push through `jj` after the file write.
+///
+/// Defaults: `enabled = true`, `remote = "origin"`, `bookmark = "main"`.
+/// `enabled = false` is the global kill switch for ephemeral workdirs
+/// or CI test runs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SyncConfig {
+    #[serde(default = "default_sync_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_sync_remote")]
+    pub remote: String,
+    #[serde(default = "default_sync_bookmark")]
+    pub bookmark: String,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_sync_enabled(),
+            remote: default_sync_remote(),
+            bookmark: default_sync_bookmark(),
+        }
+    }
+}
+
+fn default_sync_enabled() -> bool {
+    true
+}
+
+fn default_sync_remote() -> String {
+    "origin".to_string()
+}
+
+fn default_sync_bookmark() -> String {
+    "main".to_string()
+}
+
 impl Config {
     pub const CURRENT_VERSION: u32 = 1;
 
@@ -78,6 +118,7 @@ impl Config {
             version: Self::CURRENT_VERSION,
             defaults: Defaults::default(),
             themes,
+            sync: SyncConfig::default(),
         }
     }
 }
@@ -570,6 +611,71 @@ mod tests {
         let cfg = repo.read_config().unwrap();
         assert_eq!(cfg.defaults.theme, DEFAULT_THEME);
         assert!(cfg.themes.is_empty());
+    }
+
+    #[test]
+    fn init_seeds_sync_defaults() {
+        let (_tmp, repo) = fresh_repo();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.sync.enabled);
+        assert_eq!(cfg.sync.remote, "origin");
+        assert_eq!(cfg.sync.bookmark, "main");
+    }
+
+    #[test]
+    fn config_without_sync_table_back_fills_defaults() {
+        // Pre-`[sync]` workdir: config has no sync table at all.
+        // Parse must succeed and yield the default SyncConfig so older
+        // workdirs keep working transparently.
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        fs::write(repo.workdir().config_path(), "version = 1\n").unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(cfg.sync, SyncConfig::default());
+    }
+
+    #[test]
+    fn config_with_partial_sync_table_back_fills_per_field_defaults() {
+        // User sets `enabled = false` but leaves remote/bookmark out.
+        // Each missing field should fall back to its own default.
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        fs::write(
+            repo.workdir().config_path(),
+            "version = 1\n[sync]\nenabled = false\n",
+        )
+        .unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert!(!cfg.sync.enabled);
+        assert_eq!(cfg.sync.remote, "origin");
+        assert_eq!(cfg.sync.bookmark, "main");
+    }
+
+    #[test]
+    fn config_with_custom_sync_values_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let raw = concat!(
+            "version = 1\n",
+            "[sync]\n",
+            "enabled = true\n",
+            "remote = \"upstream\"\n",
+            "bookmark = \"trunk\"\n",
+        );
+        fs::write(repo.workdir().config_path(), raw).unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.sync.enabled);
+        assert_eq!(cfg.sync.remote, "upstream");
+        assert_eq!(cfg.sync.bookmark, "trunk");
     }
 
     #[test]

--- a/apps/blogctl/src/sync.rs
+++ b/apps/blogctl/src/sync.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Mutex;
 
+use time::OffsetDateTime;
+
 use crate::error::{Error, Result};
 use crate::storage::SyncConfig;
 
@@ -45,6 +47,17 @@ pub enum RebaseOutcome {
     /// Rebase completed but produced conflict markers — the user must
     /// resolve via `jj` before blogctl can proceed.
     Conflicted,
+}
+
+/// Summary of commits on `<bookmark>` that are not yet on
+/// `<bookmark>@<remote>`. Surfaced by `doctor` to catch the case
+/// where auto-push has been silently failing for a while.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnpushedSummary {
+    /// How many commits are on the local bookmark but not the remote.
+    pub count: usize,
+    /// Hours since the oldest of those commits was authored.
+    pub oldest_age_hours: i64,
 }
 
 /// The `jj` operations blogctl needs. Behind a trait so tests can swap
@@ -96,6 +109,19 @@ pub trait Jj: Send + Sync {
     /// creation on the remote (`--allow-new`). Push is best-effort —
     /// see `PushOutcome`.
     fn push(&self, workdir: &Path, remote: &str, bookmark: &str) -> Result<PushOutcome>;
+
+    /// Summarize commits on `<bookmark>` that are not yet on
+    /// `<bookmark>@<remote>`. Returns `None` when there are no
+    /// unpushed commits or when the remote ref doesn't exist (a
+    /// brand-new bookmark before its first successful push). `now`
+    /// is injected so tests are deterministic.
+    fn unpushed_summary(
+        &self,
+        workdir: &Path,
+        bookmark: &str,
+        remote: &str,
+        now: OffsetDateTime,
+    ) -> Result<Option<UnpushedSummary>>;
 }
 
 /// Real `jj` binary. Each method shells out via `std::process::Command`;
@@ -259,6 +285,50 @@ impl Jj for RealJj {
                 stderr
             }))
         }
+    }
+
+    fn unpushed_summary(
+        &self,
+        workdir: &Path,
+        bookmark: &str,
+        remote: &str,
+        now: OffsetDateTime,
+    ) -> Result<Option<UnpushedSummary>> {
+        // Revset: commits reachable from <bookmark> but not from
+        // <bookmark>@<remote>. Template prints unix epoch seconds for
+        // each commit's author timestamp, one per line.
+        let revset = format!("{bookmark}@{remote}..{bookmark}");
+        let template = "author.timestamp().format(\"%s\") ++ \"\\n\"";
+        let out = Command::new(JJ)
+            .args(["log", "-r", revset.as_str(), "--no-graph", "-T", template])
+            .current_dir(workdir)
+            .output()
+            .map_err(|source| Error::JjInvoke {
+                command: format!("{JJ} log -r {revset} -T <author-ts>"),
+                source,
+            })?;
+        if !out.status.success() {
+            // Usually means <bookmark>@<remote> doesn't exist yet
+            // (first push pending). Treat as "no unpushed-from-remote
+            // info"; doctor's other findings will still surface real
+            // problems.
+            return Ok(None);
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let mut timestamps: Vec<i64> = stdout
+            .lines()
+            .filter_map(|s| s.trim().parse::<i64>().ok())
+            .collect();
+        if timestamps.is_empty() {
+            return Ok(None);
+        }
+        timestamps.sort_unstable();
+        let oldest = OffsetDateTime::from_unix_timestamp(timestamps[0]).unwrap_or(now);
+        let age = now - oldest;
+        Ok(Some(UnpushedSummary {
+            count: timestamps.len(),
+            oldest_age_hours: age.whole_hours(),
+        }))
     }
 }
 
@@ -427,6 +497,7 @@ struct FakeState {
     status: Option<Status>,
     rebase_outcome: Option<RebaseOutcome>,
     push_outcome: Option<PushOutcome>,
+    unpushed_summary: Option<Option<UnpushedSummary>>,
 }
 
 /// One recorded call against `FakeJj`. Tests pop these and assert.
@@ -457,6 +528,11 @@ pub enum Call {
         remote: String,
         bookmark: String,
     },
+    UnpushedSummary {
+        workdir: PathBuf,
+        bookmark: String,
+        remote: String,
+    },
 }
 
 impl FakeJj {
@@ -482,6 +558,14 @@ impl FakeJj {
     /// `PushOutcome::Pushed` when unset.
     pub fn with_push_outcome(self, o: PushOutcome) -> Self {
         self.inner.lock().unwrap().push_outcome = Some(o);
+        self
+    }
+
+    /// Force `unpushed_summary()` to return `s`. Default is
+    /// `Ok(None)` (no unpushed commits) when unset. Pass
+    /// `Some(Some(summary))` for a positive result.
+    pub fn with_unpushed_summary(self, s: Option<UnpushedSummary>) -> Self {
+        self.inner.lock().unwrap().unpushed_summary = Some(s);
         self
     }
 
@@ -547,6 +631,22 @@ impl Jj for FakeJj {
             bookmark: bookmark.to_string(),
         });
         Ok(s.push_outcome.clone().unwrap_or(PushOutcome::Pushed))
+    }
+
+    fn unpushed_summary(
+        &self,
+        workdir: &Path,
+        bookmark: &str,
+        remote: &str,
+        _now: OffsetDateTime,
+    ) -> Result<Option<UnpushedSummary>> {
+        let mut s = self.inner.lock().unwrap();
+        s.calls.push(Call::UnpushedSummary {
+            workdir: workdir.to_path_buf(),
+            bookmark: bookmark.to_string(),
+            remote: remote.to_string(),
+        });
+        Ok(s.unpushed_summary.clone().unwrap_or(None))
     }
 }
 

--- a/apps/blogctl/src/sync.rs
+++ b/apps/blogctl/src/sync.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 use std::sync::Mutex;
 
 use crate::error::{Error, Result};
+use crate::storage::SyncConfig;
 
 const JJ: &str = "jj";
 
@@ -259,6 +260,133 @@ impl Jj for RealJj {
             }))
         }
     }
+}
+
+/// Per-invocation sync state: a `SyncConfig` (from `.blog-os.toml`)
+/// plus the per-command `--no-sync` flag. Built once at the entry of
+/// each write-shaped command and passed to `commit_and_push`.
+#[derive(Debug, Clone)]
+pub struct SyncOptions {
+    pub config: SyncConfig,
+    pub no_sync_flag: bool,
+}
+
+impl SyncOptions {
+    pub fn from_config(config: &SyncConfig, no_sync_flag: bool) -> Self {
+        Self {
+            config: config.clone(),
+            no_sync_flag,
+        }
+    }
+
+    /// Use built-in defaults — for `init`, which runs before
+    /// `.blog-os.toml` exists.
+    pub fn with_defaults(no_sync_flag: bool) -> Self {
+        Self {
+            config: SyncConfig::default(),
+            no_sync_flag,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.config.enabled && !self.no_sync_flag
+    }
+}
+
+/// Orchestrate one write-shaped blogctl command's commit-and-push:
+///
+/// 1. `status` — if `jj` is missing or workdir isn't a repo, warn to
+///    stderr, then just run `write` and return.
+/// 2. `fetch` — pull the latest `<remote>`. Fetch failure (offline,
+///    no remote configured) warns and skips the rebase, then proceeds
+///    with `new_change` / write / push as usual; push may also fail,
+///    that's fine.
+/// 3. `rebase_onto_remote` — rebase `@` onto `<bookmark>@<remote>`.
+///    Conflicts are a hard error: the user must resolve before
+///    blogctl can continue, otherwise we'd push a conflicted commit.
+/// 4. `new_change(message)` — empty change with the deterministic
+///    template-built message.
+/// 5. `write` — runs the caller's write closure inside the new
+///    change. `jj` auto-snapshots the resulting working-copy state.
+/// 6. `set_bookmark_to_head` — advance the bookmark to `@`.
+/// 7. `push` — best-effort. `Failed` warns to stderr; the command
+///    still exits 0 because the commit is safely local.
+///
+/// If `opts.is_active()` is false (`enabled = false` or `--no-sync`),
+/// the entire jj orchestration is skipped — `write` runs and returns
+/// whatever it produced.
+pub fn commit_and_push<F, T>(
+    jj: &dyn Jj,
+    workdir: &Path,
+    opts: &SyncOptions,
+    message: &str,
+    write: F,
+) -> Result<T>
+where
+    F: FnOnce() -> Result<T>,
+{
+    if !opts.is_active() {
+        return write();
+    }
+
+    match jj.status(workdir)? {
+        Status::Ok => {}
+        Status::JjNotInstalled => {
+            eprintln!("warning: `jj` not on PATH; skipping VCS sync (file write only)");
+            return write();
+        }
+        Status::NotAJjRepo => {
+            eprintln!(
+                "warning: {} is not a `jj` repo; skipping VCS sync (file write only)",
+                workdir.display(),
+            );
+            eprintln!("hint: run `jj git init --colocate` in this workdir to enable sync");
+            return write();
+        }
+    }
+
+    let fetch_ok = match jj.fetch(workdir, &opts.config.remote) {
+        Ok(()) => true,
+        Err(e) => {
+            // Offline, unconfigured remote, or transient network failure.
+            // Skip the rebase and continue — push may also fail, but
+            // the working copy will still be committed locally.
+            eprintln!(
+                "warning: fetch from {} failed: {e}; skipping rebase",
+                opts.config.remote
+            );
+            false
+        }
+    };
+
+    if fetch_ok {
+        match jj.rebase_onto_remote(workdir, &opts.config.bookmark, &opts.config.remote)? {
+            RebaseOutcome::Clean => {}
+            RebaseOutcome::Conflicted => {
+                return Err(Error::SyncRebaseConflict {
+                    bookmark: opts.config.bookmark.clone(),
+                    remote: opts.config.remote.clone(),
+                });
+            }
+        }
+    }
+
+    jj.new_change(workdir, message)?;
+    let result = write()?;
+    jj.set_bookmark_to_head(workdir, &opts.config.bookmark)?;
+
+    match jj.push(workdir, &opts.config.remote, &opts.config.bookmark)? {
+        PushOutcome::Pushed | PushOutcome::NothingToPush => {}
+        PushOutcome::Failed(reason) => {
+            eprintln!(
+                "warning: push to {}/{} failed: {reason}",
+                opts.config.remote, opts.config.bookmark,
+            );
+            eprintln!("hint: commit is local; retry with `jj git push` when ready");
+        }
+    }
+
+    Ok(result)
 }
 
 /// Shell `jj <args>` in `workdir`, treating any non-zero exit as a
@@ -532,5 +660,113 @@ mod tests {
             jj.rebase_onto_remote(&wd(), "main", "origin").unwrap(),
             RebaseOutcome::Conflicted
         );
+    }
+
+    fn active_opts() -> SyncOptions {
+        SyncOptions::with_defaults(false)
+    }
+
+    #[test]
+    fn commit_and_push_runs_full_flow_in_order() {
+        let jj = FakeJj::new();
+        let executed = std::cell::Cell::new(false);
+        commit_and_push(&jj, &wd(), &active_opts(), "msg", || {
+            executed.set(true);
+            Ok::<(), Error>(())
+        })
+        .unwrap();
+        assert!(executed.get());
+        let calls = jj.calls();
+        assert_eq!(calls.len(), 6, "got: {calls:?}");
+        assert!(matches!(calls[0], Call::Status { .. }));
+        assert!(matches!(calls[1], Call::Fetch { .. }));
+        assert!(matches!(calls[2], Call::Rebase { .. }));
+        assert!(matches!(
+            calls[3],
+            Call::NewChange { ref message, .. } if message == "msg"
+        ));
+        assert!(matches!(calls[4], Call::SetBookmark { .. }));
+        assert!(matches!(calls[5], Call::Push { .. }));
+    }
+
+    #[test]
+    fn commit_and_push_skips_jj_when_disabled() {
+        let jj = FakeJj::new();
+        let mut opts = active_opts();
+        opts.config.enabled = false;
+        let executed = std::cell::Cell::new(false);
+        commit_and_push(&jj, &wd(), &opts, "msg", || {
+            executed.set(true);
+            Ok::<(), Error>(())
+        })
+        .unwrap();
+        assert!(executed.get(), "write must run even when sync is disabled");
+        assert!(jj.calls().is_empty(), "no jj calls when sync is disabled");
+    }
+
+    #[test]
+    fn commit_and_push_skips_jj_when_no_sync_flag_set() {
+        let jj = FakeJj::new();
+        let opts = SyncOptions::with_defaults(true);
+        commit_and_push(&jj, &wd(), &opts, "msg", || Ok::<(), Error>(())).unwrap();
+        assert!(jj.calls().is_empty());
+    }
+
+    #[test]
+    fn commit_and_push_skips_jj_calls_when_jj_not_installed() {
+        let jj = FakeJj::new().with_status(Status::JjNotInstalled);
+        let executed = std::cell::Cell::new(false);
+        commit_and_push(&jj, &wd(), &active_opts(), "msg", || {
+            executed.set(true);
+            Ok::<(), Error>(())
+        })
+        .unwrap();
+        assert!(executed.get(), "write still runs even without jj");
+        // Only the initial status check should have fired.
+        assert_eq!(jj.calls().len(), 1);
+        assert!(matches!(jj.calls()[0], Call::Status { .. }));
+    }
+
+    #[test]
+    fn commit_and_push_skips_jj_calls_when_not_a_jj_repo() {
+        let jj = FakeJj::new().with_status(Status::NotAJjRepo);
+        commit_and_push(&jj, &wd(), &active_opts(), "msg", || Ok::<(), Error>(())).unwrap();
+        assert_eq!(jj.calls().len(), 1);
+    }
+
+    #[test]
+    fn commit_and_push_hard_fails_on_rebase_conflict() {
+        let jj = FakeJj::new().with_rebase_outcome(RebaseOutcome::Conflicted);
+        let executed = std::cell::Cell::new(false);
+        let err = commit_and_push(&jj, &wd(), &active_opts(), "msg", || {
+            executed.set(true);
+            Ok::<(), Error>(())
+        })
+        .unwrap_err();
+        assert!(matches!(err, Error::SyncRebaseConflict { .. }));
+        assert!(
+            !executed.get(),
+            "write must NOT run when rebase produced conflicts"
+        );
+        let calls = jj.calls();
+        // Status, Fetch, Rebase — then bail.
+        assert_eq!(calls.len(), 3);
+        assert!(!calls
+            .iter()
+            .any(|c| matches!(c, Call::NewChange { .. } | Call::Push { .. })));
+    }
+
+    #[test]
+    fn commit_and_push_succeeds_when_push_fails_best_effort() {
+        let jj = FakeJj::new().with_push_outcome(PushOutcome::Failed("non-FF".into()));
+        let executed = std::cell::Cell::new(false);
+        let result = commit_and_push(&jj, &wd(), &active_opts(), "msg", || {
+            executed.set(true);
+            Ok::<(), Error>(())
+        });
+        assert!(result.is_ok(), "push failure must NOT fail the command");
+        assert!(executed.get(), "write must still have run");
+        // Full call sequence happened, including push.
+        assert_eq!(jj.calls().len(), 6);
     }
 }

--- a/apps/blogctl/src/sync.rs
+++ b/apps/blogctl/src/sync.rs
@@ -1,0 +1,536 @@
+//! Version-control sync: drives `jj` so every blogctl write turns into
+//! a commit and a best-effort push. The `Jj` trait is the only thing
+//! the rest of the crate sees; tests inject a `FakeJj` that records
+//! calls without shelling out.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+
+use crate::error::{Error, Result};
+
+const JJ: &str = "jj";
+
+/// Workdir-level VCS availability. Read by the per-command sync hook
+/// to decide whether to skip silently (`JjNotInstalled`, `NotAJjRepo`)
+/// or proceed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    Ok,
+    JjNotInstalled,
+    NotAJjRepo,
+}
+
+/// Outcome of a `jj git push`. Push is best-effort — a network or
+/// non-fast-forward failure becomes `Failed(reason)`, never an `Err`.
+/// Errors are reserved for cases where we couldn't even attempt the
+/// push (process-spawn failure with a non-`NotFound` kind).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushOutcome {
+    Pushed,
+    NothingToPush,
+    Failed(String),
+}
+
+/// Outcome of `rebase_onto_remote`. Conflicts are first-class in `jj`
+/// (the rebase itself succeeds; `@` ends up with conflict markers).
+/// We surface the conflict explicitly so the sync hook can hard-fail
+/// with a clear message rather than silently push a conflicted commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebaseOutcome {
+    /// `@` was already a descendant of `<bookmark>@<remote>`, or the
+    /// rebase landed cleanly.
+    Clean,
+    /// Rebase completed but produced conflict markers — the user must
+    /// resolve via `jj` before blogctl can proceed.
+    Conflicted,
+}
+
+/// The `jj` operations blogctl needs. Behind a trait so tests can swap
+/// in `FakeJj`; the rest of the crate stays oblivious.
+///
+/// The full per-command flow:
+///
+/// 1. `status` — bail if `jj` isn't installed or the workdir isn't a
+///    repo (skip-with-warn at the call site).
+/// 2. `fetch` — pull `<remote>` so we know the latest `<bookmark>@<remote>`.
+/// 3. `rebase_onto_remote` — rebase `@` (and any prior-but-unpushed
+///    ancestors) onto `<bookmark>@<remote>`. Conflicts hard-fail.
+/// 4. `new_change` — create a new empty change on top of `@` with the
+///    deterministic message. The pending file write lands inside it.
+/// 5. *(command body writes files)*
+/// 6. `set_bookmark_to_head` — advance the bookmark to `@`.
+/// 7. `push` — best-effort; failure warns but doesn't fail the command.
+pub trait Jj: Send + Sync {
+    /// Report whether `jj` is installed and the workdir is a `jj`
+    /// repo. Used by sync hooks to decide whether to proceed.
+    fn status(&self, workdir: &Path) -> Result<Status>;
+
+    /// Fetch `remote`. Pulls remote-tracking refs (including
+    /// `<bookmark>@<remote>`) but does not modify local bookmarks.
+    fn fetch(&self, workdir: &Path, remote: &str) -> Result<()>;
+
+    /// Rebase `@` (and any of its ancestors back to `<bookmark>`) onto
+    /// `<bookmark>@<remote>`. No-op if `@` is already a descendant of
+    /// the remote tip. Returns whether the rebase produced conflicts;
+    /// callers hard-fail on `Conflicted` rather than continue.
+    fn rebase_onto_remote(
+        &self,
+        workdir: &Path,
+        bookmark: &str,
+        remote: &str,
+    ) -> Result<RebaseOutcome>;
+
+    /// Snapshot any pending working-copy changes into the current `@`
+    /// (auto-snapshot), then create a new empty change on top with
+    /// `message` as its description. After this returns, `@` is empty
+    /// and a subsequent file write lands inside it.
+    fn new_change(&self, workdir: &Path, message: &str) -> Result<()>;
+
+    /// Move (or create) `bookmark` to point at `@`. Refuses non-FF
+    /// moves — blogctl's flow always advances forward.
+    fn set_bookmark_to_head(&self, workdir: &Path, bookmark: &str) -> Result<()>;
+
+    /// Push `bookmark` to `remote`, allowing first-time bookmark
+    /// creation on the remote (`--allow-new`). Push is best-effort —
+    /// see `PushOutcome`.
+    fn push(&self, workdir: &Path, remote: &str, bookmark: &str) -> Result<PushOutcome>;
+}
+
+/// Real `jj` binary. Each method shells out via `std::process::Command`;
+/// no caching, no batching.
+#[derive(Debug, Default)]
+pub struct RealJj;
+
+impl Jj for RealJj {
+    fn status(&self, workdir: &Path) -> Result<Status> {
+        let out = match Command::new(JJ)
+            .arg("status")
+            .arg("--no-pager")
+            .current_dir(workdir)
+            .output()
+        {
+            Ok(o) => o,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(Status::JjNotInstalled);
+            }
+            Err(e) => {
+                return Err(Error::JjInvoke {
+                    command: format!("{JJ} status"),
+                    source: e,
+                });
+            }
+        };
+        if out.status.success() {
+            return Ok(Status::Ok);
+        }
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if stderr.contains("There is no jj repo") || stderr.contains("no jj repo") {
+            return Ok(Status::NotAJjRepo);
+        }
+        Err(Error::JjCommandFailed {
+            command: format!("{JJ} status"),
+            status: out.status.code().unwrap_or(-1),
+            stderr: stderr.into_owned(),
+        })
+    }
+
+    fn fetch(&self, workdir: &Path, remote: &str) -> Result<()> {
+        run_strict(workdir, &["git", "fetch", "--remote", remote])?;
+        Ok(())
+    }
+
+    fn rebase_onto_remote(
+        &self,
+        workdir: &Path,
+        bookmark: &str,
+        remote: &str,
+    ) -> Result<RebaseOutcome> {
+        // Rebase the chain `<bookmark>..@` onto `<bookmark>@<remote>`.
+        // If `@` is already a descendant of the remote tip, jj
+        // reports "Nothing changed" and exits 0 — that's the Clean
+        // no-op path.
+        let dest = format!("{bookmark}@{remote}");
+        let revset = format!("{bookmark}..@");
+        let command_str = format!("{JJ} rebase -s {revset} -d {dest}");
+        let out = Command::new(JJ)
+            .args(["rebase", "-s", revset.as_str(), "-d", dest.as_str()])
+            .current_dir(workdir)
+            .output()
+            .map_err(|io_err| Error::JjInvoke {
+                command: command_str.clone(),
+                source: io_err,
+            })?;
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            // Empty range or already-up-to-date: jj exits non-zero on
+            // some versions; treat the known "no work" phrases as Clean
+            // so this method is a true no-op when nothing needs moving.
+            if stderr.contains("Nothing changed") || stderr.contains("No revisions to rebase") {
+                return Ok(RebaseOutcome::Clean);
+            }
+            return Err(Error::JjCommandFailed {
+                command: command_str,
+                status: out.status.code().unwrap_or(-1),
+                stderr: stderr.into_owned(),
+            });
+        }
+        // Rebase succeeded — check whether `@` came out conflicted.
+        let conflict = Command::new(JJ)
+            .args([
+                "log",
+                "--no-graph",
+                "-r",
+                "@",
+                "-T",
+                "if(conflict, \"yes\", \"no\")",
+            ])
+            .current_dir(workdir)
+            .output()
+            .map_err(|source| Error::JjInvoke {
+                command: format!("{JJ} log -r @ -T conflict"),
+                source,
+            })?;
+        if !conflict.status.success() {
+            return Err(Error::JjCommandFailed {
+                command: format!("{JJ} log -r @ -T conflict"),
+                status: conflict.status.code().unwrap_or(-1),
+                stderr: String::from_utf8_lossy(&conflict.stderr).into_owned(),
+            });
+        }
+        if String::from_utf8_lossy(&conflict.stdout).trim() == "yes" {
+            Ok(RebaseOutcome::Conflicted)
+        } else {
+            Ok(RebaseOutcome::Clean)
+        }
+    }
+
+    fn new_change(&self, workdir: &Path, message: &str) -> Result<()> {
+        run_strict(workdir, &["new", "--no-edit=false", "-m", message])?;
+        Ok(())
+    }
+
+    fn set_bookmark_to_head(&self, workdir: &Path, bookmark: &str) -> Result<()> {
+        // `bookmark set` creates the bookmark if absent and moves it
+        // forward if present. Non-FF moves error without
+        // `--allow-backwards`, which is the safety we want.
+        run_strict(workdir, &["bookmark", "set", bookmark, "-r", "@"])?;
+        Ok(())
+    }
+
+    fn push(&self, workdir: &Path, remote: &str, bookmark: &str) -> Result<PushOutcome> {
+        let args = [
+            "git",
+            "push",
+            "--remote",
+            remote,
+            "--bookmark",
+            bookmark,
+            "--allow-new",
+        ];
+        let out = match Command::new(JJ).args(args).current_dir(workdir).output() {
+            Ok(o) => o,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Lost the binary between `status` and now — unusual,
+                // but report as a failure rather than panic.
+                return Ok(PushOutcome::Failed("jj not found".into()));
+            }
+            Err(e) => {
+                return Err(Error::JjInvoke {
+                    command: format!("{JJ} {}", args.join(" ")),
+                    source: e,
+                });
+            }
+        };
+        if out.status.success() {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stdout.contains("Nothing changed") || stderr.contains("Nothing changed") {
+                Ok(PushOutcome::NothingToPush)
+            } else {
+                Ok(PushOutcome::Pushed)
+            }
+        } else {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            Ok(PushOutcome::Failed(if stderr.is_empty() {
+                format!("jj git push exited with status {}", out.status)
+            } else {
+                stderr
+            }))
+        }
+    }
+}
+
+/// Shell `jj <args>` in `workdir`, treating any non-zero exit as a
+/// hard error. Used by methods where we've already confirmed the
+/// workdir is a `jj` repo (so a failure here is a real problem).
+fn run_strict(workdir: &Path, args: &[&str]) -> Result<()> {
+    let out = Command::new(JJ)
+        .args(args)
+        .current_dir(workdir)
+        .output()
+        .map_err(|source| Error::JjInvoke {
+            command: format!("{JJ} {}", args.join(" ")),
+            source,
+        })?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(Error::JjCommandFailed {
+            command: format!("{JJ} {}", args.join(" ")),
+            status: out.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        })
+    }
+}
+
+/// Test double for `Jj`. Records every call as a `Call` so assertions
+/// can pin down both the order and the arguments. Outcomes are
+/// configurable so push-failure and not-installed paths get covered
+/// without real `jj` involvement.
+#[derive(Debug, Default)]
+pub struct FakeJj {
+    inner: Mutex<FakeState>,
+}
+
+#[derive(Debug, Default)]
+struct FakeState {
+    calls: Vec<Call>,
+    status: Option<Status>,
+    rebase_outcome: Option<RebaseOutcome>,
+    push_outcome: Option<PushOutcome>,
+}
+
+/// One recorded call against `FakeJj`. Tests pop these and assert.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Call {
+    Status {
+        workdir: PathBuf,
+    },
+    Fetch {
+        workdir: PathBuf,
+        remote: String,
+    },
+    Rebase {
+        workdir: PathBuf,
+        bookmark: String,
+        remote: String,
+    },
+    NewChange {
+        workdir: PathBuf,
+        message: String,
+    },
+    SetBookmark {
+        workdir: PathBuf,
+        bookmark: String,
+    },
+    Push {
+        workdir: PathBuf,
+        remote: String,
+        bookmark: String,
+    },
+}
+
+impl FakeJj {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Force the next `status()` call to return `s`. Defaults to
+    /// `Status::Ok` when unset.
+    pub fn with_status(self, s: Status) -> Self {
+        self.inner.lock().unwrap().status = Some(s);
+        self
+    }
+
+    /// Force `rebase_onto_remote()` to return `o`. Defaults to
+    /// `RebaseOutcome::Clean` when unset.
+    pub fn with_rebase_outcome(self, o: RebaseOutcome) -> Self {
+        self.inner.lock().unwrap().rebase_outcome = Some(o);
+        self
+    }
+
+    /// Force the next `push()` call to return `o`. Defaults to
+    /// `PushOutcome::Pushed` when unset.
+    pub fn with_push_outcome(self, o: PushOutcome) -> Self {
+        self.inner.lock().unwrap().push_outcome = Some(o);
+        self
+    }
+
+    /// Snapshot of recorded calls in order.
+    pub fn calls(&self) -> Vec<Call> {
+        self.inner.lock().unwrap().calls.clone()
+    }
+}
+
+impl Jj for FakeJj {
+    fn status(&self, workdir: &Path) -> Result<Status> {
+        let mut s = self.inner.lock().unwrap();
+        s.calls.push(Call::Status {
+            workdir: workdir.to_path_buf(),
+        });
+        Ok(s.status.clone().unwrap_or(Status::Ok))
+    }
+
+    fn fetch(&self, workdir: &Path, remote: &str) -> Result<()> {
+        self.inner.lock().unwrap().calls.push(Call::Fetch {
+            workdir: workdir.to_path_buf(),
+            remote: remote.to_string(),
+        });
+        Ok(())
+    }
+
+    fn rebase_onto_remote(
+        &self,
+        workdir: &Path,
+        bookmark: &str,
+        remote: &str,
+    ) -> Result<RebaseOutcome> {
+        let mut s = self.inner.lock().unwrap();
+        s.calls.push(Call::Rebase {
+            workdir: workdir.to_path_buf(),
+            bookmark: bookmark.to_string(),
+            remote: remote.to_string(),
+        });
+        Ok(s.rebase_outcome.clone().unwrap_or(RebaseOutcome::Clean))
+    }
+
+    fn new_change(&self, workdir: &Path, message: &str) -> Result<()> {
+        self.inner.lock().unwrap().calls.push(Call::NewChange {
+            workdir: workdir.to_path_buf(),
+            message: message.to_string(),
+        });
+        Ok(())
+    }
+
+    fn set_bookmark_to_head(&self, workdir: &Path, bookmark: &str) -> Result<()> {
+        self.inner.lock().unwrap().calls.push(Call::SetBookmark {
+            workdir: workdir.to_path_buf(),
+            bookmark: bookmark.to_string(),
+        });
+        Ok(())
+    }
+
+    fn push(&self, workdir: &Path, remote: &str, bookmark: &str) -> Result<PushOutcome> {
+        let mut s = self.inner.lock().unwrap();
+        s.calls.push(Call::Push {
+            workdir: workdir.to_path_buf(),
+            remote: remote.to_string(),
+            bookmark: bookmark.to_string(),
+        });
+        Ok(s.push_outcome.clone().unwrap_or(PushOutcome::Pushed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn wd() -> PathBuf {
+        PathBuf::from("/tmp/blogctl-fake")
+    }
+
+    #[test]
+    fn fake_records_full_flow_in_order() {
+        let jj = FakeJj::new();
+        jj.status(&wd()).unwrap();
+        jj.fetch(&wd(), "origin").unwrap();
+        jj.rebase_onto_remote(&wd(), "main", "origin").unwrap();
+        jj.new_change(&wd(), "post(x): draft \"x\"").unwrap();
+        jj.set_bookmark_to_head(&wd(), "main").unwrap();
+        jj.push(&wd(), "origin", "main").unwrap();
+        assert_eq!(
+            jj.calls(),
+            vec![
+                Call::Status { workdir: wd() },
+                Call::Fetch {
+                    workdir: wd(),
+                    remote: "origin".into(),
+                },
+                Call::Rebase {
+                    workdir: wd(),
+                    bookmark: "main".into(),
+                    remote: "origin".into(),
+                },
+                Call::NewChange {
+                    workdir: wd(),
+                    message: "post(x): draft \"x\"".into(),
+                },
+                Call::SetBookmark {
+                    workdir: wd(),
+                    bookmark: "main".into(),
+                },
+                Call::Push {
+                    workdir: wd(),
+                    remote: "origin".into(),
+                    bookmark: "main".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn fake_status_defaults_to_ok() {
+        let jj = FakeJj::new();
+        assert_eq!(jj.status(&wd()).unwrap(), Status::Ok);
+    }
+
+    #[test]
+    fn fake_status_can_be_overridden() {
+        let jj = FakeJj::new().with_status(Status::JjNotInstalled);
+        assert_eq!(jj.status(&wd()).unwrap(), Status::JjNotInstalled);
+    }
+
+    #[test]
+    fn fake_push_defaults_to_pushed() {
+        let jj = FakeJj::new();
+        assert_eq!(
+            jj.push(&wd(), "origin", "main").unwrap(),
+            PushOutcome::Pushed
+        );
+    }
+
+    #[test]
+    fn fake_push_can_be_overridden_with_failure() {
+        let jj = FakeJj::new().with_push_outcome(PushOutcome::Failed("network".into()));
+        assert_eq!(
+            jj.push(&wd(), "origin", "main").unwrap(),
+            PushOutcome::Failed("network".into())
+        );
+    }
+
+    #[test]
+    fn fake_push_outcome_persists_across_calls() {
+        // The outcome is sticky — once configured, subsequent pushes
+        // return the same outcome. Matches how the per-command sync
+        // hook will call push once per invocation.
+        let jj = FakeJj::new().with_push_outcome(PushOutcome::NothingToPush);
+        assert_eq!(
+            jj.push(&wd(), "origin", "main").unwrap(),
+            PushOutcome::NothingToPush
+        );
+        assert_eq!(
+            jj.push(&wd(), "origin", "main").unwrap(),
+            PushOutcome::NothingToPush
+        );
+    }
+
+    #[test]
+    fn fake_rebase_defaults_to_clean() {
+        let jj = FakeJj::new();
+        assert_eq!(
+            jj.rebase_onto_remote(&wd(), "main", "origin").unwrap(),
+            RebaseOutcome::Clean
+        );
+    }
+
+    #[test]
+    fn fake_rebase_can_be_overridden_with_conflict() {
+        let jj = FakeJj::new().with_rebase_outcome(RebaseOutcome::Conflicted);
+        assert_eq!(
+            jj.rebase_onto_remote(&wd(), "main", "origin").unwrap(),
+            RebaseOutcome::Conflicted
+        );
+    }
+}

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -282,6 +282,34 @@ fn push_failure_does_not_fail_the_command() {
 }
 
 #[test]
+fn doctor_surfaces_stale_unpushed_commits_finding() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+
+    // Simulate "push has been failing for 48h" by having FakeJj
+    // report 3 unpushed commits, oldest 48h old.
+    let jj = FakeJj::new().with_unpushed_summary(Some(blogctl::sync::UnpushedSummary {
+        count: 3,
+        oldest_age_hours: 48,
+    }));
+    let err = commands::doctor::run(&jj, path).unwrap_err();
+    assert!(
+        matches!(err, blogctl::Error::WorkdirUnhealthy(n) if n == 1),
+        "expected WorkdirUnhealthy(1), got: {err:?}"
+    );
+}
+
+#[test]
+fn doctor_does_not_surface_stale_finding_when_push_is_current() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+
+    // No unpushed commits → no sync finding → doctor is happy.
+    let jj = FakeJj::new().with_unpushed_summary(None);
+    commands::doctor::run(&jj, path).expect("clean workdir should be healthy");
+}
+
+#[test]
 fn rebase_conflict_is_a_hard_error_and_aborts_the_write() {
     let (_tmp, path) = workdir();
     commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -1,0 +1,318 @@
+//! Integration tests for the per-command sync hook. Tests use
+//! `FakeJj` to assert on the order/shape of `jj` calls without
+//! shelling out, so they run anywhere blogctl builds.
+//!
+//! Each test exercises one write-shaped command via the library API
+//! and asserts on the call sequence; the actual `jj` binary is never
+//! invoked.
+
+use std::fs;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use blogctl::commands;
+use blogctl::kind::Kind;
+use blogctl::storage::{Repository, Workdir};
+use blogctl::sync::{Call, FakeJj, PushOutcome};
+
+fn workdir() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_path_buf();
+    (tmp, path)
+}
+
+/// Verify the canonical 6-call shape one write-shaped command produces:
+/// Status, Fetch, Rebase, NewChange, SetBookmark, Push (in order).
+fn assert_full_sync_flow(calls: &[Call], expected_message: &str) {
+    assert_eq!(calls.len(), 6, "expected 6 jj calls, got: {calls:?}");
+    assert!(
+        matches!(calls[0], Call::Status { .. }),
+        "first call must be Status, got: {:?}",
+        calls[0]
+    );
+    assert!(
+        matches!(calls[1], Call::Fetch { .. }),
+        "second call must be Fetch, got: {:?}",
+        calls[1]
+    );
+    assert!(
+        matches!(calls[2], Call::Rebase { .. }),
+        "third call must be Rebase, got: {:?}",
+        calls[2]
+    );
+    match &calls[3] {
+        Call::NewChange { message, .. } => {
+            assert_eq!(message, expected_message, "wrong commit message",)
+        }
+        other => panic!("fourth call must be NewChange, got: {other:?}"),
+    }
+    assert!(
+        matches!(calls[4], Call::SetBookmark { ref bookmark, .. } if bookmark == "main"),
+        "fifth call must be SetBookmark main, got: {:?}",
+        calls[4]
+    );
+    assert!(
+        matches!(
+            calls[5],
+            Call::Push {
+                ref remote,
+                ref bookmark,
+                ..
+            } if remote == "origin" && bookmark == "main"
+        ),
+        "sixth call must be Push origin main, got: {:?}",
+        calls[5]
+    );
+}
+
+#[test]
+fn init_drives_full_sync_with_scaffold_message() {
+    let jj = FakeJj::new();
+    let (_tmp, path) = workdir();
+    commands::init::run(&jj, path.clone(), false).unwrap();
+    // Even though the workdir isn't a real jj repo, FakeJj answers Ok
+    // unconditionally, so the full flow runs against the fake.
+    assert_full_sync_flow(&jj.calls(), "chore: scaffold workdir");
+    // And the actual file write happened.
+    assert!(path.join(".blog-os.toml").is_file());
+}
+
+#[test]
+fn new_drives_full_sync_with_draft_message() {
+    let (_tmp, path) = workdir();
+    Repository::unchecked(Workdir::new(&path)).init().unwrap();
+    let jj = FakeJj::new();
+    commands::new::run(
+        &jj,
+        "Hello World".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    assert_full_sync_flow(&jj.calls(), "post(hello-world): draft \"Hello World\"");
+    assert!(path.join("concepts/hello-world.md").is_file());
+}
+
+#[test]
+fn promote_drives_full_sync_with_stage_transition_message() {
+    let (_tmp, path) = workdir();
+    let init_jj = FakeJj::new();
+    commands::init::run(&init_jj, path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hello World".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+
+    let jj = FakeJj::new();
+    commands::promote::run(&jj, "hello-world".to_string(), path.clone(), false).unwrap();
+    // The arrow is U+2192 RIGHTWARDS ARROW per the issue spec.
+    assert_full_sync_flow(&jj.calls(), "post(hello-world): concept \u{2192} ideation");
+    assert!(path.join("ideation/hello-world.md").is_file());
+    assert!(!path.join("concepts/hello-world.md").exists());
+}
+
+#[test]
+fn demote_drives_full_sync_with_reverse_arrow_message() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hello".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    commands::promote::run(&FakeJj::new(), "hello".to_string(), path.clone(), false).unwrap();
+
+    let jj = FakeJj::new();
+    commands::demote::run(&jj, "hello".to_string(), path.clone(), false).unwrap();
+    // U+2190 LEFTWARDS ARROW.
+    assert_full_sync_flow(&jj.calls(), "post(hello): ideation \u{2190} concept");
+}
+
+#[test]
+fn readme_regenerate_drives_full_sync_with_docs_message() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+
+    let jj = FakeJj::new();
+    commands::readme::regenerate(&jj, path, false).unwrap();
+    assert_full_sync_flow(&jj.calls(), "docs: regenerate workdir README");
+}
+
+#[test]
+fn fix_drives_full_sync_with_finding_count_message() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    // Plant a stage-mismatched post so fix has something to repair.
+    let mismatch = concat!(
+        "---\n",
+        "title: \"oops\"\n",
+        "slug: oops\n",
+        "kind: post\n",
+        "theme: standard\n",
+        "status: editing\n",
+        "created_at: 2026-05-03T00:00:00Z\n",
+        "updated_at: 2026-05-03T00:00:00Z\n",
+        "tags: []\n",
+        "todoist_task_id: null\n",
+        "history_checked: false\n",
+        "---\n",
+        "body\n",
+    );
+    fs::write(path.join("concepts/oops.md"), mismatch).unwrap();
+
+    let jj = FakeJj::new();
+    commands::fix::run(&jj, path.clone(), false, false).unwrap();
+    // Exactly one repair attempted (the stage mismatch).
+    assert_full_sync_flow(&jj.calls(), "chore: fix workdir (1 findings)");
+}
+
+#[test]
+fn fix_dry_run_skips_sync_entirely() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    fs::write(
+        path.join("concepts/oops.md"),
+        concat!(
+            "---\n",
+            "title: \"oops\"\n",
+            "slug: oops\n",
+            "kind: post\n",
+            "theme: standard\n",
+            "status: editing\n",
+            "created_at: 2026-05-03T00:00:00Z\n",
+            "updated_at: 2026-05-03T00:00:00Z\n",
+            "tags: []\n",
+            "todoist_task_id: null\n",
+            "history_checked: false\n",
+            "---\n",
+            "body\n",
+        ),
+    )
+    .unwrap();
+
+    let jj = FakeJj::new();
+    let _ = commands::fix::run(&jj, path, true, false);
+    assert!(
+        jj.calls().is_empty(),
+        "dry-run must not invoke jj: {:?}",
+        jj.calls()
+    );
+}
+
+#[test]
+fn no_sync_flag_skips_jj_orchestration() {
+    let jj = FakeJj::new();
+    let (_tmp, path) = workdir();
+    commands::init::run(&jj, path.clone(), /* no_sync = */ true).unwrap();
+    // The write happened.
+    assert!(path.join(".blog-os.toml").is_file());
+    // But not a single jj call fired.
+    assert!(jj.calls().is_empty(), "got jj calls: {:?}", jj.calls());
+}
+
+#[test]
+fn config_disabled_sync_skips_jj_orchestration() {
+    let (_tmp, path) = workdir();
+    // Init the workdir first (with sync enabled by default for that
+    // invocation), then disable sync in the config.
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    let cfg_path = path.join(".blog-os.toml");
+    let mut raw = fs::read_to_string(&cfg_path).unwrap();
+    raw = raw.replace("enabled = true", "enabled = false");
+    fs::write(&cfg_path, raw).unwrap();
+
+    let jj = FakeJj::new();
+    commands::new::run(
+        &jj,
+        "Hi".to_string(),
+        path,
+        None,
+        Kind::Post,
+        None,
+        /* no_sync = */ false,
+    )
+    .unwrap();
+    assert!(
+        jj.calls().is_empty(),
+        "got jj calls despite [sync] enabled=false: {:?}",
+        jj.calls()
+    );
+}
+
+#[test]
+fn push_failure_does_not_fail_the_command() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+
+    let jj = FakeJj::new().with_push_outcome(PushOutcome::Failed("non-fast-forward".into()));
+    let result = commands::new::run(
+        &jj,
+        "Hi".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    );
+    assert!(
+        result.is_ok(),
+        "push-failure must not fail the command: {result:?}"
+    );
+    // The file write still happened.
+    assert!(path.join("concepts/hi.md").is_file());
+    // And we did go through the full sync flow including the failed push.
+    let calls = jj.calls();
+    assert_eq!(calls.len(), 6);
+    assert!(matches!(calls[5], Call::Push { .. }));
+}
+
+#[test]
+fn rebase_conflict_is_a_hard_error_and_aborts_the_write() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+
+    let jj = FakeJj::new().with_rebase_outcome(blogctl::sync::RebaseOutcome::Conflicted);
+    let result = commands::new::run(
+        &jj,
+        "Hi".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    );
+    let err = result.expect_err("rebase conflict must hard-fail");
+    assert!(
+        matches!(err, blogctl::Error::SyncRebaseConflict { .. }),
+        "got: {err:?}"
+    );
+    // Crucially: the file write did NOT happen (the closure never ran).
+    assert!(
+        !path.join("concepts/hi.md").exists(),
+        "post file must not exist after a rebase-conflict abort"
+    );
+    // Call sequence stopped after the rebase.
+    let calls = jj.calls();
+    assert_eq!(calls.len(), 3);
+    assert!(
+        !calls
+            .iter()
+            .any(|c| matches!(c, Call::NewChange { .. } | Call::Push { .. })),
+        "must not have called NewChange or Push: {calls:?}"
+    );
+}


### PR DESCRIPTION
Wraps the jj CLI behind a Send+Sync trait so commands can drive
status / fetch / rebase / new-change / bookmark / push without
shelling out from each command directly, and so tests can swap in
FakeJj to assert on call sequences without touching a real repo.

RealJj shells out to jj via std::process::Command; no new dependencies.
PushOutcome carries the best-effort semantic (network or non-FF
failure becomes a Failed(reason) rather than an Err). RebaseOutcome
surfaces conflicts explicitly so the per-command sync hook can
hard-fail rather than silently push a conflicted commit.

Follow-up commits wire this into the per-command flow, add the
.blog-os.toml [sync] table, and add a doctor finding for stale
unpushed commits.

For #445.

Adds SyncConfig to the workdir config so the per-command sync hook
can read enabled / remote / bookmark instead of hardcoding them.

Defaults: enabled=true, remote="origin", bookmark="main". Each
field has its own serde default so workdirs from before [sync]
existed parse transparently, and partial [sync] tables (just
enabled=false, say) fall back per-field to the right defaults.

For #445.

Adds sync::commit_and_push, the orchestrator that wraps a command's
file write between:

  status → fetch → rebase_onto_remote → new_change(template_message)
        → write() → set_bookmark_to_head → push

Every write-shaped command (init, new, promote, demote, readme
regenerate, fix) now takes &dyn Jj and a --no-sync flag and routes
its write through the orchestrator. Each command produces a
deterministic conventional-commit message from its own arguments
(slug, title, stages, finding count) — no LLM, no diffing.

Rationale for fetch + rebase before our jj new: blogs-and-posts
remote moves often (flake-bump bot pushes to main between blogctl
invocations), so a naive push would race and fail. Rebasing onto
<bookmark>@<remote> first keeps push as a fast-forward; rebase
conflicts hard-fail (Error::SyncRebaseConflict) so we never push
a conflicted commit.

Failure modes:
- jj not installed / not a jj repo → warn to stderr, run write
  only. No new error variants escape; the command still succeeds.
- fetch fails → warn, skip rebase, still try push (best-effort).
- push fails → warn, exit 0. Working copy is committed locally;
  user can retry with `jj git push`.
- rebase conflict → hard error. Write does NOT happen, so the
  workdir is left exactly as before.

cli::dispatch_with_jj is the new test-injection seam; production
calls it with RealJj, integration tests pass FakeJj and assert on
the recorded call sequence. tests/sync.rs covers one per command
plus the dry-run, --no-sync, config-disabled, push-failure, and
rebase-conflict paths.

For #445.

Closes #445.

Adds Jj::unpushed_summary that inspects <bookmark>@<remote>..<bookmark>
via `jj log -T 'author.timestamp().format(\"%s\")'` (unix epoch
seconds, stable to parse) and returns the count + age in hours of
the oldest unpushed commit. RealJj returns None when the remote ref
doesn't exist yet — a brand-new bookmark before its first push is
"clean," not "behind."

A new Finding::UnpushedCommitsStale variant is surfaced by
doctor::sync_audit when the oldest unpushed commit is at least
STALE_UNPUSHED_THRESHOLD_HOURS (24h) old. The sync audit is kept
separate from the filesystem audit so:

- The pure filesystem `audit()` keeps its existing signature and
  test coverage.
- `fix::run` still calls only `audit()` (sync issues aren't
  fixable; the new SkipReason::UnpushedCommits arm just keeps the
  match exhaustive in case the variant ever leaks into fix's path).
- `doctor::run` composes audit + sync_audit so the user sees both
  classes of finding in one pass.

doctor::run now takes &dyn Jj; dispatched through cli::dispatch_with_jj
the same way write-shaped commands are. Threshold age is checked
against an injected `now: OffsetDateTime` so tests stay
deterministic.