### PR TITLE
feat(blogctl): per-target TargetMetrics

### DIFF
--- a/apps/blogctl/src/classifications.rs
+++ b/apps/blogctl/src/classifications.rs
@@ -1,0 +1,150 @@
+//! Structured tag dimensions for analytics. Sits alongside the
+//! free-form `tags: Vec<String>` on `PostMetadata`: each named field
+//! captures one dimension of the post's intent (format, hook, tone,
+//! audience, strategic role) plus a multi-valued `theme` list.
+//!
+//! Values stay `Option<String>` / `Vec<String>` rather than enums so
+//! the taxonomy can evolve in `.blog-os.toml` without touching code.
+//! Validation against the declared taxonomy is a separate pass (see
+//! the `classify` command + workdir-config taxonomy issue) — this
+//! module is the storage shape only.
+
+use serde::{Deserialize, Serialize};
+
+/// One classification per dimension. Every field is optional or
+/// defaulted so older posts (predating this field) parse transparently
+/// via `#[serde(default)]` on `PostMetadata::classifications`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Classifications {
+    /// `parable`, `thesis`, `essay`, `observation`, `personal-reflection`,
+    /// `framework`. Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+
+    /// `proverb`, `contradiction`, `direct-claim`, `story-title`,
+    /// `question`, `analogy`. Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hook: Option<String>,
+
+    /// `gentle`, `sharp`, `vulnerable`, `reflective`, `provocative`.
+    /// Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tone: Option<String>,
+
+    /// `engineering`, `product`, `leadership`, `founders`, `general`.
+    /// Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audience: Option<String>,
+
+    /// `salal-positioning`, `career-brand`, `recruiting`,
+    /// `writing-practice`, `consulting-signal`. Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strategic_role: Option<String>,
+
+    /// `ambiguity`, `delivery`, `interfaces`, `leadership`, `ai`,
+    /// `engineering-culture`, `product`, `organizational-psychology`.
+    /// Multi-valued — a post can sit in several themes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub theme: Vec<String>,
+}
+
+impl Classifications {
+    /// True when every dimension is unset. Used by the post renderer's
+    /// `skip_serializing_if` to keep frontmatter quiet for posts that
+    /// haven't been classified yet.
+    pub fn is_empty(&self) -> bool {
+        self.format.is_none()
+            && self.hook.is_none()
+            && self.tone.is_none()
+            && self.audience.is_none()
+            && self.strategic_role.is_none()
+            && self.theme.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full() -> Classifications {
+        Classifications {
+            format: Some("thesis".into()),
+            hook: Some("contradiction".into()),
+            tone: Some("sharp".into()),
+            audience: Some("engineering".into()),
+            strategic_role: Some("career-brand".into()),
+            theme: vec!["ambiguity".into(), "delivery".into()],
+        }
+    }
+
+    #[test]
+    fn default_is_empty() {
+        assert!(Classifications::default().is_empty());
+    }
+
+    #[test]
+    fn full_round_trips_through_yaml() {
+        let c = full();
+        let yaml = serde_yaml_ng::to_string(&c).unwrap();
+        let back: Classifications = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn empty_dimensions_are_skipped_in_output() {
+        // A partially populated classification — only `format` set —
+        // should serialize to a single line, not a block of nulls.
+        let c = Classifications {
+            format: Some("thesis".into()),
+            ..Default::default()
+        };
+        let yaml = serde_yaml_ng::to_string(&c).unwrap();
+        assert!(yaml.contains("format: thesis"), "got: {yaml}");
+        assert!(!yaml.contains("hook"), "hook must be skipped: {yaml}");
+        assert!(!yaml.contains("tone"), "tone must be skipped: {yaml}");
+        assert!(!yaml.contains("theme"), "theme must be skipped: {yaml}");
+    }
+
+    #[test]
+    fn missing_fields_parse_as_defaults() {
+        // Pre-classifications-era YAML: just a single dimension.
+        let raw = "format: thesis\n";
+        let c: Classifications = serde_yaml_ng::from_str(raw).unwrap();
+        assert_eq!(c.format.as_deref(), Some("thesis"));
+        assert!(c.hook.is_none());
+        assert!(c.theme.is_empty());
+    }
+
+    #[test]
+    fn empty_yaml_object_parses_as_default() {
+        // A `classifications: {}` block in the parent document — every
+        // field defaulted out, equal to `Classifications::default()`.
+        let c: Classifications = serde_yaml_ng::from_str("{}").unwrap();
+        assert_eq!(c, Classifications::default());
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn theme_round_trips_multi_value() {
+        let c = Classifications {
+            theme: vec!["ambiguity".into(), "delivery".into(), "interfaces".into()],
+            ..Default::default()
+        };
+        let yaml = serde_yaml_ng::to_string(&c).unwrap();
+        let back: Classifications = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back, c);
+        assert_eq!(back.theme.len(), 3);
+    }
+
+    #[test]
+    fn theme_single_element_round_trips() {
+        // The common case: one theme, written as a single-element list.
+        let c = Classifications {
+            theme: vec!["ambiguity".into()],
+            ..Default::default()
+        };
+        let yaml = serde_yaml_ng::to_string(&c).unwrap();
+        let back: Classifications = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back, c);
+    }
+}

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -304,6 +304,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![],
+                classifications: Default::default(),
             },
             "body\n",
         )

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -345,6 +345,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![],
+                classifications: Default::default(),
             },
             "body\n",
         )

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -59,6 +59,7 @@ pub fn run(
             todoist_task_id: None,
             history_checked: false,
             targets: vec![],
+            classifications: Default::default(),
         };
         let post = Post::new(metadata, "");
         repo.create_post(&post)

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod classifications;
 pub mod cli;
 pub mod commands;
 pub mod error;
@@ -10,6 +11,7 @@ pub mod storage;
 pub mod sync;
 pub mod target;
 
+pub use classifications::Classifications;
 pub use error::{Error, Result};
 pub use kind::Kind;
 pub use post::{Post, PostMetadata};

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
+use crate::classifications::Classifications;
 use crate::error::{Error, Result};
 use crate::kind::Kind;
 use crate::stage::Stage;
@@ -39,6 +40,13 @@ pub struct PostMetadata {
     /// Default `[]` keeps existing files parsing unchanged.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub targets: Vec<TargetEntry>,
+    /// Structured tag dimensions (format, hook, tone, audience,
+    /// strategic role, theme). Sits alongside the free-form `tags`
+    /// list. Defaults to empty; skipped from serialization when no
+    /// dimension has a value so posts predating the field stay
+    /// quiet in their frontmatter.
+    #[serde(default, skip_serializing_if = "Classifications::is_empty")]
+    pub classifications: Classifications,
 }
 
 fn default_theme() -> String {
@@ -195,6 +203,7 @@ mod tests {
             todoist_task_id: None,
             history_checked: false,
             targets: vec![],
+            classifications: Default::default(),
         }
     }
 
@@ -492,6 +501,92 @@ Body.
                 published_at: None,
             },
         ];
+        let original = Post::new(metadata, "Body.\n");
+        let rendered = original.render().unwrap();
+        let reparsed = parse(&rendered).unwrap();
+        assert_eq!(reparsed.metadata, original.metadata);
+    }
+
+    #[test]
+    fn parse_classifications_from_frontmatter() {
+        let raw = r#"---
+title: "T"
+slug: t
+kind: post
+theme: standard
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+classifications:
+  format: thesis
+  hook: contradiction
+  theme:
+    - ambiguity
+    - delivery
+---
+
+body
+"#;
+        let post = parse(raw).unwrap();
+        assert_eq!(
+            post.metadata.classifications.format.as_deref(),
+            Some("thesis")
+        );
+        assert_eq!(
+            post.metadata.classifications.hook.as_deref(),
+            Some("contradiction")
+        );
+        assert_eq!(post.metadata.classifications.theme.len(), 2);
+        // Dimensions not set in YAML stay at their defaults.
+        assert!(post.metadata.classifications.tone.is_none());
+        assert!(post.metadata.classifications.audience.is_none());
+        assert!(post.metadata.classifications.strategic_role.is_none());
+    }
+
+    #[test]
+    fn parse_omitted_classifications_defaults_to_empty() {
+        // Pre-#433 frontmatter — no classifications: key at all.
+        let raw = r#"---
+title: "Pre-classifications"
+slug: pre-classifications
+kind: post
+theme: standard
+status: concept
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+tags: []
+---
+
+body
+"#;
+        let post = parse(raw).unwrap();
+        assert!(post.metadata.classifications.is_empty());
+    }
+
+    #[test]
+    fn render_omits_empty_classifications_from_yaml() {
+        let metadata = fixture_metadata();
+        assert!(metadata.classifications.is_empty());
+        let post = Post::new(metadata, "Body.\n");
+        let rendered = post.render().unwrap();
+        assert!(
+            !rendered.contains("classifications"),
+            "empty classifications must be skipped in output: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_round_trips_post_with_classifications() {
+        let mut metadata = fixture_metadata();
+        metadata.classifications = Classifications {
+            format: Some("thesis".into()),
+            hook: Some("contradiction".into()),
+            tone: Some("sharp".into()),
+            audience: Some("engineering".into()),
+            strategic_role: Some("career-brand".into()),
+            theme: vec!["ambiguity".into(), "delivery".into()],
+        };
         let original = Post::new(metadata, "Body.\n");
         let rendered = original.render().unwrap();
         let reparsed = parse(&rendered).unwrap();

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -493,12 +493,14 @@ Body.
                 status: TargetStatus::Published,
                 url: Some("https://www.linkedin.com/posts/example".into()),
                 published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+                metrics: None,
             },
             TargetEntry {
                 name: Target::Blog,
                 status: TargetStatus::Planned,
                 url: None,
                 published_at: None,
+                metrics: None,
             },
         ];
         let original = Post::new(metadata, "Body.\n");
@@ -574,6 +576,29 @@ body
             !rendered.contains("classifications"),
             "empty classifications must be skipped in output: {rendered}"
         );
+    }
+
+    #[test]
+    fn render_round_trips_post_with_target_metrics() {
+        use crate::target::{Target, TargetEntry, TargetMetrics, TargetStatus};
+        let mut metadata = fixture_metadata();
+        metadata.targets = vec![TargetEntry {
+            name: Target::Linkedin,
+            status: TargetStatus::Published,
+            url: Some("https://www.linkedin.com/posts/example".into()),
+            published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+            metrics: Some(TargetMetrics {
+                impressions: 1842,
+                reactions: 67,
+                comments: 14,
+                reposts: 5,
+                sampled_at: datetime!(2026-05-14 00:00:00 UTC),
+            }),
+        }];
+        let original = Post::new(metadata, "Body.\n");
+        let rendered = original.render().unwrap();
+        let reparsed = parse(&rendered).unwrap();
+        assert_eq!(reparsed.metadata, original.metadata);
     }
 
     #[test]

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -178,7 +178,10 @@ pub enum AuditedPost {
     Parsed {
         dir_stage: Stage,
         path: PathBuf,
-        post: Post,
+        // Boxed because `Post` carries `PostMetadata`, which (with
+        // classifications + targets + tags) is large; an unboxed
+        // variant bloats every enum slot by the same amount.
+        post: Box<Post>,
     },
     ParseFailed {
         dir_stage: Stage,
@@ -461,7 +464,7 @@ impl Repository {
                     Ok(post) => out.push(AuditedPost::Parsed {
                         dir_stage: stage,
                         path,
-                        post,
+                        post: Box::new(post),
                     }),
                     Err(error) => out.push(AuditedPost::ParseFailed {
                         dir_stage: stage,
@@ -554,6 +557,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![],
+                classifications: Default::default(),
             },
             "body\n",
         )

--- a/apps/blogctl/src/target.rs
+++ b/apps/blogctl/src/target.rs
@@ -92,6 +92,23 @@ impl FromStr for TargetStatus {
     }
 }
 
+/// Performance numbers observed for a target at a point in time.
+/// Held on `TargetEntry` rather than the post root because the same
+/// post on LinkedIn vs. a blog will have different numbers.
+///
+/// `sampled_at` is when these counts were last refreshed (a manual
+/// `metrics update` action) — older samples grow stale. Engagement
+/// rate and post age are derived in the analytics module, not stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TargetMetrics {
+    pub impressions: u64,
+    pub reactions: u64,
+    pub comments: u64,
+    pub reposts: u64,
+    #[serde(with = "time::serde::rfc3339")]
+    pub sampled_at: OffsetDateTime,
+}
+
 /// One entry in a post's `targets:` list. `url` and `published_at` are
 /// required when `status == Published` and optional otherwise; the
 /// invariant is enforced at parse time, not by the type.
@@ -107,6 +124,11 @@ pub struct TargetEntry {
         skip_serializing_if = "Option::is_none"
     )]
     pub published_at: Option<OffsetDateTime>,
+    /// Latest observed metrics for this target. `None` while the
+    /// target has never been measured (the common state for drafts
+    /// and for posts on a venue without analytics surfaced yet).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<TargetMetrics>,
 }
 
 #[cfg(test)]
@@ -185,5 +207,57 @@ mod tests {
         // skip_serializing_if drops the empty optional fields entirely
         assert!(!rendered.contains("url"));
         assert!(!rendered.contains("published_at"));
+        assert!(!rendered.contains("metrics"));
+    }
+
+    #[test]
+    fn target_metrics_round_trip() {
+        let raw = concat!(
+            "impressions: 1842\n",
+            "reactions: 67\n",
+            "comments: 14\n",
+            "reposts: 5\n",
+            "sampled_at: 2026-05-14T00:00:00Z\n",
+        );
+        let parsed: TargetMetrics = serde_yaml_ng::from_str(raw).unwrap();
+        assert_eq!(parsed.impressions, 1842);
+        assert_eq!(parsed.reactions, 67);
+        assert_eq!(parsed.comments, 14);
+        assert_eq!(parsed.reposts, 5);
+
+        let rendered = serde_yaml_ng::to_string(&parsed).unwrap();
+        let reparsed: TargetMetrics = serde_yaml_ng::from_str(&rendered).unwrap();
+        assert_eq!(reparsed, parsed);
+    }
+
+    #[test]
+    fn target_entry_with_metrics_round_trips() {
+        let raw = concat!(
+            "name: linkedin\n",
+            "status: published\n",
+            "url: https://www.linkedin.com/posts/x\n",
+            "published_at: 2026-05-08T14:32:00Z\n",
+            "metrics:\n",
+            "  impressions: 1842\n",
+            "  reactions: 67\n",
+            "  comments: 14\n",
+            "  reposts: 5\n",
+            "  sampled_at: 2026-05-14T00:00:00Z\n",
+        );
+        let parsed: TargetEntry = serde_yaml_ng::from_str(raw).unwrap();
+        let m = parsed.metrics.as_ref().expect("metrics present");
+        assert_eq!(m.impressions, 1842);
+
+        let rendered = serde_yaml_ng::to_string(&parsed).unwrap();
+        let reparsed: TargetEntry = serde_yaml_ng::from_str(&rendered).unwrap();
+        assert_eq!(reparsed, parsed);
+    }
+
+    #[test]
+    fn target_entry_without_metrics_parses_unchanged() {
+        // Pre-#433 frontmatter — no `metrics:` key on the target.
+        let raw = "name: blog\nstatus: planned\n";
+        let parsed: TargetEntry = serde_yaml_ng::from_str(raw).unwrap();
+        assert!(parsed.metrics.is_none());
     }
 }

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
@@ -1,0 +1,21 @@
+---
+title: "Classified Post"
+slug: classified-post
+kind: post
+theme: standard
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-08T00:00:00Z
+tags: []
+classifications:
+  format: thesis
+  hook: contradiction
+  tone: sharp
+  audience: engineering
+  strategic_role: career-brand
+  theme:
+    - ambiguity
+    - delivery
+---
+
+Draft text here.

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/with-target-metrics.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/with-target-metrics.md
@@ -1,0 +1,23 @@
+---
+title: "Post With Metrics"
+slug: post-with-metrics
+kind: post
+theme: standard
+status: published
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-14T00:00:00Z
+tags: []
+targets:
+  - name: linkedin
+    status: published
+    url: https://www.linkedin.com/posts/example
+    published_at: 2026-05-08T14:32:00Z
+    metrics:
+      impressions: 1842
+      reactions: 67
+      comments: 14
+      reposts: 5
+      sampled_at: 2026-05-14T00:00:00Z
+---
+
+Draft text here.


### PR DESCRIPTION
Adds a new src/classifications.rs module with the Classifications
struct: five single-valued dimensions (format, hook, tone, audience,
strategic_role) plus the multi-valued theme list. Each field is
optional or defaulted, and Classifications::is_empty() gates the
parent's skip_serializing_if so unclassified posts stay quiet in
frontmatter.

PostMetadata gets a new `classifications: Classifications` field
defaulted via #[serde(default)] so pre-#433 posts round-trip
unchanged. Every existing PostMetadata literal in the crate now
sets `classifications: Default::default()`.

AuditedPost::Parsed boxes its `post: Box<Post>` to keep the enum
size bounded after the new field grew PostMetadata past clippy's
large_enum_variant threshold. Consumers use field access through
deref so no caller code changes.

tests/fixtures/frontmatter/valid/with-classifications.md exercises
the fixture-walker tests; unit tests in post.rs cover
parse + render + round-trip + skip-empty + backwards-compat for the
new field.

Values stay String / Vec<String> (not enums) so the taxonomy can
live in .blog-os.toml and evolve without code changes — validation
against the declared taxonomy is a separate issue (#437).

For #433.

Closes #433.

Adds the TargetMetrics struct (impressions, reactions, comments,
reposts, sampled_at) to src/target.rs and the new
`metrics: Option<TargetMetrics>` field on TargetEntry. Metrics live
on the target entry, not the post root, because the same post on
LinkedIn vs. blog yields different numbers.

The field is Option / skip_serializing_if so pre-#433 targets[]
entries parse and re-render unchanged. sampled_at uses
time::serde::rfc3339, matching how created_at / updated_at /
published_at are already serialized.

Unit tests cover round-trip with metrics on a Published target,
round-trip without metrics (backwards compat), and a full
Post-level round-trip that combines targets + metrics. A new
tests/fixtures/frontmatter/valid/with-target-metrics.md exercises
the fixture-walker integration test.

Derived metrics (engagement rate, post age, staleness) compute over
this raw data at read time and live in their own module (#438).