### PR TITLE
feat(shaka): add worker-build-check to rust-worker validate

### DIFF
--- a/apps/kolohelios-portfolio/justfile
+++ b/apps/kolohelios-portfolio/justfile
@@ -12,6 +12,10 @@ build-check:
 wasm-check:
     cargo check --target wasm32-unknown-unknown
 
+worker-build-check:
+    cargo install -q worker-build --locked
+    worker-build --release
+
 test:
     cargo test
 
@@ -62,4 +66,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: build-check fmt-check lint doc-check deny machete test coverage wasm-check nix-fmt-check flake-check whitespace-check
+validate: build-check fmt-check lint doc-check deny machete test coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -83,8 +83,23 @@ validate: nix-fmt-check flake-check whitespace-check
 // wasm-target sanity check lives in `wasm-check`. The validate recipe
 // composes the wasm check so wasm-incompat deps surface here, not
 // later when wrangler tries to compile.
+//
+// `worker-build-check` mirrors the exact `cargo install worker-build
+// --locked && worker-build --release` chain `cf-deploy.yml` runs in
+// CI (#424). `wasm-check` alone catches syntactic wasm-target
+// incompatibility but not the toolchain-resolution failure mode
+// that bit #403 — wasm-pack's `which("rustc")` probe is only
+// exercised by `worker-build`. Validate runs it locally so a CI-only
+// failure of this class can no longer hide behind a green local
+// run. The `cargo install --locked` is idempotent (no-op on a
+// re-run with the same lockfile-pinned version); first-run cost is
+// the worker-build install.
 const RUST_WORKER_TEMPLATE: &str = r#"wasm-check:
     cargo check --target wasm32-unknown-unknown
+
+worker-build-check:
+    cargo install -q worker-build --locked
+    worker-build --release
 
 test:
     cargo test
@@ -136,7 +151,7 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage wasm-check nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete test coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check
 "#;
 
 // Infra projects intentionally do NOT run `nix flake check` in `validate`.


### PR DESCRIPTION
Mirrors the exact `cargo install worker-build --locked &&
worker-build --release` chain `cf-deploy.yml` runs in CI, so a
local `just validate` exercises the same wasm-pack / worker-build
toolchain probe that bit #403. `wasm-check` (a `cargo check
--target wasm32-unknown-unknown`) catches syntactic wasm-target
incompatibility but not the toolchain-resolution failure mode —
that fires inside `worker-build`, which `wasm-check` never invokes.

`worker-build-check` is in `validate`'s recipe chain; it follows
`wasm-check` since the cheaper syntactic check should fail first if
both would. `cargo install --locked` is idempotent on a re-run with
the same pinned version (no-op), so steady-state cost is just the
release build. First-run cost is the `worker-build` install.

Per #424 approach (1): cheapest-first coverage of layer 1
(platform / darwin-only blindspot). Doesn't catch layers 2-3
(GH-hosted image specifics, action side effects); we re-evaluate
those if a second instance of this class costs more cycles than
act- or devbox-shaped tooling would take to build.

Closes #424.