### PR TITLE
fix(shaka): repo audit fetches target policy from --repo, not cwd

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -51,6 +51,31 @@ pub fn api_get(endpoint: &str) -> Result<Value, GhError> {
     })
 }
 
+/// Fetch a file's raw contents from a repo via the GitHub contents
+/// API. Uses `Accept: application/vnd.github.raw` so the response
+/// body is the file itself rather than the base64-wrapped JSON the
+/// default content type returns. Returns `Ok(None)` on 404 so callers
+/// can surface "policy missing" cleanly; other errors propagate.
+pub fn fetch_raw_file(repo: &str, path: &str) -> Result<Option<String>, GhError> {
+    let endpoint = format!("repos/{repo}/contents/{path}");
+    let output = Command::new("gh")
+        .args(["api", &endpoint, "-H", "Accept: application/vnd.github.raw"])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("HTTP 404") || stderr.contains("Not Found") {
+            return Ok(None);
+        }
+        return GhCommandSnafu {
+            command: format!("gh api {endpoint}"),
+            stderr: stderr.to_string(),
+        }
+        .fail();
+    }
+    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
+}
+
 /// Run `gh api <endpoint>` and return the HTTP status code.
 /// Used for endpoints like vulnerability-alerts that signal via status code.
 pub fn api_get_status(endpoint: &str) -> Result<i32, GhError> {

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -70,27 +70,61 @@ impl Check {
 }
 
 pub fn run(repo_arg: Option<String>, fix: bool) {
-    let repo = match repo_arg {
-        Some(r) => r,
-        None => match gh::detect_repo() {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("{RED}{BOLD}error:{RESET} {e}");
-                eprintln!("Hint: pass --repo owner/repo explicitly");
-                std::process::exit(1);
-            }
-        },
-    };
-
-    let policy = match policy::load(Path::new(".")) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("{RED}{BOLD}error:{RESET} {e}");
-            eprintln!(
-                "Hint: create `.shaka/repo.cue` at the repo root \
-                describing your desired GitHub settings"
-            );
-            std::process::exit(1);
+    // Policy source decision: when --repo is explicit, fetch the
+    // target's own .shaka/repo.cue via the GitHub contents API.
+    // Using cwd's policy across repos compared the wrong policy
+    // against the wrong live state (#465). When --repo is omitted,
+    // load cwd's policy as before.
+    let (repo, policy) = match repo_arg {
+        Some(target) => {
+            let cue = match gh::fetch_raw_file(&target, ".shaka/repo.cue") {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    eprintln!("{RED}{BOLD}error:{RESET} no .shaka/repo.cue found in {target}");
+                    eprintln!(
+                        "Hint: declare the repo's desired settings in \
+                         .shaka/repo.cue at its root, or omit --repo to \
+                         audit the current repo against its own policy"
+                    );
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("{RED}{BOLD}error:{RESET} fetching policy from {target}: {e}");
+                    std::process::exit(1);
+                }
+            };
+            let p = match policy::load_from_string(&cue) {
+                Ok(p) => p,
+                Err(e) => {
+                    eprintln!(
+                        "{RED}{BOLD}error:{RESET} parsing .shaka/repo.cue from {target}: {e}"
+                    );
+                    std::process::exit(1);
+                }
+            };
+            (target, p)
+        }
+        None => {
+            let repo = match gh::detect_repo() {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                    eprintln!("Hint: pass --repo owner/repo explicitly");
+                    std::process::exit(1);
+                }
+            };
+            let p = match policy::load(Path::new(".")) {
+                Ok(p) => p,
+                Err(e) => {
+                    eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                    eprintln!(
+                        "Hint: create `.shaka/repo.cue` at the repo root \
+                        describing your desired GitHub settings"
+                    );
+                    std::process::exit(1);
+                }
+            };
+            (repo, p)
         }
     };
 

--- a/tools/shaka/src/repo/policy.rs
+++ b/tools/shaka/src/repo/policy.rs
@@ -8,7 +8,6 @@
 //! as `None` when omitted, so consumers can opt out of audit dimensions
 //! they don't care about.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -85,10 +84,25 @@ pub fn load(start: &Path) -> Result<RepoPolicy, String> {
             start.display()
         )
     })?;
+    let cue = std::fs::read_to_string(&policy_path)
+        .map_err(|e| format!("could not read {}: {e}", policy_path.display()))?;
+    load_from_string(&cue).map_err(|e| format!("{}: {e}", policy_path.display()))
+}
 
-    // Per-process schema temp file — same pattern as project::schema_check.
-    let schema_path =
-        write_schema().map_err(|e| format!("could not write repo-policy schema: {e}"))?;
+/// Parse a `.shaka/repo.cue` from its raw CUE source — used by the
+/// audit when `--repo <external>` fetches policy from the target
+/// repository instead of walking the cwd.
+pub fn load_from_string(cue: &str) -> Result<RepoPolicy, String> {
+    // Per-call tempdir so concurrent callers (e.g. parallel cargo
+    // tests) don't race on a shared `/tmp/shaka-repo-policy-<pid>/`
+    // dir. Auto-cleaned on drop.
+    let tmp = tempfile::TempDir::new().map_err(|e| format!("could not create tempdir: {e}"))?;
+    let schema_path = tmp.path().join("schema.cue");
+    std::fs::write(&schema_path, SCHEMA)
+        .map_err(|e| format!("could not write repo-policy schema: {e}"))?;
+    let policy_path = tmp.path().join("repo.cue");
+    std::fs::write(&policy_path, cue)
+        .map_err(|e| format!("could not write temp policy file: {e}"))?;
 
     let output = Command::new("cue")
         .arg("export")
@@ -103,24 +117,10 @@ pub fn load(start: &Path) -> Result<RepoPolicy, String> {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         let detail = if stderr.is_empty() { stdout } else { stderr };
-        return Err(format!(
-            "cue export failed for {}: {detail}",
-            policy_path.display()
-        ));
+        return Err(format!("cue export failed: {detail}"));
     }
 
-    serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("could not parse {}: {e}", policy_path.display()))
-}
-
-fn write_schema() -> std::io::Result<PathBuf> {
-    let path = std::env::temp_dir().join(format!(
-        "shaka-repo-policy-schema-{}.cue",
-        std::process::id()
-    ));
-    let mut f = std::fs::File::create(&path)?;
-    f.write_all(SCHEMA.as_bytes())?;
-    Ok(path)
+    serde_json::from_slice(&output.stdout).map_err(|e| format!("could not parse policy: {e}"))
 }
 
 #[cfg(test)]
@@ -156,5 +156,53 @@ mod tests {
     fn find_policy_file_returns_none_when_absent() {
         let tmp = TempDir::new().unwrap();
         assert!(find_policy_file(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn load_from_string_parses_complete_policy() {
+        let cue = r#"package repopolicy
+
+#RepoPolicy & {
+    defaultBranch: "main"
+    merge: {
+        rebase:              true
+        merge:               false
+        squash:              false
+        deleteBranchOnMerge: true
+        autoMerge:           true
+    }
+    branchProtection: {
+        requiredChecks: ["Preflight"]
+        strictStatusChecks: true
+        allowForcePush:     false
+        allowDeletion:      false
+    }
+}
+"#;
+        let policy = load_from_string(cue).expect("policy parses");
+        assert_eq!(policy.default_branch, "main");
+        assert!(policy.merge.rebase);
+        assert!(policy.merge.auto_merge);
+        let bp = policy.branch_protection.expect("branch_protection set");
+        assert_eq!(bp.required_checks, vec!["Preflight"]);
+    }
+
+    #[test]
+    fn load_from_string_rejects_incomplete_policy() {
+        // Missing merge.autoMerge — schema requires a concrete value.
+        let cue = r#"package repopolicy
+
+#RepoPolicy & {
+    defaultBranch: "main"
+    merge: {
+        rebase:              true
+        merge:               false
+        squash:              false
+        deleteBranchOnMerge: true
+    }
+}
+"#;
+        let err = load_from_string(cue).expect_err("incomplete policy rejected");
+        assert!(err.contains("autoMerge"), "actual error: {err}");
     }
 }


### PR DESCRIPTION
`shaka repo audit --repo <owner>/<repo>` previously used the cwd's
`.shaka/repo.cue` regardless of target. Audited blogs-and-posts
against kolohelios's policy, expecting "Gate" where blogs-and-posts
correctly required "Preflight" — a false-positive failure surfaced
right after PR #418/#454 landed.

With `--repo` explicit, the audit now fetches the target's
`.shaka/repo.cue` via the GitHub contents API (`Accept:
application/vnd.github.raw`) and parses it through a new
`policy::load_from_string`. Cwd policy is only used when `--repo` is
omitted. A target without a policy errors cleanly ("no .shaka/repo.cue
found in <repo>") rather than silently falling back.

`load_from_string` writes to a per-call `tempfile::TempDir`, fixing a
parallel-test race the previous shared-tempfile path would have hit
once tests started using it (the new test pair triggered exactly
that race during this PR's development).

`fetch_raw_file` lives in `gh.rs` for future use by other audits that
need to read declarative config from external repos.

Closes #465.