### PR TITLE
feat(blogctl): analytics recommendations command body

### DIFF
--- a/apps/blogctl/src/analytics/mod.rs
+++ b/apps/blogctl/src/analytics/mod.rs
@@ -9,9 +9,13 @@
 pub mod compare;
 pub mod derived;
 pub mod percentile;
+pub mod recommendations;
 pub mod summary;
 
 pub use compare::{compute as compare, Cell, Comparison, Marginal};
 pub use derived::DerivedMetrics;
 pub use percentile::{percentiles_f64, percentiles_u64, Percentiles};
+pub use recommendations::{
+    compute as recommendations, Observation, Recommendations, CLOSING_REMINDER, FORBIDDEN_WORDS,
+};
 pub use summary::{compute as summary, DimensionSummary, Summary, ValueSummary, LOW_N_THRESHOLD};

--- a/apps/blogctl/src/analytics/recommendations.rs
+++ b/apps/blogctl/src/analytics/recommendations.rs
@@ -1,0 +1,764 @@
+#![forbid(unsafe_code)]
+
+//! Heuristic observations across the analytics corpus, with the
+//! hedge language enforced by the renderer.
+//!
+//! Three constraints make this module unusual:
+//!
+//! 1. **Honesty is the load-bearing feature.** Every observation
+//!    carries `n`; every quantitative claim gets an "Early signal:"
+//!    prefix; low-n cases get "Insufficient data:". The renderer is
+//!    the language gate — never call out to ad-hoc formatting.
+//! 2. **No JSON output.** Recommendations are human-shaped prose
+//!    that exists to *be hedged*. A JSON pathway would tempt
+//!    consumers to strip the hedges and treat the claims as facts.
+//! 3. **No statistical tests.** The corpus is too small (tens of
+//!    posts). Pretending otherwise would be the exact dishonesty
+//!    this module is preventing.
+
+use time::OffsetDateTime;
+
+use crate::analytics::compare;
+use crate::analytics::percentile::percentiles_f64;
+use crate::analytics::summary;
+use crate::analytics::DerivedMetrics;
+use crate::post::Post;
+use crate::target::Target;
+
+/// A cell / value must beat its baseline by this much (relative) to
+/// register as a lift. 1.5 = 50% relative lift, matching #441's spec.
+pub const LIFT_THRESHOLD: f64 = 1.5;
+
+/// Targets with metrics older than this trigger the stale-data
+/// observation. The cap is per the spec; not configurable.
+pub const STALE_METRICS_THRESHOLD_DAYS: i64 = 30;
+
+/// Cap on the number of *inference* observations we emit (dimension
+/// lift + interaction lift + underrepresented). Stale-data
+/// observations are informational and don't count against the cap.
+pub const MAX_INFERENCE_OBSERVATIONS: usize = 5;
+
+/// Words that must NEVER appear in rendered observations. The
+/// language-gate test greps for these to catch regressions.
+pub const FORBIDDEN_WORDS: &[&str] = &["proves", "shows", "best", "winning"];
+
+/// The result of one `analytics recommendations` run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Recommendations {
+    pub target_filter: Option<Target>,
+    /// Number of distinct posts with at least one (filtered) target
+    /// that has metrics. Drives the header line.
+    pub n_total: usize,
+    pub observations: Vec<Observation>,
+}
+
+/// One heuristic observation. The hedge prefix lives in the
+/// renderer — `Observation` itself is structured data with the
+/// minimum context each heuristic produces.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Observation {
+    /// A dimension value's median engagement_rate ≥ LIFT_THRESHOLD×
+    /// the corpus median, AND n ≥ min_n.
+    DimensionLift {
+        dimension: String,
+        value: String,
+        n: usize,
+        value_median_er: f64,
+        corpus_median_er: f64,
+    },
+    /// A `(dim_a, dim_b)` cell's median engagement_rate beats at
+    /// least one of its marginals by ≥ LIFT_THRESHOLD relative, AND
+    /// cell_n ≥ min_n.
+    InteractionLift {
+        dim_a: String,
+        value_a: String,
+        dim_b: String,
+        value_b: String,
+        n: usize,
+        cell_median_er: f64,
+        marginal_a_median_er: f64,
+        marginal_b_median_er: f64,
+    },
+    /// A value with above-corpus engagement_rate but n < min_n.
+    /// "Worth more samples" rather than "this is real."
+    Underrepresented {
+        dimension: String,
+        value: String,
+        n: usize,
+        value_median_er: f64,
+        corpus_median_er: f64,
+        min_n: usize,
+    },
+    /// Published targets whose metrics haven't been refreshed in
+    /// >STALE_METRICS_THRESHOLD_DAYS days.
+    StaleMetrics {
+        slugs: Vec<String>,
+        threshold_days: i64,
+    },
+}
+
+impl Observation {
+    /// Render the hedged prose. Each variant's template bakes in
+    /// the required prefix and avoids the FORBIDDEN_WORDS list;
+    /// callers concatenate these into the full output.
+    pub fn render(&self) -> String {
+        match self {
+            Self::DimensionLift {
+                dimension,
+                value,
+                n,
+                value_median_er,
+                corpus_median_er,
+            } => format!(
+                "Early signal: {dimension}={value} correlates with higher engagement \
+                 (median {} vs corpus {}; n={n}).",
+                fmt_er(*value_median_er),
+                fmt_er(*corpus_median_er),
+            ),
+            Self::InteractionLift {
+                dim_a,
+                value_a,
+                dim_b,
+                value_b,
+                n,
+                cell_median_er,
+                marginal_a_median_er,
+                marginal_b_median_er,
+            } => format!(
+                "Early signal: {dim_a}={value_a} + {dim_b}={value_b} outperformed both marginals \
+                 in this sample (median {}; marginals {} / {}; n={n}). Treat with caution at this n.",
+                fmt_er(*cell_median_er),
+                fmt_er(*marginal_a_median_er),
+                fmt_er(*marginal_b_median_er),
+            ),
+            Self::Underrepresented {
+                dimension,
+                value,
+                n,
+                value_median_er,
+                corpus_median_er,
+                min_n,
+            } => format!(
+                "Insufficient data: {dimension}={value} has {} posts (below min_n={min_n}) \
+                 but its median engagement ({}) is above corpus ({}). Consider more samples.",
+                n,
+                fmt_er(*value_median_er),
+                fmt_er(*corpus_median_er),
+            ),
+            Self::StaleMetrics {
+                slugs,
+                threshold_days,
+            } => format!(
+                "Stale data: {} published post(s) have metrics older than {threshold_days} days \
+                 [{}]. Run `blogctl metrics update <slug>` to refresh.",
+                slugs.len(),
+                slugs.join(", "),
+            ),
+        }
+    }
+}
+
+/// Closing reminder printed unconditionally so a stray copy-paste
+/// of one observation still lands with the hedge attached.
+pub const CLOSING_REMINDER: &str =
+    "Reminder: these are correlations on a small sample. Treat as priors for what to try next, \
+     not as conclusions.";
+
+/// Run every heuristic and emit a `Recommendations` bundle.
+pub fn compute(
+    posts: &[Post],
+    target_filter: Option<Target>,
+    min_n: usize,
+    now: OffsetDateTime,
+) -> Recommendations {
+    let n_total = count_distinct_posts_with_metrics(posts, target_filter);
+    let corpus_median_er = corpus_median_engagement_rate(posts, target_filter, now);
+    let summary_all = summary::compute(posts, target_filter, None, now);
+    let compare_fmt_hook = compare::compute(posts, "format", "hook", target_filter, min_n, now);
+
+    let mut inference = Vec::new();
+    if let Some(corpus) = corpus_median_er {
+        inference.extend(dimension_lift(&summary_all, corpus, min_n));
+        inference.extend(interaction_lift(&compare_fmt_hook, min_n));
+        inference.extend(underrepresented(&summary_all, corpus, min_n));
+    }
+    // Cap inference observations only; stale-data is informational.
+    inference.truncate(MAX_INFERENCE_OBSERVATIONS);
+
+    let stale = stale_metrics(posts, target_filter, STALE_METRICS_THRESHOLD_DAYS, now);
+
+    let mut observations = inference;
+    observations.extend(stale);
+    Recommendations {
+        target_filter,
+        n_total,
+        observations,
+    }
+}
+
+fn dimension_lift(s: &summary::Summary, corpus_median_er: f64, min_n: usize) -> Vec<Observation> {
+    let mut out = Vec::new();
+    for dim in &s.dimensions {
+        for value in &dim.values {
+            let Some(er) = value.engagement_rate else {
+                continue;
+            };
+            if value.n >= min_n && er.p50 >= corpus_median_er * LIFT_THRESHOLD {
+                out.push(Observation::DimensionLift {
+                    dimension: dim.name.clone(),
+                    value: value.value.clone(),
+                    n: value.n,
+                    value_median_er: er.p50,
+                    corpus_median_er,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn interaction_lift(c: &compare::Comparison, min_n: usize) -> Vec<Observation> {
+    let mut out = Vec::new();
+    for cell in &c.cells {
+        let Some(cell_er) = cell.engagement_rate_p50 else {
+            continue;
+        };
+        if cell.n < min_n {
+            continue;
+        }
+        let marginal_a = c
+            .marginals_a
+            .iter()
+            .find(|m| m.value == cell.value_a)
+            .and_then(|m| m.engagement_rate_p50);
+        let marginal_b = c
+            .marginals_b
+            .iter()
+            .find(|m| m.value == cell.value_b)
+            .and_then(|m| m.engagement_rate_p50);
+        let (Some(a_er), Some(b_er)) = (marginal_a, marginal_b) else {
+            continue;
+        };
+        let beats_a = cell_er >= a_er * LIFT_THRESHOLD;
+        let beats_b = cell_er >= b_er * LIFT_THRESHOLD;
+        if beats_a || beats_b {
+            out.push(Observation::InteractionLift {
+                dim_a: c.dim_a.clone(),
+                value_a: cell.value_a.clone(),
+                dim_b: c.dim_b.clone(),
+                value_b: cell.value_b.clone(),
+                n: cell.n,
+                cell_median_er: cell_er,
+                marginal_a_median_er: a_er,
+                marginal_b_median_er: b_er,
+            });
+        }
+    }
+    out
+}
+
+fn underrepresented(s: &summary::Summary, corpus_median_er: f64, min_n: usize) -> Vec<Observation> {
+    let mut out = Vec::new();
+    for dim in &s.dimensions {
+        for value in &dim.values {
+            let Some(er) = value.engagement_rate else {
+                continue;
+            };
+            if value.n < min_n && er.p50 > corpus_median_er {
+                out.push(Observation::Underrepresented {
+                    dimension: dim.name.clone(),
+                    value: value.value.clone(),
+                    n: value.n,
+                    value_median_er: er.p50,
+                    corpus_median_er,
+                    min_n,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn stale_metrics(
+    posts: &[Post],
+    target_filter: Option<Target>,
+    threshold_days: i64,
+    now: OffsetDateTime,
+) -> Vec<Observation> {
+    let mut stale_slugs: Vec<String> = Vec::new();
+    for post in posts {
+        for target in &post.metadata.targets {
+            if let Some(filter) = target_filter {
+                if target.name != filter {
+                    continue;
+                }
+            }
+            let derived = DerivedMetrics::from_target(target, now);
+            if let Some(days) = derived.staleness_days {
+                if days > threshold_days {
+                    if !stale_slugs.contains(&post.metadata.slug) {
+                        stale_slugs.push(post.metadata.slug.clone());
+                    }
+                    // Avoid emitting once per stale-target on the same post.
+                    break;
+                }
+            }
+        }
+    }
+    if stale_slugs.is_empty() {
+        Vec::new()
+    } else {
+        vec![Observation::StaleMetrics {
+            slugs: stale_slugs,
+            threshold_days,
+        }]
+    }
+}
+
+fn count_distinct_posts_with_metrics(posts: &[Post], target_filter: Option<Target>) -> usize {
+    posts
+        .iter()
+        .filter(|p| {
+            p.metadata.targets.iter().any(|t| {
+                if let Some(filter) = target_filter {
+                    if t.name != filter {
+                        return false;
+                    }
+                }
+                t.metrics.is_some()
+            })
+        })
+        .count()
+}
+
+fn corpus_median_engagement_rate(
+    posts: &[Post],
+    target_filter: Option<Target>,
+    now: OffsetDateTime,
+) -> Option<f64> {
+    let mut rates = Vec::new();
+    for post in posts {
+        for target in &post.metadata.targets {
+            if let Some(filter) = target_filter {
+                if target.name != filter {
+                    continue;
+                }
+            }
+            if target.metrics.is_some() {
+                let derived = DerivedMetrics::from_target(target, now);
+                if let Some(er) = derived.engagement_rate {
+                    rates.push(er);
+                }
+            }
+        }
+    }
+    percentiles_f64(&rates).map(|p| p.p50)
+}
+
+fn fmt_er(rate: f64) -> String {
+    format!("{:.1}%", rate * 100.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    use crate::classifications::Classifications;
+    use crate::kind::Kind;
+    use crate::post::PostMetadata;
+    use crate::stage::Stage;
+    use crate::target::{TargetEntry, TargetMetrics, TargetStatus};
+
+    fn now() -> OffsetDateTime {
+        datetime!(2026-05-17 00:00:00 UTC)
+    }
+
+    fn post_with(
+        slug: &str,
+        format: Option<&str>,
+        hook: Option<&str>,
+        impressions: u64,
+        reactions: u64,
+        sampled_at: OffsetDateTime,
+    ) -> Post {
+        Post::new(
+            PostMetadata {
+                title: slug.into(),
+                slug: slug.into(),
+                kind: Kind::Post,
+                theme: "standard".into(),
+                status: Stage::Published,
+                created_at: datetime!(2026-05-01 00:00:00 UTC),
+                updated_at: datetime!(2026-05-08 00:00:00 UTC),
+                tags: vec![],
+                todoist_task_id: None,
+                history_checked: false,
+                targets: vec![TargetEntry {
+                    name: Target::Linkedin,
+                    status: TargetStatus::Published,
+                    url: Some("https://example.invalid".into()),
+                    published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+                    metrics: Some(TargetMetrics {
+                        impressions,
+                        reactions,
+                        comments: 0,
+                        reposts: 0,
+                        sampled_at,
+                    }),
+                }],
+                classifications: Classifications {
+                    format: format.map(|s| s.into()),
+                    hook: hook.map(|s| s.into()),
+                    ..Default::default()
+                },
+            },
+            "body\n",
+        )
+    }
+
+    fn no_metrics_post(slug: &str) -> Post {
+        let mut p = post_with(
+            slug,
+            Some("thesis"),
+            None,
+            1000,
+            50,
+            datetime!(2026-05-14 00:00:00 UTC),
+        );
+        p.metadata.targets[0].metrics = None;
+        p
+    }
+
+    #[test]
+    fn dimension_lift_fires_when_one_format_dominates_by_5x() {
+        // 5 thesis posts at 10% engagement, 5 parable at 2% — corpus
+        // median is somewhere in between; thesis sits well above
+        // the 1.5x lift threshold.
+        let posts: Vec<_> = (0..5)
+            .map(|i| {
+                post_with(
+                    &format!("t{i}"),
+                    Some("thesis"),
+                    None,
+                    1000,
+                    100, // 10%
+                    datetime!(2026-05-14 00:00:00 UTC),
+                )
+            })
+            .chain((0..5).map(|i| {
+                post_with(
+                    &format!("p{i}"),
+                    Some("parable"),
+                    None,
+                    1000,
+                    20, // 2%
+                    datetime!(2026-05-14 00:00:00 UTC),
+                )
+            }))
+            .collect();
+        let r = compute(&posts, Some(Target::Linkedin), 5, now());
+        // dimension_lift should fire for thesis.
+        let lifts: Vec<&Observation> = r
+            .observations
+            .iter()
+            .filter(|o| matches!(o, Observation::DimensionLift { .. }))
+            .collect();
+        assert!(
+            lifts.iter().any(
+                |o| matches!(o, Observation::DimensionLift { value, .. } if value == "thesis")
+            ),
+            "expected DimensionLift for thesis: {:?}",
+            r.observations,
+        );
+    }
+
+    #[test]
+    fn no_metrics_in_corpus_yields_only_stale_or_nothing() {
+        // Every post is metric-less → corpus_median_er is None →
+        // no inference observations fire. (Stale only fires on
+        // posts with metrics, so this fixture produces an empty
+        // observation list.)
+        let posts: Vec<_> = (0..3).map(|i| no_metrics_post(&format!("p{i}"))).collect();
+        let r = compute(&posts, Some(Target::Linkedin), 5, now());
+        assert!(
+            r.observations.is_empty(),
+            "expected no observations; got {:?}",
+            r.observations
+        );
+        assert_eq!(r.n_total, 0);
+    }
+
+    #[test]
+    fn underrepresented_fires_for_high_er_low_n() {
+        // 5 parables at 2% engagement and 1 thesis at 8% — thesis's
+        // engagement is well above corpus but n=1 < min_n=3.
+        let mut posts: Vec<_> = (0..5)
+            .map(|i| {
+                post_with(
+                    &format!("p{i}"),
+                    Some("parable"),
+                    None,
+                    1000,
+                    20,
+                    datetime!(2026-05-14 00:00:00 UTC),
+                )
+            })
+            .collect();
+        posts.push(post_with(
+            "t1",
+            Some("thesis"),
+            None,
+            1000,
+            80, // 8%
+            datetime!(2026-05-14 00:00:00 UTC),
+        ));
+        let r = compute(&posts, Some(Target::Linkedin), 3, now());
+        assert!(
+            r.observations.iter().any(
+                |o| matches!(o, Observation::Underrepresented { value, .. } if value == "thesis")
+            ),
+            "expected Underrepresented for thesis: {:?}",
+            r.observations,
+        );
+    }
+
+    #[test]
+    fn stale_metrics_fires_for_posts_sampled_more_than_30_days_ago() {
+        // Sampled 60 days before `now` → staleness > 30 → fires.
+        let p = post_with(
+            "old",
+            Some("thesis"),
+            None,
+            1000,
+            50,
+            datetime!(2026-03-18 00:00:00 UTC),
+        );
+        let r = compute(&[p], Some(Target::Linkedin), 3, now());
+        assert!(
+            r.observations
+                .iter()
+                .any(|o| matches!(o, Observation::StaleMetrics { slugs, .. } if slugs.contains(&"old".to_string()))),
+            "expected StaleMetrics for old: {:?}",
+            r.observations,
+        );
+    }
+
+    #[test]
+    fn fresh_metrics_do_not_trigger_stale_observation() {
+        // Sampled 3 days before `now` → staleness < 30 → silent.
+        let p = post_with(
+            "fresh",
+            Some("thesis"),
+            None,
+            1000,
+            50,
+            datetime!(2026-05-14 00:00:00 UTC),
+        );
+        let r = compute(&[p], Some(Target::Linkedin), 3, now());
+        assert!(
+            !r.observations
+                .iter()
+                .any(|o| matches!(o, Observation::StaleMetrics { .. })),
+            "fresh metrics should not produce stale observation: {:?}",
+            r.observations,
+        );
+    }
+
+    #[test]
+    fn interaction_lift_fires_when_cell_beats_at_least_one_marginal() {
+        // Construct a corpus where thesis+contradiction (n=3) is at
+        // 10% while thesis-marginal is ~4% and contradiction-marginal
+        // is ~4%. The cell beats both marginals by >1.5x.
+        let mut posts = Vec::new();
+        for i in 0..3 {
+            posts.push(post_with(
+                &format!("tc{i}"),
+                Some("thesis"),
+                Some("contradiction"),
+                1000,
+                100, // 10%
+                datetime!(2026-05-14 00:00:00 UTC),
+            ));
+        }
+        // Background thesis posts (with other hooks) bring the
+        // format=thesis marginal down.
+        for i in 0..5 {
+            posts.push(post_with(
+                &format!("td{i}"),
+                Some("thesis"),
+                Some("direct-claim"),
+                1000,
+                30, // 3%
+                datetime!(2026-05-14 00:00:00 UTC),
+            ));
+        }
+        // Background contradiction posts (other formats).
+        for i in 0..5 {
+            posts.push(post_with(
+                &format!("pc{i}"),
+                Some("parable"),
+                Some("contradiction"),
+                1000,
+                30, // 3%
+                datetime!(2026-05-14 00:00:00 UTC),
+            ));
+        }
+        let r = compute(&posts, Some(Target::Linkedin), 3, now());
+        assert!(
+            r.observations.iter().any(
+                |o| matches!(o, Observation::InteractionLift { value_a, value_b, .. }
+                    if value_a == "thesis" && value_b == "contradiction")
+            ),
+            "expected InteractionLift for thesis+contradiction: {:?}",
+            r.observations,
+        );
+    }
+
+    #[test]
+    fn rendered_observations_never_contain_forbidden_words() {
+        // Build a fixture that triggers every heuristic, render the
+        // observations, and grep for forbidden words.
+        let mut posts = Vec::new();
+        for i in 0..5 {
+            posts.push(post_with(
+                &format!("t{i}"),
+                Some("thesis"),
+                Some("contradiction"),
+                1000,
+                100,
+                datetime!(2026-05-14 00:00:00 UTC),
+            ));
+        }
+        for i in 0..5 {
+            posts.push(post_with(
+                &format!("p{i}"),
+                Some("parable"),
+                None,
+                1000,
+                20,
+                datetime!(2026-05-14 00:00:00 UTC),
+            ));
+        }
+        // A stale post.
+        posts.push(post_with(
+            "old",
+            Some("thesis"),
+            None,
+            1000,
+            50,
+            datetime!(2026-03-18 00:00:00 UTC),
+        ));
+        let r = compute(&posts, Some(Target::Linkedin), 3, now());
+        assert!(
+            !r.observations.is_empty(),
+            "fixture should produce some observations"
+        );
+        for obs in &r.observations {
+            let rendered = obs.render();
+            for word in FORBIDDEN_WORDS {
+                assert!(
+                    !rendered.to_lowercase().contains(word),
+                    "observation {:?} rendered with forbidden word {:?}: {}",
+                    obs,
+                    word,
+                    rendered,
+                );
+            }
+        }
+        // The closing reminder is also subject to the language gate.
+        for word in FORBIDDEN_WORDS {
+            assert!(
+                !CLOSING_REMINDER.to_lowercase().contains(word),
+                "CLOSING_REMINDER contains forbidden word {word:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn rendered_observations_always_include_n() {
+        // Every inference observation must surface `n=` so the user
+        // can size their confidence. Stale observations don't have a
+        // single n (they're a list); they get a count instead.
+        let posts: Vec<_> = (0..5)
+            .map(|i| {
+                post_with(
+                    &format!("t{i}"),
+                    Some("thesis"),
+                    None,
+                    1000,
+                    100,
+                    datetime!(2026-05-14 00:00:00 UTC),
+                )
+            })
+            .collect();
+        let r = compute(&posts, Some(Target::Linkedin), 5, now());
+        for obs in &r.observations {
+            let rendered = obs.render();
+            match obs {
+                Observation::StaleMetrics { .. } => {
+                    // Stale renders `<N> published post(s)` — N is a count.
+                }
+                _ => {
+                    assert!(
+                        rendered.contains("n="),
+                        "inference observation should include `n=`: {rendered}",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn inference_cap_applies_but_stale_is_unbounded() {
+        // Concoct many lift opportunities. The inference cap should
+        // limit them to MAX_INFERENCE_OBSERVATIONS even though more
+        // are technically eligible. Stale metrics on top of that
+        // still appear.
+        let mut posts = Vec::new();
+        // Many different formats all beating the corpus median.
+        for fmt in [
+            "thesis",
+            "essay",
+            "framework",
+            "observation",
+            "parable",
+            "personal-reflection",
+        ] {
+            for i in 0..5 {
+                posts.push(post_with(
+                    &format!("{fmt}-{i}"),
+                    Some(fmt),
+                    None,
+                    1000,
+                    100,
+                    datetime!(2026-05-14 00:00:00 UTC),
+                ));
+            }
+        }
+        // One stale post tacked on.
+        posts.push(post_with(
+            "old",
+            Some("thesis"),
+            None,
+            1000,
+            50,
+            datetime!(2026-03-18 00:00:00 UTC),
+        ));
+        let r = compute(&posts, Some(Target::Linkedin), 3, now());
+        let inference_count = r
+            .observations
+            .iter()
+            .filter(|o| !matches!(o, Observation::StaleMetrics { .. }))
+            .count();
+        assert!(
+            inference_count <= MAX_INFERENCE_OBSERVATIONS,
+            "inference cap violated: {inference_count}",
+        );
+        // And stale-data still made it through.
+        assert!(r
+            .observations
+            .iter()
+            .any(|o| matches!(o, Observation::StaleMetrics { .. })));
+    }
+}

--- a/apps/blogctl/src/commands/analytics.rs
+++ b/apps/blogctl/src/commands/analytics.rs
@@ -1,13 +1,14 @@
 //! `blogctl analytics {summary, compare, recommendations}` — read
 //! every published post's classifications + metrics and surface
-//! aggregates. summary + compare are implemented; recommendations
-//! is still a stub (behavior lands in #441).
+//! aggregates. All three commands implemented.
 
 use std::path::PathBuf;
 
 use time::OffsetDateTime;
 
-use crate::analytics::{self, Comparison, DimensionSummary, Summary, ValueSummary};
+use crate::analytics::{
+    self, Comparison, DimensionSummary, Recommendations, Summary, ValueSummary,
+};
 use crate::error::{Error, Result};
 use crate::storage::{Repository, Workdir};
 use crate::target::Target;
@@ -252,6 +253,37 @@ fn format_cell_body(cell: &analytics::Cell) -> String {
     format!("n={}  {er}", cell.n)
 }
 
-pub fn recommendations(_args: RecommendationsArgs) -> Result<()> {
-    Err(Error::Unimplemented("analytics recommendations"))
+pub fn recommendations(args: RecommendationsArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let handles = repo.list()?;
+    let posts: Vec<_> = handles
+        .iter()
+        .map(|h| repo.load_raw(&h.metadata.slug).map(|(_, post)| post))
+        .collect::<Result<_>>()?;
+    let r = analytics::recommendations(&posts, args.target, args.min_n, OffsetDateTime::now_utc());
+    print_recommendations_text(&r);
+    Ok(())
+}
+
+fn print_recommendations_text(r: &Recommendations) {
+    let target_label = r
+        .target_filter
+        .map(|t| format!("target={t}, "))
+        .unwrap_or_default();
+    println!(
+        "analytics recommendations  ({target_label}n_total={n})",
+        n = r.n_total,
+    );
+    println!();
+    if r.observations.is_empty() {
+        println!(
+            "  (no observations — add metrics and classifications to more posts to surface signal)"
+        );
+    } else {
+        for obs in &r.observations {
+            println!("  {}", obs.render());
+            println!();
+        }
+    }
+    println!("{}", analytics::CLOSING_REMINDER);
 }

--- a/apps/blogctl/tests/analytics.rs
+++ b/apps/blogctl/tests/analytics.rs
@@ -308,3 +308,50 @@ fn compare_with_no_overlapping_classifications_yields_empty_cells() {
     // format set even though no hook).
     assert!(!comparison.marginals_a.is_empty());
 }
+
+#[test]
+fn recommendations_command_succeeds_against_fixture() {
+    let tmp = fixture_workdir_with_hooks();
+    commands::analytics::recommendations(commands::analytics::RecommendationsArgs {
+        workdir: tmp.path().to_path_buf(),
+        target: None,
+        min_n: 3,
+    })
+    .unwrap();
+}
+
+#[test]
+fn recommendations_observations_use_hedged_language() {
+    // Render every observation produced against the fixture and
+    // verify the language gate (no forbidden words anywhere in the
+    // rendered output, including the closing reminder).
+    let tmp = fixture_workdir_with_hooks();
+    let repo = blogctl::Repository::open(blogctl::Workdir::new(tmp.path())).unwrap();
+    let handles = repo.list().unwrap();
+    let posts: Vec<_> = handles
+        .iter()
+        .map(|h| repo.load_raw(&h.metadata.slug).unwrap().1)
+        .collect();
+    let r = blogctl::analytics::recommendations(
+        &posts,
+        Some(Target::Linkedin),
+        3,
+        time::macros::datetime!(2026-05-17 00:00:00 UTC),
+    );
+    for obs in &r.observations {
+        let rendered = obs.render().to_lowercase();
+        for word in blogctl::analytics::FORBIDDEN_WORDS {
+            assert!(
+                !rendered.contains(word),
+                "observation rendered with forbidden word {word:?}: {rendered}",
+            );
+        }
+    }
+    let reminder = blogctl::analytics::CLOSING_REMINDER.to_lowercase();
+    for word in blogctl::analytics::FORBIDDEN_WORDS {
+        assert!(
+            !reminder.contains(word),
+            "closing reminder contains forbidden word {word:?}",
+        );
+    }
+}


### PR DESCRIPTION
Pure-domain piece #441's command body will consume. Surfaces up to
five heuristic observations across the analytics corpus, with the
hedge language baked into the renderer so it can't be dropped by
mistake.

src/analytics/recommendations.rs implements four heuristics, each
as its own pure function over the existing Summary / Comparison
data:

- dimension_lift: a value's median engagement_rate ≥ 1.5× the
  corpus median AND n ≥ min_n.
- interaction_lift: a (format, hook) cell's median ≥ 1.5× either
  of its marginals AND n ≥ min_n.
- underrepresented: above-corpus engagement_rate but n < min_n
  ("worth more samples", not "this is real").
- stale_metrics: published targets with sampled_at > 30 days
  before now.

Observation::render() is the language gate. Each variant's
format-string template bakes in the required prefix ("Early
signal:" / "Insufficient data:" / "Stale data:") and avoids
FORBIDDEN_WORDS = [proves, shows, best, winning]. A unit test
greps every rendered observation for those words to catch
regressions; another asserts every inference observation includes
`n=`.

Constants — LIFT_THRESHOLD (1.5×), STALE_METRICS_THRESHOLD_DAYS
(30), MAX_INFERENCE_OBSERVATIONS (5) — are not configurable. The
issue spec is explicit: tunable heuristics via config would be
the exact dishonesty this module is preventing.

CLOSING_REMINDER is exposed as a constant so the command body
can print it unconditionally (per the issue's "stray copy-paste
of one line still lands with the hedge attached" rule).

Nine unit tests cover: dimension_lift fires when one format
dominates 5×; underrepresented fires for high-er low-n;
stale_metrics fires for >30-day-old samples but not fresh ones;
interaction_lift fires when a cell beats both marginals;
no-metrics corpus yields no inference; the inference cap of 5
applies but stale observations are unbounded; rendered text never
contains forbidden words; rendered text always includes `n=`
(except for stale, which renders a count instead).

The command body lands in a follow-up commit on this branch.

For #441.

Closes #441.

Replaces the stub from #434 with the real implementation.

`commands::analytics::recommendations` now:
1. Walks the workdir via Repository::list (fail-fast on any
   classification / stage / frontmatter issue — analytics wants a
   clean dataset).
2. Calls analytics::recommendations() to run all four heuristics.
3. Renders the result as hedged prose with the unconditional
   closing reminder.

Output shape (per the issue's example):

  analytics recommendations  (target=linkedin, n_total=23)

    Early signal: format=thesis correlates with higher engagement
    (median 4.2% vs corpus 2.9%; n=8).

    Insufficient data: theme=interfaces has 2 posts (below
    min_n=5) but its median engagement (4.5%) is above corpus
    (2.9%). Consider more samples.

    Stale data: 3 published post(s) have metrics older than 30
    days [the-only-way-out-is-through, ...]. Run
    `blogctl metrics update <slug>` to refresh.

  Reminder: these are correlations on a small sample. Treat as
  priors for what to try next, not as conclusions.

No --json flag — recommendations are inherently human-shaped
prose that exists to be hedged. A JSON pathway would tempt
consumers to strip the hedges and treat the claims as facts.
The structured Observation enum is library-visible if a
non-blogctl consumer ever needs it.

Two integration tests:
- recommendations_command_succeeds_against_fixture (smoke test
  against the same fixture used by summary + compare tests).
- recommendations_observations_use_hedged_language (renders every
  observation produced by the fixture and grep-checks the language
  gate, including the closing reminder).