### PR TITLE
feat(blogctl): metrics update + show command bodies

### DIFF
--- a/apps/blogctl/src/commands/metrics.rs
+++ b/apps/blogctl/src/commands/metrics.rs
@@ -1,12 +1,21 @@
 //! `blogctl metrics update <slug>` / `blogctl metrics show <slug>` —
-//! per-target performance numbers. Stubs for now; behavior lands in
-//! #436 (metrics update + show).
+//! per-target performance numbers.
+//!
+//! Update overwrites; there's no history. `sampled_at` defaults to
+//! `now_utc()` and acts as the freshness signal — analytics will
+//! grow a "stale" notion on top, but the storage model stays a
+//! single point-in-time per target.
 
+use std::fs;
 use std::path::PathBuf;
 
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
 use crate::error::{Error, Result};
-use crate::sync::Jj;
-use crate::target::Target;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+use crate::target::{Target, TargetMetrics};
 
 #[derive(Debug)]
 pub struct UpdateArgs {
@@ -29,10 +38,120 @@ pub struct ShowArgs {
     pub workdir: PathBuf,
 }
 
-pub fn update(_jj: &dyn Jj, _args: UpdateArgs) -> Result<()> {
-    Err(Error::Unimplemented("metrics update"))
+pub fn update(jj: &dyn Jj, args: UpdateArgs) -> Result<()> {
+    let sampled_at = parse_sampled_at(args.sampled_at.as_deref())?;
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let (handle, mut post) = repo.load_raw(&args.slug)?;
+
+    // Find the named target. Absent → hard fail before any write or
+    // sync; the user must add the target via the existing targets[]
+    // editing flow first (out of scope here per #436).
+    let target_idx = post
+        .metadata
+        .targets
+        .iter()
+        .position(|t| t.name == args.target)
+        .ok_or_else(|| Error::TargetNotInPost {
+            slug: args.slug.clone(),
+            target: args.target,
+        })?;
+
+    let new_metrics = TargetMetrics {
+        impressions: args.impressions,
+        reactions: args.reactions,
+        comments: args.comments,
+        reposts: args.reposts,
+        sampled_at,
+    };
+    let interactions = new_metrics.reactions + new_metrics.comments + new_metrics.reposts;
+    post.metadata.targets[target_idx].metrics = Some(new_metrics);
+
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let message = format!(
+        "post({}): metrics {} imp={} int={}",
+        args.slug, args.target, args.impressions, interactions,
+    );
+    let path = handle.path.clone();
+    let target_name = args.target;
+    let impressions = args.impressions;
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        post.metadata.updated_at = OffsetDateTime::now_utc();
+        let rendered = post.render()?;
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))?;
+        Ok(())
+    })?;
+    println!(
+        "{}: metrics {target_name} set (imp={impressions} int={interactions})",
+        args.slug,
+    );
+    Ok(())
 }
 
-pub fn show(_args: ShowArgs) -> Result<()> {
-    Err(Error::Unimplemented("metrics show"))
+pub fn show(args: ShowArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    // load_raw, not load — show should work on posts with
+    // currently-invalid classifications too. Showing metrics
+    // shouldn't be blocked by an unrelated taxonomy typo.
+    let (_handle, post) = repo.load_raw(&args.slug)?;
+
+    if post.metadata.targets.is_empty() {
+        println!("{}: no targets", args.slug);
+        return Ok(());
+    }
+    println!("{} ({}):", args.slug, post.metadata.title);
+    for t in &post.metadata.targets {
+        match &t.metrics {
+            None => println!("  {} [{}]: no metrics", t.name, t.status),
+            Some(m) => {
+                let sampled = m.sampled_at.format(&Rfc3339).unwrap_or_else(|_| "?".into());
+                println!(
+                    "  {} [{}]: imp={} react={} comm={} reposts={} (sampled {sampled})",
+                    t.name, t.status, m.impressions, m.reactions, m.comments, m.reposts,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_sampled_at(raw: Option<&str>) -> Result<OffsetDateTime> {
+    match raw {
+        None => Ok(OffsetDateTime::now_utc()),
+        Some(s) => OffsetDateTime::parse(s, &Rfc3339).map_err(|source| Error::InvalidSampledAt {
+            value: s.to_string(),
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    #[test]
+    fn parse_sampled_at_defaults_to_now_when_none() {
+        let parsed = parse_sampled_at(None).unwrap();
+        // Just check it returned something in the right ballpark.
+        // Real now() is non-deterministic so we can't assert exact.
+        let drift = (OffsetDateTime::now_utc() - parsed).abs();
+        assert!(drift < time::Duration::seconds(2));
+    }
+
+    #[test]
+    fn parse_sampled_at_accepts_rfc3339() {
+        let parsed = parse_sampled_at(Some("2026-05-14T00:00:00Z")).unwrap();
+        assert_eq!(parsed, datetime!(2026-05-14 00:00:00 UTC));
+    }
+
+    #[test]
+    fn parse_sampled_at_rejects_garbage_with_useful_error() {
+        let err = parse_sampled_at(Some("yesterday")).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidSampledAt { ref value, .. } if value == "yesterday"),
+            "got: {err:?}"
+        );
+    }
 }

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -161,6 +161,21 @@ pub enum Error {
         value: String,
         allowed: Vec<String>,
     },
+
+    #[error(
+        "target {target} is not on post {slug:?} — promote it via the targets editing flow before running `metrics update`"
+    )]
+    TargetNotInPost {
+        slug: String,
+        target: crate::target::Target,
+    },
+
+    #[error("invalid --sampled-at {value:?}: expected RFC 3339 timestamp ({source})")]
+    InvalidSampledAt {
+        value: String,
+        #[source]
+        source: time::error::Parse,
+    },
 }
 
 impl Error {

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -481,6 +481,245 @@ fn classify_can_repair_post_whose_existing_classification_is_invalid() {
     assert!(!fixed.contains("thesys"));
 }
 
+/// Plant a TargetEntry on a post so `metrics update` has something
+/// to attach numbers to. Hand-edits the frontmatter directly (the
+/// "promote target to published" flow is out of #436's scope).
+fn add_published_linkedin_target(post_path: &std::path::Path) {
+    let raw = fs::read_to_string(post_path).unwrap();
+    let updated = raw.replace(
+        "tags: []\n",
+        concat!(
+            "tags: []\n",
+            "targets:\n",
+            "  - name: linkedin\n",
+            "    status: published\n",
+            "    url: https://www.linkedin.com/posts/example\n",
+            "    published_at: 2026-05-08T14:32:00Z\n",
+        ),
+    );
+    fs::write(post_path, updated).unwrap();
+}
+
+#[test]
+fn metrics_update_drives_full_sync_with_imp_int_message() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Stats".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&path.join("concepts/stats.md"));
+
+    let jj = FakeJj::new();
+    commands::metrics::update(
+        &jj,
+        commands::metrics::UpdateArgs {
+            slug: "stats".into(),
+            workdir: path.clone(),
+            target: blogctl::Target::Linkedin,
+            impressions: 1842,
+            reactions: 67,
+            comments: 14,
+            reposts: 5,
+            sampled_at: None,
+            no_sync: false,
+        },
+    )
+    .unwrap();
+    // int = 67 + 14 + 5 = 86.
+    assert_full_sync_flow(&jj.calls(), "post(stats): metrics linkedin imp=1842 int=86");
+    // And the numbers actually landed on disk.
+    let raw = fs::read_to_string(path.join("concepts/stats.md")).unwrap();
+    assert!(raw.contains("impressions: 1842"));
+    assert!(raw.contains("reactions: 67"));
+    assert!(raw.contains("comments: 14"));
+    assert!(raw.contains("reposts: 5"));
+    assert!(raw.contains("sampled_at:"));
+}
+
+#[test]
+fn metrics_update_with_sampled_at_override_uses_it() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Override".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&path.join("concepts/override.md"));
+
+    commands::metrics::update(
+        &FakeJj::new(),
+        commands::metrics::UpdateArgs {
+            slug: "override".into(),
+            workdir: path.clone(),
+            target: blogctl::Target::Linkedin,
+            impressions: 100,
+            reactions: 1,
+            comments: 0,
+            reposts: 0,
+            sampled_at: Some("2026-05-14T00:00:00Z".into()),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+    let raw = fs::read_to_string(path.join("concepts/override.md")).unwrap();
+    assert!(
+        raw.contains("sampled_at: 2026-05-14T00:00:00Z"),
+        "expected exact override timestamp, got: {raw}"
+    );
+}
+
+#[test]
+fn metrics_update_fails_when_target_absent_no_sync_no_write() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Bare".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    // Note: no add_published_linkedin_target — the post has zero
+    // targets, so metrics update should hard-fail.
+
+    let post_path = path.join("concepts/bare.md");
+    let pre = fs::read_to_string(&post_path).unwrap();
+
+    let jj = FakeJj::new();
+    let err = commands::metrics::update(
+        &jj,
+        commands::metrics::UpdateArgs {
+            slug: "bare".into(),
+            workdir: path.clone(),
+            target: blogctl::Target::Linkedin,
+            impressions: 1,
+            reactions: 0,
+            comments: 0,
+            reposts: 0,
+            sampled_at: None,
+            no_sync: false,
+        },
+    )
+    .expect_err("missing target must hard-fail");
+    assert!(
+        matches!(err, blogctl::Error::TargetNotInPost { ref slug, .. } if slug == "bare"),
+        "got: {err:?}"
+    );
+
+    // File unchanged AND no jj calls fired.
+    let post = fs::read_to_string(&post_path).unwrap();
+    assert_eq!(post, pre);
+    assert!(jj.calls().is_empty(), "got: {:?}", jj.calls());
+}
+
+#[test]
+fn metrics_update_overwrites_existing_metrics() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Overwrite".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&path.join("concepts/overwrite.md"));
+
+    // First sample.
+    commands::metrics::update(
+        &FakeJj::new(),
+        commands::metrics::UpdateArgs {
+            slug: "overwrite".into(),
+            workdir: path.clone(),
+            target: blogctl::Target::Linkedin,
+            impressions: 100,
+            reactions: 5,
+            comments: 0,
+            reposts: 0,
+            sampled_at: Some("2026-05-10T00:00:00Z".into()),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+
+    // Second sample (later). v1 has no history — second value wins.
+    commands::metrics::update(
+        &FakeJj::new(),
+        commands::metrics::UpdateArgs {
+            slug: "overwrite".into(),
+            workdir: path.clone(),
+            target: blogctl::Target::Linkedin,
+            impressions: 200,
+            reactions: 10,
+            comments: 1,
+            reposts: 0,
+            sampled_at: Some("2026-05-20T00:00:00Z".into()),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+    let raw = fs::read_to_string(path.join("concepts/overwrite.md")).unwrap();
+    assert!(raw.contains("impressions: 200"));
+    assert!(raw.contains("sampled_at: 2026-05-20T00:00:00Z"));
+    assert!(!raw.contains("impressions: 100"));
+    assert!(!raw.contains("2026-05-10"));
+}
+
+#[test]
+fn metrics_show_is_read_only_no_sync() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Visible".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&path.join("concepts/visible.md"));
+
+    // show takes no Jj impl at all — it's a read-only command.
+    // Just call it and assert it succeeds; capturing stdout is
+    // brittle and not the load-bearing claim.
+    commands::metrics::show(commands::metrics::ShowArgs {
+        slug: "visible".into(),
+        workdir: path.clone(),
+    })
+    .unwrap();
+
+    // Sanity check: file on disk untouched.
+    let pre = fs::read_to_string(path.join("concepts/visible.md")).unwrap();
+    commands::metrics::show(commands::metrics::ShowArgs {
+        slug: "visible".into(),
+        workdir: path.clone(),
+    })
+    .unwrap();
+    let post = fs::read_to_string(path.join("concepts/visible.md")).unwrap();
+    assert_eq!(pre, post);
+}
+
 #[test]
 fn rebase_conflict_is_a_hard_error_and_aborts_the_write() {
     let (_tmp, path) = workdir();


### PR DESCRIPTION
Closes #436.

Replaces the stubs from #434 with the real implementations.

`metrics update` finds the named TargetEntry on the post by
matching `--target` against `t.name` (errors with the new
Error::TargetNotInPost if absent — the user must add the target
via the existing targets[] editing flow first; that's out of scope
here per the issue). Builds a fresh TargetMetrics, overwrites
whatever was there, and writes through sync::commit_and_push with
message `post(<slug>): metrics <target> imp=<N> int=<N>`.

`sampled_at` defaults to OffsetDateTime::now_utc() and can be
overridden with --sampled-at <RFC3339>. RFC 3339 parse failures
return Error::InvalidSampledAt with the offending value and the
underlying parse error.

`metrics show` is read-only — no Jj, no sync. Prints one line per
target with raw counts and the sampled_at timestamp; targets
without metrics print "no metrics" instead. Uses load_raw so a
typo'd classification on the same post doesn't block viewing its
metrics.

Overwrite semantics are the v1 model: re-running update on a
target replaces both the counts and sampled_at. No history. The
issue's "Out:" list confirms time-series storage is out of scope.

Three unit tests cover the sampled_at parser (default-to-now,
explicit RFC 3339, garbage-input fail). Five integration tests in
tests/sync.rs cover the canonical 6-call sync flow, sampled_at
override, missing-target hard-fail (no file write, no jj noise),
overwrite-second-sample, and show-is-read-only.