### PR TITLE
feat(blogctl): CLI surface for classify, metrics, backfill, analytics

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -9,6 +9,7 @@ use crate::error::Result;
 use crate::kind::Kind;
 use crate::openrouter;
 use crate::sync::{Jj, RealJj};
+use crate::target::Target;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -109,6 +110,67 @@ pub enum Command {
         #[command(subcommand)]
         action: AiAction,
     },
+    /// Set classification dimensions on a post (format, hook, tone,
+    /// audience, strategic-role, theme). Missing flags leave the
+    /// existing value alone; `--clear-<dim>` removes it.
+    Classify {
+        slug: String,
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        #[arg(long)]
+        format: Option<String>,
+        #[arg(long)]
+        hook: Option<String>,
+        #[arg(long)]
+        tone: Option<String>,
+        #[arg(long)]
+        audience: Option<String>,
+        #[arg(long)]
+        strategic_role: Option<String>,
+        /// Comma-separated list of themes. Replaces the existing
+        /// theme list entirely.
+        #[arg(long, value_delimiter = ',')]
+        theme: Vec<String>,
+        #[arg(long)]
+        clear_format: bool,
+        #[arg(long)]
+        clear_hook: bool,
+        #[arg(long)]
+        clear_tone: bool,
+        #[arg(long)]
+        clear_audience: bool,
+        #[arg(long)]
+        clear_strategic_role: bool,
+        #[arg(long)]
+        clear_theme: bool,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
+    /// Per-target performance metrics (impressions, reactions,
+    /// comments, reposts).
+    Metrics {
+        #[command(subcommand)]
+        action: MetricsAction,
+    },
+    /// Walk every published post and fill in missing classifications
+    /// + metrics interactively, or batch-import from a JSON file.
+    Backfill {
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        /// Path to a JSON file of per-slug classifications/metrics
+        /// entries. When set, runs in non-interactive batch mode.
+        #[arg(long, value_name = "PATH")]
+        import: Option<PathBuf>,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
+    /// Analytics across classifications + metrics. Read-only.
+    Analytics {
+        #[command(subcommand)]
+        action: AnalyticsAction,
+    },
     #[command(hide = true)]
     Completions { shell: Shell },
 }
@@ -139,6 +201,87 @@ pub enum ReadmeAction {
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum MetricsAction {
+    /// Set the latest observed metrics for a target on a post.
+    Update {
+        slug: String,
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        #[arg(long, value_enum)]
+        target: Target,
+        #[arg(long)]
+        impressions: u64,
+        #[arg(long)]
+        reactions: u64,
+        #[arg(long)]
+        comments: u64,
+        #[arg(long)]
+        reposts: u64,
+        /// RFC 3339 timestamp. Defaults to `now()` if omitted.
+        #[arg(long, value_name = "RFC3339")]
+        sampled_at: Option<String>,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
+    /// Print the latest metrics for every target on a post.
+    Show {
+        slug: String,
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AnalyticsAction {
+    /// Per-dimension counts and median engagement for every
+    /// classification value across the workdir.
+    Summary {
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        #[arg(long, value_enum)]
+        target: Option<Target>,
+        /// Limit to one dimension (e.g. `format`). Omit to report
+        /// every dimension.
+        #[arg(long)]
+        dimension: Option<String>,
+        /// Emit machine-readable JSON instead of formatted text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Pairwise crosstab of two dimensions plus their marginals.
+    Compare {
+        /// First dimension (e.g. `format`).
+        dim_a: String,
+        /// Second dimension (e.g. `hook`).
+        dim_b: String,
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        #[arg(long, value_enum)]
+        target: Option<Target>,
+        /// Suppress cells with fewer than this many posts from the
+        /// text output; JSON still includes them tagged `low_n`.
+        #[arg(long, default_value_t = 3)]
+        min_n: usize,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Surface heuristic patterns with explicit hedge language.
+    Recommendations {
+        #[arg(long, value_name = "PATH")]
+        workdir: PathBuf,
+        #[arg(long, value_enum)]
+        target: Option<Target>,
+        /// Posts-per-cell threshold for "high confidence" heuristics.
+        /// Below this count, observations are flagged as
+        /// "insufficient data".
+        #[arg(long, default_value_t = 5)]
+        min_n: usize,
     },
 }
 
@@ -187,6 +330,120 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
         } => commands::fix::run(jj, workdir, dry_run, no_sync),
         Command::Ai { action } => match action {
             AiAction::Ping { prompt, model } => commands::ai::ping(prompt, model),
+        },
+        Command::Classify {
+            slug,
+            workdir,
+            format,
+            hook,
+            tone,
+            audience,
+            strategic_role,
+            theme,
+            clear_format,
+            clear_hook,
+            clear_tone,
+            clear_audience,
+            clear_strategic_role,
+            clear_theme,
+            no_sync,
+        } => commands::classify::run(
+            jj,
+            commands::classify::ClassifyArgs {
+                slug,
+                workdir,
+                format,
+                hook,
+                tone,
+                audience,
+                strategic_role,
+                theme,
+                clear_format,
+                clear_hook,
+                clear_tone,
+                clear_audience,
+                clear_strategic_role,
+                clear_theme,
+                no_sync,
+            },
+        ),
+        Command::Metrics { action } => match action {
+            MetricsAction::Update {
+                slug,
+                workdir,
+                target,
+                impressions,
+                reactions,
+                comments,
+                reposts,
+                sampled_at,
+                no_sync,
+            } => commands::metrics::update(
+                jj,
+                commands::metrics::UpdateArgs {
+                    slug,
+                    workdir,
+                    target,
+                    impressions,
+                    reactions,
+                    comments,
+                    reposts,
+                    sampled_at,
+                    no_sync,
+                },
+            ),
+            MetricsAction::Show { slug, workdir } => {
+                commands::metrics::show(commands::metrics::ShowArgs { slug, workdir })
+            }
+        },
+        Command::Backfill {
+            workdir,
+            import,
+            no_sync,
+        } => commands::backfill::run(
+            jj,
+            commands::backfill::BackfillArgs {
+                workdir,
+                import,
+                no_sync,
+            },
+        ),
+        Command::Analytics { action } => match action {
+            AnalyticsAction::Summary {
+                workdir,
+                target,
+                dimension,
+                json,
+            } => commands::analytics::summary(commands::analytics::SummaryArgs {
+                workdir,
+                target,
+                dimension,
+                json,
+            }),
+            AnalyticsAction::Compare {
+                dim_a,
+                dim_b,
+                workdir,
+                target,
+                min_n,
+                json,
+            } => commands::analytics::compare(commands::analytics::CompareArgs {
+                dim_a,
+                dim_b,
+                workdir,
+                target,
+                min_n,
+                json,
+            }),
+            AnalyticsAction::Recommendations {
+                workdir,
+                target,
+                min_n,
+            } => commands::analytics::recommendations(commands::analytics::RecommendationsArgs {
+                workdir,
+                target,
+                min_n,
+            }),
         },
         Command::Completions { shell } => {
             let mut cmd = Cli::command();
@@ -285,10 +542,221 @@ mod tests {
                 "--model",
                 "openai/gpt-4o-mini",
             ],
+            // classify — every dimension flag, both set and clear shapes.
+            vec!["blogctl", "classify", "hello", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "classify",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--format",
+                "thesis",
+                "--hook",
+                "contradiction",
+                "--tone",
+                "sharp",
+                "--audience",
+                "engineering",
+                "--strategic-role",
+                "career-brand",
+                "--theme",
+                "ambiguity,delivery",
+            ],
+            vec![
+                "blogctl",
+                "classify",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--clear-format",
+                "--clear-hook",
+                "--clear-tone",
+                "--clear-audience",
+                "--clear-strategic-role",
+                "--clear-theme",
+            ],
+            vec![
+                "blogctl",
+                "classify",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--no-sync",
+            ],
+            // metrics — update + show.
+            vec![
+                "blogctl",
+                "metrics",
+                "update",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--target",
+                "linkedin",
+                "--impressions",
+                "1842",
+                "--reactions",
+                "67",
+                "--comments",
+                "14",
+                "--reposts",
+                "5",
+            ],
+            vec![
+                "blogctl",
+                "metrics",
+                "update",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--target",
+                "linkedin",
+                "--impressions",
+                "1",
+                "--reactions",
+                "0",
+                "--comments",
+                "0",
+                "--reposts",
+                "0",
+                "--sampled-at",
+                "2026-05-14T00:00:00Z",
+                "--no-sync",
+            ],
+            vec![
+                "blogctl",
+                "metrics",
+                "show",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+            ],
+            // backfill — interactive + import.
+            vec!["blogctl", "backfill", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "backfill",
+                "--workdir",
+                "/tmp/wd",
+                "--import",
+                "/tmp/data.json",
+                "--no-sync",
+            ],
+            // analytics — every action.
+            vec!["blogctl", "analytics", "summary", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "analytics",
+                "summary",
+                "--workdir",
+                "/tmp/wd",
+                "--target",
+                "linkedin",
+                "--dimension",
+                "format",
+                "--json",
+            ],
+            vec![
+                "blogctl",
+                "analytics",
+                "compare",
+                "format",
+                "hook",
+                "--workdir",
+                "/tmp/wd",
+            ],
+            vec![
+                "blogctl",
+                "analytics",
+                "compare",
+                "format",
+                "hook",
+                "--workdir",
+                "/tmp/wd",
+                "--target",
+                "blog",
+                "--min-n",
+                "5",
+                "--json",
+            ],
+            vec![
+                "blogctl",
+                "analytics",
+                "recommendations",
+                "--workdir",
+                "/tmp/wd",
+            ],
+            vec![
+                "blogctl",
+                "analytics",
+                "recommendations",
+                "--workdir",
+                "/tmp/wd",
+                "--target",
+                "linkedin",
+                "--min-n",
+                "10",
+            ],
             vec!["blogctl", "completions", "bash"],
         ] {
             assert!(Cli::try_parse_from(args.clone()).is_ok(), "{args:?}");
         }
+    }
+
+    #[test]
+    fn metrics_update_rejects_unknown_target() {
+        let args = vec![
+            "blogctl",
+            "metrics",
+            "update",
+            "hello",
+            "--workdir",
+            "/tmp/wd",
+            "--target",
+            "mastodon",
+            "--impressions",
+            "1",
+            "--reactions",
+            "0",
+            "--comments",
+            "0",
+            "--reposts",
+            "0",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn metrics_update_requires_every_count_flag() {
+        // Missing --reactions, --comments, --reposts.
+        let args = vec![
+            "blogctl",
+            "metrics",
+            "update",
+            "hello",
+            "--workdir",
+            "/tmp/wd",
+            "--target",
+            "linkedin",
+            "--impressions",
+            "1",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
+    }
+
+    #[test]
+    fn analytics_summary_rejects_unknown_target() {
+        let args = vec![
+            "blogctl",
+            "analytics",
+            "summary",
+            "--workdir",
+            "/tmp/wd",
+            "--target",
+            "twitter",
+        ];
+        assert!(Cli::try_parse_from(args).is_err());
     }
 
     #[test]

--- a/apps/blogctl/src/commands/analytics.rs
+++ b/apps/blogctl/src/commands/analytics.rs
@@ -1,0 +1,45 @@
+//! `blogctl analytics {summary, compare, recommendations}` — read
+//! every published post's classifications + metrics and surface
+//! aggregates. Stubs for now; behavior lands in #439/#440/#441.
+
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::target::Target;
+
+#[derive(Debug)]
+pub struct SummaryArgs {
+    pub workdir: PathBuf,
+    pub target: Option<Target>,
+    pub dimension: Option<String>,
+    pub json: bool,
+}
+
+#[derive(Debug)]
+pub struct CompareArgs {
+    pub dim_a: String,
+    pub dim_b: String,
+    pub workdir: PathBuf,
+    pub target: Option<Target>,
+    pub min_n: usize,
+    pub json: bool,
+}
+
+#[derive(Debug)]
+pub struct RecommendationsArgs {
+    pub workdir: PathBuf,
+    pub target: Option<Target>,
+    pub min_n: usize,
+}
+
+pub fn summary(_args: SummaryArgs) -> Result<()> {
+    Err(Error::Unimplemented("analytics summary"))
+}
+
+pub fn compare(_args: CompareArgs) -> Result<()> {
+    Err(Error::Unimplemented("analytics compare"))
+}
+
+pub fn recommendations(_args: RecommendationsArgs) -> Result<()> {
+    Err(Error::Unimplemented("analytics recommendations"))
+}

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -1,0 +1,21 @@
+//! `blogctl backfill` — interactive walk of published posts to fill
+//! missing classifications + metrics, or batch import from a JSON
+//! file. Stub for now; behavior lands in #435 (backfill).
+
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::sync::Jj;
+
+#[derive(Debug)]
+pub struct BackfillArgs {
+    pub workdir: PathBuf,
+    /// Path to a JSON file of `{ slug → classifications/metrics }`
+    /// entries. When set, runs in batch mode (no prompts).
+    pub import: Option<PathBuf>,
+    pub no_sync: bool,
+}
+
+pub fn run(_jj: &dyn Jj, _args: BackfillArgs) -> Result<()> {
+    Err(Error::Unimplemented("backfill"))
+}

--- a/apps/blogctl/src/commands/classify.rs
+++ b/apps/blogctl/src/commands/classify.rs
@@ -1,0 +1,30 @@
+//! `blogctl classify <slug>` — set classification dimensions on a
+//! post. Stub for now; behavior lands in #437 (taxonomy + classify).
+
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::sync::Jj;
+
+#[derive(Debug, Default)]
+pub struct ClassifyArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+    pub format: Option<String>,
+    pub hook: Option<String>,
+    pub tone: Option<String>,
+    pub audience: Option<String>,
+    pub strategic_role: Option<String>,
+    pub theme: Vec<String>,
+    pub clear_format: bool,
+    pub clear_hook: bool,
+    pub clear_tone: bool,
+    pub clear_audience: bool,
+    pub clear_strategic_role: bool,
+    pub clear_theme: bool,
+    pub no_sync: bool,
+}
+
+pub fn run(_jj: &dyn Jj, _args: ClassifyArgs) -> Result<()> {
+    Err(Error::Unimplemented("classify"))
+}

--- a/apps/blogctl/src/commands/metrics.rs
+++ b/apps/blogctl/src/commands/metrics.rs
@@ -1,0 +1,38 @@
+//! `blogctl metrics update <slug>` / `blogctl metrics show <slug>` —
+//! per-target performance numbers. Stubs for now; behavior lands in
+//! #436 (metrics update + show).
+
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::sync::Jj;
+use crate::target::Target;
+
+#[derive(Debug)]
+pub struct UpdateArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+    pub target: Target,
+    pub impressions: u64,
+    pub reactions: u64,
+    pub comments: u64,
+    pub reposts: u64,
+    /// RFC 3339 timestamp; parsed by the command body. None means
+    /// "use now()".
+    pub sampled_at: Option<String>,
+    pub no_sync: bool,
+}
+
+#[derive(Debug)]
+pub struct ShowArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+}
+
+pub fn update(_jj: &dyn Jj, _args: UpdateArgs) -> Result<()> {
+    Err(Error::Unimplemented("metrics update"))
+}
+
+pub fn show(_args: ShowArgs) -> Result<()> {
+    Err(Error::Unimplemented("metrics show"))
+}

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -1,9 +1,13 @@
 pub mod ai;
+pub mod analytics;
+pub mod backfill;
+pub mod classify;
 pub mod demote;
 pub mod doctor;
 pub mod fix;
 pub mod init;
 pub mod list;
+pub mod metrics;
 pub mod new;
 pub mod promote;
 pub mod readme;

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -145,6 +145,11 @@ pub enum Error {
         "rebase of @ onto {bookmark}@{remote} produced conflicts — resolve via `jj` before re-running blogctl"
     )]
     SyncRebaseConflict { bookmark: String, remote: String },
+
+    #[error(
+        "`blogctl {0}` is not yet implemented (CLI surface only; behavior lands in a follow-up)"
+    )]
+    Unimplemented(&'static str),
 }
 
 impl Error {

--- a/apps/blogctl/src/target.rs
+++ b/apps/blogctl/src/target.rs
@@ -13,8 +13,13 @@ use crate::error::{Error, Result};
 
 /// A venue a post can be distributed to. Closed enum — adding a new
 /// venue is a deliberate code change, not a frontmatter typo away.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// `ValueEnum` is derived so `--target linkedin` parses natively at
+/// the clap layer; clap rejects unknown values with a helpful error
+/// rather than punting validation into the command body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
+#[clap(rename_all = "kebab-case")]
 pub enum Target {
     Linkedin,
     Blog,


### PR DESCRIPTION
Closes #434.

Declares the verbs the analytics/tagging slices will fill in:

- `blogctl classify <slug>` — top-level flat verb, dimension flags
  (--format, --hook, --tone, --audience, --strategic-role, --theme)
  + --clear-<dim> escape hatches.
- `blogctl metrics update <slug> --target <t> --impressions N ...`
  and `blogctl metrics show <slug>` — grouped under `metrics` since
  two actions share the same noun.
- `blogctl backfill --workdir <p> [--import file.json]` — single
  verb with interactive vs. batch modes via the optional --import.
- `blogctl analytics {summary,compare,recommendations}` — grouped
  read-only verbs sharing the analytics domain.

Each verb's run() function returns Error::Unimplemented(<name>) so
attempting to run today exits non-zero with a clear message; the
real behavior lands in the per-command follow-ups (#435/#436/#437/
#438/#439/#440/#441).

Target derives clap::ValueEnum so --target linkedin parses at the
clap layer (rather than the command body), giving a cleaner error
for unknown venues.

cli_parses_each_subcommand now covers every new verb shape; three
new tests check that clap rejects unknown targets and that required
flags on `metrics update` are enforced.