### PR TITLE
test(blogctl): end-to-end workflow + OpenRouter seam coverage

### DIFF
--- a/apps/blogctl/Cargo.lock
+++ b/apps/blogctl/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +74,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "mockito",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -91,6 +117,12 @@ dependencies = [
  "toml",
  "ureq",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -164,6 +196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +294,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,15 +327,46 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -290,6 +389,86 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "icu_collections"
@@ -449,6 +628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +659,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,10 +713,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -508,6 +761,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -539,9 +801,82 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -612,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +1011,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,10 +1048,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -815,6 +1190,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +1257,25 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1215,6 +1637,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/blogctl/Cargo.toml
+++ b/apps/blogctl/Cargo.toml
@@ -25,4 +25,5 @@ toml = "0.8"
 ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
+mockito = "1"
 tempfile = "3"

--- a/apps/blogctl/src/openrouter.rs
+++ b/apps/blogctl/src/openrouter.rs
@@ -10,8 +10,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
-const ENDPOINT: &str = "https://openrouter.ai/api/v1/chat/completions";
+const DEFAULT_ENDPOINT: &str = "https://openrouter.ai/api/v1/chat/completions";
 const API_KEY_VAR: &str = "OPENROUTER_API_KEY";
+const API_BASE_VAR: &str = "OPENROUTER_API_BASE";
+
+/// Resolve the chat-completions endpoint. Production reads the default;
+/// tests set `OPENROUTER_API_BASE` to a `mockito` server URL so the
+/// full HTTP path is exercised without depending on the live service.
+fn endpoint() -> String {
+    env::var(API_BASE_VAR).unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string())
+}
 
 pub const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4-6";
 
@@ -57,7 +65,7 @@ pub fn chat(prompt: &str, model: &str) -> Result<String> {
     // ChatRequest fields are all serializable primitives — to_value cannot fail.
     let body = serde_json::to_value(&request).expect("ChatRequest is serializable");
 
-    let response = ureq::post(ENDPOINT)
+    let response = ureq::post(&endpoint())
         .set("Authorization", &format!("Bearer {api_key}"))
         .set("Content-Type", "application/json")
         .send_json(body)
@@ -109,6 +117,31 @@ mod tests {
         let parsed: ChatResponse = serde_json::from_value(raw).unwrap();
         let content = parsed.choices.into_iter().next().map(|c| c.message.content);
         assert_eq!(content, Some("pong".to_string()));
+    }
+
+    #[test]
+    fn endpoint_defaults_to_production_url() {
+        // SAFETY: env vars are process-global. This test deliberately
+        // unsets and asserts; tests touching the same var should run
+        // serially under cargo test's default thread-per-test layout.
+        // The asymmetric set/unset cost is fine for the seam check.
+        let prev = env::var(API_BASE_VAR).ok();
+        env::remove_var(API_BASE_VAR);
+        assert_eq!(endpoint(), DEFAULT_ENDPOINT);
+        if let Some(v) = prev {
+            env::set_var(API_BASE_VAR, v);
+        }
+    }
+
+    #[test]
+    fn endpoint_honors_env_override() {
+        let prev = env::var(API_BASE_VAR).ok();
+        env::set_var(API_BASE_VAR, "http://127.0.0.1:1234/v1/chat");
+        assert_eq!(endpoint(), "http://127.0.0.1:1234/v1/chat");
+        match prev {
+            Some(v) => env::set_var(API_BASE_VAR, v),
+            None => env::remove_var(API_BASE_VAR),
+        }
     }
 
     #[test]

--- a/apps/blogctl/tests/ai_endpoint.rs
+++ b/apps/blogctl/tests/ai_endpoint.rs
@@ -1,0 +1,91 @@
+//! Exercises the `OPENROUTER_API_BASE` seam end-to-end: spin up a
+//! `mockito` server, point blogctl at it, call `commands::ai::ping`,
+//! confirm the request hit the mock and the reply text round-trips.
+//!
+//! This is what justifies the seam from commit 1. Production never
+//! sets the env var; the test does, so the full HTTP path —
+//! `ChatRequest` serialization, request firing, response parsing —
+//! runs without depending on real OpenRouter.
+
+use std::env;
+use std::sync::Mutex;
+
+use blogctl::commands;
+
+// `cargo test` runs tests in parallel by default; both env-touching
+// tests below have to serialize to avoid stepping on each other. A
+// process-level mutex held across the env-var dance is the simplest
+// guard.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const CANNED_OPENROUTER_RESPONSE: &str = r#"{
+  "id": "gen-test-001",
+  "object": "chat.completion",
+  "model": "test-model",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "pong from the mock"
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}"#;
+
+#[test]
+fn ping_hits_endpoint_via_env_override() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(CANNED_OPENROUTER_RESPONSE)
+        .create();
+
+    let prev_base = env::var("OPENROUTER_API_BASE").ok();
+    let prev_key = env::var("OPENROUTER_API_KEY").ok();
+    env::set_var(
+        "OPENROUTER_API_BASE",
+        format!("{}/chat/completions", server.url()),
+    );
+    env::set_var("OPENROUTER_API_KEY", "test-key");
+
+    let result = commands::ai::ping("hello".into(), "test-model".into());
+
+    // Restore env before asserting so a panic doesn't poison subsequent
+    // tests.
+    match prev_base {
+        Some(v) => env::set_var("OPENROUTER_API_BASE", v),
+        None => env::remove_var("OPENROUTER_API_BASE"),
+    }
+    match prev_key {
+        Some(v) => env::set_var("OPENROUTER_API_KEY", v),
+        None => env::remove_var("OPENROUTER_API_KEY"),
+    }
+
+    result.expect("ping should succeed against mock");
+    mock.assert();
+}
+
+#[test]
+fn openrouter_api_key_missing_surfaces_clean_error() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let prev_key = env::var("OPENROUTER_API_KEY").ok();
+    env::remove_var("OPENROUTER_API_KEY");
+
+    let result = commands::ai::ping("hello".into(), "test-model".into());
+
+    if let Some(v) = prev_key {
+        env::set_var("OPENROUTER_API_KEY", v);
+    }
+
+    let err = result.expect_err("missing API key must error");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+        msg.contains("openrouter") && msg.contains("api") && msg.contains("key"),
+        "error should mention the missing key; got: {err}"
+    );
+}

--- a/apps/blogctl/tests/workflow.rs
+++ b/apps/blogctl/tests/workflow.rs
@@ -1,0 +1,151 @@
+//! End-to-end lifecycle test: drives a single post from `init → new →
+//! classify → promote → metrics` against a fresh tempdir workdir.
+//!
+//! This catches the kind of regression where one command's output stops
+//! matching the next command's expected input (frontmatter rename, stage
+//! directory rename, taxonomy mismatch) — gaps unit tests miss because
+//! each one stays inside one module's contract.
+//!
+//! No AI here. `commands::ai::ping` is the only OpenRouter call site
+//! today and isn't wired into the lifecycle; the seam from #474 is
+//! exercised separately by `tests/ai_endpoint.rs`. Once the
+//! AI-integrated commands tracked in #483 land (`draft`, `refine`,
+//! `final-edit`), they'll slot into this file rather than a new one.
+
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
+use blogctl::commands::{self, classify::ClassifyArgs, metrics::UpdateArgs};
+use blogctl::kind::Kind;
+use blogctl::stage::Stage;
+use blogctl::storage::{Repository, Workdir};
+use blogctl::sync::FakeJj;
+use blogctl::target::{Target, TargetEntry, TargetStatus};
+
+fn fresh_workdir() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().to_path_buf();
+    (tmp, path)
+}
+
+fn promote_to_published(workdir: &PathBuf, slug: &str) {
+    // Concept → Ideation → Editing → FinalEditing → Published is four
+    // hops; one promote call per hop, each asserting we advanced.
+    for expected in [
+        Stage::Ideation,
+        Stage::Editing,
+        Stage::FinalEditing,
+        Stage::Published,
+    ] {
+        commands::promote::run(&FakeJj::new(), slug.to_string(), workdir.clone(), true)
+            .expect("promote");
+        let repo = Repository::open(Workdir::new(workdir)).expect("reopen");
+        let (handle, _) = repo.load(slug).expect("load after promote");
+        assert_eq!(handle.stage, expected, "stage after promote");
+    }
+}
+
+#[test]
+fn lifecycle_init_new_classify_promote_metrics() {
+    let (_tmp, workdir) = fresh_workdir();
+
+    // 1. init — scaffolds .blog-os.toml + stage dirs + README.
+    commands::init::run(&FakeJj::new(), workdir.clone(), true).expect("init");
+
+    // 2. new — creates a Concept-stage draft.
+    commands::new::run(
+        &FakeJj::new(),
+        "Test post title".into(),
+        workdir.clone(),
+        None,
+        Kind::Post,
+        None,
+        true,
+    )
+    .expect("new");
+
+    // The slugifier is deterministic for ASCII input; we know what to
+    // look for. Loading via Repository is the same call site the rest
+    // of the tool uses, so any divergence between writer and reader
+    // surfaces here.
+    let slug = "test-post-title";
+    let repo = Repository::open(Workdir::new(&workdir)).expect("open after new");
+    let (handle, post) = repo.load(slug).expect("load after new");
+    assert_eq!(handle.stage, Stage::Concept);
+    assert_eq!(post.metadata.slug, slug);
+    assert_eq!(post.metadata.title, "Test post title");
+    assert!(post.metadata.classifications.format.is_none());
+
+    // 3. classify — set format + hook against the default taxonomy.
+    let mut args = ClassifyArgs {
+        slug: slug.into(),
+        workdir: workdir.clone(),
+        no_sync: true,
+        ..Default::default()
+    };
+    args.format = Some("thesis".into());
+    args.hook = Some("contradiction".into());
+    commands::classify::run(&FakeJj::new(), args).expect("classify");
+
+    let repo = Repository::open(Workdir::new(&workdir)).expect("reopen after classify");
+    let (_, post) = repo.load(slug).expect("load after classify");
+    assert_eq!(
+        post.metadata.classifications.format.as_deref(),
+        Some("thesis")
+    );
+    assert_eq!(
+        post.metadata.classifications.hook.as_deref(),
+        Some("contradiction")
+    );
+
+    // 4. promote — walk Concept → Published, four hops.
+    promote_to_published(&workdir, slug);
+
+    // 5. metrics — `update` requires a target already in the post's
+    // targets[]. Adding a target is currently a manual frontmatter edit
+    // (no `add-target` command exists; tracked in #483 as part of the
+    // AI-integrated workflow gap survey). We rewrite the post directly
+    // to seed a `planned` linkedin target so metrics has something to
+    // update.
+    let repo = Repository::open(Workdir::new(&workdir)).expect("reopen pre-metrics");
+    let (handle, mut post) = repo.load_raw(slug).expect("load_raw pre-metrics");
+    post.metadata.targets.push(TargetEntry {
+        name: Target::Linkedin,
+        status: TargetStatus::Planned,
+        url: None,
+        published_at: None,
+        metrics: None,
+    });
+    std::fs::write(&handle.path, post.render().expect("render")).expect("write seeded target");
+
+    commands::metrics::update(
+        &FakeJj::new(),
+        UpdateArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            target: Target::Linkedin,
+            impressions: 1_234,
+            reactions: 42,
+            comments: 7,
+            reposts: 3,
+            sampled_at: None,
+            no_sync: true,
+        },
+    )
+    .expect("metrics update");
+
+    let repo = Repository::open(Workdir::new(&workdir)).expect("reopen final");
+    let (_, post) = repo.load(slug).expect("load final");
+    let linkedin = post
+        .metadata
+        .targets
+        .iter()
+        .find(|t| matches!(t.name, Target::Linkedin))
+        .expect("linkedin target present");
+    let m = linkedin.metrics.as_ref().expect("metrics block populated");
+    assert_eq!(m.impressions, 1_234);
+    assert_eq!(m.reactions, 42);
+    assert_eq!(m.comments, 7);
+    assert_eq!(m.reposts, 3);
+}


### PR DESCRIPTION
Replaces the const `ENDPOINT` with a small `endpoint()` fn that reads
`OPENROUTER_API_BASE`, defaulting to the real chat-completions URL.

Production never sets the var; tests will (#474) point it at a
`mockito` server so the workflow integration test can exercise the
full HTTP path — request serialization, response parsing, error
handling — without depending on the live OpenRouter service or burning
the free-tier rate limit on every CI run.

The seam is one function with two callers and one new env var; no
trait abstraction or fake-provider layer leaking into prod.

Two integration tests, both honoring the "real files under
tests/fixtures isn't needed because tempdirs are simpler here" pattern
the existing tests/sync.rs already uses:

- `tests/workflow.rs` drives a single post from `init → new → classify
  → promote (× 4) → metrics` against a fresh tempdir workdir, asserting
  on Repository state after each step. Catches regressions where one
  command's output stops matching the next command's expected input
  (frontmatter rename, stage rename, taxonomy drift).
- `tests/ai_endpoint.rs` spins up a `mockito` server, points blogctl
  at it via `OPENROUTER_API_BASE`, calls `commands::ai::ping`, and
  asserts the mock was hit. Justifies the seam from the preceding
  commit and also covers the missing-API-key error path.

The original issue (#474) framed `classify` as the AI integration
point; survey of the code showed `classify` is purely a flag-setter
and the only OpenRouter call site is `commands::ai::ping`. Refined
scope reflects that. The product gaps that survey surfaced (no `draft`,
`refine`, `final-edit`, or `publish` command; targets must be added by
hand-editing frontmatter) are tracked in #483 so they don't get lost.

Closes #474