### PR TITLE
feat(blogctl): doctor/fix flag missing .jj as a hard precondition

### DIFF
--- a/apps/blogctl/flake.nix
+++ b/apps/blogctl/flake.nix
@@ -55,6 +55,11 @@
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             nativeBuildInputs = [ pkgs.installShellFiles ];
+            # Integration tests in tests/cli.rs spawn `jj` directly (and
+            # exercise blogctl commands whose precondition check shells
+            # out to `jj status`). Without `jujutsu` on PATH the test
+            # suite fails inside the nix-build sandbox.
+            nativeCheckInputs = [ pkgs.jujutsu ];
             postInstall = ''
               installShellCompletion --cmd blogctl \
                 --bash <($out/bin/blogctl completions bash) \

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::io;
 use std::path::PathBuf;
 
@@ -5,11 +6,20 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 
 use crate::commands;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::kind::Kind;
 use crate::openrouter;
 use crate::sync::{Jj, RealJj};
 use crate::target::Target;
+
+/// Resolve an optional `--workdir` to a concrete path, defaulting to
+/// the current working directory when the flag is omitted.
+fn workdir_or_pwd(workdir: Option<PathBuf>) -> Result<PathBuf> {
+    match workdir {
+        Some(p) => Ok(p),
+        None => env::current_dir().map_err(Error::CurrentDirUnavailable),
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -35,8 +45,9 @@ pub enum Command {
     New {
         /// Post title — slug is derived from this unless `--slug` is given.
         title: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         /// Override the auto-derived slug.
         #[arg(long)]
         slug: Option<String>,
@@ -54,20 +65,23 @@ pub enum Command {
     },
     /// List every post in the workdir, grouped by stage.
     List {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
     },
     /// Print a post's frontmatter and body.
     Show {
         slug: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
     },
     /// Move a post to the next workflow stage.
     Promote {
         slug: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -75,8 +89,9 @@ pub enum Command {
     /// Move a post one stage back.
     Demote {
         slug: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -89,15 +104,17 @@ pub enum Command {
     /// Audit a workdir for layout, frontmatter, and config problems.
     /// Exits non-zero if any finding is surfaced.
     Doctor {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
     },
     /// Apply doctor's auto-correctable repairs. Skipped findings
     /// remain non-zero so `fix` followed by `doctor` is a useful
     /// idempotency check.
     Fix {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         /// Print the plan without writing anything.
         #[arg(long)]
         dry_run: bool,
@@ -115,8 +132,9 @@ pub enum Command {
     /// existing value alone; `--clear-<dim>` removes it.
     Classify {
         slug: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         #[arg(long)]
         format: Option<String>,
         #[arg(long)]
@@ -156,8 +174,9 @@ pub enum Command {
     /// Walk every published post and fill in missing classifications
     /// + metrics interactively, or batch-import from a JSON file.
     Backfill {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         /// Path to a JSON file of per-slug classifications/metrics
         /// entries. When set, runs in non-interactive batch mode.
         #[arg(long, value_name = "PATH")]
@@ -196,8 +215,9 @@ pub enum ReadmeAction {
     /// baked into `blogctl`. Use after a `blogctl` upgrade to pick up
     /// template changes.
     Regenerate {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -209,8 +229,9 @@ pub enum MetricsAction {
     /// Set the latest observed metrics for a target on a post.
     Update {
         slug: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         #[arg(long, value_enum)]
         target: Target,
         #[arg(long)]
@@ -231,8 +252,9 @@ pub enum MetricsAction {
     /// Print the latest metrics for every target on a post.
     Show {
         slug: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
     },
 }
 
@@ -241,8 +263,9 @@ pub enum AnalyticsAction {
     /// Per-dimension counts and median engagement for every
     /// classification value across the workdir.
     Summary {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         #[arg(long, value_enum)]
         target: Option<Target>,
         /// Limit to one dimension (e.g. `format`). Omit to report
@@ -259,8 +282,9 @@ pub enum AnalyticsAction {
         dim_a: String,
         /// Second dimension (e.g. `hook`).
         dim_b: String,
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         #[arg(long, value_enum)]
         target: Option<Target>,
         /// Suppress cells with fewer than this many posts from the
@@ -273,8 +297,9 @@ pub enum AnalyticsAction {
     },
     /// Surface heuristic patterns with explicit hedge language.
     Recommendations {
+        /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
-        workdir: PathBuf,
+        workdir: Option<PathBuf>,
         #[arg(long, value_enum)]
         target: Option<Target>,
         /// Posts-per-cell threshold for "high confidence" heuristics.
@@ -304,30 +329,38 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             kind,
             theme,
             no_sync,
-        } => commands::new::run(jj, title, workdir, slug, kind, theme, no_sync),
-        Command::List { workdir } => commands::list::run(workdir),
-        Command::Show { slug, workdir } => commands::show::run(slug, workdir),
+        } => commands::new::run(
+            jj,
+            title,
+            workdir_or_pwd(workdir)?,
+            slug,
+            kind,
+            theme,
+            no_sync,
+        ),
+        Command::List { workdir } => commands::list::run(workdir_or_pwd(workdir)?),
+        Command::Show { slug, workdir } => commands::show::run(slug, workdir_or_pwd(workdir)?),
         Command::Promote {
             slug,
             workdir,
             no_sync,
-        } => commands::promote::run(jj, slug, workdir, no_sync),
+        } => commands::promote::run(jj, slug, workdir_or_pwd(workdir)?, no_sync),
         Command::Demote {
             slug,
             workdir,
             no_sync,
-        } => commands::demote::run(jj, slug, workdir, no_sync),
+        } => commands::demote::run(jj, slug, workdir_or_pwd(workdir)?, no_sync),
         Command::Readme { action } => match action {
             ReadmeAction::Regenerate { workdir, no_sync } => {
-                commands::readme::regenerate(jj, workdir, no_sync)
+                commands::readme::regenerate(jj, workdir_or_pwd(workdir)?, no_sync)
             }
         },
-        Command::Doctor { workdir } => commands::doctor::run(jj, workdir),
+        Command::Doctor { workdir } => commands::doctor::run(jj, workdir_or_pwd(workdir)?),
         Command::Fix {
             workdir,
             dry_run,
             no_sync,
-        } => commands::fix::run(jj, workdir, dry_run, no_sync),
+        } => commands::fix::run(jj, workdir_or_pwd(workdir)?, dry_run, no_sync),
         Command::Ai { action } => match action {
             AiAction::Ping { prompt, model } => commands::ai::ping(prompt, model),
         },
@@ -351,7 +384,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             jj,
             commands::classify::ClassifyArgs {
                 slug,
-                workdir,
+                workdir: workdir_or_pwd(workdir)?,
                 format,
                 hook,
                 tone,
@@ -382,7 +415,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 jj,
                 commands::metrics::UpdateArgs {
                     slug,
-                    workdir,
+                    workdir: workdir_or_pwd(workdir)?,
                     target,
                     impressions,
                     reactions,
@@ -393,7 +426,10 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 },
             ),
             MetricsAction::Show { slug, workdir } => {
-                commands::metrics::show(commands::metrics::ShowArgs { slug, workdir })
+                commands::metrics::show(commands::metrics::ShowArgs {
+                    slug,
+                    workdir: workdir_or_pwd(workdir)?,
+                })
             }
         },
         Command::Backfill {
@@ -403,7 +439,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
         } => commands::backfill::run(
             jj,
             commands::backfill::BackfillArgs {
-                workdir,
+                workdir: workdir_or_pwd(workdir)?,
                 import,
                 no_sync,
             },
@@ -415,7 +451,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 dimension,
                 json,
             } => commands::analytics::summary(commands::analytics::SummaryArgs {
-                workdir,
+                workdir: workdir_or_pwd(workdir)?,
                 target,
                 dimension,
                 json,
@@ -430,7 +466,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             } => commands::analytics::compare(commands::analytics::CompareArgs {
                 dim_a,
                 dim_b,
-                workdir,
+                workdir: workdir_or_pwd(workdir)?,
                 target,
                 min_n,
                 json,
@@ -440,7 +476,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 target,
                 min_n,
             } => commands::analytics::recommendations(commands::analytics::RecommendationsArgs {
-                workdir,
+                workdir: workdir_or_pwd(workdir)?,
                 target,
                 min_n,
             }),
@@ -779,15 +815,52 @@ mod tests {
     }
 
     #[test]
-    fn workdir_is_required_for_every_subcommand() {
+    fn init_requires_explicit_workdir() {
+        // `init` creates the workdir layout; defaulting to PWD would
+        // scatter stage dirs into wherever the user happens to be.
+        // Every other subcommand defaults to PWD (see
+        // `workdir_defaults_to_pwd_when_omitted`).
+        assert!(Cli::try_parse_from(["blogctl", "init"]).is_err());
+    }
+
+    #[test]
+    fn workdir_defaults_to_pwd_when_omitted() {
+        // Every non-`init` subcommand should parse successfully without
+        // an explicit `--workdir`; the dispatcher resolves the missing
+        // value to `std::env::current_dir()` at run time.
         for args in [
-            vec!["blogctl", "init"],
             vec!["blogctl", "new", "Hello"],
             vec!["blogctl", "list"],
             vec!["blogctl", "show", "hello"],
+            vec!["blogctl", "promote", "hello"],
+            vec!["blogctl", "demote", "hello"],
+            vec!["blogctl", "readme", "regenerate"],
             vec!["blogctl", "doctor"],
+            vec!["blogctl", "fix"],
+            vec!["blogctl", "classify", "hello"],
+            vec![
+                "blogctl",
+                "metrics",
+                "update",
+                "hello",
+                "--target",
+                "linkedin",
+                "--impressions",
+                "1",
+                "--reactions",
+                "0",
+                "--comments",
+                "0",
+                "--reposts",
+                "0",
+            ],
+            vec!["blogctl", "metrics", "show", "hello"],
+            vec!["blogctl", "backfill"],
+            vec!["blogctl", "analytics", "summary"],
+            vec!["blogctl", "analytics", "compare", "format", "hook"],
+            vec!["blogctl", "analytics", "recommendations"],
         ] {
-            assert!(Cli::try_parse_from(args.clone()).is_err(), "{args:?}");
+            assert!(Cli::try_parse_from(args.clone()).is_ok(), "{args:?}");
         }
     }
 }

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -22,6 +22,16 @@ pub const STALE_UNPUSHED_THRESHOLD_HOURS: i64 = 24;
 
 #[derive(Debug)]
 pub enum Finding {
+    /// The `jj` binary is not on `$PATH`. blogctl writes assume a
+    /// VC-tracked workdir; without `jj`, every change accumulates
+    /// silently with no commit trail.
+    JjNotInstalled,
+    /// The workdir exists but is not a `jj` repository. Same hazard
+    /// as `JjNotInstalled` — writes have no commit trail until the
+    /// user runs `jj git init --colocate` (or equivalent).
+    NotAJjRepo {
+        workdir: PathBuf,
+    },
     ConfigMissing,
     ConfigUnparsable {
         error: Error,
@@ -82,6 +92,15 @@ pub enum Finding {
 impl fmt::Display for Finding {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::JjNotInstalled => write!(
+                f,
+                "jj is not installed: blogctl uses `jj` to commit every write — install jj and re-run"
+            ),
+            Self::NotAJjRepo { workdir } => write!(
+                f,
+                "not a jj repo: {} — run `jj git init --colocate` in the workdir to enable commit tracking",
+                workdir.display()
+            ),
             Self::ConfigMissing => write!(f, "config missing: .blog-os.toml does not exist"),
             Self::ConfigUnparsable { error } => write!(f, "config unparsable: {error}"),
             Self::StageDirMissing { stage } => {
@@ -256,15 +275,11 @@ pub fn audit(workdir: &Workdir) -> Result<Vec<Finding>> {
 }
 
 /// Sync-state audit. Separate from `audit()` so the filesystem pass
-/// stays pure and `fix` (which only reads filesystem findings)
-/// continues to know nothing about VCS state. Returns an empty list
-/// when `jj` is unavailable or the workdir isn't a `jj` repo — those
-/// are not "findings" worth blocking on.
+/// stays pure. Precondition: `jj.status()` returns `Status::Ok` —
+/// `full_audit` guarantees this gate before calling, so we don't
+/// re-query.
 pub fn sync_audit(workdir: &Workdir, jj: &dyn Jj, now: OffsetDateTime) -> Result<Vec<Finding>> {
     let mut findings = Vec::new();
-    if !matches!(jj.status(workdir.root())?, Status::Ok) {
-        return Ok(findings);
-    }
     let cfg = match Repository::unchecked(workdir.clone()).audit_config() {
         ConfigStatus::Ok(cfg) => cfg,
         // The config layer's own findings (Missing / Unparsable) are
@@ -287,10 +302,27 @@ pub fn sync_audit(workdir: &Workdir, jj: &dyn Jj, now: OffsetDateTime) -> Result
     Ok(findings)
 }
 
+/// Full audit: jj precondition + filesystem audit + sync audit.
+/// Short-circuits to a single `JjNotInstalled` or `NotAJjRepo`
+/// finding when `.jj` is unavailable — those are hard preconditions
+/// for blogctl, so further per-post checks would only add noise.
+pub fn full_audit(workdir: &Workdir, jj: &dyn Jj, now: OffsetDateTime) -> Result<Vec<Finding>> {
+    match jj.status(workdir.root())? {
+        Status::Ok => {
+            let mut findings = audit(workdir)?;
+            findings.extend(sync_audit(workdir, jj, now)?);
+            Ok(findings)
+        }
+        Status::JjNotInstalled => Ok(vec![Finding::JjNotInstalled]),
+        Status::NotAJjRepo => Ok(vec![Finding::NotAJjRepo {
+            workdir: workdir.root().to_path_buf(),
+        }]),
+    }
+}
+
 pub fn run(jj: &dyn Jj, workdir: PathBuf) -> Result<()> {
     let wd = Workdir::new(&workdir);
-    let mut findings = audit(&wd)?;
-    findings.extend(sync_audit(&wd, jj, OffsetDateTime::now_utc())?);
+    let findings = full_audit(&wd, jj, OffsetDateTime::now_utc())?;
     if findings.is_empty() {
         println!("workdir healthy: {}", workdir.display());
         return Ok(());
@@ -605,9 +637,9 @@ mod tests {
     fn run_returns_workdir_unhealthy_on_findings() {
         let (tmp, _workdir) = fresh_workdir();
         fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
-        // FakeJj with NotAJjRepo: sync_audit is a no-op, so we only
-        // see the filesystem finding (the stray entry).
-        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        // `Status::Ok` keeps the filesystem audit path live so the
+        // stray-entry finding actually surfaces.
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::Ok);
         let err = run(&jj, tmp.path().to_path_buf()).unwrap_err();
         assert!(matches!(err, Error::WorkdirUnhealthy(n) if n >= 1));
     }
@@ -615,24 +647,37 @@ mod tests {
     #[test]
     fn run_returns_ok_on_clean_workdir() {
         let (tmp, _workdir) = fresh_workdir();
-        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::Ok);
         run(&jj, tmp.path().to_path_buf()).unwrap();
     }
 
     #[test]
-    fn sync_audit_returns_empty_when_jj_not_installed() {
+    fn full_audit_short_circuits_on_jj_not_installed() {
         let (_tmp, workdir) = fresh_workdir();
         let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::JjNotInstalled);
-        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
-        assert!(findings.is_empty());
+        let findings = full_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert!(matches!(findings[0], Finding::JjNotInstalled));
     }
 
     #[test]
-    fn sync_audit_returns_empty_when_not_a_jj_repo() {
+    fn full_audit_short_circuits_on_not_a_jj_repo() {
         let (_tmp, workdir) = fresh_workdir();
+        // Plant a filesystem-level finding that would normally surface
+        // through `audit()` — short-circuit must suppress it.
+        fs::write(_tmp.path().join("concepts/.DS_Store"), "x").unwrap();
         let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
-        let findings = sync_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
-        assert!(findings.is_empty());
+        let findings = full_audit(&workdir, &jj, OffsetDateTime::now_utc()).unwrap();
+        assert_eq!(findings.len(), 1, "got: {findings:?}");
+        assert!(matches!(findings[0], Finding::NotAJjRepo { .. }));
+    }
+
+    #[test]
+    fn run_reports_not_a_jj_repo() {
+        let (tmp, _workdir) = fresh_workdir();
+        let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        let err = run(&jj, tmp.path().to_path_buf()).unwrap_err();
+        assert!(matches!(err, Error::WorkdirUnhealthy(1)));
     }
 
     #[test]

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -54,6 +54,7 @@ pub enum SkipReason {
     ConfigUnparsable,
     UnpushedCommits,
     InvalidClassification,
+    JjUnavailable,
 }
 
 impl fmt::Display for SkipReason {
@@ -70,6 +71,9 @@ impl fmt::Display for SkipReason {
             }
             Self::InvalidClassification => {
                 "manual: `blogctl classify` to a valid value, or add it to the taxonomy"
+            }
+            Self::JjUnavailable => {
+                "manual: install jj and run `jj git init --colocate` in the workdir"
             }
         };
         f.write_str(s)
@@ -132,6 +136,12 @@ pub fn plan(findings: Vec<Finding>) -> Vec<Repair> {
                 finding: f,
                 reason: SkipReason::InvalidClassification,
             }),
+            f @ (Finding::JjNotInstalled | Finding::NotAJjRepo { .. }) => {
+                skips.push(Repair::Skip {
+                    finding: f,
+                    reason: SkipReason::JjUnavailable,
+                })
+            }
         }
     }
 
@@ -272,10 +282,22 @@ where
 
 pub fn run(jj: &dyn Jj, workdir: PathBuf, dry_run: bool, no_sync: bool) -> Result<()> {
     let wd = Workdir::new(&workdir);
-    let findings = doctor::audit(&wd)?;
+    let findings = doctor::full_audit(&wd, jj, OffsetDateTime::now_utc())?;
     if findings.is_empty() {
         println!("workdir healthy: {}", workdir.display());
         return Ok(());
+    }
+    // Refuse to write anything when `.jj` is unavailable — commit
+    // tracking is a hard precondition. `full_audit` short-circuits to
+    // exactly the jj finding, so we just print and bail.
+    if findings
+        .iter()
+        .any(|f| matches!(f, Finding::JjNotInstalled | Finding::NotAJjRepo { .. }))
+    {
+        for finding in &findings {
+            println!("{finding}");
+        }
+        return Err(Error::WorkdirUnhealthy(findings.len()));
     }
 
     let plan = plan(findings);
@@ -594,5 +616,27 @@ mod tests {
         let jj = FakeJj::new();
         let err = run(&jj, tmp.path().to_path_buf(), false, true).unwrap_err();
         assert!(matches!(err, Error::WorkdirUnhealthy(_)));
+    }
+
+    #[test]
+    fn run_refuses_to_write_when_jj_is_unavailable() {
+        // Plant a repairable finding (mismatched stage) plus a workdir
+        // with `Status::NotAJjRepo`. `full_audit` short-circuits to
+        // just the jj finding, and `run` must refuse to apply any
+        // repair — otherwise the rewrite would land without a commit
+        // trail.
+        let (tmp, _workdir) = fresh_workdir();
+        let mismatched = fixture_post("oops", Stage::Editing);
+        let path = tmp.path().join("concepts/oops.md");
+        let raw_before = mismatched.render().unwrap();
+        fs::write(&path, &raw_before).unwrap();
+
+        let jj = FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
+        let err = run(&jj, tmp.path().to_path_buf(), false, true).unwrap_err();
+        assert!(matches!(err, Error::WorkdirUnhealthy(1)));
+
+        // File must be untouched.
+        let raw_after = fs::read_to_string(&path).unwrap();
+        assert_eq!(raw_before, raw_after, "fix must not write when jj missing");
     }
 }

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -111,6 +111,9 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[error("could not resolve current working directory: {0}")]
+    CurrentDirUnavailable(#[source] std::io::Error),
+
     #[error(
         "workdir unhealthy: {0} finding(s); run `blogctl fix` to repair the auto-correctable subset"
     )]

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -38,6 +38,22 @@ fn workdir_arg(workdir: &Path) -> String {
     workdir.to_str().expect("workdir path utf-8").to_string()
 }
 
+/// Initialize the tempdir as a colocated `jj` repo so `doctor` and
+/// `fix` see `Status::Ok` from the sync layer. blogctl treats `.jj`
+/// as a hard precondition for those commands.
+fn jj_init(workdir: &Path) {
+    let out = Command::new("jj")
+        .args(["git", "init", "--colocate"])
+        .current_dir(workdir)
+        .output()
+        .expect("failed to spawn jj");
+    assert!(
+        out.status.success(),
+        "jj git init --colocate failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 #[test]
 fn init_creates_expected_layout() {
     let tmp = TempDir::new().unwrap();
@@ -278,9 +294,13 @@ fn new_rejects_unknown_theme_with_known_list() {
 fn doctor_reports_clean_workdir_with_zero_exit() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());
+    jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd]), "init");
-    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
+    assert_success(
+        &run(&["new", "Hello", "--workdir", &wd, "--no-sync"]),
+        "new",
+    );
 
     let out = run(&["doctor", "--workdir", &wd]);
     assert_success(&out, "doctor (clean)");
@@ -291,16 +311,20 @@ fn doctor_reports_clean_workdir_with_zero_exit() {
 fn fix_repairs_stage_mismatch_and_leaves_workdir_clean() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());
+    jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd]), "init");
-    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
+    assert_success(
+        &run(&["new", "Hello", "--workdir", &wd, "--no-sync"]),
+        "new",
+    );
     // Move the file from concepts/ to editing/ without rewriting
     // frontmatter — that's a stage mismatch fix can repair.
     let from = tmp.path().join("concepts/hello.md");
     let to = tmp.path().join("editing/hello.md");
     std::fs::rename(&from, &to).unwrap();
 
-    let fix_out = run(&["fix", "--workdir", &wd]);
+    let fix_out = run(&["fix", "--workdir", &wd, "--no-sync"]);
     assert_success(&fix_out, "fix");
     assert!(
         stdout(&fix_out).contains("fixed"),
@@ -321,9 +345,13 @@ fn fix_repairs_stage_mismatch_and_leaves_workdir_clean() {
 fn fix_dry_run_makes_no_changes() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());
+    jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd]), "init");
-    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
+    assert_success(
+        &run(&["new", "Hello", "--workdir", &wd, "--no-sync"]),
+        "new",
+    );
     let from = tmp.path().join("concepts/hello.md");
     let to = tmp.path().join("editing/hello.md");
     std::fs::rename(&from, &to).unwrap();
@@ -339,10 +367,11 @@ fn fix_dry_run_makes_no_changes() {
 fn fix_exits_nonzero_when_skipped_findings_remain() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());
-    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    jj_init(tmp.path());
+    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
     std::fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
 
-    let out = run(&["fix", "--workdir", &wd]);
+    let out = run(&["fix", "--workdir", &wd, "--no-sync"]);
     assert!(!out.status.success(), "expected non-zero exit");
     assert!(stdout(&out).contains("skipped"), "got: {}", stdout(&out));
 }
@@ -351,8 +380,9 @@ fn fix_exits_nonzero_when_skipped_findings_remain() {
 fn doctor_reports_findings_with_nonzero_exit() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());
+    jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
     // Plant several distinct findings: stray file, removed stage dir.
     std::fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
     std::fs::remove_dir_all(tmp.path().join("editing")).unwrap();
@@ -366,4 +396,38 @@ fn doctor_reports_findings_with_nonzero_exit() {
         "got: {combined}"
     );
     assert!(combined.contains("workdir unhealthy"), "got: {combined}");
+}
+
+#[test]
+fn doctor_flags_missing_jj_repo() {
+    // No `jj_init` here — the workdir is intentionally not a jj repo.
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+
+    let out = run(&["doctor", "--workdir", &wd]);
+    assert!(!out.status.success(), "doctor should exit non-zero");
+    let combined = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(combined.contains("not a jj repo"), "got: {combined}");
+}
+
+#[test]
+fn fix_refuses_to_write_without_jj_repo() {
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
+    // Plant a repair-able stage mismatch — fix would normally land it.
+    let from = tmp.path().join("concepts/hello.md");
+    let to = tmp.path().join("editing/hello.md");
+    let raw_before = std::fs::read_to_string(&from).unwrap();
+    std::fs::rename(&from, &to).unwrap();
+
+    let out = run(&["fix", "--workdir", &wd]);
+    assert!(!out.status.success(), "fix should refuse without jj");
+    let combined = format!("{}{}", stdout(&out), stderr(&out));
+    assert!(combined.contains("not a jj repo"), "got: {combined}");
+    // The repairable file must be untouched.
+    let raw_after = std::fs::read_to_string(&to).unwrap();
+    assert_eq!(raw_before, raw_after, "fix wrote without commit tracking");
 }

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -177,12 +177,24 @@ fn fix_drives_full_sync_with_finding_count_message() {
 
     let jj = FakeJj::new();
     commands::fix::run(&jj, path.clone(), false, false).unwrap();
-    // Exactly one repair attempted (the stage mismatch).
-    assert_full_sync_flow(&jj.calls(), "chore: fix workdir (1 findings)");
+    // `fix::run` calls full_audit first (Status + UnpushedSummary),
+    // then commit_and_push wraps the apply (canonical 6-call flow).
+    let calls = jj.calls();
+    assert!(
+        matches!(calls[0], Call::Status { .. }),
+        "first call must be the audit-gate Status, got: {:?}",
+        calls[0]
+    );
+    assert!(
+        matches!(calls[1], Call::UnpushedSummary { .. }),
+        "second call must be the audit's UnpushedSummary, got: {:?}",
+        calls[1]
+    );
+    assert_full_sync_flow(&calls[2..], "chore: fix workdir (1 findings)");
 }
 
 #[test]
-fn fix_dry_run_skips_sync_entirely() {
+fn fix_dry_run_skips_commit_and_push_but_still_audits() {
     let (_tmp, path) = workdir();
     commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
     fs::write(
@@ -207,11 +219,13 @@ fn fix_dry_run_skips_sync_entirely() {
 
     let jj = FakeJj::new();
     let _ = commands::fix::run(&jj, path, true, false);
-    assert!(
-        jj.calls().is_empty(),
-        "dry-run must not invoke jj: {:?}",
-        jj.calls()
-    );
+    // Dry-run skips commit_and_push but the audit gate still needs
+    // jj.status() (to decide whether to short-circuit) and
+    // sync_audit's unpushed_summary check. Two calls, no writes.
+    let calls = jj.calls();
+    assert_eq!(calls.len(), 2, "expected 2 audit calls, got: {calls:?}");
+    assert!(matches!(calls[0], Call::Status { .. }));
+    assert!(matches!(calls[1], Call::UnpushedSummary { .. }));
 }
 
 #[test]


### PR DESCRIPTION
Every non-init subcommand now accepts an optional --workdir; when
omitted, the dispatcher resolves it to std::env::current_dir(). init
keeps the explicit requirement — defaulting it would scatter stage
dirs into wherever the user happened to be when they typo'd the
invocation.

jj is the commit mechanism for every blogctl write — without .jj, edits
accumulate with no version-control trail. doctor now surfaces a
JjNotInstalled or NotAJjRepo finding (short-circuiting the rest of the
audit, since further per-post output would be noise without a working
repo). fix refuses to write anything when the same precondition is
violated; the user has to run jj git init --colocate (or install jj)
before fix will touch the workdir.

Drops the defensive jj.status() re-check inside sync_audit — full_audit
now guarantees the gate, so the duplicate query was wasted work.

Closes #464