### PR TITLE
feat(blogctl): classify command body

### DIFF
--- a/apps/blogctl/src/classifications.rs
+++ b/apps/blogctl/src/classifications.rs
@@ -11,6 +11,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::taxonomy::{Taxonomy, Violation};
+
 /// One classification per dimension. Every field is optional or
 /// defaulted so older posts (predating this field) parse transparently
 /// via `#[serde(default)]` on `PostMetadata::classifications`.
@@ -59,6 +61,70 @@ impl Classifications {
             && self.audience.is_none()
             && self.strategic_role.is_none()
             && self.theme.is_empty()
+    }
+
+    /// Enumerate every value not allowed by `taxonomy`. Dimensions
+    /// the taxonomy doesn't declare are skipped silently — that lets
+    /// the user phase a dimension in or out of `.blog-os.toml`
+    /// without invalidating posts in the meantime.
+    ///
+    /// Returns every violation in one pass (doctor consumes the
+    /// full list); fail-fast callers wrap this in
+    /// `validate(&Taxonomy)`.
+    pub fn violations(&self, taxonomy: &Taxonomy) -> Vec<Violation> {
+        let mut out = Vec::new();
+        for (name, opt) in self.single_valued_entries() {
+            let Some(value) = opt else { continue };
+            let Some(dim) = taxonomy.dimension(name) else {
+                continue;
+            };
+            if !dim.allows(value) {
+                out.push(Violation {
+                    dimension: name.to_string(),
+                    value: value.to_string(),
+                    allowed: dim.values.clone(),
+                });
+            }
+        }
+        for (name, values) in self.multi_valued_entries() {
+            let Some(dim) = taxonomy.dimension(name) else {
+                continue;
+            };
+            for value in values {
+                if !dim.allows(value) {
+                    out.push(Violation {
+                        dimension: name.to_string(),
+                        value: value.clone(),
+                        allowed: dim.values.clone(),
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    /// Convenience: `Ok(())` when every classified value is allowed,
+    /// `Err` on the first violation. Repository load paths use this;
+    /// doctor uses `violations()` directly to enumerate.
+    pub fn validate(&self, taxonomy: &Taxonomy) -> Result<(), Violation> {
+        match self.violations(taxonomy).into_iter().next() {
+            Some(v) => Err(v),
+            None => Ok(()),
+        }
+    }
+
+    fn single_valued_entries(&self) -> [(&'static str, Option<&str>); 5] {
+        [
+            ("format", self.format.as_deref()),
+            ("hook", self.hook.as_deref()),
+            ("tone", self.tone.as_deref()),
+            ("audience", self.audience.as_deref()),
+            ("strategic_role", self.strategic_role.as_deref()),
+        ]
+    }
+
+    fn multi_valued_entries(&self) -> [(&'static str, &[String]); 1] {
+        [("theme", &self.theme)]
     }
 }
 
@@ -146,5 +212,74 @@ mod tests {
         let yaml = serde_yaml_ng::to_string(&c).unwrap();
         let back: Classifications = serde_yaml_ng::from_str(&yaml).unwrap();
         assert_eq!(back, c);
+    }
+
+    #[test]
+    fn validate_accepts_every_v1_value() {
+        let c = full();
+        let t = Taxonomy::current_v1();
+        assert_eq!(c.violations(&t), vec![]);
+        assert!(c.validate(&t).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_typo_in_single_valued_dimension() {
+        let c = Classifications {
+            format: Some("thesys".into()),
+            ..Default::default()
+        };
+        let t = Taxonomy::current_v1();
+        let err = c.validate(&t).expect_err("should reject typo");
+        assert_eq!(err.dimension, "format");
+        assert_eq!(err.value, "thesys");
+        // Error carries the allowed list — it's its own cheat sheet.
+        assert!(err.allowed.contains(&"thesis".to_string()));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_theme_element() {
+        // Only the bad element shows up — the good one is silent.
+        let c = Classifications {
+            theme: vec!["ambiguity".into(), "made-up".into()],
+            ..Default::default()
+        };
+        let v = c.violations(&Taxonomy::current_v1());
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].dimension, "theme");
+        assert_eq!(v[0].value, "made-up");
+    }
+
+    #[test]
+    fn violations_lists_every_bad_value_in_one_pass() {
+        let c = Classifications {
+            format: Some("madeup-format".into()),
+            tone: Some("madeup-tone".into()),
+            theme: vec!["madeup-theme".into()],
+            ..Default::default()
+        };
+        let v = c.violations(&Taxonomy::current_v1());
+        assert_eq!(v.len(), 3);
+        let dims: Vec<&str> = v.iter().map(|x| x.dimension.as_str()).collect();
+        assert!(dims.contains(&"format"));
+        assert!(dims.contains(&"tone"));
+        assert!(dims.contains(&"theme"));
+    }
+
+    #[test]
+    fn validate_silent_on_dimensions_taxonomy_does_not_declare() {
+        // Empty taxonomy — nothing to validate against, nothing to reject.
+        let c = full();
+        let t = Taxonomy::default();
+        assert!(c.violations(&t).is_empty());
+        assert!(c.validate(&t).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_unset_dimensions_even_with_taxonomy() {
+        // A post that hasn't been classified yet — every dim is None —
+        // must validate cleanly against any taxonomy.
+        let c = Classifications::default();
+        let t = Taxonomy::current_v1();
+        assert!(c.validate(&t).is_ok());
     }
 }

--- a/apps/blogctl/src/commands/classify.rs
+++ b/apps/blogctl/src/commands/classify.rs
@@ -1,10 +1,24 @@
 //! `blogctl classify <slug>` — set classification dimensions on a
-//! post. Stub for now; behavior lands in #437 (taxonomy + classify).
+//! post.
+//!
+//! Each `--<dim> value` overwrites the corresponding dimension;
+//! `--clear-<dim>` removes it. Unspecified dimensions are left
+//! untouched. `--theme a,b` replaces the entire theme list (the only
+//! multi-valued dimension in v1).
+//!
+//! Validates the resulting `Classifications` against the workdir's
+//! taxonomy *before* the file write — an invalid value fails fast
+//! with an error that lists the allowed options.
 
+use std::fs;
 use std::path::PathBuf;
 
+use time::OffsetDateTime;
+
+use crate::classifications::Classifications;
 use crate::error::{Error, Result};
-use crate::sync::Jj;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
 
 #[derive(Debug, Default)]
 pub struct ClassifyArgs {
@@ -25,6 +39,223 @@ pub struct ClassifyArgs {
     pub no_sync: bool,
 }
 
-pub fn run(_jj: &dyn Jj, _args: ClassifyArgs) -> Result<()> {
-    Err(Error::Unimplemented("classify"))
+pub fn run(jj: &dyn Jj, args: ClassifyArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let (handle, mut post) = repo.load_raw(&args.slug)?;
+
+    let changed_dims = apply(&mut post.metadata.classifications, &args);
+    if changed_dims.is_empty() {
+        println!("{}: no classification changes", args.slug);
+        return Ok(());
+    }
+
+    // Validate against the workdir's taxonomy BEFORE touching the
+    // filesystem or the jj graph. The error carries the dimension's
+    // allowed list so the user sees the legal options on the spot.
+    let taxonomy = repo.read_taxonomy()?;
+    if let Err(v) = post.metadata.classifications.validate(&taxonomy) {
+        return Err(Error::InvalidClassification {
+            path: handle.path.clone(),
+            dimension: v.dimension,
+            value: v.value,
+            allowed: v.allowed,
+        });
+    }
+
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let dim_summary = changed_dims.join(",");
+    let message = format!("post({}): classify ({dim_summary})", args.slug);
+    let path = handle.path.clone();
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        post.metadata.updated_at = OffsetDateTime::now_utc();
+        let rendered = post.render()?;
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))?;
+        Ok(())
+    })?;
+    println!("{}: classified ({dim_summary})", args.slug);
+    Ok(())
+}
+
+/// Apply CLI args to `c`. Returns the list of dimension names that
+/// actually changed — used both for the commit message and to skip
+/// the write entirely when nothing changed.
+fn apply(c: &mut Classifications, args: &ClassifyArgs) -> Vec<String> {
+    let mut changed = Vec::new();
+
+    apply_single(
+        &mut c.format,
+        &args.format,
+        args.clear_format,
+        "format",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.hook,
+        &args.hook,
+        args.clear_hook,
+        "hook",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.tone,
+        &args.tone,
+        args.clear_tone,
+        "tone",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.audience,
+        &args.audience,
+        args.clear_audience,
+        "audience",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.strategic_role,
+        &args.strategic_role,
+        args.clear_strategic_role,
+        "strategic_role",
+        &mut changed,
+    );
+
+    // Theme is multi-valued. --theme a,b REPLACES the list; --clear-theme
+    // empties it. They're mutually exclusive in spirit; if both are set
+    // we honor --clear-theme last (matches the spirit of an explicit
+    // clear).
+    if !args.theme.is_empty() && c.theme != args.theme {
+        c.theme = args.theme.clone();
+        changed.push("theme".into());
+    }
+    if args.clear_theme && !c.theme.is_empty() {
+        c.theme.clear();
+        if !changed.contains(&"theme".to_string()) {
+            changed.push("theme".into());
+        }
+    }
+
+    changed
+}
+
+fn apply_single(
+    field: &mut Option<String>,
+    new_value: &Option<String>,
+    clear: bool,
+    name: &str,
+    changed: &mut Vec<String>,
+) {
+    // Explicit clear takes precedence over a set in the same invocation.
+    if clear {
+        if field.is_some() {
+            *field = None;
+            changed.push(name.into());
+        }
+        return;
+    }
+    if let Some(v) = new_value {
+        if field.as_deref() != Some(v.as_str()) {
+            *field = Some(v.clone());
+            changed.push(name.into());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_args() -> ClassifyArgs {
+        ClassifyArgs {
+            slug: "x".into(),
+            workdir: PathBuf::new(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_sets_unset_single_valued_dimension() {
+        let mut c = Classifications::default();
+        let mut a = empty_args();
+        a.format = Some("thesis".into());
+        let changed = apply(&mut c, &a);
+        assert_eq!(c.format.as_deref(), Some("thesis"));
+        assert_eq!(changed, vec!["format"]);
+    }
+
+    #[test]
+    fn apply_clears_via_clear_flag() {
+        let mut c = Classifications {
+            tone: Some("sharp".into()),
+            ..Default::default()
+        };
+        let mut a = empty_args();
+        a.clear_tone = true;
+        let changed = apply(&mut c, &a);
+        assert!(c.tone.is_none());
+        assert_eq!(changed, vec!["tone"]);
+    }
+
+    #[test]
+    fn apply_clear_takes_precedence_over_set() {
+        let mut c = Classifications::default();
+        let mut a = empty_args();
+        a.tone = Some("sharp".into());
+        a.clear_tone = true;
+        let changed = apply(&mut c, &a);
+        assert!(c.tone.is_none());
+        // Nothing actually changed — it was None and stayed None.
+        assert!(changed.is_empty());
+    }
+
+    #[test]
+    fn apply_theme_replaces_list() {
+        let mut c = Classifications {
+            theme: vec!["ambiguity".into()],
+            ..Default::default()
+        };
+        let mut a = empty_args();
+        a.theme = vec!["delivery".into(), "interfaces".into()];
+        let changed = apply(&mut c, &a);
+        assert_eq!(c.theme, vec!["delivery", "interfaces"]);
+        assert_eq!(changed, vec!["theme"]);
+    }
+
+    #[test]
+    fn apply_clear_theme_empties_the_list() {
+        let mut c = Classifications {
+            theme: vec!["ambiguity".into()],
+            ..Default::default()
+        };
+        let mut a = empty_args();
+        a.clear_theme = true;
+        let changed = apply(&mut c, &a);
+        assert!(c.theme.is_empty());
+        assert_eq!(changed, vec!["theme"]);
+    }
+
+    #[test]
+    fn apply_returns_empty_when_nothing_changes() {
+        // Args claim to set format=thesis but it's already thesis.
+        let mut c = Classifications {
+            format: Some("thesis".into()),
+            ..Default::default()
+        };
+        let mut a = empty_args();
+        a.format = Some("thesis".into());
+        assert!(apply(&mut c, &a).is_empty());
+    }
+
+    #[test]
+    fn apply_updates_multiple_dimensions_in_one_call() {
+        let mut c = Classifications::default();
+        let mut a = empty_args();
+        a.format = Some("thesis".into());
+        a.hook = Some("contradiction".into());
+        a.theme = vec!["ambiguity".into()];
+        let changed = apply(&mut c, &a);
+        // Order matters for the commit message; should be the order
+        // dimensions are applied.
+        assert_eq!(changed, vec!["format", "hook", "theme"]);
+    }
 }

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -69,6 +69,14 @@ pub enum Finding {
         bookmark: String,
         remote: String,
     },
+    /// A classification value on `path` is not in the workdir's
+    /// declared taxonomy (`[classifications.<dimension>]`).
+    InvalidClassification {
+        path: PathBuf,
+        dimension: String,
+        value: String,
+        allowed: Vec<String>,
+    },
 }
 
 impl fmt::Display for Finding {
@@ -133,6 +141,17 @@ impl fmt::Display for Finding {
             } => write!(
                 f,
                 "{count} unpushed commit(s) on {bookmark}; oldest is {oldest_age_hours}h old (auto-push to {remote} may be failing silently)",
+            ),
+            Self::InvalidClassification {
+                path,
+                dimension,
+                value,
+                allowed,
+            } => write!(
+                f,
+                "invalid classification in {}: {dimension}={value:?} is not in the taxonomy (allowed: {})",
+                path.display(),
+                allowed.join(", "),
             ),
         }
     }
@@ -204,6 +223,18 @@ pub fn audit(workdir: &Workdir) -> Result<Vec<Finding>> {
                             path: path.clone(),
                             theme: meta.theme.clone(),
                             known: cfg.themes.keys().cloned().collect(),
+                        });
+                    }
+                    // Run taxonomy validation per dimension and emit
+                    // one finding per violation — doctor enumerates,
+                    // unlike Repository::load which fail-fasts.
+                    let taxonomy = crate::taxonomy::Taxonomy::new(cfg.classifications.clone());
+                    for v in meta.classifications.violations(&taxonomy) {
+                        findings.push(Finding::InvalidClassification {
+                            path: path.clone(),
+                            dimension: v.dimension,
+                            value: v.value,
+                            allowed: v.allowed,
                         });
                     }
                 }
@@ -497,6 +528,77 @@ mod tests {
         assert!(findings
             .iter()
             .any(|f| matches!(f, Finding::StrayEntry { .. })));
+    }
+
+    #[test]
+    fn audit_flags_invalid_classifications_per_dimension() {
+        let (tmp, workdir) = fresh_workdir();
+        let mut post = fixture_post("multi-bad", Stage::Concept);
+        // Two bad single-valued dims + one bad theme element.
+        post.metadata.classifications.format = Some("not-a-format".into());
+        post.metadata.classifications.tone = Some("brisk".into());
+        post.metadata.classifications.theme.push("ambiguity".into()); // good
+        post.metadata
+            .classifications
+            .theme
+            .push("made-up-theme".into()); // bad
+        fs::write(
+            tmp.path().join("concepts/multi-bad.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        let invalid: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| matches!(f, Finding::InvalidClassification { .. }))
+            .collect();
+        assert_eq!(
+            invalid.len(),
+            3,
+            "expected one finding per bad value: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn audit_silent_on_classifications_when_taxonomy_is_empty() {
+        // Wipe the taxonomy in the config; doctor should accept any
+        // classification value (permissive on undeclared dimensions).
+        let (tmp, workdir) = fresh_workdir();
+        // Erase `[classifications.*]` by writing a minimal config.
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            "version = 1\n[themes.standard]\n",
+        )
+        .unwrap();
+
+        let mut post = fixture_post("anything", Stage::Concept);
+        post.metadata.classifications.format = Some("whatever-i-want".into());
+        fs::write(
+            tmp.path().join("concepts/anything.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        assert!(!findings
+            .iter()
+            .any(|f| matches!(f, Finding::InvalidClassification { .. })));
+    }
+
+    #[test]
+    fn invalid_classification_finding_lists_allowed_values() {
+        let f = Finding::InvalidClassification {
+            path: PathBuf::from("concepts/typo.md"),
+            dimension: "format".into(),
+            value: "thesys".into(),
+            allowed: vec!["thesis".into(), "essay".into()],
+        };
+        let rendered = format!("{f}");
+        assert!(rendered.contains("thesys"));
+        assert!(rendered.contains("thesis"));
+        assert!(rendered.contains("essay"));
+        assert!(rendered.contains("format"));
     }
 
     #[test]

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -53,6 +53,7 @@ pub enum SkipReason {
     ConfigMissing,
     ConfigUnparsable,
     UnpushedCommits,
+    InvalidClassification,
 }
 
 impl fmt::Display for SkipReason {
@@ -66,6 +67,9 @@ impl fmt::Display for SkipReason {
             Self::ConfigUnparsable => "manual: edit .blog-os.toml by hand",
             Self::UnpushedCommits => {
                 "manual: investigate auto-push (network? auth? wrong bookmark name?)"
+            }
+            Self::InvalidClassification => {
+                "manual: `blogctl classify` to a valid value, or add it to the taxonomy"
             }
         };
         f.write_str(s)
@@ -123,6 +127,10 @@ pub fn plan(findings: Vec<Finding>) -> Vec<Repair> {
             f @ Finding::UnpushedCommitsStale { .. } => skips.push(Repair::Skip {
                 finding: f,
                 reason: SkipReason::UnpushedCommits,
+            }),
+            f @ Finding::InvalidClassification { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::InvalidClassification,
             }),
         }
     }

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -150,6 +150,17 @@ pub enum Error {
         "`blogctl {0}` is not yet implemented (CLI surface only; behavior lands in a follow-up)"
     )]
     Unimplemented(&'static str),
+
+    #[error(
+        "invalid classification in {path}: {dimension}={value:?} is not in the taxonomy. allowed values: {}",
+        allowed.join(", "),
+    )]
+    InvalidClassification {
+        path: PathBuf,
+        dimension: String,
+        value: String,
+        allowed: Vec<String>,
+    },
 }
 
 impl Error {

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -10,6 +10,7 @@ pub mod stage;
 pub mod storage;
 pub mod sync;
 pub mod target;
+pub mod taxonomy;
 
 pub use classifications::Classifications;
 pub use error::{Error, Result};
@@ -18,3 +19,4 @@ pub use post::{Post, PostMetadata};
 pub use stage::Stage;
 pub use storage::{Repository, Workdir};
 pub use target::{Target, TargetEntry, TargetStatus};
+pub use taxonomy::{Dimension, Taxonomy};

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -324,6 +324,24 @@ impl Repository {
     /// frontmatter status, or if any classification value is not in
     /// the workdir's taxonomy.
     pub fn load(&self, slug: &str) -> Result<(PostHandle, Post)> {
+        let (handle, post) = self.load_raw(slug)?;
+        let taxonomy = self.read_taxonomy()?;
+        if let Err(v) = post.metadata.classifications.validate(&taxonomy) {
+            return Err(Error::InvalidClassification {
+                path: handle.path.clone(),
+                dimension: v.dimension,
+                value: v.value,
+                allowed: v.allowed,
+            });
+        }
+        Ok((handle, post))
+    }
+
+    /// Like `load`, but skips taxonomy validation. The `classify`
+    /// command uses this so a post with stale/invalid classifications
+    /// can still be rewritten to a valid set — otherwise the very
+    /// tool meant to fix the problem would be blocked by it.
+    pub fn load_raw(&self, slug: &str) -> Result<(PostHandle, Post)> {
         let (stage, path) = self
             .locate(slug)?
             .ok_or_else(|| Error::PostNotFound(slug.to_string()))?;
@@ -334,15 +352,6 @@ impl Repository {
                 slug: slug.to_string(),
                 dir_stage: stage,
                 fm_stage: post.metadata.status,
-            });
-        }
-        let taxonomy = self.read_taxonomy()?;
-        if let Err(v) = post.metadata.classifications.validate(&taxonomy) {
-            return Err(Error::InvalidClassification {
-                path: path.clone(),
-                dimension: v.dimension,
-                value: v.value,
-                allowed: v.allowed,
             });
         }
         let handle = PostHandle {

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -8,6 +8,7 @@ use time::OffsetDateTime;
 use crate::error::{Error, Result};
 use crate::post::{Post, PostMetadata};
 use crate::stage::Stage;
+use crate::taxonomy::{Dimension, Taxonomy};
 
 const CONFIG_FILE: &str = ".blog-os.toml";
 const README_FILE: &str = "README.md";
@@ -37,6 +38,12 @@ pub struct Config {
     pub themes: BTreeMap<String, ThemeConfig>,
     #[serde(default)]
     pub sync: SyncConfig,
+    /// Declarative classification taxonomy — the set of allowed
+    /// values per dimension. Loaded as `Taxonomy` and used to
+    /// validate `Classifications` at post-load time and from
+    /// `blogctl classify` before any write.
+    #[serde(default)]
+    pub classifications: BTreeMap<String, Dimension>,
 }
 
 /// Workdir-wide defaults. Currently just the theme `blogctl new` selects
@@ -119,6 +126,7 @@ impl Config {
             defaults: Defaults::default(),
             themes,
             sync: SyncConfig::default(),
+            classifications: Taxonomy::current_v1().to_btreemap(),
         }
     }
 }
@@ -272,6 +280,14 @@ impl Repository {
         toml::from_str(&raw).map_err(|source| Error::ConfigParse { path, source })
     }
 
+    /// Build a `Taxonomy` from the workdir's `[classifications.*]`
+    /// tables. The same call site used by `load`/`list` and by
+    /// `blogctl classify`.
+    pub fn read_taxonomy(&self) -> Result<Taxonomy> {
+        let config = self.read_config()?;
+        Ok(Taxonomy::new(config.classifications))
+    }
+
     /// Write the canonical README into the workdir. Returns `true` if
     /// the file was (over)written, `false` if a README already existed
     /// and `force` was false (init's path — preserves a user's
@@ -304,8 +320,9 @@ impl Repository {
     }
 
     /// Load a post by slug. Fails if the post is missing, if the slug
-    /// resolves in two stages, or if the directory disagrees with the
-    /// frontmatter status.
+    /// resolves in two stages, if the directory disagrees with the
+    /// frontmatter status, or if any classification value is not in
+    /// the workdir's taxonomy.
     pub fn load(&self, slug: &str) -> Result<(PostHandle, Post)> {
         let (stage, path) = self
             .locate(slug)?
@@ -319,6 +336,15 @@ impl Repository {
                 fm_stage: post.metadata.status,
             });
         }
+        let taxonomy = self.read_taxonomy()?;
+        if let Err(v) = post.metadata.classifications.validate(&taxonomy) {
+            return Err(Error::InvalidClassification {
+                path: path.clone(),
+                dimension: v.dimension,
+                value: v.value,
+                allowed: v.allowed,
+            });
+        }
         let handle = PostHandle {
             stage,
             path,
@@ -328,9 +354,10 @@ impl Repository {
     }
 
     /// Enumerate every post under the workdir, sorted by stage then slug.
-    /// Fails on any frontmatter or stage mismatch — consistent with the
-    /// "fail loudly" design constraint.
+    /// Fails on any frontmatter / stage / classification problem — consistent
+    /// with the "fail loudly" design constraint.
     pub fn list(&self) -> Result<Vec<PostHandle>> {
+        let taxonomy = self.read_taxonomy()?;
         let mut handles = Vec::new();
         for &stage in Stage::ALL {
             let dir = self.workdir.stage_dir(stage);
@@ -352,6 +379,14 @@ impl Repository {
                         slug: post.metadata.slug,
                         dir_stage: stage,
                         fm_stage: post.metadata.status,
+                    });
+                }
+                if let Err(v) = post.metadata.classifications.validate(&taxonomy) {
+                    return Err(Error::InvalidClassification {
+                        path: path.clone(),
+                        dimension: v.dimension,
+                        value: v.value,
+                        allowed: v.allowed,
                     });
                 }
                 handles.push(PostHandle {
@@ -973,5 +1008,91 @@ mod tests {
         assert_eq!(stray.len(), 1);
         assert!(stray[0].path.ends_with("archive"));
         assert_eq!(stray[0].dir_stage, Stage::Concept);
+    }
+
+    #[test]
+    fn init_seeds_v1_taxonomy() {
+        let (_tmp, repo) = fresh_repo();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.classifications.contains_key("format"));
+        assert!(cfg.classifications.contains_key("theme"));
+        // The seeded v1 set matches Taxonomy::current_v1().
+        assert_eq!(cfg.classifications, Taxonomy::current_v1().to_btreemap());
+    }
+
+    #[test]
+    fn read_taxonomy_builds_from_classifications_table() {
+        let (_tmp, repo) = fresh_repo();
+        let tax = repo.read_taxonomy().unwrap();
+        let format = tax.dimension("format").expect("format dim seeded");
+        assert!(format.allows("thesis"));
+        assert!(!format.allows("thesys"));
+    }
+
+    #[test]
+    fn config_without_classifications_table_back_fills_empty_map() {
+        // Pre-#437 config — no [classifications.*] tables at all.
+        // Reading must succeed; the resulting taxonomy is permissive
+        // (empty) so posts validate cleanly.
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        fs::write(repo.workdir().config_path(), "version = 1\n").unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.classifications.is_empty());
+        let tax = repo.read_taxonomy().unwrap();
+        assert!(tax.is_empty());
+    }
+
+    #[test]
+    fn load_rejects_post_with_invalid_classification() {
+        let (tmp, repo) = fresh_repo();
+        // Plant a post with `format: thesys` (typo) directly on disk.
+        // create_post would go through Post::new which doesn't
+        // validate — that's fine, we want to simulate a stale or
+        // hand-edited post.
+        let mut post = fixture_post("typo", Stage::Concept);
+        post.metadata.classifications.format = Some("thesys".into());
+        fs::write(tmp.path().join("concepts/typo.md"), post.render().unwrap()).unwrap();
+        let err = repo.load("typo").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::InvalidClassification { ref dimension, ref value, .. }
+                    if dimension == "format" && value == "thesys"
+            ),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn list_rejects_workdir_with_invalid_classification() {
+        let (tmp, repo) = fresh_repo();
+        let mut post = fixture_post("typo", Stage::Concept);
+        post.metadata.classifications.tone = Some("snarky".into());
+        fs::write(tmp.path().join("concepts/typo.md"), post.render().unwrap()).unwrap();
+        let err = repo.list().unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::InvalidClassification { ref dimension, .. } if dimension == "tone"
+            ),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn load_accepts_unclassified_post() {
+        let (tmp, repo) = fresh_repo();
+        let post = fixture_post("no-class", Stage::Concept);
+        fs::write(
+            tmp.path().join("concepts/no-class.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+        let (_handle, loaded) = repo.load("no-class").unwrap();
+        assert!(loaded.metadata.classifications.is_empty());
     }
 }

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -1,0 +1,242 @@
+//! Declarative classification taxonomy. The set of allowed values per
+//! dimension lives in `.blog-os.toml` under `[classifications.*]`;
+//! this module loads it into a `Taxonomy` and runs the validation
+//! pass against `Classifications` instances.
+//!
+//! The taxonomy is data, not code — adding a new format or theme
+//! is a config edit, not a Rust change. The struct's *dimension
+//! names* (`format`, `hook`, `tone`, `audience`, `strategic_role`,
+//! `theme`) come from `Classifications`'s field names and are
+//! fixed; the *values* inside each dimension are user-configurable.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One dimension of the taxonomy: a list of allowed values plus a
+/// `multi` flag that documents whether the dimension is single- or
+/// multi-valued semantically. The Rust type system carries the
+/// single/multi distinction (each `Classifications` field is either
+/// `Option<String>` or `Vec<String>`), so `multi` is informational
+/// only — kept for the taxonomy file's self-documentation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dimension {
+    #[serde(default)]
+    pub multi: bool,
+    pub values: Vec<String>,
+}
+
+impl Dimension {
+    /// True when `value` is one of the dimension's declared options.
+    pub fn allows(&self, value: &str) -> bool {
+        self.values.iter().any(|v| v == value)
+    }
+}
+
+/// The full taxonomy — a map from dimension name to its allowed
+/// values. Wraps a `BTreeMap` so the `from(config.classifications)`
+/// path is direct and call sites stay readable.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Taxonomy {
+    dimensions: BTreeMap<String, Dimension>,
+}
+
+impl Taxonomy {
+    pub fn new(dimensions: BTreeMap<String, Dimension>) -> Self {
+        Self { dimensions }
+    }
+
+    /// Look up a dimension by name. `None` means "not declared" —
+    /// validation is permissive on undeclared dimensions so the user
+    /// can roll out (or remove) a dimension from their taxonomy
+    /// without invalidating every post.
+    pub fn dimension(&self, name: &str) -> Option<&Dimension> {
+        self.dimensions.get(name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.dimensions.is_empty()
+    }
+
+    /// The v1 taxonomy baked into `init`. Mirrors the table in #437's
+    /// issue body. Edit here when adding a starter value.
+    pub fn current_v1() -> Self {
+        Self {
+            dimensions: starter_v1(),
+        }
+    }
+
+    /// Hand back the underlying map. Used by `Config::current()` to
+    /// seed `.blog-os.toml`'s `[classifications.*]` tables.
+    pub fn into_btreemap(self) -> BTreeMap<String, Dimension> {
+        self.dimensions
+    }
+
+    /// Same as `into_btreemap` but doesn't consume `self`.
+    pub fn to_btreemap(&self) -> BTreeMap<String, Dimension> {
+        self.dimensions.clone()
+    }
+}
+
+impl From<BTreeMap<String, Dimension>> for Taxonomy {
+    fn from(dimensions: BTreeMap<String, Dimension>) -> Self {
+        Self::new(dimensions)
+    }
+}
+
+/// One bad classification value found during validation. `allowed`
+/// carries the dimension's declared list so the error message
+/// doubles as a cheat sheet — the user shouldn't have to grep the
+/// taxonomy file to learn the legal options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+    pub dimension: String,
+    pub value: String,
+    pub allowed: Vec<String>,
+}
+
+/// The dimension names `Classifications` knows about. Kept in code
+/// because the struct's field set is fixed; only the *values* inside
+/// each dimension are config-driven.
+pub const SINGLE_VALUED: &[&str] = &["format", "hook", "tone", "audience", "strategic_role"];
+pub const MULTI_VALUED: &[&str] = &["theme"];
+
+fn starter_v1() -> BTreeMap<String, Dimension> {
+    let mut m = BTreeMap::new();
+    m.insert(
+        "format".into(),
+        Dimension {
+            multi: false,
+            values: strs(&[
+                "parable",
+                "thesis",
+                "essay",
+                "observation",
+                "personal-reflection",
+                "framework",
+            ]),
+        },
+    );
+    m.insert(
+        "hook".into(),
+        Dimension {
+            multi: false,
+            values: strs(&[
+                "proverb",
+                "contradiction",
+                "direct-claim",
+                "story-title",
+                "question",
+                "analogy",
+            ]),
+        },
+    );
+    m.insert(
+        "tone".into(),
+        Dimension {
+            multi: false,
+            values: strs(&["gentle", "sharp", "vulnerable", "reflective", "provocative"]),
+        },
+    );
+    m.insert(
+        "audience".into(),
+        Dimension {
+            multi: false,
+            values: strs(&[
+                "engineering",
+                "product",
+                "leadership",
+                "founders",
+                "general",
+            ]),
+        },
+    );
+    m.insert(
+        "strategic_role".into(),
+        Dimension {
+            multi: false,
+            values: strs(&[
+                "salal-positioning",
+                "career-brand",
+                "recruiting",
+                "writing-practice",
+                "consulting-signal",
+            ]),
+        },
+    );
+    m.insert(
+        "theme".into(),
+        Dimension {
+            multi: true,
+            values: strs(&[
+                "ambiguity",
+                "delivery",
+                "interfaces",
+                "leadership",
+                "ai",
+                "engineering-culture",
+                "product",
+                "organizational-psychology",
+            ]),
+        },
+    );
+    m
+}
+
+fn strs(slice: &[&str]) -> Vec<String> {
+    slice.iter().map(|s| (*s).to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_v1_includes_every_known_dimension() {
+        let t = Taxonomy::current_v1();
+        for name in SINGLE_VALUED.iter().chain(MULTI_VALUED.iter()) {
+            assert!(
+                t.dimension(name).is_some(),
+                "current_v1 should declare {name}",
+            );
+        }
+    }
+
+    #[test]
+    fn current_v1_theme_is_multi_valued() {
+        let t = Taxonomy::current_v1();
+        let theme = t.dimension("theme").unwrap();
+        assert!(theme.multi);
+    }
+
+    #[test]
+    fn current_v1_format_is_single_valued() {
+        let t = Taxonomy::current_v1();
+        let format = t.dimension("format").unwrap();
+        assert!(!format.multi);
+        assert!(format.allows("thesis"));
+        assert!(!format.allows("thesys"));
+    }
+
+    #[test]
+    fn empty_taxonomy_is_default() {
+        assert!(Taxonomy::default().is_empty());
+    }
+
+    #[test]
+    fn dimension_from_toml_round_trips() {
+        let raw = "multi = true\nvalues = [\"a\", \"b\"]\n";
+        let d: Dimension = toml::from_str(raw).unwrap();
+        assert!(d.multi);
+        assert_eq!(d.values.len(), 2);
+        assert!(d.allows("a"));
+        assert!(!d.allows("c"));
+    }
+
+    #[test]
+    fn dimension_multi_defaults_to_false() {
+        let raw = "values = [\"x\", \"y\"]\n";
+        let d: Dimension = toml::from_str(raw).unwrap();
+        assert!(!d.multi);
+    }
+}

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -310,6 +310,178 @@ fn doctor_does_not_surface_stale_finding_when_push_is_current() {
 }
 
 #[test]
+fn classify_drives_full_sync_with_changed_dimensions_in_message() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hello".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+
+    let jj = FakeJj::new();
+    commands::classify::run(
+        &jj,
+        commands::classify::ClassifyArgs {
+            slug: "hello".into(),
+            workdir: path.clone(),
+            format: Some("thesis".into()),
+            hook: Some("contradiction".into()),
+            theme: vec!["ambiguity".into(), "delivery".into()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_full_sync_flow(&jj.calls(), "post(hello): classify (format,hook,theme)");
+
+    // And the post on disk now carries the new classifications.
+    let raw = fs::read_to_string(path.join("concepts/hello.md")).unwrap();
+    assert!(raw.contains("format: thesis"));
+    assert!(raw.contains("hook: contradiction"));
+    assert!(raw.contains("ambiguity"));
+    assert!(raw.contains("delivery"));
+}
+
+#[test]
+fn classify_with_invalid_value_fails_before_any_write() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hi".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+
+    let pre = fs::read_to_string(path.join("concepts/hi.md")).unwrap();
+
+    let jj = FakeJj::new();
+    let err = commands::classify::run(
+        &jj,
+        commands::classify::ClassifyArgs {
+            slug: "hi".into(),
+            workdir: path.clone(),
+            format: Some("not-a-format".into()),
+            ..Default::default()
+        },
+    )
+    .expect_err("invalid value must hard-fail");
+    assert!(
+        matches!(err, blogctl::Error::InvalidClassification { ref dimension, .. } if dimension == "format"),
+        "got: {err:?}"
+    );
+
+    // File on disk is unchanged AND no jj calls fired.
+    let post = fs::read_to_string(path.join("concepts/hi.md")).unwrap();
+    assert_eq!(post, pre, "file must be untouched");
+    assert!(
+        jj.calls().is_empty(),
+        "jj must not be called: {:?}",
+        jj.calls()
+    );
+}
+
+#[test]
+fn classify_with_no_changes_skips_sync() {
+    // Set classifications once, then run classify again with the same
+    // values — nothing changes, so no commit, no push, no jj noise.
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Stable".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+
+    commands::classify::run(
+        &FakeJj::new(),
+        commands::classify::ClassifyArgs {
+            slug: "stable".into(),
+            workdir: path.clone(),
+            format: Some("thesis".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Second invocation with the same value → no-op.
+    let jj = FakeJj::new();
+    commands::classify::run(
+        &jj,
+        commands::classify::ClassifyArgs {
+            slug: "stable".into(),
+            workdir: path.clone(),
+            format: Some("thesis".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        jj.calls().is_empty(),
+        "no-op classify must not call jj: {:?}",
+        jj.calls()
+    );
+}
+
+#[test]
+fn classify_can_repair_post_whose_existing_classification_is_invalid() {
+    // The user typo'd `format: thesys` in the past (or removed a value
+    // from the taxonomy). `classify` must still be able to load and
+    // rewrite the post — otherwise the only fix tool is blocked by
+    // the problem it's meant to fix.
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Repair".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    // Plant the typo by hand-editing the file (simulates a stale post).
+    let post_path = path.join("concepts/repair.md");
+    let raw = fs::read_to_string(&post_path).unwrap();
+    let with_typo = raw.replace(
+        "tags: []\n",
+        "tags: []\nclassifications:\n  format: thesys\n",
+    );
+    fs::write(&post_path, with_typo).unwrap();
+
+    // Now classify with a valid value — should succeed and overwrite.
+    let jj = FakeJj::new();
+    commands::classify::run(
+        &jj,
+        commands::classify::ClassifyArgs {
+            slug: "repair".into(),
+            workdir: path.clone(),
+            format: Some("thesis".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let fixed = fs::read_to_string(&post_path).unwrap();
+    assert!(fixed.contains("format: thesis"));
+    assert!(!fixed.contains("thesys"));
+}
+
+#[test]
 fn rebase_conflict_is_a_hard_error_and_aborts_the_write() {
     let (_tmp, path) = workdir();
     commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();


### PR DESCRIPTION
Adds a declarative classification taxonomy with the seed values from
#437's issue body and wires it into post load + doctor.

The taxonomy lives in .blog-os.toml as `[classifications.<name>]`
tables; src/taxonomy.rs loads them into a Taxonomy (BTreeMap of
Dimension { multi, values }). init seeds the v1 set so a fresh
workdir validates correctly out of the box; older workdirs without
any [classifications.*] tables continue to parse and skip validation
(permissive on undeclared dimensions, so the user can phase a
dimension in or out without invalidating every post).

Classifications::violations(&Taxonomy) enumerates every bad value
(doctor uses this); Classifications::validate is the fail-fast
wrapper used by Repository::load and Repository::list. Both
load paths now reject an invalid value with the new
Error::InvalidClassification, whose error message lists the allowed
values so the failure doubles as a cheat sheet.

doctor::audit calls violations() on every parsed post and emits one
Finding::InvalidClassification per bad value — matches the doctor
pattern of enumerating problems rather than fail-fasting.
fix::plan maps the finding to Repair::Skip with a manual-fix hint
(SkipReason::InvalidClassification).

The classify command body lands in a follow-up commit on this
branch.

For #437.

Closes #437.

Replaces the stub from #434 with the real implementation.

The flow: load the post (via load_raw — which is like load but
skips taxonomy validation, so the very tool meant to fix a typo'd
classification isn't blocked by it), apply CLI args to a mutable
Classifications, validate against the workdir's taxonomy, and write
through sync::commit_and_push with a deterministic message of the
form `post(<slug>): classify (<changed-dims>)`.

Semantics:
- --<dim> <value> sets/replaces a single-valued dimension.
- --clear-<dim> unsets it; takes precedence over --<dim> in the
  same invocation.
- --theme a,b replaces the entire theme list (the only multi-valued
  dimension in v1); --clear-theme empties it.
- Unspecified dimensions are left untouched.

Pre-validation runs before the write — an invalid value never
touches the filesystem or the jj graph. The error inherits its
message from Error::InvalidClassification, which already lists the
allowed values so the failure is its own cheat sheet.

No-op invocations (every flag matches the current value) skip the
sync entirely so re-running classify with the same args doesn't
churn commits.

Repository::load_raw is the new sibling to Repository::load that
skips taxonomy validation. classify uses it; nothing else does.