### PR TITLE
feat(todoist): 1Password-backed auth login/status/logout

### DIFF
--- a/tools/todoist/Cargo.lock
+++ b/tools/todoist/Cargo.lock
@@ -59,6 +59,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,10 +117,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -117,10 +203,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -141,6 +279,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,12 +373,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "todoist"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "tempfile",
+ "toml",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -172,10 +444,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -191,3 +521,112 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/tools/todoist/Cargo.toml
+++ b/tools/todoist/Cargo.toml
@@ -12,3 +12,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/tools/todoist/README.md
+++ b/tools/todoist/README.md
@@ -2,8 +2,27 @@
 
 Command-line client for `Todoist`. Wraps the `Todoist` REST API for the
 operations that come up often enough to want a keyboard shortcut:
-listing tasks, adding tasks, completing tasks. Authentication uses a
-1Password reference rather than a plaintext token on disk.
+listing tasks, adding tasks, completing tasks.
 
-This is a skeleton: every subcommand returns `not yet implemented`.
-Follow-up issues (#476–#479) fill in the bodies.
+## Auth
+
+The `Todoist` API token is never stored on disk in plaintext. Instead,
+`todoist` stores a 1Password secret reference (an `op://` URI) and
+resolves it on demand via the `op` command-line tool.
+
+```
+todoist auth login --op-ref "op://Personal/Todoist API/credential"
+todoist auth status
+todoist auth logout
+```
+
+The `config.toml` file lives at `$XDG_CONFIG_HOME/todoist/config.toml`
+(defaulting to `~/.config/todoist/config.toml`) and contains only
+the reference — never the token. `auth login` rejects a reference
+that `op read` cannot resolve, so a bad ref fails fast instead of
+turning into a surprise 401 later.
+
+## Status
+
+Auth is implemented (#476). Task operations are still stubs;
+follow-up issues (#477–#479) fill them in.

--- a/tools/todoist/src/auth.rs
+++ b/tools/todoist/src/auth.rs
@@ -1,0 +1,250 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Config {
+    pub token_op_ref: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct OpError {
+    pub message: String,
+}
+
+impl std::fmt::Display for OpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for OpError {}
+
+pub trait OpRunner {
+    fn read(&self, op_ref: &str) -> Result<String, OpError>;
+}
+
+pub struct RealOp;
+
+impl OpRunner for RealOp {
+    fn read(&self, op_ref: &str) -> Result<String, OpError> {
+        let output = Command::new("op")
+            .args(["read", op_ref])
+            .output()
+            .map_err(|e| OpError {
+                message: format!("could not run `op`: {e}"),
+            })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            return Err(OpError {
+                message: format!("op read failed: {stderr}"),
+            });
+        }
+        // SECURITY: never log or debug-print this string. It is the
+        // Todoist API token in plaintext, lifted from 1Password just
+        // long enough to make the request.
+        let token = String::from_utf8(output.stdout)
+            .map_err(|e| OpError {
+                message: format!("op read stdout not utf8: {e}"),
+            })?
+            .trim_end_matches('\n')
+            .to_string();
+        Ok(token)
+    }
+}
+
+pub fn default_config_path() -> Result<PathBuf> {
+    let base = if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        PathBuf::from(xdg)
+    } else {
+        let home = std::env::var("HOME").context("HOME is not set")?;
+        PathBuf::from(home).join(".config")
+    };
+    Ok(base.join("todoist").join("config.toml"))
+}
+
+pub fn login(op: &impl OpRunner, config_path: &Path, op_ref: &str) -> Result<()> {
+    op.read(op_ref)
+        .map_err(|e| anyhow!("could not resolve {op_ref}: {e}"))?;
+    let config = Config {
+        token_op_ref: op_ref.to_string(),
+    };
+    let serialized = toml::to_string(&config).context("serializing config")?;
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    std::fs::write(config_path, serialized)
+        .with_context(|| format!("writing {}", config_path.display()))?;
+    Ok(())
+}
+
+pub enum AuthState {
+    NotLoggedIn,
+    Configured {
+        op_ref: String,
+        resolve_err: Option<String>,
+    },
+}
+
+pub fn status(op: &impl OpRunner, config_path: &Path) -> Result<AuthState> {
+    if !config_path.exists() {
+        return Ok(AuthState::NotLoggedIn);
+    }
+    let raw = std::fs::read_to_string(config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let config: Config = toml::from_str(&raw).context("parsing config")?;
+    let resolve_err = op.read(&config.token_op_ref).err().map(|e| e.message);
+    Ok(AuthState::Configured {
+        op_ref: config.token_op_ref,
+        resolve_err,
+    })
+}
+
+pub fn logout(config_path: &Path) -> Result<()> {
+    match std::fs::remove_file(config_path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(anyhow::Error::new(e).context(format!("removing {}", config_path.display()))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    struct FakeOp {
+        responses: Mutex<HashMap<String, Result<String, String>>>,
+    }
+
+    impl FakeOp {
+        fn ok(op_ref: &str, value: &str) -> Self {
+            let mut m = HashMap::new();
+            m.insert(op_ref.to_string(), Ok(value.to_string()));
+            Self {
+                responses: Mutex::new(m),
+            }
+        }
+
+        fn err(op_ref: &str, message: &str) -> Self {
+            let mut m = HashMap::new();
+            m.insert(op_ref.to_string(), Err(message.to_string()));
+            Self {
+                responses: Mutex::new(m),
+            }
+        }
+    }
+
+    impl OpRunner for FakeOp {
+        fn read(&self, op_ref: &str) -> Result<String, OpError> {
+            let m = self.responses.lock().unwrap();
+            match m.get(op_ref) {
+                Some(Ok(v)) => Ok(v.clone()),
+                Some(Err(msg)) => Err(OpError {
+                    message: msg.clone(),
+                }),
+                None => Err(OpError {
+                    message: format!("unexpected ref {op_ref}"),
+                }),
+            }
+        }
+    }
+
+    fn temp_path() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested").join("config.toml");
+        (dir, path)
+    }
+
+    #[test]
+    fn config_round_trips_through_toml() {
+        let config = Config {
+            token_op_ref: "op://Personal/Todoist API/credential".to_string(),
+        };
+        let serialized = toml::to_string(&config).unwrap();
+        let parsed: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(parsed, config);
+    }
+
+    #[test]
+    fn login_writes_config_when_op_resolves() {
+        let (_dir, path) = temp_path();
+        let op = FakeOp::ok("op://Personal/Todoist/credential", "the-token");
+        login(&op, &path, "op://Personal/Todoist/credential").unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("op://Personal/Todoist/credential"));
+        assert!(!raw.contains("the-token"), "token must never hit disk");
+    }
+
+    #[test]
+    fn login_does_not_write_when_op_errors() {
+        let (_dir, path) = temp_path();
+        let op = FakeOp::err("op://Personal/Todoist/credential", "vault locked");
+        let err = login(&op, &path, "op://Personal/Todoist/credential").unwrap_err();
+        assert!(err.to_string().contains("vault locked"));
+        assert!(!path.exists(), "config must not be written on failure");
+    }
+
+    #[test]
+    fn status_reports_not_logged_in_when_config_missing() {
+        let (_dir, path) = temp_path();
+        let op = FakeOp::ok("anything", "x");
+        matches!(status(&op, &path).unwrap(), AuthState::NotLoggedIn);
+    }
+
+    #[test]
+    fn status_reports_configured_and_ok_when_resolve_succeeds() {
+        let (_dir, path) = temp_path();
+        let op = FakeOp::ok("op://x", "tok");
+        login(&op, &path, "op://x").unwrap();
+        match status(&op, &path).unwrap() {
+            AuthState::Configured {
+                op_ref,
+                resolve_err,
+            } => {
+                assert_eq!(op_ref, "op://x");
+                assert!(resolve_err.is_none());
+            }
+            _ => panic!("expected Configured"),
+        }
+    }
+
+    #[test]
+    fn status_reports_configured_with_error_when_resolve_fails() {
+        let (_dir, path) = temp_path();
+        let writable = FakeOp::ok("op://x", "tok");
+        login(&writable, &path, "op://x").unwrap();
+        let broken = FakeOp::err("op://x", "vault locked");
+        match status(&broken, &path).unwrap() {
+            AuthState::Configured {
+                op_ref,
+                resolve_err,
+            } => {
+                assert_eq!(op_ref, "op://x");
+                assert_eq!(resolve_err.as_deref(), Some("vault locked"));
+            }
+            _ => panic!("expected Configured"),
+        }
+    }
+
+    #[test]
+    fn logout_removes_existing_config() {
+        let (_dir, path) = temp_path();
+        let op = FakeOp::ok("op://x", "tok");
+        login(&op, &path, "op://x").unwrap();
+        assert!(path.exists());
+        logout(&path).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn logout_is_idempotent_when_no_config() {
+        let (_dir, path) = temp_path();
+        logout(&path).unwrap();
+    }
+}

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::{bail, Result};
 use clap::{Args, Parser, Subcommand};
 
+mod auth;
+
 #[derive(Parser)]
 #[command(name = "todoist", version, about = "Command-line client for Todoist")]
 struct Cli {
@@ -93,8 +95,46 @@ fn main() -> Result<()> {
 
 fn dispatch(command: Command) -> Result<()> {
     match command {
-        Command::Auth(_) => bail!("auth subcommands are not yet implemented"),
+        Command::Auth(AuthCmd { command }) => handle_auth(command),
         Command::Tasks(_) => bail!("tasks subcommands are not yet implemented"),
+    }
+}
+
+fn handle_auth(cmd: AuthSubcommand) -> Result<()> {
+    let path = auth::default_config_path()?;
+    let op = auth::RealOp;
+    match cmd {
+        AuthSubcommand::Login { op_ref } => {
+            auth::login(&op, &path, &op_ref)?;
+            println!("saved token reference to {}", path.display());
+            Ok(())
+        }
+        AuthSubcommand::Status => {
+            println!("{}", render_status(auth::status(&op, &path)?));
+            Ok(())
+        }
+        AuthSubcommand::Logout => {
+            auth::logout(&path)?;
+            println!("removed token reference (if any)");
+            Ok(())
+        }
+    }
+}
+
+fn render_status(state: auth::AuthState) -> String {
+    match state {
+        auth::AuthState::NotLoggedIn => "not logged in".to_string(),
+        auth::AuthState::Configured {
+            op_ref,
+            resolve_err,
+        } => {
+            let line = format!("token reference: {op_ref}");
+            let check = match resolve_err {
+                None => "resolve check: ok".to_string(),
+                Some(detail) => format!("resolve check: failed ({detail})"),
+            };
+            format!("{line}\n{check}")
+        }
     }
 }
 
@@ -180,12 +220,29 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_auth_returns_unimplemented_error() {
-        let err = dispatch(Command::Auth(AuthCmd {
-            command: AuthSubcommand::Status,
-        }))
-        .unwrap_err();
-        assert!(err.to_string().contains("auth"));
+    fn render_status_handles_not_logged_in() {
+        let out = render_status(auth::AuthState::NotLoggedIn);
+        assert_eq!(out, "not logged in");
+    }
+
+    #[test]
+    fn render_status_handles_resolved_configuration() {
+        let out = render_status(auth::AuthState::Configured {
+            op_ref: "op://x".to_string(),
+            resolve_err: None,
+        });
+        assert!(out.contains("op://x"));
+        assert!(out.contains("ok"));
+    }
+
+    #[test]
+    fn render_status_handles_failed_resolution() {
+        let out = render_status(auth::AuthState::Configured {
+            op_ref: "op://x".to_string(),
+            resolve_err: Some("vault locked".to_string()),
+        });
+        assert!(out.contains("op://x"));
+        assert!(out.contains("vault locked"));
     }
 
     #[test]


### PR DESCRIPTION
Auth subcommands now store and use a 1Password secret reference for the
Todoist API token rather than the token itself. `auth login --op-ref
<ref>` validates the reference by trying `op read` once, then writes a
TOML config holding only the `op://` URI to
`\$XDG_CONFIG_HOME/todoist/config.toml`. The token never touches disk,
env, or logs; it is fetched fresh from 1Password at request time and
held only as a local `String` for the duration of the call.

The `OpRunner` trait abstracts the shellout so tests can fake it. A
`RealOp` impl wraps `Command::new(\"op\")`; an in-test `FakeOp`
returns canned responses. `XDG_CONFIG_HOME` resolution is hand-rolled
to avoid the `dirs` crate's MPL-2.0 transitive (`option-ext`), which
isn't on the project's license allowlist.

Closes #476