### PR TITLE
test(blogctl): drop --no-sync workarounds now that sync is fixed

### DIFF
--- a/apps/blogctl/src/sync.rs
+++ b/apps/blogctl/src/sync.rs
@@ -425,10 +425,15 @@ where
             // Offline, unconfigured remote, or transient network failure.
             // Skip the rebase and continue — push may also fail, but
             // the working copy will still be committed locally.
-            eprintln!(
-                "warning: fetch from {} failed: {e}; skipping rebase",
-                opts.config.remote
-            );
+            // The "no remote configured" case is the common pre-first-push
+            // state of a fresh workdir; surfacing it as a warning every
+            // write is noise the user can't act on.
+            if !cause_is_missing_remote(&e) {
+                eprintln!(
+                    "warning: fetch from {} failed: {e}; skipping rebase",
+                    opts.config.remote
+                );
+            }
             false
         }
     };
@@ -452,15 +457,30 @@ where
     match jj.push(workdir, &opts.config.remote, &opts.config.bookmark)? {
         PushOutcome::Pushed | PushOutcome::NothingToPush => {}
         PushOutcome::Failed(reason) => {
-            eprintln!(
-                "warning: push to {}/{} failed: {reason}",
-                opts.config.remote, opts.config.bookmark,
-            );
-            eprintln!("hint: commit is local; retry with `jj git push` when ready");
+            // Same suppression as the fetch path: a fresh workdir with
+            // no configured remote will surface this on every write.
+            if !reason.contains("No git remotes") {
+                eprintln!(
+                    "warning: push to {}/{} failed: {reason}",
+                    opts.config.remote, opts.config.bookmark,
+                );
+                eprintln!("hint: commit is local; retry with `jj git push` when ready");
+            }
         }
     }
 
     Ok(result)
+}
+
+/// True when `err` represents `jj git fetch` failing because the
+/// configured remote doesn't exist in the colocated `.git`. Surfaced
+/// so the sync hook can suppress the otherwise-noisy warning for the
+/// common pre-first-push state.
+fn cause_is_missing_remote(err: &Error) -> bool {
+    matches!(
+        err,
+        Error::JjCommandFailed { stderr, .. } if stderr.contains("No git remotes")
+    )
 }
 
 /// Shell `jj <args>` in `workdir`, treating any non-zero exit as a
@@ -661,6 +681,28 @@ mod tests {
 
     fn wd() -> PathBuf {
         PathBuf::from("/tmp/blogctl-fake")
+    }
+
+    #[test]
+    fn cause_is_missing_remote_matches_jj_no_remotes_error() {
+        let err = Error::JjCommandFailed {
+            command: "jj git fetch --remote origin".into(),
+            status: 1,
+            stderr:
+                "Warning: No git remotes matching 'origin'\nError: No git remotes to fetch from\n"
+                    .into(),
+        };
+        assert!(cause_is_missing_remote(&err));
+    }
+
+    #[test]
+    fn cause_is_missing_remote_ignores_unrelated_failures() {
+        let err = Error::JjCommandFailed {
+            command: "jj git fetch --remote origin".into(),
+            status: 1,
+            stderr: "Error: connection refused\n".into(),
+        };
+        assert!(!cause_is_missing_remote(&err));
     }
 
     #[test]

--- a/apps/blogctl/src/sync.rs
+++ b/apps/blogctl/src/sync.rs
@@ -233,7 +233,11 @@ impl Jj for RealJj {
     }
 
     fn new_change(&self, workdir: &Path, message: &str) -> Result<()> {
-        run_strict(workdir, &["new", "--no-edit=false", "-m", message])?;
+        // `--no-edit` is a bare boolean flag in current jj; the old
+        // `--no-edit=false` syntax errors with "unexpected value".
+        // Default `jj new` already moves @ to the new commit, which
+        // is exactly what we want here.
+        run_strict(workdir, &["new", "-m", message])?;
         Ok(())
     }
 

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -296,11 +296,8 @@ fn doctor_reports_clean_workdir_with_zero_exit() {
     let wd = workdir_arg(tmp.path());
     jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
-    assert_success(
-        &run(&["new", "Hello", "--workdir", &wd, "--no-sync"]),
-        "new",
-    );
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
 
     let out = run(&["doctor", "--workdir", &wd]);
     assert_success(&out, "doctor (clean)");
@@ -313,18 +310,15 @@ fn fix_repairs_stage_mismatch_and_leaves_workdir_clean() {
     let wd = workdir_arg(tmp.path());
     jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
-    assert_success(
-        &run(&["new", "Hello", "--workdir", &wd, "--no-sync"]),
-        "new",
-    );
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
     // Move the file from concepts/ to editing/ without rewriting
     // frontmatter — that's a stage mismatch fix can repair.
     let from = tmp.path().join("concepts/hello.md");
     let to = tmp.path().join("editing/hello.md");
     std::fs::rename(&from, &to).unwrap();
 
-    let fix_out = run(&["fix", "--workdir", &wd, "--no-sync"]);
+    let fix_out = run(&["fix", "--workdir", &wd]);
     assert_success(&fix_out, "fix");
     assert!(
         stdout(&fix_out).contains("fixed"),
@@ -347,11 +341,8 @@ fn fix_dry_run_makes_no_changes() {
     let wd = workdir_arg(tmp.path());
     jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
-    assert_success(
-        &run(&["new", "Hello", "--workdir", &wd, "--no-sync"]),
-        "new",
-    );
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
+    assert_success(&run(&["new", "Hello", "--workdir", &wd]), "new");
     let from = tmp.path().join("concepts/hello.md");
     let to = tmp.path().join("editing/hello.md");
     std::fs::rename(&from, &to).unwrap();
@@ -368,10 +359,10 @@ fn fix_exits_nonzero_when_skipped_findings_remain() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());
     jj_init(tmp.path());
-    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
     std::fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
 
-    let out = run(&["fix", "--workdir", &wd, "--no-sync"]);
+    let out = run(&["fix", "--workdir", &wd]);
     assert!(!out.status.success(), "expected non-zero exit");
     assert!(stdout(&out).contains("skipped"), "got: {}", stdout(&out));
 }
@@ -382,7 +373,7 @@ fn doctor_reports_findings_with_nonzero_exit() {
     let wd = workdir_arg(tmp.path());
     jj_init(tmp.path());
 
-    assert_success(&run(&["init", "--workdir", &wd, "--no-sync"]), "init");
+    assert_success(&run(&["init", "--workdir", &wd]), "init");
     // Plant several distinct findings: stray file, removed stage dir.
     std::fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
     std::fs::remove_dir_all(tmp.path().join("editing")).unwrap();


### PR DESCRIPTION
Current jj rejects --no-edit=false: --no-edit is a bare boolean flag,
not a key=value. The original intent (have the new commit become @,
which is the default behavior) is preserved without the flag.

Previously hard-failed every write against a real jj repo. Existing
FakeJj tests only assert on the message argument so they remain
green.

Refs #470

A brand-new colocated jj+git repo before its first push has no
configured remote — the common pre-first-push state for a fresh
blogctl workdir. Every blogctl write was surfacing two unactionable
warnings:

  warning: fetch from origin failed: ...; skipping rebase
  warning: push to origin/main failed: ...

Both reduce to the same root cause: \"No git remotes matching '...'\"
in jj's stderr. The fetch error is already caught and the rebase
skipped; the push failure is already non-fatal. Suppressing the
warnings in just the missing-remote case keeps real failures
(offline, auth expired, network glitch) visible while removing the
floor noise.

Refs #470

#467 sidestepped the two bugs above by passing --no-sync on the
setup init/new/fix calls in five doctor/fix integration tests.
Reverting those workarounds is the end-to-end test: each affected
test now exercises the full commit_and_push path against a real
jj-init'd tempdir (no upstream remote), which is much stronger than
any FakeJj-based assertion would be.

If --no-edit=false had returned, or the no-remote warnings had crept
back, the cli test suite would fail with the exact errors that
seeded #470 in the first place.

Closes #470