### PR TITLE
feat(blogctl): analytics compare command body + crosstab renderer

### DIFF
--- a/apps/blogctl/src/analytics/compare.rs
+++ b/apps/blogctl/src/analytics/compare.rs
@@ -1,0 +1,431 @@
+#![forbid(unsafe_code)]
+
+//! Pairwise crosstab of two dimensions, plus per-dimension marginals.
+//!
+//! "Thesis posts with a contradiction hook" vs. "thesis posts with a
+//! direct-claim hook" is the load-bearing question this answers; the
+//! marginals (the per-dimension medians, ignoring the other axis)
+//! exist so the user can tell whether a strong cell is the cell's
+//! intersection winning or just the strong dimension dragging its
+//! weight.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+use time::OffsetDateTime;
+
+use crate::analytics::percentile::{percentiles_f64, percentiles_u64};
+use crate::analytics::summary;
+use crate::analytics::DerivedMetrics;
+use crate::classifications::Classifications;
+use crate::post::Post;
+use crate::target::Target;
+
+/// Full result of a `compare <dim_a> <dim_b>` query — every cell
+/// (non-empty intersection only) plus both marginals.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Comparison {
+    pub dim_a: String,
+    pub dim_b: String,
+    pub target_filter: Option<Target>,
+    pub min_n: usize,
+    /// Non-empty cells only. Cells with n == 0 don't appear — the
+    /// text renderer fills them in with `--`, but in the data model
+    /// "no posts" is encoded by absence rather than a zero row.
+    pub cells: Vec<Cell>,
+    /// dim_a values collapsed across all of dim_b.
+    pub marginals_a: Vec<Marginal>,
+    /// dim_b values collapsed across all of dim_a.
+    pub marginals_b: Vec<Marginal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Cell {
+    pub value_a: String,
+    pub value_b: String,
+    pub n: usize,
+    pub impressions_p50: u64,
+    /// `None` when every sample in the cell had `engagement_rate ==
+    /// None` (e.g. all zero-impression).
+    pub engagement_rate_p50: Option<f64>,
+    pub low_n: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Marginal {
+    pub dimension: String,
+    pub value: String,
+    pub n: usize,
+    pub impressions_p50: u64,
+    pub engagement_rate_p50: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Sample {
+    impressions: u64,
+    engagement_rate: Option<f64>,
+}
+
+/// Compute the crosstab. A post contributes one sample to every
+/// `(value_a, value_b)` cross-product of its values on `dim_a` and
+/// `dim_b`, filtered to targets that match `target_filter` (or all
+/// targets, if `None`) and have metrics. Multi-valued dimensions
+/// (e.g. `theme: [a, b]`) explode into multiple cells.
+pub fn compute(
+    posts: &[Post],
+    dim_a: &str,
+    dim_b: &str,
+    target_filter: Option<Target>,
+    min_n: usize,
+    now: OffsetDateTime,
+) -> Comparison {
+    let mut buckets: BTreeMap<(String, String), Vec<Sample>> = BTreeMap::new();
+
+    for post in posts {
+        let values_a = dimension_values(&post.metadata.classifications, dim_a);
+        let values_b = dimension_values(&post.metadata.classifications, dim_b);
+        if values_a.is_empty() || values_b.is_empty() {
+            continue;
+        }
+        for target in &post.metadata.targets {
+            if let Some(filter) = target_filter {
+                if target.name != filter {
+                    continue;
+                }
+            }
+            let Some(metrics) = &target.metrics else {
+                continue;
+            };
+            let derived = DerivedMetrics::from_target(target, now);
+            let sample = Sample {
+                impressions: metrics.impressions,
+                engagement_rate: derived.engagement_rate,
+            };
+            for va in &values_a {
+                for vb in &values_b {
+                    buckets
+                        .entry((va.clone(), vb.clone()))
+                        .or_default()
+                        .push(sample);
+                }
+            }
+        }
+    }
+
+    let cells: Vec<Cell> = buckets
+        .into_iter()
+        .map(|((value_a, value_b), samples)| build_cell(value_a, value_b, &samples, min_n))
+        .collect();
+
+    let marginals_a = build_marginals(posts, dim_a, target_filter, now);
+    let marginals_b = build_marginals(posts, dim_b, target_filter, now);
+
+    Comparison {
+        dim_a: dim_a.to_string(),
+        dim_b: dim_b.to_string(),
+        target_filter,
+        min_n,
+        cells,
+        marginals_a,
+        marginals_b,
+    }
+}
+
+/// Find a cell by (value_a, value_b). `None` when the intersection
+/// had no samples. Text renderers use this to lay out a full grid
+/// of cells where the data model only stores the non-empty ones.
+impl Comparison {
+    pub fn cell(&self, value_a: &str, value_b: &str) -> Option<&Cell> {
+        self.cells
+            .iter()
+            .find(|c| c.value_a == value_a && c.value_b == value_b)
+    }
+
+    /// Distinct `dim_a` values across the cells, in alphabetical
+    /// order. The text renderer uses these to lay out rows.
+    pub fn row_values(&self) -> Vec<String> {
+        let mut s: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for c in &self.cells {
+            s.insert(c.value_a.clone());
+        }
+        s.into_iter().collect()
+    }
+
+    /// Distinct `dim_b` values across the cells, in alphabetical
+    /// order. The text renderer uses these for column headers.
+    pub fn column_values(&self) -> Vec<String> {
+        let mut s: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for c in &self.cells {
+            s.insert(c.value_b.clone());
+        }
+        s.into_iter().collect()
+    }
+}
+
+fn build_cell(value_a: String, value_b: String, samples: &[Sample], min_n: usize) -> Cell {
+    let impressions: Vec<u64> = samples.iter().map(|s| s.impressions).collect();
+    let engagement_rates: Vec<f64> = samples.iter().filter_map(|s| s.engagement_rate).collect();
+    Cell {
+        value_a,
+        value_b,
+        n: samples.len(),
+        impressions_p50: percentiles_u64(&impressions)
+            .expect("samples.len() >= 1 by construction")
+            .p50,
+        engagement_rate_p50: percentiles_f64(&engagement_rates).map(|p| p.p50),
+        low_n: samples.len() < min_n,
+    }
+}
+
+fn build_marginals(
+    posts: &[Post],
+    dim: &str,
+    target_filter: Option<Target>,
+    now: OffsetDateTime,
+) -> Vec<Marginal> {
+    // Reuse summary::compute restricted to this one dimension —
+    // free percentile path, same definition of "sample".
+    let s = summary::compute(posts, target_filter, Some(dim), now);
+    s.dimensions
+        .into_iter()
+        .flat_map(|d| {
+            d.values.into_iter().map(move |v| Marginal {
+                dimension: d.name.clone(),
+                value: v.value,
+                n: v.n,
+                impressions_p50: v.impressions.p50,
+                engagement_rate_p50: v.engagement_rate.map(|p| p.p50),
+            })
+        })
+        .collect()
+}
+
+fn dimension_values(c: &Classifications, dim: &str) -> Vec<String> {
+    match dim {
+        "format" => c.format.iter().cloned().collect(),
+        "hook" => c.hook.iter().cloned().collect(),
+        "tone" => c.tone.iter().cloned().collect(),
+        "audience" => c.audience.iter().cloned().collect(),
+        "strategic_role" => c.strategic_role.iter().cloned().collect(),
+        "theme" => c.theme.clone(),
+        _ => vec![], // unknown dimension — no samples contribute
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    use crate::kind::Kind;
+    use crate::post::PostMetadata;
+    use crate::stage::Stage;
+    use crate::target::{TargetEntry, TargetMetrics, TargetStatus};
+
+    fn now() -> OffsetDateTime {
+        datetime!(2026-05-17 00:00:00 UTC)
+    }
+
+    fn fixture_post(
+        slug: &str,
+        format: Option<&str>,
+        hook: Option<&str>,
+        themes: &[&str],
+        impressions: u64,
+        reactions: u64,
+    ) -> Post {
+        Post::new(
+            PostMetadata {
+                title: slug.into(),
+                slug: slug.into(),
+                kind: Kind::Post,
+                theme: "standard".into(),
+                status: Stage::Published,
+                created_at: datetime!(2026-05-01 00:00:00 UTC),
+                updated_at: datetime!(2026-05-08 00:00:00 UTC),
+                tags: vec![],
+                todoist_task_id: None,
+                history_checked: false,
+                targets: vec![TargetEntry {
+                    name: Target::Linkedin,
+                    status: TargetStatus::Published,
+                    url: Some("https://example.invalid".into()),
+                    published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+                    metrics: Some(TargetMetrics {
+                        impressions,
+                        reactions,
+                        comments: 0,
+                        reposts: 0,
+                        sampled_at: datetime!(2026-05-14 00:00:00 UTC),
+                    }),
+                }],
+                classifications: Classifications {
+                    format: format.map(|s| s.to_string()),
+                    hook: hook.map(|s| s.to_string()),
+                    theme: themes.iter().map(|s| (*s).to_string()).collect(),
+                    ..Default::default()
+                },
+            },
+            "body\n",
+        )
+    }
+
+    #[test]
+    fn empty_input_yields_no_cells_no_marginals() {
+        let c = compute(&[], "format", "hook", None, 3, now());
+        assert!(c.cells.is_empty());
+        assert!(c.marginals_a.is_empty());
+        assert!(c.marginals_b.is_empty());
+    }
+
+    #[test]
+    fn cell_only_appears_when_intersection_is_non_empty() {
+        // thesis + contradiction posts, but no thesis + question.
+        let posts = vec![
+            fixture_post("a", Some("thesis"), Some("contradiction"), &[], 1000, 50),
+            fixture_post("b", Some("thesis"), Some("contradiction"), &[], 1500, 80),
+        ];
+        let c = compute(&posts, "format", "hook", None, 3, now());
+        assert_eq!(c.cells.len(), 1);
+        assert_eq!(c.cells[0].value_a, "thesis");
+        assert_eq!(c.cells[0].value_b, "contradiction");
+        assert_eq!(c.cells[0].n, 2);
+        assert!(c.cell("thesis", "question").is_none());
+    }
+
+    #[test]
+    fn low_n_flag_uses_provided_min_n_threshold() {
+        // min_n = 5, n = 2 → low_n=true. Same data with min_n = 2
+        // → low_n=false.
+        let posts = vec![
+            fixture_post("a", Some("thesis"), Some("contradiction"), &[], 1000, 50),
+            fixture_post("b", Some("thesis"), Some("contradiction"), &[], 1500, 80),
+        ];
+        let strict = compute(&posts, "format", "hook", None, 5, now());
+        assert!(strict.cells[0].low_n);
+        let lax = compute(&posts, "format", "hook", None, 2, now());
+        assert!(!lax.cells[0].low_n);
+    }
+
+    #[test]
+    fn multi_valued_theme_explodes_into_multiple_cells() {
+        // One post with theme=[a, b] and format=thesis → contributes
+        // to (thesis, a) AND (thesis, b).
+        let p = fixture_post(
+            "x",
+            Some("thesis"),
+            None,
+            &["ambiguity", "delivery"],
+            1000,
+            50,
+        );
+        let c = compute(&[p], "format", "theme", None, 3, now());
+        assert_eq!(c.cells.len(), 2);
+        for cell in &c.cells {
+            assert_eq!(cell.value_a, "thesis");
+            assert_eq!(cell.n, 1);
+        }
+    }
+
+    #[test]
+    fn marginals_are_independent_of_the_crosstab() {
+        // 3 thesis posts, 2 with hook=contradiction, 1 with no hook.
+        // Crosstab has 1 cell (thesis × contradiction, n=2). The
+        // marginal for thesis should still see all 3.
+        let posts = vec![
+            fixture_post("a", Some("thesis"), Some("contradiction"), &[], 1000, 50),
+            fixture_post("b", Some("thesis"), Some("contradiction"), &[], 1500, 80),
+            fixture_post("c", Some("thesis"), None, &[], 800, 30),
+        ];
+        let c = compute(&posts, "format", "hook", None, 3, now());
+        // Cells: only thesis × contradiction with n=2.
+        assert_eq!(c.cells.len(), 1);
+        assert_eq!(c.cells[0].n, 2);
+        // marginal_a (format=thesis) should see n=3 — independent of
+        // whether the post has a hook set.
+        let thesis_marg = c.marginals_a.iter().find(|m| m.value == "thesis").unwrap();
+        assert_eq!(thesis_marg.n, 3);
+    }
+
+    #[test]
+    fn unknown_dimension_yields_no_cells() {
+        // The dim name doesn't match any Classifications field —
+        // dimension_values returns empty, no samples contribute.
+        let p = fixture_post("x", Some("thesis"), Some("contradiction"), &[], 1000, 50);
+        let c = compute(&[p], "format", "not-a-dim", None, 3, now());
+        assert!(c.cells.is_empty());
+        // dim_a's marginal still computes — only the unknown dim drops.
+        // (summary::compute on "not-a-dim" yields no dimension, so
+        // marginals_b is empty too.)
+        assert!(c.marginals_b.is_empty());
+        // marginals_a should have format=thesis.
+        let thesis = c.marginals_a.iter().find(|m| m.value == "thesis").unwrap();
+        assert_eq!(thesis.n, 1);
+    }
+
+    #[test]
+    fn target_filter_excludes_other_targets() {
+        // One post with metrics on Linkedin AND a separate post with
+        // metrics on Blog (same classification) — Linkedin filter
+        // sees only the first sample.
+        let li = fixture_post("li", Some("thesis"), Some("contradiction"), &[], 1000, 50);
+        let mut blog = fixture_post(
+            "blog",
+            Some("thesis"),
+            Some("contradiction"),
+            &[],
+            5000,
+            100,
+        );
+        blog.metadata.targets[0].name = Target::Blog;
+        let c = compute(
+            &[li, blog],
+            "format",
+            "hook",
+            Some(Target::Linkedin),
+            3,
+            now(),
+        );
+        assert_eq!(c.cells.len(), 1);
+        assert_eq!(c.cells[0].n, 1);
+    }
+
+    #[test]
+    fn row_and_column_values_are_alphabetical() {
+        let posts = vec![
+            fixture_post("a", Some("thesis"), Some("contradiction"), &[], 1000, 50),
+            fixture_post("b", Some("parable"), Some("question"), &[], 1000, 50),
+            fixture_post("c", Some("parable"), Some("contradiction"), &[], 1000, 50),
+        ];
+        let c = compute(&posts, "format", "hook", None, 3, now());
+        assert_eq!(c.row_values(), vec!["parable", "thesis"]);
+        assert_eq!(c.column_values(), vec!["contradiction", "question"]);
+    }
+
+    #[test]
+    fn json_shape_serializes_expected_fields() {
+        let posts = vec![fixture_post(
+            "a",
+            Some("thesis"),
+            Some("contradiction"),
+            &[],
+            1000,
+            50,
+        )];
+        let c = compute(&posts, "format", "hook", None, 3, now());
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&c).unwrap()).unwrap();
+        assert_eq!(v["dim_a"], "format");
+        assert_eq!(v["dim_b"], "hook");
+        assert_eq!(v["min_n"], 3);
+        assert!(v["target_filter"].is_null());
+        let cell = &v["cells"][0];
+        assert_eq!(cell["value_a"], "thesis");
+        assert_eq!(cell["value_b"], "contradiction");
+        assert_eq!(cell["n"], 1);
+        assert_eq!(cell["low_n"], true);
+        assert!(cell["impressions_p50"].is_number());
+        // engagement_rate_p50 is a number (0.05) — not null.
+        assert!(cell["engagement_rate_p50"].is_number());
+    }
+}

--- a/apps/blogctl/src/analytics/mod.rs
+++ b/apps/blogctl/src/analytics/mod.rs
@@ -6,10 +6,12 @@
 //! and so the analytics commands route every raw arithmetic operation
 //! through this module rather than reinventing it inline.
 
+pub mod compare;
 pub mod derived;
 pub mod percentile;
 pub mod summary;
 
+pub use compare::{compute as compare, Cell, Comparison, Marginal};
 pub use derived::DerivedMetrics;
 pub use percentile::{percentiles_f64, percentiles_u64, Percentiles};
 pub use summary::{compute as summary, DimensionSummary, Summary, ValueSummary, LOW_N_THRESHOLD};

--- a/apps/blogctl/src/commands/analytics.rs
+++ b/apps/blogctl/src/commands/analytics.rs
@@ -1,13 +1,13 @@
 //! `blogctl analytics {summary, compare, recommendations}` — read
 //! every published post's classifications + metrics and surface
-//! aggregates. summary is implemented; compare and recommendations
-//! are still stubs (behavior lands in #440/#441).
+//! aggregates. summary + compare are implemented; recommendations
+//! is still a stub (behavior lands in #441).
 
 use std::path::PathBuf;
 
 use time::OffsetDateTime;
 
-use crate::analytics::{self, DimensionSummary, Summary, ValueSummary};
+use crate::analytics::{self, Comparison, DimensionSummary, Summary, ValueSummary};
 use crate::error::{Error, Result};
 use crate::storage::{Repository, Workdir};
 use crate::target::Target;
@@ -129,8 +129,127 @@ fn format_er(rate: f64) -> String {
     format!("{:.1}%", rate * 100.0)
 }
 
-pub fn compare(_args: CompareArgs) -> Result<()> {
-    Err(Error::Unimplemented("analytics compare"))
+pub fn compare(args: CompareArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let handles = repo.list()?;
+    let posts: Vec<_> = handles
+        .iter()
+        .map(|h| repo.load_raw(&h.metadata.slug).map(|(_, post)| post))
+        .collect::<Result<_>>()?;
+    let comparison = analytics::compare(
+        &posts,
+        &args.dim_a,
+        &args.dim_b,
+        args.target,
+        args.min_n,
+        OffsetDateTime::now_utc(),
+    );
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&comparison).map_err(Error::SummaryJson)?
+        );
+    } else {
+        print_compare_text(&comparison);
+    }
+    Ok(())
+}
+
+fn print_compare_text(c: &Comparison) {
+    let target_label = c
+        .target_filter
+        .map(|t| format!("target={t}"))
+        .unwrap_or_else(|| "all targets".into());
+    println!(
+        "compare {} \u{00d7} {}  ({})",
+        c.dim_a, c.dim_b, target_label,
+    );
+    println!();
+
+    let rows = c.row_values();
+    let cols = c.column_values();
+    if rows.is_empty() || cols.is_empty() {
+        println!("(no posts match this comparison)");
+    } else {
+        // Column widths: each column at least max(col_name, "n=NN X.X%"),
+        // with two spaces of padding between columns.
+        let row_label_width = rows.iter().map(|s| s.len()).max().unwrap_or(0).max(8);
+        let col_widths: Vec<usize> = cols
+            .iter()
+            .map(|col| {
+                let mut w = col.len();
+                for row in &rows {
+                    if let Some(cell) = c.cell(row, col) {
+                        w = w.max(format_cell_body(cell).len());
+                    }
+                }
+                w.max(8)
+            })
+            .collect();
+
+        // Header row.
+        print!("{:<width$}", "", width = row_label_width + 2);
+        for (col, w) in cols.iter().zip(col_widths.iter()) {
+            print!("  {col:<w$}", col = col, w = w);
+        }
+        println!();
+
+        // Data rows.
+        for row in &rows {
+            print!("{row:<width$}", row = row, width = row_label_width + 2);
+            for (col, w) in cols.iter().zip(col_widths.iter()) {
+                let body = match c.cell(row, col) {
+                    None => "--".to_string(),
+                    Some(cell) => format_cell_body(cell),
+                };
+                print!("  {body:<w$}", body = body, w = w);
+            }
+            println!();
+        }
+    }
+
+    println!();
+    println!("marginals:");
+    print_marginals(&c.marginals_a);
+    print_marginals(&c.marginals_b);
+}
+
+fn print_marginals(marginals: &[analytics::Marginal]) {
+    // Label width sized to the longest "<dim>=<value>:" string in this
+    // marginal slice — keeps the columns aligned within each group.
+    let label_width = marginals
+        .iter()
+        .map(|m| m.dimension.len() + m.value.len() + 2)
+        .max()
+        .unwrap_or(0)
+        .max(8);
+    for m in marginals {
+        let label = format!("{}={}:", m.dimension, m.value);
+        let er = m
+            .engagement_rate_p50
+            .map(format_er)
+            .unwrap_or_else(|| "\u{2014}".into());
+        println!(
+            "  {label:<label_width$}  n={n:<3}   eng p50={er}",
+            label = label,
+            label_width = label_width,
+            n = m.n,
+            er = er,
+        );
+    }
+}
+
+/// Body of one cell: `n=N  X.X%` or `n=N  (low)` when the cell is
+/// below min_n. Empty cells render as `--` in the renderer, not here.
+fn format_cell_body(cell: &analytics::Cell) -> String {
+    if cell.low_n {
+        return format!("n={}  (low)", cell.n);
+    }
+    let er = cell
+        .engagement_rate_p50
+        .map(format_er)
+        .unwrap_or_else(|| "\u{2014}".into());
+    format!("n={}  {er}", cell.n)
 }
 
 pub fn recommendations(_args: RecommendationsArgs) -> Result<()> {

--- a/apps/blogctl/tests/analytics.rs
+++ b/apps/blogctl/tests/analytics.rs
@@ -178,3 +178,133 @@ fn summary_with_unknown_dimension_filter_yields_empty() {
     );
     assert!(nothing.dimensions.is_empty());
 }
+
+/// Like fixture_workdir, but every post also has a hook set so
+/// compare(format, hook) has cells to populate. thesis posts
+/// alternate between contradiction and direct-claim; parable posts
+/// use question.
+fn fixture_workdir_with_hooks() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    commands::init::run(&FakeJj::new(), tmp.path().to_path_buf(), false).unwrap();
+
+    let posts = [
+        ("thesis-one", "thesis", "contradiction", 1000_u64, 50_u64),
+        ("thesis-two", "thesis", "contradiction", 2000, 100),
+        ("thesis-three", "thesis", "contradiction", 1500, 75),
+        ("thesis-four", "thesis", "direct-claim", 800, 24),
+        ("thesis-five", "thesis", "direct-claim", 900, 27),
+        ("parable-one", "parable", "question", 1200, 24),
+        ("parable-two", "parable", "question", 1300, 26),
+    ];
+    for (slug, format, hook, imp, react) in posts {
+        seed_post(tmp.path(), slug, format, imp, react);
+        // Apply the hook on top of the format set by seed_post.
+        commands::classify::run(
+            &FakeJj::new(),
+            commands::classify::ClassifyArgs {
+                slug: slug.into(),
+                workdir: tmp.path().to_path_buf(),
+                hook: Some(hook.into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn compare_command_succeeds_against_fixture() {
+    let tmp = fixture_workdir_with_hooks();
+    commands::analytics::compare(commands::analytics::CompareArgs {
+        dim_a: "format".into(),
+        dim_b: "hook".into(),
+        workdir: tmp.path().to_path_buf(),
+        target: None,
+        min_n: 3,
+        json: false,
+    })
+    .unwrap();
+}
+
+#[test]
+fn compare_json_shape_for_fixture() {
+    let tmp = fixture_workdir_with_hooks();
+    let repo = blogctl::Repository::open(blogctl::Workdir::new(tmp.path())).unwrap();
+    let handles = repo.list().unwrap();
+    let posts: Vec<_> = handles
+        .iter()
+        .map(|h| repo.load_raw(&h.metadata.slug).unwrap().1)
+        .collect();
+    let comparison = blogctl::analytics::compare(
+        &posts,
+        "format",
+        "hook",
+        Some(Target::Linkedin),
+        3,
+        time::macros::datetime!(2026-05-17 00:00:00 UTC),
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&comparison).unwrap()).unwrap();
+    assert_eq!(v["dim_a"], "format");
+    assert_eq!(v["dim_b"], "hook");
+    assert_eq!(v["min_n"], 3);
+    assert_eq!(v["target_filter"], "linkedin");
+    let cells = v["cells"].as_array().unwrap();
+    // Three non-empty cells:
+    //   thesis × contradiction (n=3, not low-n)
+    //   thesis × direct-claim  (n=2, low-n)
+    //   parable × question     (n=2, low-n)
+    assert_eq!(cells.len(), 3);
+    let lookup = |a: &str, b: &str| {
+        cells
+            .iter()
+            .find(|c| c["value_a"] == a && c["value_b"] == b)
+            .unwrap_or_else(|| panic!("missing cell {a} × {b}"))
+    };
+    let tc = lookup("thesis", "contradiction");
+    assert_eq!(tc["n"], 3);
+    assert_eq!(tc["low_n"], false);
+    let td = lookup("thesis", "direct-claim");
+    assert_eq!(td["n"], 2);
+    assert_eq!(td["low_n"], true);
+    // Marginals: format=thesis has n=5, format=parable has n=2.
+    let format_thesis = v["marginals_a"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["value"] == "thesis")
+        .unwrap();
+    assert_eq!(format_thesis["n"], 5);
+    let hook_contradiction = v["marginals_b"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["value"] == "contradiction")
+        .unwrap();
+    assert_eq!(hook_contradiction["n"], 3);
+}
+
+#[test]
+fn compare_with_no_overlapping_classifications_yields_empty_cells() {
+    let tmp = fixture_workdir(); // posts have format but no hook
+    let repo = blogctl::Repository::open(blogctl::Workdir::new(tmp.path())).unwrap();
+    let handles = repo.list().unwrap();
+    let posts: Vec<_> = handles
+        .iter()
+        .map(|h| repo.load_raw(&h.metadata.slug).unwrap().1)
+        .collect();
+    let comparison = blogctl::analytics::compare(
+        &posts,
+        "format",
+        "hook",
+        None,
+        3,
+        time::macros::datetime!(2026-05-17 00:00:00 UTC),
+    );
+    // No post has both format AND hook set → no cells.
+    assert!(comparison.cells.is_empty());
+    // But the format marginal still has values (the posts have
+    // format set even though no hook).
+    assert!(!comparison.marginals_a.is_empty());
+}


### PR DESCRIPTION
Pure-domain piece #440's command body will consume. Builds the
pairwise crosstab of two classification dimensions plus the
per-dimension marginals — same data shape the analytics summary
command emits, just sliced two ways instead of one.

src/analytics/compare.rs:

- Comparison { dim_a, dim_b, target_filter, min_n, cells,
  marginals_a, marginals_b }
- Cell { value_a, value_b, n, impressions_p50,
  engagement_rate_p50, low_n }
- Marginal { dimension, value, n, impressions_p50,
  engagement_rate_p50 }
- compute() walks every post, every target with metrics, builds
  the (value_a × value_b) cross-product per sample, and emits one
  Cell per non-empty intersection. Multi-valued theme explodes
  into multiple cells per the issue spec.
- low_n is computed against the caller-supplied min_n (different
  knob from summary's hardcoded LOW_N_THRESHOLD — the issue
  documents distinct semantics).
- Comparison::cell / row_values / column_values are text-renderer
  helpers; the text view needs to lay out empty cells as `--`,
  which means iterating the row × column grid rather than the
  sparse cell list.

build_marginals reuses summary::compute restricted to one
dimension — free percentile path, same sample definition.
Compare and summary now share an analytics::DerivedMetrics view
of every sample.

Nine unit tests cover empty-input, empty-intersection-omitted,
low_n threshold against min_n, multi-valued theme explosion,
marginals computed independently of the crosstab, unknown
dimension yields no cells, target filter, row/column alphabetical
sort, and a JSON-shape round-trip.

This commit stacks on top of #469 (analytics summary). The
follow-up commit on this branch wires up the command body.

For #440.

Closes #440.

Wires `commands::analytics::compare` to call analytics::compare
and render either a crosstab text view or the documented JSON.

Text renderer:

  compare format × hook  (target=linkedin)

                  contradiction   direct-claim    question
  parable         --              --              n=2  (low)
  thesis          n=3  4.8%       n=2  (low)      --

  marginals:
    format=parable:    n=2     eng p50=2.0%
    format=thesis:     n=5     eng p50=4.2%
    hook=contradiction: n=3    eng p50=4.8%
    ...

Empty cells render as `--` (no post in that intersection). Cells
below `--min-n` show `n=N (low)` instead of the median — the
issue spec's honesty rule: low-confidence numbers don't get a
prominent display in text. JSON includes every cell with a low_n
flag so machine consumers can apply their own threshold.

Marginals are listed below the crosstab, one line per
`<dim>=<value>: n=N eng p50=X%`. They share the table's number
formatting so the user can quickly sanity-check whether a hot
cell is the cell winning or a strong marginal dragging it.

Column widths size to the longest cell body within each column
(falling back to the column name's length). Row labels size to
the longest dim_a value. Both are bottom-capped at 8 chars so
narrow data doesn't produce a cramped table.

Three integration tests in tests/analytics.rs:
- compare_command_succeeds_against_fixture (smoke test for the
  full text render path against a real workdir built via the
  library API)
- compare_json_shape_for_fixture (pins the documented JSON shape
  including cell counts, low_n flags, and both marginals)
- compare_with_no_overlapping_classifications_yields_empty_cells
  (posts have format but no hook → no cells, but format
  marginals still populate)