### PR TITLE
feat(blogctl): gate promote on the current stage's exit predicates

### DIFF
--- a/apps/blogctl/src/commands/promote.rs
+++ b/apps/blogctl/src/commands/promote.rs
@@ -2,16 +2,33 @@ use std::path::PathBuf;
 
 use time::OffsetDateTime;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::storage::{Repository, Workdir};
 use crate::sync::{self, Jj, SyncOptions};
 
 pub fn run(jj: &dyn Jj, slug: String, workdir: PathBuf, no_sync: bool) -> Result<()> {
     let repo = Repository::open(Workdir::new(&workdir))?;
-    let (handle, _post) = repo.load(&slug)?;
+    let (handle, post) = repo.load(&slug)?;
     let next = handle.stage.promote()?;
-    let message = format!("post({slug}): {} \u{2192} {next}", handle.stage);
     let config = repo.read_config()?;
+
+    // Gate on the current stage's exit predicates, if any are configured.
+    // Absent config or empty `exit` means "no gate" — the predicate
+    // language is opt-in per stage.
+    if let Some(stage_cfg) = config.stage_config(post.metadata.kind, handle.stage) {
+        for predicate in &stage_cfg.exit {
+            if !predicate.evaluate(&post)? {
+                return Err(Error::PromoteBlocked {
+                    slug: slug.clone(),
+                    from: handle.stage,
+                    to: next,
+                    predicate: predicate.to_string(),
+                });
+            }
+        }
+    }
+
+    let message = format!("post({slug}): {} \u{2192} {next}", handle.stage);
     let opts = SyncOptions::from_config(&config.sync, no_sync);
 
     let new_handle = sync::commit_and_push(jj, &workdir, &opts, &message, || {

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -30,6 +30,16 @@ pub enum Error {
     #[error("cannot promote from {0}: already at the final workflow stage")]
     PromoteFromTerminal(Stage),
 
+    #[error(
+        "cannot promote {slug:?} from {from} to {to}: exit predicate {predicate} not satisfied"
+    )]
+    PromoteBlocked {
+        slug: String,
+        from: Stage,
+        to: Stage,
+        predicate: String,
+    },
+
     #[error("cannot demote from {0}: already at the first workflow stage")]
     DemoteFromInitial(Stage),
 

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -130,6 +130,9 @@ pub enum Error {
     #[error("OpenRouter response contained no choices")]
     OpenrouterEmptyResponse,
 
+    #[error("could not parse predicate: {0}")]
+    PredicateParse(String),
+
     #[error("could not invoke `{command}`: {source}")]
     JjInvoke {
         command: String,

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -133,6 +133,9 @@ pub enum Error {
     #[error("could not parse predicate: {0}")]
     PredicateParse(String),
 
+    #[error("could not evaluate predicate {predicate:?}: {reason}")]
+    PredicateEval { predicate: String, reason: String },
+
     #[error("could not invoke `{command}`: {source}")]
     JjInvoke {
         command: String,

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod kind;
 pub mod openrouter;
 pub mod post;
+pub mod predicate;
 pub mod slug;
 pub mod stage;
 pub mod storage;

--- a/apps/blogctl/src/predicate.rs
+++ b/apps/blogctl/src/predicate.rs
@@ -15,6 +15,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 use crate::error::{Error, Result};
@@ -120,6 +121,19 @@ impl FromStr for Predicate {
     type Err = Error;
     fn from_str(s: &str) -> Result<Self> {
         Self::parse(s)
+    }
+}
+
+impl Serialize for Predicate {
+    fn serialize<S: Serializer>(&self, ser: S) -> std::result::Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Predicate {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        Predicate::parse(&s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/apps/blogctl/src/predicate.rs
+++ b/apps/blogctl/src/predicate.rs
@@ -1,0 +1,354 @@
+//! Tiny predicate language used by stage exit criteria.
+//!
+//! Grammar is intentionally boring — no eval, no expressions:
+//!
+//! ```text
+//! <accessor> <op> <literal>
+//! ```
+//!
+//! Accessors: `body.words`, `body.chars`, `frontmatter.<field>`,
+//! `frontmatter.<field>.len`. Ops: `==`, `!=`, `>=`, `<=`, `>`, `<`.
+//! Literals: integer, double-quoted string, `true`/`false`. Adding a new
+//! accessor is a new variant — the language resists growing into an
+//! expression evaluator.
+
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::{Error, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Accessor {
+    BodyWords,
+    BodyChars,
+    Frontmatter(String),
+    FrontmatterLen(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Op {
+    Eq,
+    Ne,
+    Ge,
+    Le,
+    Gt,
+    Lt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Literal {
+    Int(i64),
+    Str(String),
+    Bool(bool),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Predicate {
+    pub accessor: Accessor,
+    pub op: Op,
+    pub literal: Literal,
+}
+
+impl Predicate {
+    /// Parse a single predicate line. Three tokens: an accessor, an
+    /// operator, and a literal. The literal token is "everything after
+    /// the operator, trimmed" so quoted strings can contain spaces.
+    pub fn parse(input: &str) -> Result<Self> {
+        let trimmed = input.trim();
+        let (acc_tok, after_acc) = next_token(trimmed)
+            .ok_or_else(|| Error::PredicateParse(format!("empty predicate: {input:?}")))?;
+        let (op_tok, after_op) = next_token(after_acc)
+            .ok_or_else(|| Error::PredicateParse(format!("missing operator: {input:?}")))?;
+        let lit_tok = after_op.trim();
+        if lit_tok.is_empty() {
+            return Err(Error::PredicateParse(format!("missing literal: {input:?}")));
+        }
+
+        Ok(Self {
+            accessor: parse_accessor(acc_tok)?,
+            op: parse_op(op_tok)?,
+            literal: parse_literal(lit_tok)?,
+        })
+    }
+}
+
+impl FromStr for Predicate {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
+impl fmt::Display for Predicate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {}", self.accessor, self.op, self.literal)
+    }
+}
+
+impl fmt::Display for Accessor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Accessor::BodyWords => f.write_str("body.words"),
+            Accessor::BodyChars => f.write_str("body.chars"),
+            Accessor::Frontmatter(field) => write!(f, "frontmatter.{field}"),
+            Accessor::FrontmatterLen(field) => write!(f, "frontmatter.{field}.len"),
+        }
+    }
+}
+
+impl fmt::Display for Op {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Op::Eq => "==",
+            Op::Ne => "!=",
+            Op::Ge => ">=",
+            Op::Le => "<=",
+            Op::Gt => ">",
+            Op::Lt => "<",
+        })
+    }
+}
+
+impl fmt::Display for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Literal::Int(n) => write!(f, "{n}"),
+            Literal::Str(s) => write!(f, "{s:?}"),
+            Literal::Bool(b) => write!(f, "{b}"),
+        }
+    }
+}
+
+/// Lift the leading non-whitespace run as a token. Returns the token
+/// and the rest of the slice starting at the next character (which may
+/// be whitespace — callers re-trim before scanning).
+fn next_token(s: &str) -> Option<(&str, &str)> {
+    let s = s.trim_start();
+    if s.is_empty() {
+        return None;
+    }
+    let end = s.find(char::is_whitespace).unwrap_or(s.len());
+    Some((&s[..end], &s[end..]))
+}
+
+fn parse_accessor(tok: &str) -> Result<Accessor> {
+    match tok {
+        "body.words" => Ok(Accessor::BodyWords),
+        "body.chars" => Ok(Accessor::BodyChars),
+        other => {
+            if let Some(rest) = other.strip_prefix("frontmatter.") {
+                if rest.is_empty() {
+                    return Err(Error::PredicateParse(format!(
+                        "frontmatter accessor missing field name: {tok:?}"
+                    )));
+                }
+                if let Some(field) = rest.strip_suffix(".len") {
+                    if field.is_empty() || field.contains('.') {
+                        return Err(Error::PredicateParse(format!(
+                            "invalid frontmatter accessor: {tok:?}"
+                        )));
+                    }
+                    Ok(Accessor::FrontmatterLen(field.to_string()))
+                } else if rest.contains('.') {
+                    Err(Error::PredicateParse(format!(
+                        "nested frontmatter paths not supported: {tok:?}"
+                    )))
+                } else {
+                    Ok(Accessor::Frontmatter(rest.to_string()))
+                }
+            } else {
+                Err(Error::PredicateParse(format!("unknown accessor: {tok:?}")))
+            }
+        }
+    }
+}
+
+fn parse_op(tok: &str) -> Result<Op> {
+    match tok {
+        "==" => Ok(Op::Eq),
+        "!=" => Ok(Op::Ne),
+        ">=" => Ok(Op::Ge),
+        "<=" => Ok(Op::Le),
+        ">" => Ok(Op::Gt),
+        "<" => Ok(Op::Lt),
+        other => Err(Error::PredicateParse(format!(
+            "unknown operator: {other:?}"
+        ))),
+    }
+}
+
+fn parse_literal(tok: &str) -> Result<Literal> {
+    if tok == "true" {
+        return Ok(Literal::Bool(true));
+    }
+    if tok == "false" {
+        return Ok(Literal::Bool(false));
+    }
+    if let Some(inner) = tok.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+        // No escape syntax — embedded `"` is rejected to keep the grammar boring.
+        if inner.contains('"') {
+            return Err(Error::PredicateParse(format!(
+                "string literal may not contain `\"`: {tok:?}"
+            )));
+        }
+        return Ok(Literal::Str(inner.to_string()));
+    }
+    tok.parse::<i64>()
+        .map(Literal::Int)
+        .map_err(|_| Error::PredicateParse(format!("not a valid literal: {tok:?}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_body_words_with_int_literal() {
+        let p = Predicate::parse("body.words >= 150").unwrap();
+        assert_eq!(p.accessor, Accessor::BodyWords);
+        assert_eq!(p.op, Op::Ge);
+        assert_eq!(p.literal, Literal::Int(150));
+    }
+
+    #[test]
+    fn parses_body_chars() {
+        let p = Predicate::parse("body.chars > 0").unwrap();
+        assert_eq!(p.accessor, Accessor::BodyChars);
+    }
+
+    #[test]
+    fn parses_frontmatter_field_with_string_literal() {
+        let p = Predicate::parse(r#"frontmatter.title == "Hello""#).unwrap();
+        assert_eq!(p.accessor, Accessor::Frontmatter("title".to_string()));
+        assert_eq!(p.op, Op::Eq);
+        assert_eq!(p.literal, Literal::Str("Hello".to_string()));
+    }
+
+    #[test]
+    fn parses_frontmatter_len() {
+        let p = Predicate::parse("frontmatter.tags.len > 0").unwrap();
+        assert_eq!(p.accessor, Accessor::FrontmatterLen("tags".to_string()));
+        assert_eq!(p.op, Op::Gt);
+        assert_eq!(p.literal, Literal::Int(0));
+    }
+
+    #[test]
+    fn parses_bool_literal() {
+        let p = Predicate::parse("frontmatter.history_checked == true").unwrap();
+        assert_eq!(p.literal, Literal::Bool(true));
+        let p = Predicate::parse("frontmatter.history_checked != false").unwrap();
+        assert_eq!(p.literal, Literal::Bool(false));
+    }
+
+    #[test]
+    fn parses_negative_int() {
+        let p = Predicate::parse("body.words > -1").unwrap();
+        assert_eq!(p.literal, Literal::Int(-1));
+    }
+
+    #[test]
+    fn parses_string_literal_with_internal_whitespace() {
+        let p = Predicate::parse(r#"frontmatter.title == "Hello World""#).unwrap();
+        assert_eq!(p.literal, Literal::Str("Hello World".to_string()));
+    }
+
+    #[test]
+    fn tolerates_extra_internal_whitespace() {
+        let p = Predicate::parse("  body.words   >=    150  ").unwrap();
+        assert_eq!(p.accessor, Accessor::BodyWords);
+        assert_eq!(p.literal, Literal::Int(150));
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert!(matches!(
+            Predicate::parse(""),
+            Err(Error::PredicateParse(_))
+        ));
+        assert!(matches!(
+            Predicate::parse("   "),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_literal() {
+        assert!(matches!(
+            Predicate::parse("body.words >="),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_accessor() {
+        assert!(matches!(
+            Predicate::parse("post.length > 0"),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_operator() {
+        assert!(matches!(
+            Predicate::parse("body.words =~ 150"),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_nested_frontmatter_path() {
+        // The boring-grammar rule: single field name after `frontmatter.`,
+        // with the only allowed suffix being `.len`.
+        assert!(matches!(
+            Predicate::parse("frontmatter.classifications.format == \"thesis\""),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_bare_frontmatter() {
+        assert!(matches!(
+            Predicate::parse("frontmatter. == 1"),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_literal() {
+        assert!(matches!(
+            Predicate::parse("body.words >= maybe"),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_string_literal_with_embedded_quote() {
+        assert!(matches!(
+            Predicate::parse(r#"frontmatter.title == "a"b""#),
+            Err(Error::PredicateParse(_))
+        ));
+    }
+
+    #[test]
+    fn display_round_trips_through_parse() {
+        let cases = [
+            "body.words >= 150",
+            "body.chars < 1000",
+            r#"frontmatter.title == "Example""#,
+            "frontmatter.tags.len > 0",
+            "frontmatter.history_checked == true",
+        ];
+        for input in cases {
+            let p = Predicate::parse(input).unwrap();
+            let rendered = p.to_string();
+            let reparsed = Predicate::parse(&rendered).unwrap();
+            assert_eq!(p, reparsed, "round-trip failed for {input:?}");
+        }
+    }
+
+    #[test]
+    fn from_str_dispatches_to_parse() {
+        let p: Predicate = "body.words >= 1".parse().unwrap();
+        assert_eq!(p.accessor, Accessor::BodyWords);
+    }
+}

--- a/apps/blogctl/src/predicate.rs
+++ b/apps/blogctl/src/predicate.rs
@@ -15,7 +15,10 @@
 use std::fmt;
 use std::str::FromStr;
 
+use serde_json::Value;
+
 use crate::error::{Error, Result};
+use crate::post::Post;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Accessor {
@@ -49,7 +52,48 @@ pub struct Predicate {
     pub literal: Literal,
 }
 
+/// The value an accessor resolves to. Narrow on purpose — the predicate
+/// language can only compare these three shapes, plus an "absent" signal
+/// for unset frontmatter fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Resolved {
+    Int(i64),
+    Str(String),
+    Bool(bool),
+    Absent,
+}
+
+impl Resolved {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Resolved::Int(_) => "int",
+            Resolved::Str(_) => "string",
+            Resolved::Bool(_) => "bool",
+            Resolved::Absent => "absent",
+        }
+    }
+}
+
 impl Predicate {
+    /// Evaluate this predicate against a `Post`. Returns `Ok(bool)` on a
+    /// successful comparison; `Err(PredicateEval)` when the accessor
+    /// can't be resolved or the literal's type doesn't match the
+    /// accessor's value type.
+    pub fn evaluate(&self, post: &Post) -> Result<bool> {
+        let resolved = self
+            .accessor
+            .resolve(post)
+            .map_err(|reason| self.eval_err(reason))?;
+        compare(&resolved, self.op, &self.literal).map_err(|reason| self.eval_err(reason))
+    }
+
+    fn eval_err(&self, reason: String) -> Error {
+        Error::PredicateEval {
+            predicate: self.to_string(),
+            reason,
+        }
+    }
+
     /// Parse a single predicate line. Three tokens: an accessor, an
     /// operator, and a literal. The literal token is "everything after
     /// the operator, trimmed" so quoted strings can contain spaces.
@@ -116,6 +160,122 @@ impl fmt::Display for Literal {
             Literal::Str(s) => write!(f, "{s:?}"),
             Literal::Bool(b) => write!(f, "{b}"),
         }
+    }
+}
+
+impl Accessor {
+    fn resolve(&self, post: &Post) -> std::result::Result<Resolved, String> {
+        match self {
+            Accessor::BodyWords => Ok(Resolved::Int(count_words(&post.body) as i64)),
+            Accessor::BodyChars => Ok(Resolved::Int(post.body.chars().count() as i64)),
+            Accessor::Frontmatter(field) => {
+                let tree = frontmatter_tree(post)?;
+                match tree.get(field) {
+                    None => Ok(Resolved::Absent),
+                    Some(v) => resolve_scalar(v, field),
+                }
+            }
+            Accessor::FrontmatterLen(field) => {
+                let tree = frontmatter_tree(post)?;
+                match tree.get(field) {
+                    None => Ok(Resolved::Absent),
+                    Some(Value::Array(items)) => Ok(Resolved::Int(items.len() as i64)),
+                    Some(Value::String(s)) => Ok(Resolved::Int(s.chars().count() as i64)),
+                    Some(other) => Err(format!(
+                        "frontmatter.{field}.len is only defined for arrays and strings, got {}",
+                        json_type(other)
+                    )),
+                }
+            }
+        }
+    }
+}
+
+fn count_words(body: &str) -> usize {
+    body.split_whitespace().count()
+}
+
+/// Serialize `PostMetadata` to a JSON object so the accessor can walk it
+/// dynamically without growing a hard-coded match arm per field. The
+/// clone is cheap relative to a predicate-gated stage transition.
+fn frontmatter_tree(post: &Post) -> std::result::Result<serde_json::Map<String, Value>, String> {
+    let value = serde_json::to_value(&post.metadata)
+        .map_err(|e| format!("could not serialize frontmatter: {e}"))?;
+    match value {
+        Value::Object(map) => Ok(map),
+        _ => Err("frontmatter did not serialize to an object".into()),
+    }
+}
+
+fn resolve_scalar(value: &Value, field: &str) -> std::result::Result<Resolved, String> {
+    match value {
+        Value::Null => Ok(Resolved::Absent),
+        Value::Bool(b) => Ok(Resolved::Bool(*b)),
+        Value::String(s) => Ok(Resolved::Str(s.clone())),
+        Value::Number(n) => n
+            .as_i64()
+            .map(Resolved::Int)
+            .ok_or_else(|| format!("frontmatter.{field} is not an integer")),
+        Value::Array(_) | Value::Object(_) => Err(format!(
+            "frontmatter.{field} is a {}; use .len or pick a scalar field",
+            json_type(value)
+        )),
+    }
+}
+
+fn json_type(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn compare(resolved: &Resolved, op: Op, literal: &Literal) -> std::result::Result<bool, String> {
+    if matches!(resolved, Resolved::Absent) {
+        return Err("accessor resolved to absent (field unset)".into());
+    }
+    match (resolved, literal) {
+        (Resolved::Int(lhs), Literal::Int(rhs)) => Ok(apply_ord(*lhs, *rhs, op)),
+        (Resolved::Str(lhs), Literal::Str(rhs)) => apply_eq(lhs == rhs, op, "string"),
+        (Resolved::Bool(lhs), Literal::Bool(rhs)) => apply_eq(lhs == rhs, op, "bool"),
+        (lhs, rhs) => Err(format!(
+            "type mismatch: accessor is {}, literal is {}",
+            lhs.type_name(),
+            literal_type(rhs),
+        )),
+    }
+}
+
+fn apply_ord(lhs: i64, rhs: i64, op: Op) -> bool {
+    match op {
+        Op::Eq => lhs == rhs,
+        Op::Ne => lhs != rhs,
+        Op::Ge => lhs >= rhs,
+        Op::Le => lhs <= rhs,
+        Op::Gt => lhs > rhs,
+        Op::Lt => lhs < rhs,
+    }
+}
+
+fn apply_eq(eq: bool, op: Op, type_name: &str) -> std::result::Result<bool, String> {
+    match op {
+        Op::Eq => Ok(eq),
+        Op::Ne => Ok(!eq),
+        other => Err(format!(
+            "operator {other} is not defined for {type_name}; only == and != apply"
+        )),
+    }
+}
+
+fn literal_type(l: &Literal) -> &'static str {
+    match l {
+        Literal::Int(_) => "int",
+        Literal::Str(_) => "string",
+        Literal::Bool(_) => "bool",
     }
 }
 
@@ -350,5 +510,144 @@ mod tests {
     fn from_str_dispatches_to_parse() {
         let p: Predicate = "body.words >= 1".parse().unwrap();
         assert_eq!(p.accessor, Accessor::BodyWords);
+    }
+
+    mod evaluate {
+        use super::*;
+        use crate::classifications::Classifications;
+        use crate::kind::Kind;
+        use crate::post::{Post, PostMetadata};
+        use crate::stage::Stage;
+        use time::macros::datetime;
+
+        fn fixture(body: &str) -> Post {
+            Post::new(
+                PostMetadata {
+                    title: "Example Title".into(),
+                    slug: "example".into(),
+                    kind: Kind::Post,
+                    theme: "standard".into(),
+                    status: Stage::Ideation,
+                    created_at: datetime!(2026-05-03 00:00:00 UTC),
+                    updated_at: datetime!(2026-05-03 00:00:00 UTC),
+                    tags: vec!["rust".into(), "tooling".into()],
+                    todoist_task_id: None,
+                    history_checked: true,
+                    targets: vec![],
+                    classifications: Classifications::default(),
+                },
+                body,
+            )
+        }
+
+        fn eval(input: &str, post: &Post) -> Result<bool> {
+            Predicate::parse(input).unwrap().evaluate(post)
+        }
+
+        #[test]
+        fn body_words_counts_whitespace_separated_tokens() {
+            let post = fixture("one two three four five");
+            assert!(eval("body.words >= 5", &post).unwrap());
+            assert!(eval("body.words == 5", &post).unwrap());
+            assert!(!eval("body.words > 5", &post).unwrap());
+        }
+
+        #[test]
+        fn body_words_handles_runs_of_whitespace() {
+            let post = fixture("alpha   beta\nbeta\tgamma");
+            // Four tokens — "alpha", "beta", "beta", "gamma".
+            assert!(eval("body.words == 4", &post).unwrap());
+        }
+
+        #[test]
+        fn body_chars_counts_unicode_characters() {
+            let post = fixture("héllo"); // 5 chars, 6 bytes.
+            assert!(eval("body.chars == 5", &post).unwrap());
+        }
+
+        #[test]
+        fn frontmatter_string_equality() {
+            let post = fixture("body");
+            assert!(eval(r#"frontmatter.title == "Example Title""#, &post).unwrap());
+            assert!(eval(r#"frontmatter.title != "Other""#, &post).unwrap());
+        }
+
+        #[test]
+        fn frontmatter_bool_equality() {
+            let post = fixture("body");
+            assert!(eval("frontmatter.history_checked == true", &post).unwrap());
+            assert!(!eval("frontmatter.history_checked == false", &post).unwrap());
+        }
+
+        #[test]
+        fn frontmatter_string_rejects_ordering_operator() {
+            let post = fixture("body");
+            let err = eval(r#"frontmatter.title > "A""#, &post).unwrap_err();
+            assert!(
+                matches!(err, Error::PredicateEval { ref reason, .. } if reason.contains("only == and !=")),
+                "got: {err:?}"
+            );
+        }
+
+        #[test]
+        fn frontmatter_len_on_array() {
+            let post = fixture("body");
+            // tags = ["rust", "tooling"] from the fixture.
+            assert!(eval("frontmatter.tags.len == 2", &post).unwrap());
+            assert!(eval("frontmatter.tags.len > 0", &post).unwrap());
+        }
+
+        #[test]
+        fn frontmatter_len_on_string() {
+            let post = fixture("body");
+            // title = "Example Title" — 13 chars.
+            assert!(eval("frontmatter.title.len == 13", &post).unwrap());
+        }
+
+        #[test]
+        fn type_mismatch_errors_with_clear_message() {
+            let post = fixture("body");
+            let err = eval(r#"frontmatter.title == 5"#, &post).unwrap_err();
+            assert!(
+                matches!(err, Error::PredicateEval { ref reason, .. } if reason.contains("type mismatch")),
+                "got: {err:?}"
+            );
+        }
+
+        #[test]
+        fn absent_frontmatter_field_errors() {
+            // `todoist_task_id` is None on the fixture and serializes to
+            // null; the evaluator surfaces that distinctly from a value
+            // mismatch.
+            let post = fixture("body");
+            let err = eval(r#"frontmatter.todoist_task_id == "x""#, &post).unwrap_err();
+            assert!(
+                matches!(err, Error::PredicateEval { ref reason, .. } if reason.contains("absent")),
+                "got: {err:?}"
+            );
+        }
+
+        #[test]
+        fn unknown_frontmatter_field_errors() {
+            let post = fixture("body");
+            let err = eval(r#"frontmatter.no_such_field == "x""#, &post).unwrap_err();
+            assert!(
+                matches!(err, Error::PredicateEval { ref reason, .. } if reason.contains("absent")),
+                "got: {err:?}"
+            );
+        }
+
+        #[test]
+        fn eval_error_carries_canonical_predicate_text() {
+            let post = fixture("");
+            let err = eval(r#"frontmatter.title == 5"#, &post).unwrap_err();
+            match err {
+                Error::PredicateEval { predicate, .. } => {
+                    // Display canonicalizes: int literal stays unquoted.
+                    assert_eq!(predicate, "frontmatter.title == 5");
+                }
+                other => panic!("expected PredicateEval, got {other:?}"),
+            }
+        }
     }
 }

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::error::{Error, Result};
+use crate::kind::Kind;
 use crate::post::{Post, PostMetadata};
+use crate::predicate::Predicate;
 use crate::stage::Stage;
 use crate::taxonomy::{Dimension, Taxonomy};
 
@@ -44,20 +46,34 @@ pub struct Config {
     /// `blogctl classify` before any write.
     #[serde(default)]
     pub classifications: BTreeMap<String, Dimension>,
+    /// Per-kind stage configuration: prompts, exit predicates, optional
+    /// model overrides. Keyed by `Kind::as_str()`, so the TOML table
+    /// reads `[kinds.post.stages.ideation]`. Unknown kind/stage names
+    /// are tolerated at parse time and silently ignored at lookup time —
+    /// see `Config::stage_config`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub kinds: BTreeMap<String, KindConfig>,
 }
 
-/// Workdir-wide defaults. Currently just the theme `blogctl new` selects
-/// when `--theme` is not given; will grow as additional defaults land.
+/// Workdir-wide defaults. The theme `blogctl new` selects when `--theme`
+/// is not given, plus the default OpenRouter model `run-stage`/`draft`
+/// uses when a stage doesn't override it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Defaults {
     #[serde(default = "default_theme_name")]
     pub theme: String,
+    /// OpenRouter model to use when a stage doesn't specify one.
+    /// Optional because workdirs that never call the LLM don't need to
+    /// commit to a model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 impl Default for Defaults {
     fn default() -> Self {
         Self {
             theme: DEFAULT_THEME.to_string(),
+            model: None,
         }
     }
 }
@@ -73,6 +89,29 @@ fn default_theme_name() -> String {
 pub struct ThemeConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub prompts: BTreeMap<String, String>,
+}
+
+/// Per-kind stage configuration. Keyed by `Stage::as_str()` so the TOML
+/// reads `[kinds.post.stages.ideation]`. Unknown stage names sit unused.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct KindConfig {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub stages: BTreeMap<String, StageConfig>,
+}
+
+/// One stage's prompt, exit criteria, and optional model override.
+///
+/// `prompt` is workdir-relative — convention puts templates under
+/// `prompts/`, but the path is taken verbatim. `exit` predicates are
+/// parsed eagerly at config-load time so a malformed predicate surfaces
+/// as a config parse error rather than a crash deep inside `promote`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct StageConfig {
+    pub prompt: PathBuf,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exit: Vec<Predicate>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 /// VCS auto-sync settings. Controls whether write-shaped blogctl
@@ -127,7 +166,27 @@ impl Config {
             themes,
             sync: SyncConfig::default(),
             classifications: Taxonomy::current_v1().to_btreemap(),
+            kinds: BTreeMap::new(),
         }
+    }
+
+    /// Look up the `[kinds.<kind>.stages.<stage>]` entry, if present.
+    /// Returns `None` for kinds or stages the user hasn't configured —
+    /// callers decide whether absence is fatal (`draft` needs a prompt)
+    /// or benign (`promote` with no exit predicates is allowed).
+    pub fn stage_config(&self, kind: Kind, stage: Stage) -> Option<&StageConfig> {
+        self.kinds
+            .get(kind.as_str())
+            .and_then(|k| k.stages.get(stage.as_str()))
+    }
+
+    /// Resolve the OpenRouter model for a `(kind, stage)` call site:
+    /// stage override wins over the workdir default. Returns `None` if
+    /// neither is set.
+    pub fn model_for(&self, kind: Kind, stage: Stage) -> Option<&str> {
+        self.stage_config(kind, stage)
+            .and_then(|s| s.model.as_deref())
+            .or(self.defaults.model.as_deref())
     }
 }
 
@@ -1103,5 +1162,141 @@ mod tests {
         .unwrap();
         let (_handle, loaded) = repo.load("no-class").unwrap();
         assert!(loaded.metadata.classifications.is_empty());
+    }
+
+    #[test]
+    fn config_without_kinds_table_back_fills_empty_map() {
+        // Pre-#233 configs have no `[kinds.*]` tables; the field must
+        // default to an empty map so existing workdirs keep parsing.
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        fs::write(repo.workdir().config_path(), "version = 1\n").unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.kinds.is_empty());
+        assert!(cfg.defaults.model.is_none());
+    }
+
+    #[test]
+    fn config_parses_kinds_stages_from_toml() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let raw = concat!(
+            "version = 1\n",
+            "\n",
+            "[defaults]\n",
+            "model = \"anthropic/claude-sonnet-4-6\"\n",
+            "\n",
+            "[kinds.post.stages.ideation]\n",
+            "prompt = \"prompts/ideation-post.md\"\n",
+            "exit = [\"body.words >= 150\"]\n",
+            "\n",
+            "[kinds.article.stages.ideation]\n",
+            "prompt = \"prompts/ideation-article.md\"\n",
+            "model = \"anthropic/claude-opus-4-7\"\n",
+            "exit = [\"body.words >= 800\"]\n",
+        );
+        fs::write(repo.workdir().config_path(), raw).unwrap();
+        let cfg = repo.read_config().unwrap();
+
+        assert_eq!(
+            cfg.defaults.model.as_deref(),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+
+        let post_stage = cfg.stage_config(Kind::Post, Stage::Ideation).unwrap();
+        assert_eq!(post_stage.prompt, PathBuf::from("prompts/ideation-post.md"));
+        assert_eq!(post_stage.exit.len(), 1);
+        assert!(post_stage.model.is_none());
+
+        let article_stage = cfg.stage_config(Kind::Article, Stage::Ideation).unwrap();
+        assert_eq!(
+            article_stage.model.as_deref(),
+            Some("anthropic/claude-opus-4-7")
+        );
+    }
+
+    #[test]
+    fn config_parse_rejects_malformed_exit_predicate() {
+        // The whole point of eager predicate parsing: a typo in
+        // .blog-os.toml fails at read_config(), not deep inside promote.
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let raw = concat!(
+            "version = 1\n",
+            "[kinds.post.stages.ideation]\n",
+            "prompt = \"prompts/ideation-post.md\"\n",
+            "exit = [\"body.words >=\"]\n",
+        );
+        fs::write(repo.workdir().config_path(), raw).unwrap();
+        let err = repo.read_config().unwrap_err();
+        assert!(matches!(err, Error::ConfigParse { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn stage_config_returns_none_for_unconfigured_kind_or_stage() {
+        let (_tmp, repo) = fresh_repo();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.stage_config(Kind::Post, Stage::Ideation).is_none());
+    }
+
+    #[test]
+    fn model_for_falls_back_to_defaults_model() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let raw = concat!(
+            "version = 1\n",
+            "[defaults]\n",
+            "model = \"anthropic/claude-sonnet-4-6\"\n",
+            "[kinds.post.stages.ideation]\n",
+            "prompt = \"prompts/ideation-post.md\"\n",
+        );
+        fs::write(repo.workdir().config_path(), raw).unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(
+            cfg.model_for(Kind::Post, Stage::Ideation),
+            Some("anthropic/claude-sonnet-4-6")
+        );
+    }
+
+    #[test]
+    fn model_for_prefers_stage_override_over_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let raw = concat!(
+            "version = 1\n",
+            "[defaults]\n",
+            "model = \"anthropic/claude-sonnet-4-6\"\n",
+            "[kinds.article.stages.ideation]\n",
+            "prompt = \"prompts/ideation-article.md\"\n",
+            "model = \"anthropic/claude-opus-4-7\"\n",
+        );
+        fs::write(repo.workdir().config_path(), raw).unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(
+            cfg.model_for(Kind::Article, Stage::Ideation),
+            Some("anthropic/claude-opus-4-7")
+        );
+    }
+
+    #[test]
+    fn model_for_returns_none_when_neither_default_nor_override_set() {
+        let (_tmp, repo) = fresh_repo();
+        let cfg = repo.read_config().unwrap();
+        assert!(cfg.model_for(Kind::Post, Stage::Ideation).is_none());
     }
 }

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -122,6 +122,115 @@ fn promote_drives_full_sync_with_stage_transition_message() {
 }
 
 #[test]
+fn promote_blocks_when_current_stage_exit_predicate_fails() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hello World".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    // Append a stage config gating concept→ideation on body.words >= 5.
+    // The new post's body is empty, so the gate must block.
+    let cfg_path = path.join(".blog-os.toml");
+    let mut cfg = fs::read_to_string(&cfg_path).unwrap();
+    cfg.push_str(concat!(
+        "\n[kinds.post.stages.concept]\n",
+        "prompt = \"prompts/concept-post.md\"\n",
+        "exit = [\"body.words >= 5\"]\n",
+    ));
+    fs::write(&cfg_path, cfg).unwrap();
+
+    let jj = FakeJj::new();
+    let err =
+        commands::promote::run(&jj, "hello-world".to_string(), path.clone(), false).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            blogctl::error::Error::PromoteBlocked { ref predicate, .. }
+                if predicate == "body.words >= 5"
+        ),
+        "got: {err:?}"
+    );
+    // The blocked promote must not have touched jj or the file system.
+    assert!(jj.calls().is_empty(), "blocked promote should not call jj");
+    assert!(path.join("concepts/hello-world.md").is_file());
+    assert!(!path.join("ideation/hello-world.md").exists());
+}
+
+#[test]
+fn promote_passes_gate_when_exit_predicate_satisfied() {
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hello World".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    // Plant a body the predicate will accept and a matching gate.
+    let post_path = path.join("concepts/hello-world.md");
+    let on_disk = fs::read_to_string(&post_path).unwrap();
+    fs::write(
+        &post_path,
+        format!("{on_disk}\nfive six seven eight nine ten\n"),
+    )
+    .unwrap();
+    let cfg_path = path.join(".blog-os.toml");
+    let mut cfg = fs::read_to_string(&cfg_path).unwrap();
+    cfg.push_str(concat!(
+        "\n[kinds.post.stages.concept]\n",
+        "prompt = \"prompts/concept-post.md\"\n",
+        "exit = [\"body.words >= 5\"]\n",
+    ));
+    fs::write(&cfg_path, cfg).unwrap();
+
+    let jj = FakeJj::new();
+    commands::promote::run(&jj, "hello-world".to_string(), path.clone(), false).unwrap();
+    assert_full_sync_flow(&jj.calls(), "post(hello-world): concept \u{2192} ideation");
+    assert!(path.join("ideation/hello-world.md").is_file());
+}
+
+#[test]
+fn promote_with_no_stage_config_for_kind_is_ungated() {
+    // A workdir with a stage config for `article` but not `post` must
+    // still allow `post` promotion — the gate is opt-in per (kind, stage).
+    let (_tmp, path) = workdir();
+    commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        "Hello".to_string(),
+        path.clone(),
+        None,
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    let cfg_path = path.join(".blog-os.toml");
+    let mut cfg = fs::read_to_string(&cfg_path).unwrap();
+    cfg.push_str(concat!(
+        "\n[kinds.article.stages.concept]\n",
+        "prompt = \"prompts/concept-article.md\"\n",
+        "exit = [\"body.words >= 9999\"]\n",
+    ));
+    fs::write(&cfg_path, cfg).unwrap();
+
+    let jj = FakeJj::new();
+    commands::promote::run(&jj, "hello".to_string(), path.clone(), false).unwrap();
+    assert!(path.join("ideation/hello.md").is_file());
+}
+
+#[test]
 fn demote_drives_full_sync_with_reverse_arrow_message() {
     let (_tmp, path) = workdir();
     commands::init::run(&FakeJj::new(), path.clone(), false).unwrap();


### PR DESCRIPTION
Tiny structural predicate language for the config-driven stage
pipeline: `<accessor> <op> <literal>` parsed into an enum, with no
expression evaluator. Accessors cover body word/char counts and
single-field frontmatter access (with a `.len` suffix for collection
fields). Operators are the standard six. Literals are int, double-quoted
string, and bool.

Adding a new accessor is a new enum variant — the grammar resists
growing into anything Turing-complete by construction.

Wire Predicate::evaluate(&Post) -> Result<bool>. Body accessors count
words and chars directly; frontmatter accessors round-trip the metadata
through serde_json::Value so adding a new field doesn't require a match
arm here.

Ordering operators (>, >=, <, <=) only apply to integers — strings and
bools accept == and != only, since lexicographic ordering on either
makes the predicate language harder to reason about than it earns. An
absent frontmatter field fails with a distinct `absent` reason so the
promote gate (next commit) can render a useful message instead of a
confusing type mismatch.

Extend Config with two new shapes:

  * `defaults.model` (optional) — workdir-wide OpenRouter model that
    `run-stage`/`draft` falls back to when a stage doesn't specify one.
  * `[kinds.<kind>.stages.<stage>]` tables carrying `prompt` (workdir-
    relative path; convention is `prompts/`), `exit` predicates, and an
    optional `model` override.

Predicate exit strings are deserialized straight into `Vec<Predicate>`
via a new Serialize/Deserialize impl on Predicate, so a malformed
predicate in `.blog-os.toml` surfaces as a clean ConfigParse error at
read time instead of detonating inside `promote`.

`Config::stage_config` and `Config::model_for` give callers the two
lookups they need; both return None when nothing is configured so the
gate behavior (next commit) can choose between "no predicates, allow"
and "no prompt, error."

Before relocating the post to the next stage, evaluate every predicate
in `[kinds.<kind>.stages.<current>].exit` against the loaded post. The
first failing predicate short-circuits with PromoteBlocked naming the
failing predicate text — no commit, no push, no relocation.

The gate is opt-in per (kind, stage): an absent stage config or empty
`exit` list means "no gate, allow the promote." That keeps existing
workdirs (none of which yet have predicates) behaving exactly as
before, and lets a new workdir adopt predicates one stage at a time.