### PR TITLE
feat(blogctl): draft command — AI-assisted body from a seed prompt

### DIFF
--- a/apps/blogctl/src/analytics/compare.rs
+++ b/apps/blogctl/src/analytics/compare.rs
@@ -265,6 +265,7 @@ mod tests {
                     theme: themes.iter().map(|s| (*s).to_string()).collect(),
                     ..Default::default()
                 },
+                ai: None,
             },
             "body\n",
         )

--- a/apps/blogctl/src/analytics/recommendations.rs
+++ b/apps/blogctl/src/analytics/recommendations.rs
@@ -412,6 +412,7 @@ mod tests {
                     hook: hook.map(|s| s.into()),
                     ..Default::default()
                 },
+                ai: None,
             },
             "body\n",
         )

--- a/apps/blogctl/src/analytics/summary.rs
+++ b/apps/blogctl/src/analytics/summary.rs
@@ -236,6 +236,7 @@ mod tests {
                     theme: themes.iter().map(|s| (*s).to_string()).collect(),
                     ..Default::default()
                 },
+                ai: None,
             },
             "body\n",
         )
@@ -268,6 +269,7 @@ mod tests {
                     }),
                 }],
                 classifications: Classifications::default(),
+                ai: None,
             },
             "body\n",
         )

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -127,6 +127,27 @@ pub enum Command {
         #[command(subcommand)]
         action: AiAction,
     },
+    /// Generate a post body via OpenRouter from a single prompt seeded
+    /// with the post's title + existing notes. Post must be in the
+    /// `ideation` stage. Requires `OPENROUTER_API_KEY` in the
+    /// environment — wrap the invocation in `op run --env-file=.env --
+    /// ...` to resolve it from 1Password.
+    Draft {
+        slug: String,
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Instruction to send to the model (alongside the post's
+        /// title + existing body).
+        #[arg(long)]
+        prompt: String,
+        /// OpenRouter model identifier.
+        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
+        model: String,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// Set classification dimensions on a post (format, hook, tone,
     /// audience, strategic-role, theme). Missing flags leave the
     /// existing value alone; `--clear-<dim>` removes it.
@@ -364,6 +385,22 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
         Command::Ai { action } => match action {
             AiAction::Ping { prompt, model } => commands::ai::ping(prompt, model),
         },
+        Command::Draft {
+            slug,
+            workdir,
+            prompt,
+            model,
+            no_sync,
+        } => commands::draft::run(
+            jj,
+            commands::draft::DraftArgs {
+                slug,
+                workdir: workdir_or_pwd(workdir)?,
+                prompt,
+                model,
+                no_sync,
+            },
+        ),
         Command::Classify {
             slug,
             workdir,

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -368,6 +368,7 @@ mod tests {
                 history_checked: false,
                 targets: vec![],
                 classifications: Default::default(),
+                ai: None,
             },
             "body\n",
         )

--- a/apps/blogctl/src/commands/draft.rs
+++ b/apps/blogctl/src/commands/draft.rs
@@ -1,0 +1,184 @@
+//! `blogctl draft <slug> --prompt <text>` — generate the post body via
+//! OpenRouter, seeded by the post's title + existing body + a single
+//! user prompt.
+//!
+//! Operates on `Ideation`-stage posts only. Other stages error; the
+//! intent is that `draft` produces the "first real body" pass, while
+//! later passes go through `refine` / `final-edit` (tracked in #483).
+//!
+//! Writes the model's reply directly into the post body (replacing
+//! existing content) and records an audit trail in `metadata.ai.draft`
+//! so a future reader can see what prompt + model produced this output.
+
+use std::fs;
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::openrouter;
+use crate::post::{AiDraftRecord, AiHistory};
+use crate::stage::Stage;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+
+#[derive(Debug)]
+pub struct DraftArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+    pub prompt: String,
+    pub model: String,
+    pub no_sync: bool,
+}
+
+pub fn run(jj: &dyn Jj, args: DraftArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let (handle, mut post) = repo.load_raw(&args.slug)?;
+
+    if handle.stage != Stage::Ideation {
+        return Err(Error::DraftWrongStage {
+            slug: args.slug,
+            stage: handle.stage,
+        });
+    }
+
+    let llm_prompt = build_prompt(&post.metadata.title, &post.body, &args.prompt);
+    let reply = openrouter::chat(&llm_prompt, &args.model)?;
+
+    post.body = reply;
+    post.metadata.ai = Some(merge_draft_record(
+        post.metadata.ai.take(),
+        AiDraftRecord {
+            prompt: args.prompt.clone(),
+            model: args.model.clone(),
+            generated_at: OffsetDateTime::now_utc(),
+        },
+    ));
+
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let message = format!("post({}): draft via {}", args.slug, args.model);
+    let path = handle.path.clone();
+    let model = args.model.clone();
+    let slug = args.slug.clone();
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        post.metadata.updated_at = OffsetDateTime::now_utc();
+        let rendered = post.render()?;
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))?;
+        Ok(())
+    })?;
+    println!("{slug}: drafted via {model}");
+    Ok(())
+}
+
+/// Compose the LLM prompt: small preamble giving the model role +
+/// markdown expectation, then the post's title and existing body as
+/// context, then the user's instruction. Kept as a separate fn so the
+/// shape is unit-testable without spinning up a mock server.
+fn build_prompt(title: &str, existing_body: &str, user_prompt: &str) -> String {
+    let mut s = String::with_capacity(
+        // Rough size estimate; the +256 covers the boilerplate.
+        title.len() + existing_body.len() + user_prompt.len() + 256,
+    );
+    s.push_str(
+        "You are drafting a blog post. \
+         Produce the post body in Markdown. \
+         Do not include a title, frontmatter, or commentary about your output — \
+         only the body text the reader will see.\n\n",
+    );
+    s.push_str("Title: ");
+    s.push_str(title);
+    s.push_str("\n\n");
+    if !existing_body.trim().is_empty() {
+        s.push_str("Existing seed/notes:\n");
+        s.push_str(existing_body.trim());
+        s.push_str("\n\n");
+    }
+    s.push_str("Author instruction: ");
+    s.push_str(user_prompt);
+    s
+}
+
+/// Fold a new `AiDraftRecord` into the post's optional `AiHistory`,
+/// preserving any other AI-history fields a future `refine`/
+/// `final-edit` command might have written.
+fn merge_draft_record(existing: Option<AiHistory>, new_draft: AiDraftRecord) -> AiHistory {
+    let mut history = existing.unwrap_or_default();
+    history.draft = Some(new_draft);
+    history
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_includes_title_and_user_instruction() {
+        let p = build_prompt("The Title", "", "write three paragraphs");
+        assert!(p.contains("Title: The Title"));
+        assert!(p.contains("Author instruction: write three paragraphs"));
+    }
+
+    #[test]
+    fn prompt_includes_existing_body_when_non_empty() {
+        let p = build_prompt("T", "some seed notes", "expand");
+        assert!(p.contains("Existing seed/notes:"));
+        assert!(p.contains("some seed notes"));
+    }
+
+    #[test]
+    fn prompt_skips_seed_block_when_body_is_empty() {
+        let p = build_prompt("T", "", "go");
+        assert!(!p.contains("Existing seed/notes:"));
+    }
+
+    #[test]
+    fn prompt_skips_seed_block_when_body_is_whitespace() {
+        // Trimmed-empty body should be treated as no seed; emitting
+        // an "Existing seed/notes:\n\n" block confuses the model
+        // about whether there's hidden content.
+        let p = build_prompt("T", "   \n  \t\n", "go");
+        assert!(!p.contains("Existing seed/notes:"));
+    }
+
+    #[test]
+    fn prompt_specifies_markdown_and_excludes_frontmatter() {
+        let p = build_prompt("T", "", "go");
+        assert!(p.to_lowercase().contains("markdown"));
+        assert!(p.to_lowercase().contains("frontmatter"));
+    }
+
+    #[test]
+    fn merge_creates_history_when_none_existed() {
+        let h = merge_draft_record(
+            None,
+            AiDraftRecord {
+                prompt: "p".into(),
+                model: "m".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert!(h.draft.is_some());
+    }
+
+    #[test]
+    fn merge_overwrites_prior_draft_record() {
+        let prior = AiHistory {
+            draft: Some(AiDraftRecord {
+                prompt: "old".into(),
+                model: "old-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+        };
+        let h = merge_draft_record(
+            Some(prior),
+            AiDraftRecord {
+                prompt: "new".into(),
+                model: "new-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert_eq!(h.draft.unwrap().prompt, "new");
+    }
+}

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -376,6 +376,7 @@ mod tests {
                 history_checked: false,
                 targets: vec![],
                 classifications: Default::default(),
+                ai: None,
             },
             "body\n",
         )

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod backfill;
 pub mod classify;
 pub mod demote;
 pub mod doctor;
+pub mod draft;
 pub mod fix;
 pub mod init;
 pub mod list;

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -60,6 +60,7 @@ pub fn run(
             history_checked: false,
             targets: vec![],
             classifications: Default::default(),
+            ai: None,
         };
         let post = Post::new(metadata, "");
         repo.create_post(&post)

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -40,6 +40,11 @@ pub enum Error {
         predicate: String,
     },
 
+    #[error(
+        "cannot draft post {slug:?} from stage {stage}: drafting requires the post to be in the `ideation` stage"
+    )]
+    DraftWrongStage { slug: String, stage: Stage },
+
     #[error("cannot demote from {0}: already at the first workflow stage")]
     DemoteFromInitial(Stage),
 

--- a/apps/blogctl/src/openrouter.rs
+++ b/apps/blogctl/src/openrouter.rs
@@ -119,12 +119,17 @@ mod tests {
         assert_eq!(content, Some("pong".to_string()));
     }
 
+    // Both endpoint env tests mutate the same process-global var;
+    // cargo runs unit tests in parallel by default, so without
+    // serialization each test sees the other's half-step and asserts
+    // inconsistently (observed as a flake under cargo-llvm-cov). A
+    // module-local mutex held across the env-var dance is the lightest
+    // guard that works.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn endpoint_defaults_to_production_url() {
-        // SAFETY: env vars are process-global. This test deliberately
-        // unsets and asserts; tests touching the same var should run
-        // serially under cargo test's default thread-per-test layout.
-        // The asymmetric set/unset cost is fine for the seam check.
+        let _guard = ENV_LOCK.lock().unwrap();
         let prev = env::var(API_BASE_VAR).ok();
         env::remove_var(API_BASE_VAR);
         assert_eq!(endpoint(), DEFAULT_ENDPOINT);
@@ -135,6 +140,7 @@ mod tests {
 
     #[test]
     fn endpoint_honors_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
         let prev = env::var(API_BASE_VAR).ok();
         env::set_var(API_BASE_VAR, "http://127.0.0.1:1234/v1/chat");
         assert_eq!(endpoint(), "http://127.0.0.1:1234/v1/chat");

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -47,6 +47,29 @@ pub struct PostMetadata {
     /// quiet in their frontmatter.
     #[serde(default, skip_serializing_if = "Classifications::is_empty")]
     pub classifications: Classifications,
+    /// AI-assisted operations audit trail. Populated by `blogctl
+    /// draft` (and future `refine`/`final-edit` commands) so a future
+    /// reader can see what prompt + model produced the current body.
+    /// `None` for posts that haven't been touched by AI commands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ai: Option<AiHistory>,
+}
+
+/// Per-AI-command audit records. Each field is `Option` so a post that
+/// went through `draft` but not `refine` doesn't carry an empty
+/// `refine:` block in its frontmatter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct AiHistory {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft: Option<AiDraftRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AiDraftRecord {
+    pub prompt: String,
+    pub model: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub generated_at: OffsetDateTime,
 }
 
 fn default_theme() -> String {
@@ -204,6 +227,7 @@ mod tests {
             history_checked: false,
             targets: vec![],
             classifications: Default::default(),
+            ai: None,
         }
     }
 

--- a/apps/blogctl/src/predicate.rs
+++ b/apps/blogctl/src/predicate.rs
@@ -549,6 +549,7 @@ mod tests {
                     history_checked: true,
                     targets: vec![],
                     classifications: Classifications::default(),
+                    ai: None,
                 },
                 body,
             )

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -661,6 +661,7 @@ mod tests {
                 history_checked: false,
                 targets: vec![],
                 classifications: Default::default(),
+                ai: None,
             },
             "body\n",
         )

--- a/apps/blogctl/tests/analytics_render.rs
+++ b/apps/blogctl/tests/analytics_render.rs
@@ -68,6 +68,7 @@ fn post(
                 hook: hook.map(|s| s.into()),
                 ..Default::default()
             },
+            ai: None,
         },
         "body\n",
     )

--- a/apps/blogctl/tests/workflow.rs
+++ b/apps/blogctl/tests/workflow.rs
@@ -6,22 +6,52 @@
 //! directory rename, taxonomy mismatch) — gaps unit tests miss because
 //! each one stays inside one module's contract.
 //!
-//! No AI here. `commands::ai::ping` is the only OpenRouter call site
-//! today and isn't wired into the lifecycle; the seam from #474 is
-//! exercised separately by `tests/ai_endpoint.rs`. Once the
-//! AI-integrated commands tracked in #483 land (`draft`, `refine`,
-//! `final-edit`), they'll slot into this file rather than a new one.
+//! The AI-touching path lands here too via `lifecycle_with_draft`,
+//! which drives `commands::draft` against a `mockito` server using the
+//! `OPENROUTER_API_BASE` seam (#474). Once the rest of the
+//! AI-integrated commands tracked in #483 land (`refine`,
+//! `final-edit`), they'll extend the same test rather than spawning
+//! new ones.
 
+use std::env;
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use tempfile::TempDir;
 
-use blogctl::commands::{self, classify::ClassifyArgs, metrics::UpdateArgs};
+use blogctl::commands::{self, classify::ClassifyArgs, draft::DraftArgs, metrics::UpdateArgs};
+use blogctl::error::Error;
 use blogctl::kind::Kind;
 use blogctl::stage::Stage;
 use blogctl::storage::{Repository, Workdir};
 use blogctl::sync::FakeJj;
 use blogctl::target::{Target, TargetEntry, TargetStatus};
+
+// `tests/ai_endpoint.rs` also touches OPENROUTER_API_BASE; both
+// processes run in parallel by default. Process-level mutex keeps the
+// env-var dance from racing within this binary; cargo runs each
+// integration test binary in its own process so the two files don't
+// interfere with each other.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const CANNED_DRAFT_REPLY: &str =
+    "## Drafted body\n\nFirst paragraph from the mock.\n\nSecond paragraph from the mock.\n";
+
+const CANNED_OPENROUTER_RESPONSE: &str = r###"{
+  "id": "gen-test-001",
+  "object": "chat.completion",
+  "model": "test-model",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "## Drafted body\n\nFirst paragraph from the mock.\n\nSecond paragraph from the mock.\n"
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}"###;
 
 fn fresh_workdir() -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("tempdir");
@@ -148,4 +178,102 @@ fn lifecycle_init_new_classify_promote_metrics() {
     assert_eq!(m.reactions, 42);
     assert_eq!(m.comments, 7);
     assert_eq!(m.reposts, 3);
+}
+
+/// Drive an `Ideation`-stage post through `commands::draft` against a
+/// `mockito` server. Asserts the body was replaced with the mock's
+/// reply and the `ai.draft` audit block was populated. Also asserts
+/// that drafting from a non-`Ideation` stage errors cleanly.
+#[test]
+fn lifecycle_with_draft_uses_mocked_openrouter() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let mut server = mockito::Server::new();
+    let mock = server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(CANNED_OPENROUTER_RESPONSE)
+        .create();
+
+    let prev_base = env::var("OPENROUTER_API_BASE").ok();
+    let prev_key = env::var("OPENROUTER_API_KEY").ok();
+    env::set_var(
+        "OPENROUTER_API_BASE",
+        format!("{}/chat/completions", server.url()),
+    );
+    env::set_var("OPENROUTER_API_KEY", "test-key");
+
+    let result = run_draft_lifecycle();
+
+    match prev_base {
+        Some(v) => env::set_var("OPENROUTER_API_BASE", v),
+        None => env::remove_var("OPENROUTER_API_BASE"),
+    }
+    match prev_key {
+        Some(v) => env::set_var("OPENROUTER_API_KEY", v),
+        None => env::remove_var("OPENROUTER_API_KEY"),
+    }
+
+    result.expect("draft lifecycle should succeed");
+    mock.assert();
+}
+
+fn run_draft_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true)?;
+    commands::new::run(
+        &FakeJj::new(),
+        "Draft test post".into(),
+        workdir.clone(),
+        None,
+        Kind::Post,
+        None,
+        true,
+    )?;
+    let slug = "draft-test-post";
+
+    // Trying to draft at Concept must fail with DraftWrongStage. Catch
+    // before promoting so the negative path is exercised inside the
+    // same lifecycle test instead of a tiny standalone case.
+    let err = commands::draft::run(
+        &FakeJj::new(),
+        DraftArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: "go".into(),
+            model: "test-model".into(),
+            no_sync: true,
+        },
+    )
+    .expect_err("draft at Concept must error");
+    assert!(
+        matches!(err, Error::DraftWrongStage { .. }),
+        "expected DraftWrongStage, got: {err:?}"
+    );
+
+    commands::promote::run(&FakeJj::new(), slug.to_string(), workdir.clone(), true)?;
+
+    commands::draft::run(
+        &FakeJj::new(),
+        DraftArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: "write me three paragraphs about mocking".into(),
+            model: "test-model".into(),
+            no_sync: true,
+        },
+    )?;
+
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let (_, post) = repo.load(slug)?;
+    assert_eq!(
+        post.body.trim(),
+        CANNED_DRAFT_REPLY.trim(),
+        "body should match the canned mock reply"
+    );
+    let ai = post.metadata.ai.as_ref().expect("ai block populated");
+    let draft = ai.draft.as_ref().expect("ai.draft populated");
+    assert_eq!(draft.prompt, "write me three paragraphs about mocking");
+    assert_eq!(draft.model, "test-model");
+    Ok(())
 }


### PR DESCRIPTION
First slice of the AI-integrated content workflow tracked in #483.
`blogctl draft <slug> --prompt <text>` generates the post body via
OpenRouter, seeded with the post's title + existing seed/notes + the
user's instruction, and writes the model's reply directly into the
post body.

Gates on `Ideation` stage. Drafting at any other stage errors cleanly
with a message that names the stage; the intent is that `draft`
produces the first real body and later passes go through future
`refine` / `final-edit` commands.

Records an audit trail in `metadata.ai.draft` ({prompt, model,
generated_at}) so a reader can see what produced the current body.
The `ai` field is optional with `skip_serializing_if = Option::is_none`
so existing posts parse unchanged and posts never touched by AI stay
quiet in their frontmatter.

Tests cover the prompt-construction helper (six cases including
empty-body, whitespace-only-body, and audit-record merge semantics) and
extend `tests/workflow.rs` with `lifecycle_with_draft_uses_mocked_openrouter`
— promotes to `Ideation`, drafts against a `mockito` server using the
`OPENROUTER_API_BASE` seam from #474, and asserts both the body
replacement and the `ai.draft` block. Also exercises the negative path
(draft from `Concept` → `DraftWrongStage`).

Also serializes the two `openrouter::tests::endpoint_*` unit tests
with a module-local mutex; they mutate the same process-global env
var and were flaking under cargo-llvm-cov as the test surface grew.

Closes #489


Closes #497
