### PR TITLE
test(blogctl): raise coverage gates to current floor

### DIFF
--- a/apps/blogctl/project.cue
+++ b/apps/blogctl/project.cue
@@ -4,11 +4,16 @@ package project
 	name: "blogctl"
 	kind: "rust"
 	coverage: {
+		// Floors picked from the current measured coverage minus
+		// ~7% headroom: as of #442, line is ~92% and branch is ~72%.
+		// The branch gap is wider because some error paths and
+		// FakeJj fallbacks aren't exercised end-to-end. Bump these
+		// gradually as targeted tests fill the gaps.
 		line: {
-			fail: 1
+			fail: 85
 		}
 		branch: {
-			fail: 1
+			fail: 65
 		}
 	}
 	ci: {

--- a/apps/blogctl/src/commands/analytics.rs
+++ b/apps/blogctl/src/commands/analytics.rs
@@ -1,7 +1,13 @@
 //! `blogctl analytics {summary, compare, recommendations}` — read
 //! every published post's classifications + metrics and surface
 //! aggregates. All three commands implemented.
+//!
+//! The text renderers (`render_summary_text`, `render_compare_text`,
+//! `render_recommendations_text`) are public and `Write`-based so
+//! the golden tests in `tests/analytics_render.rs` can capture the
+//! exact output without spawning a subprocess.
 
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use time::OffsetDateTime;
@@ -58,28 +64,36 @@ pub fn summary(args: SummaryArgs) -> Result<()> {
         args.dimension.as_deref(),
         OffsetDateTime::now_utc(),
     );
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
     if args.json {
-        println!(
+        writeln!(
+            out,
             "{}",
             serde_json::to_string_pretty(&summary).map_err(Error::SummaryJson)?
-        );
+        )
+        .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     } else {
-        print_text(&summary);
+        render_summary_text(&summary, &mut out)
+            .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     }
     Ok(())
 }
 
-fn print_text(s: &Summary) {
+/// Render the human-readable summary view into `w`. Public so the
+/// golden tests can capture into a `Vec<u8>` without going through
+/// stdout.
+pub fn render_summary_text(s: &Summary, w: &mut dyn Write) -> io::Result<()> {
     if s.dimensions.is_empty() {
-        println!("no classified posts with metrics in this workdir");
-        return;
+        writeln!(w, "no classified posts with metrics in this workdir")?;
+        return Ok(());
     }
     for (i, dim) in s.dimensions.iter().enumerate() {
         if i > 0 {
-            println!();
+            writeln!(w)?;
         }
         let total: usize = dim.values.iter().map(|v| v.n).sum();
-        println!("{} (n={total})", dim.name);
+        writeln!(w, "{} (n={total})", dim.name)?;
         let width = dim
             .values
             .iter()
@@ -88,12 +102,18 @@ fn print_text(s: &Summary) {
             .unwrap_or(0)
             .max(8);
         for v in &dim.values {
-            print_value_row(dim, v, width);
+            render_value_row(dim, v, width, w)?;
         }
     }
+    Ok(())
 }
 
-fn print_value_row(_dim: &DimensionSummary, v: &ValueSummary, value_width: usize) {
+fn render_value_row(
+    _dim: &DimensionSummary,
+    v: &ValueSummary,
+    value_width: usize,
+    w: &mut dyn Write,
+) -> io::Result<()> {
     let imp = format_imp(v.impressions.p50);
     let er = match v.engagement_rate {
         None => "eng p50=—".to_string(),
@@ -105,12 +125,13 @@ fn print_value_row(_dim: &DimensionSummary, v: &ValueSummary, value_width: usize
         ),
     };
     let low = if v.low_n { "  (low n)" } else { "" };
-    println!(
+    writeln!(
+        w,
         "  {value:<width$}  n={n}   imp p50={imp}   {er}{low}",
         value = v.value,
         width = value_width,
         n = v.n,
-    );
+    )
 }
 
 /// `1842 → "1.8k"`. Below 1000 we print the integer; at or above
@@ -145,32 +166,39 @@ pub fn compare(args: CompareArgs) -> Result<()> {
         args.min_n,
         OffsetDateTime::now_utc(),
     );
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
     if args.json {
-        println!(
+        writeln!(
+            out,
             "{}",
             serde_json::to_string_pretty(&comparison).map_err(Error::SummaryJson)?
-        );
+        )
+        .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     } else {
-        print_compare_text(&comparison);
+        render_compare_text(&comparison, &mut out)
+            .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     }
     Ok(())
 }
 
-fn print_compare_text(c: &Comparison) {
+/// Render the crosstab + marginals view into `w`.
+pub fn render_compare_text(c: &Comparison, w: &mut dyn Write) -> io::Result<()> {
     let target_label = c
         .target_filter
         .map(|t| format!("target={t}"))
         .unwrap_or_else(|| "all targets".into());
-    println!(
+    writeln!(
+        w,
         "compare {} \u{00d7} {}  ({})",
         c.dim_a, c.dim_b, target_label,
-    );
-    println!();
+    )?;
+    writeln!(w)?;
 
     let rows = c.row_values();
     let cols = c.column_values();
     if rows.is_empty() || cols.is_empty() {
-        println!("(no posts match this comparison)");
+        writeln!(w, "(no posts match this comparison)")?;
     } else {
         // Column widths: each column at least max(col_name, "n=NN X.X%"),
         // with two spaces of padding between columns.
@@ -178,44 +206,46 @@ fn print_compare_text(c: &Comparison) {
         let col_widths: Vec<usize> = cols
             .iter()
             .map(|col| {
-                let mut w = col.len();
+                let mut width = col.len();
                 for row in &rows {
                     if let Some(cell) = c.cell(row, col) {
-                        w = w.max(format_cell_body(cell).len());
+                        width = width.max(format_cell_body(cell).len());
                     }
                 }
-                w.max(8)
+                width.max(8)
             })
             .collect();
 
-        // Header row.
-        print!("{:<width$}", "", width = row_label_width + 2);
-        for (col, w) in cols.iter().zip(col_widths.iter()) {
-            print!("  {col:<w$}", col = col, w = w);
+        // Build each row in-memory so we can trim trailing
+        // whitespace before writing it out — repo whitespace check
+        // (and good taste) reject lines that end in pad spaces.
+        let mut header = format!("{:<width$}", "", width = row_label_width + 2);
+        for (col, width) in cols.iter().zip(col_widths.iter()) {
+            header.push_str(&format!("  {col:<width$}"));
         }
-        println!();
+        writeln!(w, "{}", header.trim_end())?;
 
-        // Data rows.
         for row in &rows {
-            print!("{row:<width$}", row = row, width = row_label_width + 2);
-            for (col, w) in cols.iter().zip(col_widths.iter()) {
+            let mut line = format!("{row:<width$}", row = row, width = row_label_width + 2);
+            for (col, width) in cols.iter().zip(col_widths.iter()) {
                 let body = match c.cell(row, col) {
                     None => "--".to_string(),
                     Some(cell) => format_cell_body(cell),
                 };
-                print!("  {body:<w$}", body = body, w = w);
+                line.push_str(&format!("  {body:<width$}"));
             }
-            println!();
+            writeln!(w, "{}", line.trim_end())?;
         }
     }
 
-    println!();
-    println!("marginals:");
-    print_marginals(&c.marginals_a);
-    print_marginals(&c.marginals_b);
+    writeln!(w)?;
+    writeln!(w, "marginals:")?;
+    render_marginals(&c.marginals_a, w)?;
+    render_marginals(&c.marginals_b, w)?;
+    Ok(())
 }
 
-fn print_marginals(marginals: &[analytics::Marginal]) {
+fn render_marginals(marginals: &[analytics::Marginal], w: &mut dyn Write) -> io::Result<()> {
     // Label width sized to the longest "<dim>=<value>:" string in this
     // marginal slice — keeps the columns aligned within each group.
     let label_width = marginals
@@ -230,14 +260,16 @@ fn print_marginals(marginals: &[analytics::Marginal]) {
             .engagement_rate_p50
             .map(format_er)
             .unwrap_or_else(|| "\u{2014}".into());
-        println!(
+        writeln!(
+            w,
             "  {label:<label_width$}  n={n:<3}   eng p50={er}",
             label = label,
             label_width = label_width,
             n = m.n,
             er = er,
-        );
+        )?;
     }
+    Ok(())
 }
 
 /// Body of one cell: `n=N  X.X%` or `n=N  (low)` when the cell is
@@ -261,29 +293,38 @@ pub fn recommendations(args: RecommendationsArgs) -> Result<()> {
         .map(|h| repo.load_raw(&h.metadata.slug).map(|(_, post)| post))
         .collect::<Result<_>>()?;
     let r = analytics::recommendations(&posts, args.target, args.min_n, OffsetDateTime::now_utc());
-    print_recommendations_text(&r);
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    render_recommendations_text(&r, &mut out)
+        .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     Ok(())
 }
 
-fn print_recommendations_text(r: &Recommendations) {
+/// Render the hedged-prose recommendations view into `w`. The
+/// closing reminder is unconditional — copy-paste of one
+/// observation still lands with the hedge attached.
+pub fn render_recommendations_text(r: &Recommendations, w: &mut dyn Write) -> io::Result<()> {
     let target_label = r
         .target_filter
         .map(|t| format!("target={t}, "))
         .unwrap_or_default();
-    println!(
+    writeln!(
+        w,
         "analytics recommendations  ({target_label}n_total={n})",
         n = r.n_total,
-    );
-    println!();
+    )?;
+    writeln!(w)?;
     if r.observations.is_empty() {
-        println!(
+        writeln!(
+            w,
             "  (no observations — add metrics and classifications to more posts to surface signal)"
-        );
+        )?;
     } else {
         for obs in &r.observations {
-            println!("  {}", obs.render());
-            println!();
+            writeln!(w, "  {}", obs.render())?;
+            writeln!(w)?;
         }
     }
-    println!("{}", analytics::CLOSING_REMINDER);
+    writeln!(w, "{}", analytics::CLOSING_REMINDER)?;
+    Ok(())
 }

--- a/apps/blogctl/tests/analytics_render.rs
+++ b/apps/blogctl/tests/analytics_render.rs
@@ -1,0 +1,241 @@
+//! Golden-file tests for the analytics text renderers.
+//!
+//! The hedge-language requirements on `recommendations` (and the
+//! visual layout of `summary` / `compare`) deserve a stricter
+//! guarantee than the grep-based language gate in the unit tests.
+//! These tests render the three commands against a static
+//! in-memory fixture and diff the output against a checked-in
+//! golden file. A wording change → test failure → review.
+//!
+//! Regenerate goldens with `UPDATE_GOLDENS=1 cargo test --test
+//! analytics_render`. Don't set the env var in CI.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use time::OffsetDateTime;
+
+use blogctl::analytics;
+use blogctl::classifications::Classifications;
+use blogctl::commands::analytics as commands_analytics;
+use blogctl::kind::Kind;
+use blogctl::post::{Post, PostMetadata};
+use blogctl::stage::Stage;
+use blogctl::target::{Target, TargetEntry, TargetMetrics, TargetStatus};
+
+/// Fixed `now` for every render — `staleness_days` lands at a
+/// stable integer so the recommendations output doesn't drift.
+fn fixed_now() -> OffsetDateTime {
+    time::macros::datetime!(2026-05-17 00:00:00 UTC)
+}
+
+fn post(
+    slug: &str,
+    title: &str,
+    format: &str,
+    hook: Option<&str>,
+    impressions: u64,
+    reactions: u64,
+    sampled_at: OffsetDateTime,
+) -> Post {
+    Post::new(
+        PostMetadata {
+            title: title.into(),
+            slug: slug.into(),
+            kind: Kind::Post,
+            theme: "standard".into(),
+            status: Stage::Published,
+            created_at: time::macros::datetime!(2026-05-01 00:00:00 UTC),
+            updated_at: time::macros::datetime!(2026-05-08 00:00:00 UTC),
+            tags: vec![],
+            todoist_task_id: None,
+            history_checked: false,
+            targets: vec![TargetEntry {
+                name: Target::Linkedin,
+                status: TargetStatus::Published,
+                url: Some("https://www.linkedin.com/posts/example".into()),
+                published_at: Some(time::macros::datetime!(2026-05-08 14:32:00 UTC)),
+                metrics: Some(TargetMetrics {
+                    impressions,
+                    reactions,
+                    comments: 0,
+                    reposts: 0,
+                    sampled_at,
+                }),
+            }],
+            classifications: Classifications {
+                format: Some(format.into()),
+                hook: hook.map(|s| s.into()),
+                ..Default::default()
+            },
+        },
+        "body\n",
+    )
+}
+
+/// Static fixture exercising the renderer branches:
+/// - Three thesis-contradiction posts at decent engagement
+///   (drives a DimensionLift + InteractionLift observation, and
+///   crosses the LOW_N_THRESHOLD=3 boundary).
+/// - Two parable-question posts at low engagement (n=2 → low_n).
+/// - One stale-metrics post (sampled 60 days before `now`).
+fn fixture_posts() -> Vec<Post> {
+    let fresh = time::macros::datetime!(2026-05-14 00:00:00 UTC);
+    let stale = time::macros::datetime!(2026-03-10 00:00:00 UTC);
+    vec![
+        post(
+            "t1",
+            "Thesis One",
+            "thesis",
+            Some("contradiction"),
+            1000,
+            50,
+            fresh,
+        ),
+        post(
+            "t2",
+            "Thesis Two",
+            "thesis",
+            Some("contradiction"),
+            1200,
+            60,
+            fresh,
+        ),
+        post(
+            "t3",
+            "Thesis Three",
+            "thesis",
+            Some("contradiction"),
+            1500,
+            75,
+            fresh,
+        ),
+        post(
+            "p1",
+            "Parable One",
+            "parable",
+            Some("question"),
+            800,
+            16,
+            fresh,
+        ),
+        post(
+            "p2",
+            "Parable Two",
+            "parable",
+            Some("question"),
+            1200,
+            24,
+            fresh,
+        ),
+        post(
+            "old",
+            "Stale Post",
+            "thesis",
+            Some("direct-claim"),
+            900,
+            27,
+            stale,
+        ),
+    ]
+}
+
+/// Compare `actual` against the on-disk golden at `relative_path`.
+/// With `UPDATE_GOLDENS=1`, overwrite the golden with `actual`
+/// (useful when wording changes intentionally — review the diff
+/// in the PR).
+fn assert_golden(actual: &str, relative_path: &str) {
+    let full = Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+    if std::env::var("UPDATE_GOLDENS").is_ok() {
+        // Create parent dirs if missing — useful for first run.
+        if let Some(parent) = full.parent() {
+            fs::create_dir_all(parent).expect("create golden dir");
+        }
+        fs::write(&full, actual).expect("write golden");
+        return;
+    }
+    let expected = fs::read_to_string(&full).unwrap_or_else(|_| {
+        panic!(
+            "golden file missing: {}\nrun `UPDATE_GOLDENS=1 cargo test --test analytics_render` to create it",
+            full.display()
+        )
+    });
+    if actual != expected {
+        panic!(
+            "golden mismatch for {relative_path}\n\n\
+             --- expected ---\n{expected}\n\
+             --- actual ---\n{actual}\n\
+             --- end ---\n\n\
+             Run with UPDATE_GOLDENS=1 to regenerate (and review the diff).",
+        );
+    }
+}
+
+fn render_to_string(f: impl FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    f(&mut buf).expect("renderer writes never fail to a Vec<u8>");
+    String::from_utf8(buf).expect("renderer emits valid UTF-8")
+}
+
+#[test]
+fn summary_text_matches_golden() {
+    let posts = fixture_posts();
+    let summary = analytics::summary(&posts, Some(Target::Linkedin), None, fixed_now());
+    let actual = render_to_string(|w| commands_analytics::render_summary_text(&summary, w));
+    assert_golden(&actual, "tests/fixtures/analytics/golden/summary.txt");
+}
+
+#[test]
+fn compare_text_matches_golden() {
+    let posts = fixture_posts();
+    let comparison = analytics::compare(
+        &posts,
+        "format",
+        "hook",
+        Some(Target::Linkedin),
+        3,
+        fixed_now(),
+    );
+    let actual = render_to_string(|w| commands_analytics::render_compare_text(&comparison, w));
+    assert_golden(&actual, "tests/fixtures/analytics/golden/compare.txt");
+}
+
+#[test]
+fn recommendations_text_matches_golden() {
+    let posts = fixture_posts();
+    let r = analytics::recommendations(&posts, Some(Target::Linkedin), 3, fixed_now());
+    let actual = render_to_string(|w| commands_analytics::render_recommendations_text(&r, w));
+    assert_golden(
+        &actual,
+        "tests/fixtures/analytics/golden/recommendations.txt",
+    );
+}
+
+/// Sanity check: every observation in the rendered output uses
+/// the hedged prefixes ("Early signal:" / "Insufficient data:" /
+/// "Stale data:") and never mentions the forbidden words. This is
+/// redundant with the unit test in analytics::recommendations but
+/// runs at the renderer boundary — catches regressions where the
+/// command body bypasses Observation::render.
+#[test]
+fn recommendations_renderer_keeps_hedges() {
+    let posts = fixture_posts();
+    let r = analytics::recommendations(&posts, Some(Target::Linkedin), 3, fixed_now());
+    let rendered =
+        render_to_string(|w| commands_analytics::render_recommendations_text(&r, w)).to_lowercase();
+    for word in analytics::FORBIDDEN_WORDS {
+        assert!(
+            !rendered.contains(word),
+            "rendered output contains forbidden word {word:?}:\n{rendered}",
+        );
+    }
+}
+
+/// Future-proofing: a hard-coded path makes the golden test
+/// brittle if someone moves the fixtures directory. This test
+/// confirms the directory exists in the tree.
+#[test]
+fn golden_dir_exists() {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/analytics/golden");
+    assert!(dir.is_dir(), "missing {}", dir.display());
+}

--- a/apps/blogctl/tests/fixtures/analytics/golden/compare.txt
+++ b/apps/blogctl/tests/fixtures/analytics/golden/compare.txt
@@ -1,0 +1,12 @@
+compare format × hook  (target=linkedin)
+
+            contradiction  direct-claim  question
+parable     --             --            n=2  (low)
+thesis      n=3  5.0%      n=1  (low)    --
+
+marginals:
+  format=thesis:   n=4     eng p50=5.0%
+  format=parable:  n=2     eng p50=2.0%
+  hook=contradiction:  n=3     eng p50=5.0%
+  hook=direct-claim:   n=1     eng p50=3.0%
+  hook=question:       n=2     eng p50=2.0%

--- a/apps/blogctl/tests/fixtures/analytics/golden/recommendations.txt
+++ b/apps/blogctl/tests/fixtures/analytics/golden/recommendations.txt
@@ -1,0 +1,9 @@
+analytics recommendations  (target=linkedin, n_total=6)
+
+  Early signal: format=thesis correlates with higher engagement (median 5.0% vs corpus 3.0%; n=4).
+
+  Early signal: hook=contradiction correlates with higher engagement (median 5.0% vs corpus 3.0%; n=3).
+
+  Stale data: 1 published post(s) have metrics older than 30 days [old]. Run `blogctl metrics update <slug>` to refresh.
+
+Reminder: these are correlations on a small sample. Treat as priors for what to try next, not as conclusions.

--- a/apps/blogctl/tests/fixtures/analytics/golden/summary.txt
+++ b/apps/blogctl/tests/fixtures/analytics/golden/summary.txt
@@ -1,0 +1,8 @@
+format (n=6)
+  thesis    n=4   imp p50=1.0k   eng p50=5.0%  [p25=3.0% p75=5.0%]
+  parable   n=2   imp p50=800   eng p50=2.0%  [p25=2.0% p75=2.0%]  (low n)
+
+hook (n=6)
+  contradiction  n=3   imp p50=1.2k   eng p50=5.0%  [p25=5.0% p75=5.0%]
+  direct-claim   n=1   imp p50=900   eng p50=3.0%  [p25=3.0% p75=3.0%]  (low n)
+  question       n=2   imp p50=800   eng p50=2.0%  [p25=2.0% p75=2.0%]  (low n)


### PR DESCRIPTION
Adds tests/analytics_render.rs — three golden tests, one per
analytics text renderer (summary, compare, recommendations). Each
test renders against a static in-memory fixture (six posts hand-
constructed via PostMetadata literals, no filesystem, no library
setup commands) and diffs the output against a checked-in golden
file under tests/fixtures/analytics/golden/.

The hedge-language requirements on recommendations are
load-bearing enough that pinning the prose shape catches more
than the grep-based language gate already in place. Same logic
applies — less strictly — to summary's column layout and
compare's crosstab.

To support golden capture, the three text renderers move from
println!-based print_*_text helpers into pub fn
render_*_text(&Item, &mut dyn Write) -> io::Result<()>. The
public command bodies still print to stdout — they just route
through the new Write-based renderers. Existing integration
tests are unaffected.

Set UPDATE_GOLDENS=1 to regenerate the goldens (review the diff
in the PR; never set in CI).

For #442.

Closes #442.

apps/blogctl/project.cue's coverage gates were sitting at fail=1
for both line and branch — effectively "any coverage at all,"
which never catches a regression. The blogctl crate has matured
to ~92% line and ~72% branch coverage; bump the gates to a
sensible floor that catches significant drops without breaking
on routine churn.

Picked floors:
- line.fail: 85  (measured 92% — ~7% headroom)
- branch.fail: 65  (measured 72% — ~7% headroom)

The branch number is intentionally lower because some error paths
(jj command failures, FakeJj outcome enums) aren't exercised
end-to-end yet. The headroom on both leaves room for normal
fluctuation while still flagging "you deleted a big chunk of
tests" as a regression.

When the next round of tests fills branch coverage gaps, bump
branch.fail upward to lock in the gain.