### PR TITLE
feat(blogctl): draft command writes <slug>.draft-N.md sidecars

### DIFF
--- a/apps/blogctl/Cargo.lock
+++ b/apps/blogctl/Cargo.lock
@@ -107,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "minijinja",
  "mockito",
  "serde",
  "serde_json",
@@ -647,6 +648,22 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
+name = "minijinja"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/apps/blogctl/Cargo.toml
+++ b/apps/blogctl/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+minijinja = { version = "2", default-features = false, features = ["serde", "loader"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -86,6 +86,22 @@ pub enum Command {
         #[arg(long)]
         no_sync: bool,
     },
+    /// Render the configured prompt for a post's current stage, call
+    /// OpenRouter, and write the reply as
+    /// `<workdir>/drafts/<slug>.draft-N.md` for review. Requires a
+    /// `[kinds.<kind>.stages.<current>]` entry in `.blog-os.toml`.
+    Draft {
+        slug: String,
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Override the model the config would otherwise resolve to.
+        #[arg(long)]
+        model: Option<String>,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// Move a post one stage back.
     Demote {
         slug: String,
@@ -350,6 +366,12 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             workdir,
             no_sync,
         } => commands::demote::run(jj, slug, workdir_or_pwd(workdir)?, no_sync),
+        Command::Draft {
+            slug,
+            workdir,
+            model,
+            no_sync,
+        } => commands::draft::run(jj, slug, workdir_or_pwd(workdir)?, model, no_sync),
         Command::Readme { action } => match action {
             ReadmeAction::Regenerate { workdir, no_sync } => {
                 commands::readme::regenerate(jj, workdir_or_pwd(workdir)?, no_sync)
@@ -545,6 +567,17 @@ mod tests {
                 "hello",
                 "--workdir",
                 "/tmp/wd",
+                "--no-sync",
+            ],
+            vec!["blogctl", "draft", "hello", "--workdir", "/tmp/wd"],
+            vec![
+                "blogctl",
+                "draft",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
+                "--model",
+                "anthropic/claude-opus-4-7",
                 "--no-sync",
             ],
             vec!["blogctl", "demote", "hello", "--workdir", "/tmp/wd"],
@@ -834,6 +867,7 @@ mod tests {
             vec!["blogctl", "show", "hello"],
             vec!["blogctl", "promote", "hello"],
             vec!["blogctl", "demote", "hello"],
+            vec!["blogctl", "draft", "hello"],
             vec!["blogctl", "readme", "regenerate"],
             vec!["blogctl", "doctor"],
             vec!["blogctl", "fix"],

--- a/apps/blogctl/src/commands/draft.rs
+++ b/apps/blogctl/src/commands/draft.rs
@@ -1,0 +1,120 @@
+use std::fs;
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::openrouter;
+use crate::prompts;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+
+/// Generate a draft for `slug` by rendering the configured prompt
+/// template and calling OpenRouter. The reply lands as
+/// `<workdir>/drafts/<slug>.draft-N.md` (next-free integer) — sidecar
+/// to the post so the LLM output is never silently merged into the body.
+pub fn run(
+    jj: &dyn Jj,
+    slug: String,
+    workdir: PathBuf,
+    model_override: Option<String>,
+    no_sync: bool,
+) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let (handle, post) = repo.load(&slug)?;
+    let config = repo.read_config()?;
+
+    let stage_cfg = config
+        .stage_config(post.metadata.kind, handle.stage)
+        .ok_or(Error::DraftStageUnconfigured {
+            kind: post.metadata.kind,
+            stage: handle.stage,
+        })?;
+
+    let prompt_path = repo.workdir().root().join(&stage_cfg.prompt);
+    let rendered_prompt = prompts::render(&prompt_path, &post)?;
+
+    let model = match model_override {
+        Some(m) => m,
+        None => config
+            .model_for(post.metadata.kind, handle.stage)
+            .ok_or(Error::DraftModelUnconfigured {
+                kind: post.metadata.kind,
+                stage: handle.stage,
+            })?
+            .to_string(),
+    };
+
+    let reply = openrouter::chat(&rendered_prompt, &model)?;
+
+    let drafts_dir = repo.workdir().drafts_dir();
+    fs::create_dir_all(&drafts_dir).map_err(|e| Error::io(&drafts_dir, e))?;
+    let draft_path = next_draft_path(&repo, &slug)?;
+    let draft_name = draft_path
+        .file_name()
+        .expect("draft_path always has a file name")
+        .to_string_lossy()
+        .into_owned();
+
+    let message = format!("post({slug}): draft {draft_name} via {model}");
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+
+    let written = sync::commit_and_push(jj, &workdir, &opts, &message, || {
+        fs::write(&draft_path, &reply).map_err(|e| Error::io(&draft_path, e))?;
+        Ok(draft_path.clone())
+    })?;
+
+    println!("wrote {}", written.display());
+    Ok(())
+}
+
+/// First free `drafts/<slug>.draft-N.md`, starting at N=1. The loop's
+/// upper bound exists so a bug can't spin the disk forever; a user
+/// iterating by hand will give up long before the cap fires.
+fn next_draft_path(repo: &Repository, slug: &str) -> Result<PathBuf> {
+    for n in 1..=999u32 {
+        let p = repo.workdir().draft_path(slug, n);
+        if !p.exists() {
+            return Ok(p);
+        }
+    }
+    Err(Error::DraftFloodLimit(slug.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn repo_with_drafts_dir() -> (TempDir, Repository) {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        repo.init().unwrap();
+        fs::create_dir_all(repo.workdir().drafts_dir()).unwrap();
+        (tmp, repo)
+    }
+
+    #[test]
+    fn next_draft_path_starts_at_one() {
+        let (_tmp, repo) = repo_with_drafts_dir();
+        let p = next_draft_path(&repo, "hello").unwrap();
+        assert!(p.ends_with("hello.draft-1.md"));
+    }
+
+    #[test]
+    fn next_draft_path_skips_existing_drafts() {
+        let (_tmp, repo) = repo_with_drafts_dir();
+        for n in 1..=3 {
+            fs::write(repo.workdir().draft_path("hello", n), "stub").unwrap();
+        }
+        let p = next_draft_path(&repo, "hello").unwrap();
+        assert!(p.ends_with("hello.draft-4.md"));
+    }
+
+    #[test]
+    fn next_draft_path_per_slug_numbering_is_independent() {
+        let (_tmp, repo) = repo_with_drafts_dir();
+        fs::write(repo.workdir().draft_path("alpha", 1), "stub").unwrap();
+        let p = next_draft_path(&repo, "beta").unwrap();
+        assert!(p.ends_with("beta.draft-1.md"));
+    }
+}

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod backfill;
 pub mod classify;
 pub mod demote;
 pub mod doctor;
+pub mod draft;
 pub mod fix;
 pub mod init;
 pub mod list;

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -146,6 +146,32 @@ pub enum Error {
     #[error("could not evaluate predicate {predicate:?}: {reason}")]
     PredicateEval { predicate: String, reason: String },
 
+    #[error("could not render prompt template {path}: {source}")]
+    PromptRender {
+        path: PathBuf,
+        #[source]
+        source: minijinja::Error,
+    },
+
+    #[error(
+        "no [kinds.{kind}.stages.{stage}] in .blog-os.toml — configure a prompt before running draft"
+    )]
+    DraftStageUnconfigured {
+        kind: crate::kind::Kind,
+        stage: crate::stage::Stage,
+    },
+
+    #[error(
+        "no model set for kinds.{kind}.stages.{stage} or defaults.model — pass --model or configure one"
+    )]
+    DraftModelUnconfigured {
+        kind: crate::kind::Kind,
+        stage: crate::stage::Stage,
+    },
+
+    #[error("draft slot exhausted for {0:?}: 999 drafts already exist (housekeeping needed)")]
+    DraftFloodLimit(String),
+
     #[error("could not invoke `{command}`: {source}")]
     JjInvoke {
         command: String,

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -7,6 +7,7 @@ pub mod kind;
 pub mod openrouter;
 pub mod post;
 pub mod predicate;
+pub mod prompts;
 pub mod slug;
 pub mod stage;
 pub mod storage;

--- a/apps/blogctl/src/prompts.rs
+++ b/apps/blogctl/src/prompts.rs
@@ -1,0 +1,139 @@
+//! Prompt template rendering for the config-driven stage pipeline.
+//!
+//! Templates are minijinja files (Jinja-style `{{ var }}` and `{% if %}`),
+//! resolved relative to the workdir root. Each render gets two top-level
+//! variables: `body` (the post's Markdown body, verbatim) and
+//! `frontmatter` (the full `PostMetadata` as a structured value).
+
+use std::fs;
+use std::path::Path;
+
+use minijinja::{context, Environment, Value};
+
+use crate::error::{Error, Result};
+use crate::post::Post;
+
+/// Render `template_path` against `post`. The path is taken verbatim —
+/// callers resolve workdir-relative paths themselves before calling in.
+pub fn render(template_path: &Path, post: &Post) -> Result<String> {
+    let source = fs::read_to_string(template_path).map_err(|e| Error::io(template_path, e))?;
+    render_str(template_path, &source, post)
+}
+
+/// Render an in-memory template. Useful for tests and for any future
+/// command that wants to render a string the user typed on the CLI
+/// rather than a file.
+pub fn render_str(template_path: &Path, source: &str, post: &Post) -> Result<String> {
+    let mut env = Environment::new();
+    env.add_template("prompt", source)
+        .map_err(|source| Error::PromptRender {
+            path: template_path.to_path_buf(),
+            source,
+        })?;
+    let tmpl = env.get_template("prompt").expect("template was just added");
+    let frontmatter = Value::from_serialize(&post.metadata);
+    tmpl.render(context! { body => &post.body, frontmatter => frontmatter })
+        .map_err(|source| Error::PromptRender {
+            path: template_path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+    use time::macros::datetime;
+
+    use crate::classifications::Classifications;
+    use crate::kind::Kind;
+    use crate::post::{Post, PostMetadata};
+    use crate::stage::Stage;
+
+    fn fixture_post(body: &str) -> Post {
+        Post::new(
+            PostMetadata {
+                title: "Example Title".into(),
+                slug: "example".into(),
+                kind: Kind::Post,
+                theme: "standard".into(),
+                status: Stage::Ideation,
+                created_at: datetime!(2026-05-03 00:00:00 UTC),
+                updated_at: datetime!(2026-05-03 00:00:00 UTC),
+                tags: vec!["rust".into(), "tooling".into()],
+                todoist_task_id: None,
+                history_checked: false,
+                targets: vec![],
+                classifications: Classifications::default(),
+            },
+            body,
+        )
+    }
+
+    #[test]
+    fn renders_body_variable() {
+        let post = fixture_post("seed notes");
+        let path = PathBuf::from("inline.md");
+        let out = render_str(&path, "Body: {{ body }}", &post).unwrap();
+        assert_eq!(out, "Body: seed notes");
+    }
+
+    #[test]
+    fn renders_frontmatter_scalar() {
+        let post = fixture_post("");
+        let out = render_str(
+            &PathBuf::from("inline.md"),
+            "Title: {{ frontmatter.title }}",
+            &post,
+        )
+        .unwrap();
+        assert_eq!(out, "Title: Example Title");
+    }
+
+    #[test]
+    fn renders_frontmatter_array_field() {
+        let post = fixture_post("");
+        let out = render_str(
+            &PathBuf::from("inline.md"),
+            "{% for tag in frontmatter.tags %}- {{ tag }}\n{% endfor %}",
+            &post,
+        )
+        .unwrap();
+        assert_eq!(out, "- rust\n- tooling\n");
+    }
+
+    #[test]
+    fn render_reads_template_from_disk() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("ideation-post.md");
+        fs::write(&path, "Topic: {{ frontmatter.title }}\n\n{{ body }}").unwrap();
+        let post = fixture_post("seed line");
+        let out = render(&path, &post).unwrap();
+        assert_eq!(out, "Topic: Example Title\n\nseed line");
+    }
+
+    #[test]
+    fn missing_template_file_surfaces_as_io_error() {
+        let post = fixture_post("");
+        let err = render(&PathBuf::from("/no/such/template.md"), &post).unwrap_err();
+        assert!(matches!(err, Error::Io { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn malformed_template_surfaces_as_prompt_render_error() {
+        let post = fixture_post("");
+        // Unclosed `{% if %}` block.
+        let err = render_str(
+            &PathBuf::from("inline.md"),
+            "{% if frontmatter.title %}orphan",
+            &post,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, Error::PromptRender { ref path, .. } if path == &PathBuf::from("inline.md")),
+            "got: {err:?}"
+        );
+    }
+}

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -222,6 +222,17 @@ impl Workdir {
         self.stage_dir(stage).join(format!("{slug}.md"))
     }
 
+    /// Top-level directory drafts land in. Lives outside the stage
+    /// directories so the post walk (list/doctor/audit) doesn't pick
+    /// the AI-generated drafts up as posts.
+    pub fn drafts_dir(&self) -> PathBuf {
+        self.root.join("drafts")
+    }
+
+    pub fn draft_path(&self, slug: &str, n: u32) -> PathBuf {
+        self.drafts_dir().join(format!("{slug}.draft-{n}.md"))
+    }
+
     /// All directories that should exist after `init`. Only the stage
     /// directories — prompt files live at the workdir root next to
     /// `.blog-os.toml` and `README.md`.


### PR DESCRIPTION
Add a tiny `prompts` module wrapping minijinja's environment so the
draft command (next commit) can render a workdir-relative template
against a Post's body and frontmatter.

Two entry points: `render(path, post)` reads from disk and renders;
`render_str(path, source, post)` renders an in-memory template against
a labeled path (kept around for tests and for any future CLI flag that
lets a user pass a template inline).

Template context: `body` (verbatim string) and `frontmatter` (full
PostMetadata via `serde`'s Value adapter). Anything serializable in
PostMetadata is reachable from the template; no per-field whitelist.

Add `blogctl draft <slug>` — the AI-integrated draft step of the
stage pipeline. The command loads the post, looks up
`[kinds.<kind>.stages.<current>]` in `.blog-os.toml`, renders the
configured prompt template against the post's body and frontmatter via
minijinja, calls OpenRouter with the resolved model (stage override >
defaults.model > `--model` flag), and writes the reply to
`<workdir>/drafts/<slug>.draft-N.md` where N is the first free
integer per slug.

Drafts live under a top-level `drafts/` directory rather than
alongside the post in its stage dir — the stage-dir post walk
(`list`/`doctor`/`audit_posts`) treats every `.md` file as a
frontmatter-prefixed post, and AI-generated drafts have no frontmatter.
Keeping them outside the stage layout sidesteps the parse-failure
issue without complicating the walk.

Refusing loudly when prerequisites are absent: no stage config →
DraftStageUnconfigured, no model resolvable → DraftModelUnconfigured.
Both fire before any HTTP request so a misconfigured workdir can't
silently waste tokens.

Closes #233.

#483 still tracks the `refine` and `final-edit` commands, which
follow the same shape as `draft` but with as-yet-unpinned write
semantics (replace? merge? append?). Filing them as separate issues
once we use `draft` enough to learn what those commands should do.