### PR TITLE
docs(blogctl): README updates for classifications, metrics, analytics

### DIFF
--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -37,6 +37,8 @@ at the `workdir` root next to the `config`; refresh the README from
 
 ## Commands
 
+Workflow plumbing — moving posts through the editorial pipeline:
+
 ```text
 blogctl init    --workdir <path>
 blogctl new     "Post Title" --workdir <path> [--slug SLUG]
@@ -46,11 +48,40 @@ blogctl promote <slug> --workdir <path>
 blogctl demote  <slug> --workdir <path>
 ```
 
+Classifying posts and recording per-venue performance:
+
+```text
+blogctl classify <slug> --workdir <path> \
+  [--format X] [--hook X] [--tone X] [--audience X] \
+  [--strategic-role X] [--theme A,B,...] \
+  [--clear-<dim>]
+blogctl metrics update <slug> --workdir <path> \
+  --target <linkedin|blog> \
+  --impressions N --reactions N --comments N --reposts N \
+  [--sampled-at <RFC3339>]
+blogctl metrics show <slug> --workdir <path>
+blogctl backfill --workdir <path> [--import <file.json>]
+```
+
+Analytics across the corpus — read-only, no mutations:
+
+```text
+blogctl analytics summary         --workdir <path> [--target T] [--dimension D] [--json]
+blogctl analytics compare <A> <B> --workdir <path> [--target T] [--min-n N] [--json]
+blogctl analytics recommendations --workdir <path> [--target T] [--min-n N]
+```
+
 `new` writes a fresh `.md` into `concepts/` with a slug derived from the
 title (override with `--slug`). `promote`/`demote` move the file across
 stage directories and rewrite `status:` and `updated_at:` in the
 frontmatter. `published` won't demote without a future `--force` flag;
 `abandoned` is reserved for a future explicit transition.
+
+`classify` and `metrics update` take a slug and overwrite the named
+dimensions/metrics. `metrics update` requires all four counts —
+partial samples are easier to forget than full ones. `backfill` walks
+every published post (or imports a JSON batch with `--import`) so the
+existing backlog doesn't need one-at-a-time updates.
 
 ## Markdown file format
 
@@ -60,17 +91,30 @@ title: "Example Title"
 slug: example-title
 kind: post
 theme: standard
-status: concept
+status: published
 created_at: 2026-05-03T00:00:00Z
-updated_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-14T00:00:00Z
 tags: []
-todoist_task_id: null
-history_checked: false
+classifications:
+  format: thesis
+  hook: contradiction
+  tone: sharp
+  audience: engineering
+  strategic_role: career-brand
+  theme:
+    - ambiguity
+    - delivery
 targets:
   - name: linkedin
     status: published
     url: https://www.linkedin.com/posts/example
     published_at: 2026-05-08T14:32:00Z
+    metrics:
+      impressions: 1842
+      reactions: 67
+      comments: 14
+      reposts: 5
+      sampled_at: 2026-05-14T00:00:00Z
   - name: blog
     status: planned
 ---
@@ -91,12 +135,116 @@ distribution venues and per-venue state (`planned`, `published`,
 target's `status` is `published`, both `url` and `published_at` are
 required; each venue may appear at most once per post.
 
+`classifications` (also optional, defaults to empty) are structured tag
+dimensions used by `analytics`. `targets[].metrics` records the most
+recent observed performance numbers for that venue.
+
+## Taxonomy
+
+Classifications are validated against a per-workdir taxonomy declared
+in `.blog-os.toml` under `[classifications.<dimension>]` tables:
+
+```toml
+[classifications.format]
+values = ["parable", "thesis", "essay", "observation",
+          "personal-reflection", "framework"]
+
+[classifications.hook]
+values = ["proverb", "contradiction", "direct-claim",
+          "story-title", "question", "analogy"]
+
+[classifications.tone]
+values = ["gentle", "sharp", "vulnerable", "reflective", "provocative"]
+
+[classifications.audience]
+values = ["engineering", "product", "leadership", "founders", "general"]
+
+[classifications.strategic_role]
+values = ["salal-positioning", "career-brand", "recruiting",
+          "writing-practice", "consulting-signal"]
+
+[classifications.theme]
+multi = true
+values = ["ambiguity", "delivery", "interfaces", "leadership", "ai",
+          "engineering-culture", "product", "organizational-psychology"]
+```
+
+`init` seeds these tables with the v1 defaults shown above. Adding a
+new value is a `.blog-os.toml` edit, not a code change; remove a
+dimension's table entirely to stop validating that dimension. Posts
+with values outside the declared list refuse to load — `blogctl
+doctor` surfaces the offenders.
+
+`multi = false` is the default (single-valued); `multi = true` accepts
+a list. `theme` is the only multi-valued dimension in v1.
+
+## Analytics workflow
+
+Once you've classified posts and logged metrics for a few weeks, the
+`analytics` commands surface patterns:
+
+```bash
+# 1. Draft and publish a post (existing flow).
+blogctl new "The only way out is through" --workdir ~/blog-os
+# ... edits ...
+blogctl promote the-only-way-out-is-through --workdir ~/blog-os
+# (repeat through final-editing → published)
+
+# 2. After publishing on LinkedIn, edit `targets[]` in the post's
+#    frontmatter to record `url` and `published_at` (by hand for now,
+#    or via a future helper).
+
+# 3. After a few days, log the metrics.
+blogctl metrics update the-only-way-out-is-through \
+  --target linkedin \
+  --impressions 1842 --reactions 67 --comments 14 --reposts 5 \
+  --workdir ~/blog-os
+
+# 4. Classify the post.
+blogctl classify the-only-way-out-is-through \
+  --format thesis \
+  --hook contradiction \
+  --tone sharp \
+  --audience engineering \
+  --strategic-role career-brand \
+  --theme ambiguity,delivery \
+  --workdir ~/blog-os
+
+# 5. Refresh metrics weekly. `metrics show` prints the current
+#    snapshot per target.
+blogctl metrics show the-only-way-out-is-through --workdir ~/blog-os
+
+# 6. Once you have ~15+ measured posts, look at signals:
+blogctl analytics summary         --workdir ~/blog-os
+blogctl analytics compare format hook --workdir ~/blog-os
+blogctl analytics recommendations --workdir ~/blog-os
+```
+
+For an existing backlog of published posts with no classifications or
+metrics, `blogctl backfill --workdir ~/blog-os` walks them
+interactively. With `--import file.json`, it merges a per-slug JSON
+batch in one commit — useful when the numbers came out of a CSV
+export or a one-off scrape.
+
+### A note on what analytics will (and won't) tell you
+
+Every analytics command operates on a small sample — tens of posts,
+not hundreds. The numbers are correlations, not causes; the output is
+priors for what to try next, not conclusions. `analytics
+recommendations` makes this explicit in every line (`Early signal:`,
+`Insufficient data:`, `Stale data:`) and ends every run with a closing
+reminder. Treat the other two analytics views the same way: they're
+useful for picking the next experiment, not for declaring winners.
+
 ## Extension points
 
 - `commands/` — add a new `pub fn run(...)` module and wire it into
   `cli::Command`.
 - `storage::Repository` — only place that touches the filesystem.
 - `post::Post::parse`/`render` — only place that touches YAML.
+- `analytics/` — pure-domain math (percentiles, summary, compare,
+  derived metrics, recommendations); the `commands::analytics`
+  layer only deals with text/JSON rendering.
 
 OpenRouter calls, prompt loading, historical-consistency checks, and
 `Todoist` import are deliberately out of this slice; they slot in alongside


### PR DESCRIPTION
Closes #443.

Updates apps/blogctl/README.md to reflect the analytics chain that
shipped via #433/#434/#435/#436/#437/#438/#439/#440/#441/#442.

- Commands section: now grouped into "workflow plumbing"
  (init/new/list/show/promote/demote), "classifying + per-venue
  performance" (classify/metrics update/metrics show/backfill),
  and "analytics" (summary/compare/recommendations) for skimming.
- Markdown file format: the example frontmatter now shows a
  populated classifications block plus per-target metrics. New
  paragraph explains both fields' semantics.
- New Taxonomy section: documents the [classifications.*] tables
  in .blog-os.toml, lists the v1 seed values, explains
  multi-valued vs. single-valued (theme is the lone multi).
- New Analytics workflow section: the 6-step worked example from
  the issue spec, end-to-end from `new` through analytics. The
  closing "A note on what analytics will (and won't) tell you"
  paragraph mirrors recommendations::CLOSING_REMINDER's language
  so the documentation and runtime text reinforce each other.
- Extension points list adds the analytics/ module.

Worked-example commands cross-checked against the shipped CLI via
--help — every flag and argument matches the binary. The
example uses `--workdir <path>` explicitly even though that flag
is now optional (defaults to cwd) because explicit is clearer in
documentation.

No links to issues or PRs per the issue's "issue numbers rot"
rule.