### PR TITLE
feat(blogctl): backfill interactive mode (stdin prompts)

### DIFF
--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -21,9 +22,11 @@ use time::OffsetDateTime;
 
 use crate::classifications::Classifications;
 use crate::error::{Error, Result};
+use crate::stage::Stage;
 use crate::storage::{Repository, Workdir};
 use crate::sync::{self, Jj, SyncOptions};
-use crate::target::{Target, TargetEntry, TargetMetrics};
+use crate::target::{Target, TargetEntry, TargetMetrics, TargetStatus};
+use crate::taxonomy::Taxonomy;
 
 #[derive(Debug)]
 pub struct BackfillArgs {
@@ -52,7 +55,13 @@ struct BackfillEntry {
 pub fn run(jj: &dyn Jj, args: BackfillArgs) -> Result<()> {
     match &args.import {
         Some(path) => run_import(jj, &args, path.clone()),
-        None => Err(Error::Unimplemented("backfill interactive mode")),
+        None => {
+            let stdin = std::io::stdin();
+            let mut input = BufReader::new(stdin.lock());
+            let stdout = std::io::stdout();
+            let mut output = stdout.lock();
+            run_interactive(jj, &args, &mut input, &mut output)
+        }
     }
 }
 
@@ -235,6 +244,357 @@ fn merge_metrics(
     }
     entry.metrics = Some(source.clone());
     MergeMetricsOutcome::Applied
+}
+
+#[derive(Debug, PartialEq)]
+enum LoopControl {
+    Continue,
+    Quit,
+}
+
+/// Interactive backfill — walks every published post and prompts for
+/// missing classifications + metrics on stdin. Each post that gets
+/// changes is committed individually so partial progress persists if
+/// the user quits mid-walk.
+///
+/// Generic over `BufRead` / `Write` so tests can drive stdin with a
+/// canned input buffer.
+pub fn run_interactive<R: BufRead, W: Write>(
+    jj: &dyn Jj,
+    args: &BackfillArgs,
+    input: &mut R,
+    output: &mut W,
+) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let taxonomy = repo.read_taxonomy()?;
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let handles = repo.list()?;
+
+    let ctx = InteractiveCtx {
+        jj,
+        repo: &repo,
+        taxonomy: &taxonomy,
+        opts: &opts,
+        args,
+    };
+    let mut walked = 0_usize;
+    for handle in &handles {
+        if handle.stage != Stage::Published {
+            continue;
+        }
+        walked += 1;
+        match process_one(&ctx, &handle.metadata.slug, input, output)? {
+            LoopControl::Continue => {}
+            LoopControl::Quit => {
+                writeln!(output, "quitting; partial progress preserved").ok();
+                break;
+            }
+        }
+    }
+
+    writeln!(output, "backfill: walked {walked} published post(s)").ok();
+    Ok(())
+}
+
+/// Bundle of immutable refs passed to `process_one` for every post.
+/// Carved out of `run_interactive`'s locals so the function's arg
+/// list stays under clippy's `too_many_arguments` cap.
+struct InteractiveCtx<'a> {
+    jj: &'a dyn Jj,
+    repo: &'a Repository,
+    taxonomy: &'a Taxonomy,
+    opts: &'a SyncOptions,
+    args: &'a BackfillArgs,
+}
+
+fn process_one<R: BufRead, W: Write>(
+    ctx: &InteractiveCtx<'_>,
+    slug: &str,
+    input: &mut R,
+    output: &mut W,
+) -> Result<LoopControl> {
+    let (handle, mut post) = ctx.repo.load_raw(slug)?;
+
+    // Determine what's missing. A post is "complete" when every
+    // single-valued classification is set and every published
+    // target has metrics. theme is intentionally not required
+    // (multi-valued; empty is meaningful).
+    let cls_missing = single_dim_missing(&post.metadata.classifications);
+    let needs_metrics: Vec<Target> = post
+        .metadata
+        .targets
+        .iter()
+        .filter(|t| t.status == TargetStatus::Published && t.metrics.is_none())
+        .map(|t| t.name)
+        .collect();
+    if cls_missing.is_empty() && needs_metrics.is_empty() {
+        return Ok(LoopControl::Continue);
+    }
+
+    writeln!(output, "---").ok();
+    writeln!(output, "{} ({})", post.metadata.title, slug).ok();
+    let body_summary: String = post.body.chars().take(200).collect();
+    if !body_summary.is_empty() {
+        writeln!(output, "{}", body_summary).ok();
+    }
+    writeln!(output).ok();
+
+    let mut changed = false;
+    // Both prompt loops can short-circuit. We track the user's exit
+    // request but commit any in-flight changes BEFORE honoring it —
+    // otherwise the user types format=thesis, hits `q`, and loses
+    // that choice.
+    let mut skip_remaining_metrics = false;
+    let mut commit_then_quit = false;
+
+    // Prompt for missing single-valued classifications.
+    'classify: for dim in &cls_missing {
+        match prompt_dimension(dim, ctx.taxonomy, input, output)? {
+            DimPick::Value(v) => {
+                set_classification(&mut post.metadata.classifications, dim, &v);
+                changed = true;
+            }
+            DimPick::Skip => continue,
+            DimPick::SkipPost => {
+                skip_remaining_metrics = true;
+                break 'classify;
+            }
+            DimPick::Quit => {
+                commit_then_quit = true;
+                break 'classify;
+            }
+        }
+    }
+
+    // Only prompt for metrics if the classification loop didn't ask
+    // us to skip this whole post or quit.
+    if !skip_remaining_metrics && !commit_then_quit {
+        'metrics: for target in &needs_metrics {
+            match prompt_metrics(*target, input, output)? {
+                MetricsPick::Values(m) => {
+                    if matches!(
+                        merge_metrics(&mut post.metadata.targets, *target, &m),
+                        MergeMetricsOutcome::Applied
+                    ) {
+                        changed = true;
+                    }
+                }
+                MetricsPick::Skip => continue,
+                MetricsPick::SkipPost => break 'metrics,
+                MetricsPick::Quit => {
+                    commit_then_quit = true;
+                    break 'metrics;
+                }
+            }
+        }
+    }
+
+    if !changed {
+        return Ok(if commit_then_quit {
+            LoopControl::Quit
+        } else {
+            LoopControl::Continue
+        });
+    }
+
+    // Validate before write — invalid value would have been
+    // rejected at prompt time, but a hand-edited workdir could
+    // still arrive here with a stale value on an unprompted dim.
+    if let Err(v) = post.metadata.classifications.validate(ctx.taxonomy) {
+        writeln!(
+            output,
+            "warning: skipping {slug} — {} = {:?} is not in the taxonomy",
+            v.dimension, v.value,
+        )
+        .ok();
+        return Ok(LoopControl::Continue);
+    }
+
+    post.metadata.updated_at = OffsetDateTime::now_utc();
+    let rendered = post.render()?;
+    let path = handle.path.clone();
+    let message = format!("chore: backfill post({slug})");
+    sync::commit_and_push(ctx.jj, &ctx.args.workdir, ctx.opts, &message, || {
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))
+    })?;
+    writeln!(output, "  → committed").ok();
+    Ok(if commit_then_quit {
+        LoopControl::Quit
+    } else {
+        LoopControl::Continue
+    })
+}
+
+fn single_dim_missing(c: &Classifications) -> Vec<&'static str> {
+    let mut out = Vec::new();
+    if c.format.is_none() {
+        out.push("format");
+    }
+    if c.hook.is_none() {
+        out.push("hook");
+    }
+    if c.tone.is_none() {
+        out.push("tone");
+    }
+    if c.audience.is_none() {
+        out.push("audience");
+    }
+    if c.strategic_role.is_none() {
+        out.push("strategic_role");
+    }
+    out
+}
+
+fn set_classification(c: &mut Classifications, dim: &str, value: &str) {
+    match dim {
+        "format" => c.format = Some(value.to_string()),
+        "hook" => c.hook = Some(value.to_string()),
+        "tone" => c.tone = Some(value.to_string()),
+        "audience" => c.audience = Some(value.to_string()),
+        "strategic_role" => c.strategic_role = Some(value.to_string()),
+        _ => {} // unknown dim — never reached for the dims we prompt for
+    }
+}
+
+enum DimPick {
+    Value(String),
+    Skip,
+    SkipPost,
+    Quit,
+}
+
+enum MetricsPick {
+    Values(TargetMetrics),
+    Skip,
+    SkipPost,
+    Quit,
+}
+
+/// Prompt for a single-valued dimension. The user can pick by
+/// number, type a literal value, type `s` to skip this dim,
+/// `S` to skip the whole post, or `q` to quit the whole walk.
+fn prompt_dimension<R: BufRead, W: Write>(
+    dim: &str,
+    taxonomy: &Taxonomy,
+    input: &mut R,
+    output: &mut W,
+) -> Result<DimPick> {
+    let values: Vec<String> = taxonomy
+        .dimension(dim)
+        .map(|d| d.values.clone())
+        .unwrap_or_default();
+    writeln!(output, "{dim}:").ok();
+    for (i, v) in values.iter().enumerate() {
+        writeln!(output, "  {}. {}", i + 1, v).ok();
+    }
+    writeln!(output, "  s. skip this dimension").ok();
+    writeln!(output, "  S. skip this post").ok();
+    writeln!(output, "  q. quit").ok();
+    loop {
+        write!(output, "> ").ok();
+        output.flush().ok();
+        let line = read_line(input)?;
+        match line.as_str() {
+            "" | "s" => return Ok(DimPick::Skip),
+            "S" => return Ok(DimPick::SkipPost),
+            "q" => return Ok(DimPick::Quit),
+            other => {
+                if let Ok(n) = other.parse::<usize>() {
+                    if n >= 1 && n <= values.len() {
+                        return Ok(DimPick::Value(values[n - 1].clone()));
+                    }
+                }
+                // Literal: only accept if it's in the allowed list.
+                if values.iter().any(|v| v == other) {
+                    return Ok(DimPick::Value(other.to_string()));
+                }
+                writeln!(
+                    output,
+                    "  (not a valid choice; pick a number, type an allowed value, or s/S/q)"
+                )
+                .ok();
+            }
+        }
+    }
+}
+
+fn prompt_metrics<R: BufRead, W: Write>(
+    target: Target,
+    input: &mut R,
+    output: &mut W,
+) -> Result<MetricsPick> {
+    writeln!(
+        output,
+        "metrics for {target} (s/S/q to skip/skip-post/quit):"
+    )
+    .ok();
+    let imp = match prompt_u64("impressions", input, output)? {
+        NumPick::Value(v) => v,
+        NumPick::Skip => return Ok(MetricsPick::Skip),
+        NumPick::SkipPost => return Ok(MetricsPick::SkipPost),
+        NumPick::Quit => return Ok(MetricsPick::Quit),
+    };
+    let react = match prompt_u64("reactions", input, output)? {
+        NumPick::Value(v) => v,
+        NumPick::Skip => return Ok(MetricsPick::Skip),
+        NumPick::SkipPost => return Ok(MetricsPick::SkipPost),
+        NumPick::Quit => return Ok(MetricsPick::Quit),
+    };
+    let comm = match prompt_u64("comments", input, output)? {
+        NumPick::Value(v) => v,
+        NumPick::Skip => return Ok(MetricsPick::Skip),
+        NumPick::SkipPost => return Ok(MetricsPick::SkipPost),
+        NumPick::Quit => return Ok(MetricsPick::Quit),
+    };
+    let repo = match prompt_u64("reposts", input, output)? {
+        NumPick::Value(v) => v,
+        NumPick::Skip => return Ok(MetricsPick::Skip),
+        NumPick::SkipPost => return Ok(MetricsPick::SkipPost),
+        NumPick::Quit => return Ok(MetricsPick::Quit),
+    };
+    Ok(MetricsPick::Values(TargetMetrics {
+        impressions: imp,
+        reactions: react,
+        comments: comm,
+        reposts: repo,
+        sampled_at: OffsetDateTime::now_utc(),
+    }))
+}
+
+enum NumPick {
+    Value(u64),
+    Skip,
+    SkipPost,
+    Quit,
+}
+
+fn prompt_u64<R: BufRead, W: Write>(label: &str, input: &mut R, output: &mut W) -> Result<NumPick> {
+    loop {
+        write!(output, "  {label}: ").ok();
+        output.flush().ok();
+        let line = read_line(input)?;
+        match line.as_str() {
+            "s" => return Ok(NumPick::Skip),
+            "S" => return Ok(NumPick::SkipPost),
+            "q" => return Ok(NumPick::Quit),
+            other => {
+                if let Ok(n) = other.parse::<u64>() {
+                    return Ok(NumPick::Value(n));
+                }
+                writeln!(output, "  (expected a non-negative integer; got {other:?})").ok();
+            }
+        }
+    }
+}
+
+fn read_line<R: BufRead>(input: &mut R) -> Result<String> {
+    let mut buf = String::new();
+    input.read_line(&mut buf).map_err(|e| Error::Io {
+        path: PathBuf::from("<stdin>"),
+        source: e,
+    })?;
+    Ok(buf.trim().to_string())
 }
 
 #[cfg(test)]

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -1,11 +1,29 @@
-//! `blogctl backfill` — interactive walk of published posts to fill
-//! missing classifications + metrics, or batch import from a JSON
-//! file. Stub for now; behavior lands in #435 (backfill).
+//! `blogctl backfill` — fill in missing classifications + metrics
+//! across the published backlog.
+//!
+//! Two modes:
+//!
+//! - `--import <file.json>` (batch): merge a JSON file of per-slug
+//!   entries into the matching posts. One commit covers the whole
+//!   batch; unknown slugs / unknown targets / invalid taxonomy
+//!   values warn to stderr and produce a non-zero exit but partial
+//!   progress is preserved.
+//! - (no `--import`, interactive): walks every published post and
+//!   prompts for missing dimensions/metrics on stdin. Lands in a
+//!   follow-up commit on this branch.
 
+use std::collections::HashMap;
+use std::fs;
 use std::path::PathBuf;
 
+use serde::Deserialize;
+use time::OffsetDateTime;
+
+use crate::classifications::Classifications;
 use crate::error::{Error, Result};
-use crate::sync::Jj;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+use crate::target::{Target, TargetEntry, TargetMetrics};
 
 #[derive(Debug)]
 pub struct BackfillArgs {
@@ -16,6 +34,367 @@ pub struct BackfillArgs {
     pub no_sync: bool,
 }
 
-pub fn run(_jj: &dyn Jj, _args: BackfillArgs) -> Result<()> {
-    Err(Error::Unimplemented("backfill"))
+/// One entry in the backfill JSON. Mirrors the schema in #435.
+#[derive(Debug, Deserialize)]
+struct BackfillEntry {
+    slug: String,
+    #[serde(default)]
+    classifications: Option<Classifications>,
+    /// Map from target name (kebab-case string — `"linkedin"`,
+    /// `"blog"`) to the metrics to apply. Keys are parsed into
+    /// `Target` at merge time so the deserializer doesn't reject
+    /// future venues we haven't taught the enum about yet (we just
+    /// warn and skip them).
+    #[serde(default)]
+    metrics: Option<HashMap<String, TargetMetrics>>,
+}
+
+pub fn run(jj: &dyn Jj, args: BackfillArgs) -> Result<()> {
+    match &args.import {
+        Some(path) => run_import(jj, &args, path.clone()),
+        None => Err(Error::Unimplemented("backfill interactive mode")),
+    }
+}
+
+fn run_import(jj: &dyn Jj, args: &BackfillArgs, path: PathBuf) -> Result<()> {
+    let raw = fs::read_to_string(&path).map_err(|e| Error::io(&path, e))?;
+    let entries: Vec<BackfillEntry> =
+        serde_json::from_str(&raw).map_err(Error::BackfillImportParse)?;
+
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let taxonomy = repo.read_taxonomy()?;
+
+    // Process each entry. Track changed post paths + which posts
+    // actually need writing; warnings accumulate but don't abort.
+    let mut warnings: Vec<String> = Vec::new();
+    let mut writes: Vec<(PathBuf, String)> = Vec::new(); // (path, rendered)
+
+    for entry in &entries {
+        match apply_entry(&repo, &taxonomy, entry) {
+            Ok(None) => {} // no-op — fully idempotent
+            Ok(Some(write)) => writes.push(write),
+            Err(msg) => warnings.push(msg),
+        }
+    }
+
+    // Print warnings to stderr; they don't fail the command but do
+    // flip the exit code at the end.
+    for w in &warnings {
+        eprintln!("warning: {w}");
+    }
+
+    if writes.is_empty() {
+        if warnings.is_empty() {
+            println!("backfill: every post already up-to-date");
+        }
+        return if warnings.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::BackfillPartialFailure(warnings.len()))
+        };
+    }
+
+    let n = writes.len();
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let message = format!("chore: backfill {n} posts");
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        for (path, rendered) in &writes {
+            fs::write(path, rendered).map_err(|e| Error::io(path, e))?;
+        }
+        Ok(())
+    })?;
+    println!("backfill: updated {n} post(s)");
+
+    if warnings.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::BackfillPartialFailure(warnings.len()))
+    }
+}
+
+/// Apply one entry. Returns:
+/// - `Ok(None)` when the post already has the requested state (no
+///   write needed — idempotent).
+/// - `Ok(Some((path, rendered)))` when the entry produced changes
+///   that should be written to disk.
+/// - `Err(msg)` when the entry can't be applied at all — caller
+///   accumulates `msg` as a warning.
+fn apply_entry(
+    repo: &Repository,
+    taxonomy: &crate::taxonomy::Taxonomy,
+    entry: &BackfillEntry,
+) -> std::result::Result<Option<(PathBuf, String)>, String> {
+    let (handle, mut post) = match repo.load_raw(&entry.slug) {
+        Ok(p) => p,
+        Err(_) => return Err(format!("post not found: {}", entry.slug)),
+    };
+    let mut changed = false;
+
+    if let Some(source) = &entry.classifications {
+        if merge_classifications(&mut post.metadata.classifications, source) {
+            changed = true;
+        }
+    }
+
+    if let Some(metrics_map) = &entry.metrics {
+        for (target_name, metrics) in metrics_map {
+            let target: Target = match target_name.parse() {
+                Ok(t) => t,
+                Err(_) => {
+                    return Err(format!(
+                        "unknown target {target_name:?} on post {}",
+                        entry.slug
+                    ));
+                }
+            };
+            match merge_metrics(&mut post.metadata.targets, target, metrics) {
+                MergeMetricsOutcome::Applied => changed = true,
+                MergeMetricsOutcome::Unchanged => {}
+                MergeMetricsOutcome::TargetMissing => {
+                    return Err(format!(
+                        "target {target} is not on post {} — add the target first",
+                        entry.slug
+                    ));
+                }
+            }
+        }
+    }
+
+    // Pre-write taxonomy check — fails fast with a helpful error
+    // listing the dimension's allowed values.
+    if let Err(v) = post.metadata.classifications.validate(taxonomy) {
+        return Err(format!(
+            "invalid classification on {}: {}={:?} (allowed: {})",
+            entry.slug,
+            v.dimension,
+            v.value,
+            v.allowed.join(", ")
+        ));
+    }
+
+    if !changed {
+        return Ok(None);
+    }
+
+    post.metadata.updated_at = OffsetDateTime::now_utc();
+    let rendered = post.render().map_err(|e| format!("{}: {e}", entry.slug))?;
+    Ok(Some((handle.path.clone(), rendered)))
+}
+
+/// Merge `source` into `target`. Single-valued dims are overwritten
+/// when set in `source`; `theme` is replaced when non-empty.
+/// Returns `true` when anything actually changed.
+fn merge_classifications(target: &mut Classifications, source: &Classifications) -> bool {
+    let mut changed = false;
+    if source.format.is_some() && target.format != source.format {
+        target.format = source.format.clone();
+        changed = true;
+    }
+    if source.hook.is_some() && target.hook != source.hook {
+        target.hook = source.hook.clone();
+        changed = true;
+    }
+    if source.tone.is_some() && target.tone != source.tone {
+        target.tone = source.tone.clone();
+        changed = true;
+    }
+    if source.audience.is_some() && target.audience != source.audience {
+        target.audience = source.audience.clone();
+        changed = true;
+    }
+    if source.strategic_role.is_some() && target.strategic_role != source.strategic_role {
+        target.strategic_role = source.strategic_role.clone();
+        changed = true;
+    }
+    if !source.theme.is_empty() && target.theme != source.theme {
+        target.theme = source.theme.clone();
+        changed = true;
+    }
+    changed
+}
+
+#[derive(Debug, PartialEq)]
+enum MergeMetricsOutcome {
+    Applied,
+    Unchanged,
+    TargetMissing,
+}
+
+fn merge_metrics(
+    targets: &mut [TargetEntry],
+    target: Target,
+    source: &TargetMetrics,
+) -> MergeMetricsOutcome {
+    let Some(entry) = targets.iter_mut().find(|t| t.name == target) else {
+        return MergeMetricsOutcome::TargetMissing;
+    };
+    if entry.metrics.as_ref() == Some(source) {
+        return MergeMetricsOutcome::Unchanged;
+    }
+    entry.metrics = Some(source.clone());
+    MergeMetricsOutcome::Applied
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    fn sample_metrics() -> TargetMetrics {
+        TargetMetrics {
+            impressions: 100,
+            reactions: 10,
+            comments: 2,
+            reposts: 1,
+            sampled_at: datetime!(2026-05-14 00:00:00 UTC),
+        }
+    }
+
+    #[test]
+    fn merge_classifications_sets_unset_dimensions() {
+        let mut t = Classifications::default();
+        let s = Classifications {
+            format: Some("thesis".into()),
+            ..Default::default()
+        };
+        assert!(merge_classifications(&mut t, &s));
+        assert_eq!(t.format.as_deref(), Some("thesis"));
+    }
+
+    #[test]
+    fn merge_classifications_overrides_existing_values() {
+        let mut t = Classifications {
+            tone: Some("gentle".into()),
+            ..Default::default()
+        };
+        let s = Classifications {
+            tone: Some("sharp".into()),
+            ..Default::default()
+        };
+        assert!(merge_classifications(&mut t, &s));
+        assert_eq!(t.tone.as_deref(), Some("sharp"));
+    }
+
+    #[test]
+    fn merge_classifications_is_idempotent_on_equal_values() {
+        let mut t = Classifications {
+            format: Some("thesis".into()),
+            ..Default::default()
+        };
+        let s = Classifications {
+            format: Some("thesis".into()),
+            ..Default::default()
+        };
+        assert!(!merge_classifications(&mut t, &s));
+    }
+
+    #[test]
+    fn merge_classifications_skips_none_source_fields() {
+        // Source has format=None, hook=Some. Target's format must
+        // stay as-is.
+        let mut t = Classifications {
+            format: Some("thesis".into()),
+            ..Default::default()
+        };
+        let s = Classifications {
+            hook: Some("contradiction".into()),
+            ..Default::default()
+        };
+        merge_classifications(&mut t, &s);
+        assert_eq!(t.format.as_deref(), Some("thesis"));
+        assert_eq!(t.hook.as_deref(), Some("contradiction"));
+    }
+
+    #[test]
+    fn merge_classifications_replaces_theme_list() {
+        let mut t = Classifications {
+            theme: vec!["ambiguity".into()],
+            ..Default::default()
+        };
+        let s = Classifications {
+            theme: vec!["delivery".into(), "interfaces".into()],
+            ..Default::default()
+        };
+        assert!(merge_classifications(&mut t, &s));
+        assert_eq!(t.theme, vec!["delivery", "interfaces"]);
+    }
+
+    #[test]
+    fn merge_metrics_applies_to_existing_target() {
+        let mut targets = vec![TargetEntry {
+            name: Target::Linkedin,
+            status: crate::target::TargetStatus::Published,
+            url: Some("https://example.invalid".into()),
+            published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+            metrics: None,
+        }];
+        let outcome = merge_metrics(&mut targets, Target::Linkedin, &sample_metrics());
+        assert_eq!(outcome, MergeMetricsOutcome::Applied);
+        assert_eq!(targets[0].metrics.as_ref(), Some(&sample_metrics()));
+    }
+
+    #[test]
+    fn merge_metrics_target_missing_signals_caller() {
+        let mut targets: Vec<TargetEntry> = vec![];
+        let outcome = merge_metrics(&mut targets, Target::Linkedin, &sample_metrics());
+        assert_eq!(outcome, MergeMetricsOutcome::TargetMissing);
+    }
+
+    #[test]
+    fn merge_metrics_idempotent_on_equal_value() {
+        let mut targets = vec![TargetEntry {
+            name: Target::Linkedin,
+            status: crate::target::TargetStatus::Published,
+            url: Some("https://example.invalid".into()),
+            published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
+            metrics: Some(sample_metrics()),
+        }];
+        let outcome = merge_metrics(&mut targets, Target::Linkedin, &sample_metrics());
+        assert_eq!(outcome, MergeMetricsOutcome::Unchanged);
+    }
+
+    #[test]
+    fn backfill_entry_round_trips_through_json() {
+        let raw = r#"[
+            {
+                "slug": "the-only-way-out-is-through",
+                "classifications": {
+                    "format": "thesis",
+                    "hook": "contradiction",
+                    "theme": ["ambiguity"]
+                },
+                "metrics": {
+                    "linkedin": {
+                        "impressions": 1234,
+                        "reactions": 45,
+                        "comments": 12,
+                        "reposts": 3,
+                        "sampled_at": "2026-05-14T00:00:00Z"
+                    }
+                }
+            }
+        ]"#;
+        let entries: Vec<BackfillEntry> = serde_json::from_str(raw).unwrap();
+        assert_eq!(entries.len(), 1);
+        let e = &entries[0];
+        assert_eq!(e.slug, "the-only-way-out-is-through");
+        let cls = e.classifications.as_ref().unwrap();
+        assert_eq!(cls.format.as_deref(), Some("thesis"));
+        assert_eq!(cls.theme, vec!["ambiguity"]);
+        let m = e.metrics.as_ref().unwrap();
+        assert_eq!(m.get("linkedin").unwrap().impressions, 1234);
+    }
+
+    #[test]
+    fn empty_classifications_and_metrics_parses_as_no_changes() {
+        // A skeleton entry with only the slug — used by hand-edited
+        // JSON files that want to leave a placeholder.
+        let raw = r#"[{ "slug": "post-x" }]"#;
+        let entries: Vec<BackfillEntry> = serde_json::from_str(raw).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].classifications.is_none());
+        assert!(entries[0].metrics.is_none());
+    }
 }

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -182,6 +182,12 @@ pub enum Error {
         #[source]
         source: time::error::Parse,
     },
+
+    #[error("could not parse backfill import file: {0}")]
+    BackfillImportParse(#[source] serde_json::Error),
+
+    #[error("backfill completed with {0} warning(s) — see stderr for details")]
+    BackfillPartialFailure(usize),
 }
 
 impl Error {

--- a/apps/blogctl/tests/backfill.rs
+++ b/apps/blogctl/tests/backfill.rs
@@ -285,22 +285,110 @@ fn import_full_batch_lands_in_one_commit() {
     }
 }
 
-#[test]
-fn interactive_mode_is_unimplemented_for_now() {
-    // The no-import path returns Error::Unimplemented until the
-    // follow-up commit on this branch wires up stdin prompts.
+/// Build a fixture workdir, promote `bare-post` all the way to
+/// published, so the interactive walk actually sees it.
+fn fixture_workdir_with_published() -> TempDir {
     let tmp = fixture_workdir();
-    let result = commands::backfill::run(
+    // Promote bare-post: concept → ideation → editing → final-editing
+    // → published. classify + metrics would normally be done at
+    // various stages; here we just walk it through.
+    for _ in 0..4 {
+        commands::promote::run(
+            &FakeJj::new(),
+            "bare-post".to_string(),
+            tmp.path().to_path_buf(),
+            false,
+        )
+        .unwrap();
+    }
+    tmp
+}
+
+#[test]
+fn interactive_skips_dimensions_via_blank_input_then_quits() {
+    // Drive: every classification prompt → empty line (skip), then
+    // metrics prompts: skip the whole post (S). One published post,
+    // no changes, exit clean.
+    let tmp = fixture_workdir_with_published();
+    // 5 single-valued dimensions, each prompted; skip each. Then
+    // metrics block — skip the whole post.
+    let input_bytes = b"\n\n\n\n\nS\n";
+    let mut input = std::io::Cursor::new(&input_bytes[..]);
+    let mut output: Vec<u8> = Vec::new();
+    commands::backfill::run_interactive(
         &FakeJj::new(),
-        commands::backfill::BackfillArgs {
+        &commands::backfill::BackfillArgs {
             workdir: tmp.path().to_path_buf(),
             import: None,
             no_sync: false,
         },
-    );
-    let err = result.expect_err("interactive mode not yet implemented");
+        &mut input,
+        &mut output,
+    )
+    .unwrap();
+    let stdout = String::from_utf8(output).unwrap();
     assert!(
-        matches!(err, blogctl::Error::Unimplemented(_)),
-        "got: {err:?}"
+        stdout.contains("walked 1"),
+        "expected walk summary in output, got: {stdout}"
     );
+    // No changes written — frontmatter still has empty classifications.
+    let raw = fs::read_to_string(tmp.path().join("published/bare-post.md")).unwrap();
+    assert!(!raw.contains("format: thesis"));
+}
+
+#[test]
+fn interactive_writes_classification_picked_by_number() {
+    let tmp = fixture_workdir_with_published();
+    // Sequence:
+    //   format: 2  (second item in current_v1's format list = "thesis")
+    //   hook:   skip
+    //   tone:   skip
+    //   audience: skip
+    //   strategic_role: skip
+    //   metrics for linkedin: skip-post (S)
+    let input_bytes = b"2\n\n\n\n\nS\n";
+    let mut input = std::io::Cursor::new(&input_bytes[..]);
+    let mut output: Vec<u8> = Vec::new();
+    commands::backfill::run_interactive(
+        &FakeJj::new(),
+        &commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: None,
+            no_sync: false,
+        },
+        &mut input,
+        &mut output,
+    )
+    .unwrap();
+    let raw = fs::read_to_string(tmp.path().join("published/bare-post.md")).unwrap();
+    assert!(
+        raw.contains("format: thesis"),
+        "expected format=thesis after picking #2, got:\n{raw}"
+    );
+}
+
+#[test]
+fn interactive_quits_immediately_on_q() {
+    let tmp = fixture_workdir_with_published();
+    // First prompt sees `q` — quit immediately. File on disk is
+    // untouched (no commit).
+    let pre = fs::read_to_string(tmp.path().join("published/bare-post.md")).unwrap();
+    let input_bytes = b"q\n";
+    let mut input = std::io::Cursor::new(&input_bytes[..]);
+    let mut output: Vec<u8> = Vec::new();
+    commands::backfill::run_interactive(
+        &FakeJj::new(),
+        &commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: None,
+            no_sync: false,
+        },
+        &mut input,
+        &mut output,
+    )
+    .unwrap();
+    let post = fs::read_to_string(tmp.path().join("published/bare-post.md")).unwrap();
+    assert_eq!(pre, post, "file should be untouched after immediate quit");
+    let stdout = String::from_utf8(output).unwrap();
+    assert!(stdout.contains("quitting"));
 }

--- a/apps/blogctl/tests/backfill.rs
+++ b/apps/blogctl/tests/backfill.rs
@@ -1,0 +1,306 @@
+//! Integration tests for `blogctl backfill --import`. Builds a real
+//! workdir, drops a JSON import file alongside it, runs the command,
+//! and asserts on the resulting frontmatter.
+
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use blogctl::commands;
+use blogctl::kind::Kind;
+use blogctl::sync::FakeJj;
+
+fn add_published_linkedin_target(post_path: &Path) {
+    let raw = fs::read_to_string(post_path).unwrap();
+    let updated = raw.replace(
+        "tags: []\n",
+        concat!(
+            "tags: []\n",
+            "targets:\n",
+            "  - name: linkedin\n",
+            "    status: published\n",
+            "    url: https://www.linkedin.com/posts/example\n",
+            "    published_at: 2026-05-08T14:32:00Z\n",
+        ),
+    );
+    fs::write(post_path, updated).unwrap();
+}
+
+fn fixture_workdir() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    commands::init::run(&FakeJj::new(), tmp.path().to_path_buf(), false).unwrap();
+    // One bare post with a LinkedIn target but no metrics + no
+    // classifications. Backfill should fill them in.
+    commands::new::run(
+        &FakeJj::new(),
+        "Bare Post".to_string(),
+        tmp.path().to_path_buf(),
+        Some("bare-post".to_string()),
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&tmp.path().join("concepts/bare-post.md"));
+    tmp
+}
+
+fn write_import(workdir: &Path, contents: &str) -> std::path::PathBuf {
+    let path = workdir.join("backfill.json");
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+#[test]
+fn import_fills_classifications_and_metrics_for_bare_post() {
+    let tmp = fixture_workdir();
+    let import = write_import(
+        tmp.path(),
+        r#"[
+            {
+                "slug": "bare-post",
+                "classifications": {
+                    "format": "thesis",
+                    "hook": "contradiction",
+                    "theme": ["ambiguity"]
+                },
+                "metrics": {
+                    "linkedin": {
+                        "impressions": 1842,
+                        "reactions": 67,
+                        "comments": 14,
+                        "reposts": 5,
+                        "sampled_at": "2026-05-14T00:00:00Z"
+                    }
+                }
+            }
+        ]"#,
+    );
+
+    commands::backfill::run(
+        &FakeJj::new(),
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+
+    let raw = fs::read_to_string(tmp.path().join("concepts/bare-post.md")).unwrap();
+    assert!(raw.contains("format: thesis"));
+    assert!(raw.contains("hook: contradiction"));
+    assert!(raw.contains("ambiguity"));
+    assert!(raw.contains("impressions: 1842"));
+    assert!(raw.contains("sampled_at: 2026-05-14T00:00:00Z"));
+}
+
+#[test]
+fn import_re_run_is_idempotent_no_extra_writes() {
+    let tmp = fixture_workdir();
+    let import = write_import(
+        tmp.path(),
+        r#"[
+            {
+                "slug": "bare-post",
+                "classifications": { "format": "thesis" }
+            }
+        ]"#,
+    );
+    commands::backfill::run(
+        &FakeJj::new(),
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import.clone()),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+    let raw_after_first = fs::read_to_string(tmp.path().join("concepts/bare-post.md")).unwrap();
+
+    // Second run with the same JSON — should be a complete no-op
+    // because every field already matches.
+    let jj = FakeJj::new();
+    commands::backfill::run(
+        &jj,
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+    let raw_after_second = fs::read_to_string(tmp.path().join("concepts/bare-post.md")).unwrap();
+    assert_eq!(
+        raw_after_first, raw_after_second,
+        "second import on already-applied data should not modify the file"
+    );
+    // And nothing went through the jj graph on the second run.
+    assert!(
+        jj.calls().is_empty(),
+        "no-op backfill must not produce jj calls: {:?}",
+        jj.calls()
+    );
+}
+
+#[test]
+fn import_with_unknown_slug_warns_continues_and_returns_partial_failure() {
+    let tmp = fixture_workdir();
+    let import = write_import(
+        tmp.path(),
+        r#"[
+            { "slug": "bare-post", "classifications": { "format": "thesis" } },
+            { "slug": "does-not-exist", "classifications": { "format": "essay" } }
+        ]"#,
+    );
+    let result = commands::backfill::run(
+        &FakeJj::new(),
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import),
+            no_sync: false,
+        },
+    );
+    let err = result.expect_err("unknown slug should produce a partial-failure error");
+    assert!(
+        matches!(err, blogctl::Error::BackfillPartialFailure(n) if n == 1),
+        "got: {err:?}"
+    );
+    // Partial progress preserved: the known slug got its update.
+    let raw = fs::read_to_string(tmp.path().join("concepts/bare-post.md")).unwrap();
+    assert!(raw.contains("format: thesis"));
+}
+
+#[test]
+fn import_with_metrics_for_missing_target_warns() {
+    let tmp = fixture_workdir();
+    // bare-post has a LinkedIn target but no Blog target.
+    let import = write_import(
+        tmp.path(),
+        r#"[
+            {
+                "slug": "bare-post",
+                "metrics": {
+                    "blog": {
+                        "impressions": 100,
+                        "reactions": 5,
+                        "comments": 0,
+                        "reposts": 0,
+                        "sampled_at": "2026-05-14T00:00:00Z"
+                    }
+                }
+            }
+        ]"#,
+    );
+    let result = commands::backfill::run(
+        &FakeJj::new(),
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import),
+            no_sync: false,
+        },
+    );
+    let err = result.expect_err("missing target should produce a partial-failure error");
+    assert!(
+        matches!(err, blogctl::Error::BackfillPartialFailure(n) if n == 1),
+        "got: {err:?}"
+    );
+}
+
+#[test]
+fn import_with_invalid_classification_warns() {
+    let tmp = fixture_workdir();
+    let import = write_import(
+        tmp.path(),
+        r#"[
+            { "slug": "bare-post", "classifications": { "format": "made-up-format" } }
+        ]"#,
+    );
+    let result = commands::backfill::run(
+        &FakeJj::new(),
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import),
+            no_sync: false,
+        },
+    );
+    let err = result.expect_err("invalid value should produce a partial-failure error");
+    assert!(
+        matches!(err, blogctl::Error::BackfillPartialFailure(n) if n == 1),
+        "got: {err:?}"
+    );
+    // File on disk must be untouched (the entry errored before write).
+    let raw = fs::read_to_string(tmp.path().join("concepts/bare-post.md")).unwrap();
+    assert!(!raw.contains("made-up-format"));
+}
+
+#[test]
+fn import_full_batch_lands_in_one_commit() {
+    let tmp = fixture_workdir();
+    // Add a second bare post so we have two entries.
+    commands::new::run(
+        &FakeJj::new(),
+        "Second".to_string(),
+        tmp.path().to_path_buf(),
+        Some("second".to_string()),
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&tmp.path().join("concepts/second.md"));
+
+    let import = write_import(
+        tmp.path(),
+        r#"[
+            { "slug": "bare-post", "classifications": { "format": "thesis" } },
+            { "slug": "second",    "classifications": { "format": "essay" } }
+        ]"#,
+    );
+    let jj = FakeJj::new();
+    commands::backfill::run(
+        &jj,
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: Some(import),
+            no_sync: false,
+        },
+    )
+    .unwrap();
+
+    // One commit covers the whole batch.
+    let calls = jj.calls();
+    let new_changes: Vec<_> = calls
+        .iter()
+        .filter(|c| matches!(c, blogctl::sync::Call::NewChange { .. }))
+        .collect();
+    assert_eq!(
+        new_changes.len(),
+        1,
+        "expected exactly one commit for the batch, got: {calls:?}",
+    );
+    if let blogctl::sync::Call::NewChange { message, .. } = new_changes[0] {
+        assert_eq!(message, "chore: backfill 2 posts");
+    }
+}
+
+#[test]
+fn interactive_mode_is_unimplemented_for_now() {
+    // The no-import path returns Error::Unimplemented until the
+    // follow-up commit on this branch wires up stdin prompts.
+    let tmp = fixture_workdir();
+    let result = commands::backfill::run(
+        &FakeJj::new(),
+        commands::backfill::BackfillArgs {
+            workdir: tmp.path().to_path_buf(),
+            import: None,
+            no_sync: false,
+        },
+    );
+    let err = result.expect_err("interactive mode not yet implemented");
+    assert!(
+        matches!(err, blogctl::Error::Unimplemented(_)),
+        "got: {err:?}"
+    );
+}


### PR DESCRIPTION
Implements the batch half of #435. `blogctl backfill --import
file.json` parses the array of per-slug entries, merges
classifications + metrics into each matching post, validates the
result against the workdir's taxonomy, and lands every change as
one commit (`chore: backfill <N> posts`).

JSON schema (matches the issue spec):
```
  [
    {
      "slug": "the-only-way-out-is-through",
      "classifications": {
        "format": "thesis", "hook": "contradiction",
        "theme": ["ambiguity"]
      },
      "metrics": {
        "linkedin": {
          "impressions": 1234, "reactions": 45,
          "comments": 12, "reposts": 3,
          "sampled_at": "2026-05-14T00:00:00Z"
        }
      }
    }
  ]
```
Merge semantics:
- Single-valued dimensions: Some(value) overwrites; None leaves the
  field alone.
- theme: non-empty list replaces; empty list leaves it alone (per
  classify command's semantics).
- metrics is a map from target name to TargetMetrics — keys parsed
  to Target at merge time.

Per the issue's "errors print to stderr with a non-zero exit"
rule, partial failures (unknown slug, unknown target name, target
not on post, invalid taxonomy value) warn to stderr but don't
abort the run. After every entry is processed, the command emits
the batch commit for whatever did apply and returns
Error::BackfillPartialFailure when any warning fired.

Idempotency is enforced at multiple layers: per-dim and per-target
merges return whether anything changed; if every entry is a
no-op, no write happens and no commit lands. Re-running the same
import on already-applied data is silent and free.

Ten unit tests cover the merger logic + JSON round-trip; seven
integration tests in tests/backfill.rs cover the success path,
idempotency on re-run, every warning path (unknown slug, missing
target, invalid classification), and the batch-as-one-commit
shape.

The interactive mode (no --import) still returns
Error::Unimplemented; the follow-up commit on this branch wires
up stdin prompts.

For #435.

Closes #435.

Replaces the no-import path's Unimplemented stub with a real
interactive walk. `blogctl backfill` (no --import flag) iterates
every published post that's missing classifications or metrics
and prompts the user on stdin.

Each prompt is one of:
- numeric pick from the dimension's taxonomy values
- literal value (must be in the allowed list)
- `s` to skip this dimension
- `S` to skip the rest of this post (commits anything gathered so
  far before moving on)
- `q` to quit the walk (commits anything gathered so far)

Metric prompts ask for impressions/reactions/comments/reposts in
sequence; sampled_at is set to now() automatically.

Each post that gets changes is committed individually via
sync::commit_and_push — partial progress persists if the user
quits mid-walk, matching the issue's "press q to quit
(already-written posts persist)" rule.

Generic over `BufRead` / `Write` so tests can drive stdin with a
canned input buffer. `run` (the public entry) uses stdin/stdout;
`run_interactive` (also public for tests) takes the readers
explicitly.

Three integration tests in tests/backfill.rs:
- interactive_skips_dimensions_via_blank_input_then_quits — empty
  lines (skip) for every classification, then skip-post on
  metrics; file untouched, no commits.
- interactive_writes_classification_picked_by_number — pick by
  number, then skip-post on metrics; commits the
  classifications-only change.
- interactive_quits_immediately_on_q — first prompt sees q;
  file untouched.

Two design points worth noting:
- Skip-post and quit honor in-flight changes: the user who picks
  format=thesis then hits q gets a commit with that one change.
  Implemented via skip_remaining_metrics / commit_then_quit flags
  rather than early-return from the prompt loops.
- InteractiveCtx bundles immutable refs (jj, repo, taxonomy,
  opts, args) into a single struct passed to process_one — keeps
  the function's arg list under clippy's too_many_arguments cap.