### PR TITLE
feat(infra/home): publish to FlakeHub + audit rule for consumers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       base_ref: ${{ steps.base.outputs.ref }}
       blogctl: ${{ steps.filter.outputs.blogctl }}
+      home: ${{ steps.filter.outputs.home }}
       image: ${{ steps.filter.outputs.image }}
       nix-lib: ${{ steps.filter.outputs.nix-lib }}
       shaka: ${{ steps.filter.outputs.shaka }}
@@ -46,6 +47,8 @@ jobs:
             - 'apps/blogctl/**'
           image:
             - 'infra/devbox/**'
+          home:
+            - 'infra/home/**'
           nix-lib:
             - 'nix/kolohelios-nix/**'
           shaka:
@@ -154,6 +157,31 @@ jobs:
         name: linode-image
         path: result/nixos.img
         retention-days: 7
+  build-home:
+    name: Build infra/home
+    needs:
+    - preflight
+    - changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.home == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - uses: DeterminateSystems/nix-installer-action@main
+      with:
+        determinate: true
+        flakehub: true
+    - uses: DeterminateSystems/flakehub-cache-action@v3
+    - run: nix flake check ./infra/home
+    - uses: DeterminateSystems/flakehub-push@main
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      with:
+        directory: infra/home
+        name: kolohelios/home
+        rolling: true
+        visibility: public
   build-nix-lib:
     name: Build kolohelios-nix
     needs:
@@ -211,6 +239,7 @@ jobs:
     - preflight
     - build-blogctl
     - build-image
+    - build-home
     - build-nix-lib
     - build-shaka
     if: always()

--- a/infra/home/project.cue
+++ b/infra/home/project.cue
@@ -3,4 +3,21 @@ package project
 #Project & {
 	name: "home"
 	kind: "infra"
+	ci: {
+		build: {
+			filterKey:   "home"
+			jobId:       "home"
+			displayName: "infra/home"
+			// Lib-style flake (nixosModules + darwinConfigurations + devShells,
+			// no native build output); `nix flake check` forces eval of every
+			// output that flakehub-push then uploads as source.
+			nixCommand: "check"
+			publish: {
+				kind:       "flakehub"
+				name:       "kolohelios/home"
+				visibility: "public"
+				rolling:    true
+			}
+		}
+	}
 }

--- a/tools/shaka/audit-config.cue
+++ b/tools/shaka/audit-config.cue
@@ -8,6 +8,7 @@ package audit
 		{name: "rust-coverage-threshold-nonzero", severity: "fail"},
 		{name: "rust-license-dual", severity: "fail"},
 		{name: "kolohelios-nix-via-flakehub", severity: "fail"},
+		{name: "kolohelios-home-via-flakehub", severity: "fail"},
 		{name: "validate-recipe-meaningful", severity: "fail"},
 	]
 }

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -101,11 +101,13 @@ struct RustHasTests;
 struct RustCoverageThresholdNonzero;
 struct RustLicenseDual;
 struct KoloheliosNixViaFlakehub;
+struct KoloheliosHomeViaFlakehub;
 struct ValidateRecipeMeaningful;
 
 const REQUIRED_RUST_LICENSE: &str = r#"license = "MIT OR Apache-2.0""#;
 const REQUIRED_KOLOHELIOS_NIX_URL: &str =
     "https://flakehub.com/f/kolohelios/kolohelios-nix/*.tar.gz";
+const REQUIRED_KOLOHELIOS_HOME_URL: &str = "https://flakehub.com/f/kolohelios/home/*.tar.gz";
 
 impl Rule for ReadmePresent {
     fn name(&self) -> &'static str {
@@ -224,11 +226,33 @@ impl Rule for KoloheliosNixViaFlakehub {
         let Ok(contents) = std::fs::read_to_string(&flake) else {
             return RuleResult::Pass;
         };
-        match extract_kolohelios_nix_url(&contents) {
+        match extract_input_url(&contents, "kolohelios-nix") {
             None => RuleResult::Pass,
             Some(url) if url == REQUIRED_KOLOHELIOS_NIX_URL => RuleResult::Pass,
             Some(url) => RuleResult::Fail(format!(
                 "kolohelios-nix input must use FlakeHub URL `{REQUIRED_KOLOHELIOS_NIX_URL}` (found: `{url}`)"
+            )),
+        }
+    }
+}
+
+impl Rule for KoloheliosHomeViaFlakehub {
+    fn name(&self) -> &'static str {
+        "kolohelios-home-via-flakehub"
+    }
+    fn applies(&self, _meta: &ProjectMeta) -> bool {
+        true
+    }
+    fn check(&self, project_dir: &Path, _meta: &ProjectMeta) -> RuleResult {
+        let flake = project_dir.join("flake.nix");
+        let Ok(contents) = std::fs::read_to_string(&flake) else {
+            return RuleResult::Pass;
+        };
+        match extract_input_url(&contents, "home-env") {
+            None => RuleResult::Pass,
+            Some(url) if url == REQUIRED_KOLOHELIOS_HOME_URL => RuleResult::Pass,
+            Some(url) => RuleResult::Fail(format!(
+                "home-env input must use FlakeHub URL `{REQUIRED_KOLOHELIOS_HOME_URL}` (found: `{url}`)"
             )),
         }
     }
@@ -329,23 +353,25 @@ fn is_placeholder_body_line(stripped: &str) -> bool {
     matches!(body, "true" | ":")
 }
 
-// Parses an inline `kolohelios-nix.url = "<url>";` declaration, accepting
+// Parses an inline `<input_name>.url = "<url>";` declaration, accepting
 // both the in-block form (inside `inputs = { ... }`) and the top-level
-// `inputs.kolohelios-nix.url = "..."` form. Returns the URL if found,
+// `inputs.<input_name>.url = "..."` form. Returns the URL if found,
 // ignoring lines that are commented out (whitespace then `#`). Block-form
-// (`kolohelios-nix = { url = "..."; }`) is intentionally not supported —
-// every current consumer uses the inline form, and the rule fails closed
-// (returns None → Pass via "rule didn't apply") rather than silently
+// (`<input_name> = { url = "..."; }`) is intentionally not supported —
+// every current consumer uses the inline form, and callers fail closed
+// (return None → Pass via "rule didn't apply") rather than silently
 // accepting a malformed declaration.
-fn extract_kolohelios_nix_url(flake_contents: &str) -> Option<String> {
+fn extract_input_url(flake_contents: &str, input_name: &str) -> Option<String> {
+    let top_prefix = format!("inputs.{input_name}.url");
+    let block_prefix = format!("{input_name}.url");
     for line in flake_contents.lines() {
         let trimmed = line.trim_start();
         if trimmed.starts_with('#') {
             continue;
         }
         let Some(after_attr) = trimmed
-            .strip_prefix("inputs.kolohelios-nix.url")
-            .or_else(|| trimmed.strip_prefix("kolohelios-nix.url"))
+            .strip_prefix(top_prefix.as_str())
+            .or_else(|| trimmed.strip_prefix(block_prefix.as_str()))
         else {
             continue;
         };
@@ -371,6 +397,7 @@ fn rules() -> Vec<Box<dyn Rule>> {
         Box::new(RustCoverageThresholdNonzero),
         Box::new(RustLicenseDual),
         Box::new(KoloheliosNixViaFlakehub),
+        Box::new(KoloheliosHomeViaFlakehub),
         Box::new(ValidateRecipeMeaningful),
     ]
 }
@@ -1057,6 +1084,88 @@ mod tests {
         .unwrap();
         assert_eq!(
             KoloheliosNixViaFlakehub.check(tmp.path(), &infra_meta()),
+            RuleResult::Pass
+        );
+    }
+
+    #[test]
+    fn kolohelios_home_via_flakehub_passes_when_no_flake_nix() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(
+            KoloheliosHomeViaFlakehub.check(tmp.path(), &infra_meta()),
+            RuleResult::Pass
+        );
+    }
+
+    #[test]
+    fn kolohelios_home_via_flakehub_passes_when_flake_does_not_reference_input() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("flake.nix"),
+            "{ inputs.nixpkgs.url = \"github:NixOS/nixpkgs\"; outputs = { ... }: { }; }\n",
+        )
+        .unwrap();
+        assert_eq!(
+            KoloheliosHomeViaFlakehub.check(tmp.path(), &infra_meta()),
+            RuleResult::Pass
+        );
+    }
+
+    #[test]
+    fn kolohelios_home_via_flakehub_passes_for_canonical_url() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("flake.nix"),
+            "{\n  inputs = {\n    home-env.url = \"https://flakehub.com/f/kolohelios/home/*.tar.gz\";\n    nixpkgs.follows = \"kolohelios-nix/nixpkgs\";\n  };\n}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            KoloheliosHomeViaFlakehub.check(tmp.path(), &infra_meta()),
+            RuleResult::Pass
+        );
+    }
+
+    #[test]
+    fn kolohelios_home_via_flakehub_fails_for_path_input() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("flake.nix"),
+            "{\n  inputs = {\n    home-env.url = \"path:../home\";\n  };\n}\n",
+        )
+        .unwrap();
+        match KoloheliosHomeViaFlakehub.check(tmp.path(), &infra_meta()) {
+            RuleResult::Fail(msg) => {
+                assert!(msg.contains("path:../home"), "got: {msg}");
+                assert!(msg.contains("FlakeHub URL"), "got: {msg}");
+            }
+            other => panic!("expected Fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kolohelios_home_via_flakehub_fails_for_github_url() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("flake.nix"),
+            "{\n  inputs.home-env.url = \"github:kolohelios/home\";\n}\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            KoloheliosHomeViaFlakehub.check(tmp.path(), &infra_meta()),
+            RuleResult::Fail(_)
+        ));
+    }
+
+    #[test]
+    fn kolohelios_home_via_flakehub_ignores_comment_only_mentions() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("flake.nix"),
+            "{\n  # home-env.url could be a path: input from a sibling flake\n  inputs.nixpkgs.url = \"github:NixOS/nixpkgs\";\n}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            KoloheliosHomeViaFlakehub.check(tmp.path(), &infra_meta()),
             RuleResult::Pass
         );
     }


### PR DESCRIPTION
Wires `infra/home` for FlakeHub publishing so `infra/devbox` (and any
future consumer) can pin `nixosModules.home` via a FlakeHub URL rather
than a sibling `path:` reference (which fails in pure-eval mode).

- `feat(infra/home): publish to FlakeHub via shaka ci.build` — adds a
  `ci.build` block to `infra/home/project.cue` and regenerates
  `.github/workflows/main.yaml`. The new `build-home` job runs
  `nix flake check ./infra/home` on every PR that touches `infra/home/**`
  and on `push` to `main` publishes `kolohelios/home` to FlakeHub
  (rolling, public).
- `feat(shaka): add kolohelios-home-via-flakehub audit rule` — mirrors
  `kolohelios-nix-via-flakehub`: any project whose `flake.nix` declares
  an input named `home-env` must point it at the canonical FlakeHub URL.
  Catches the re-introduction of `path:../home` or
  `github:kolohelios/home` after `infra/devbox` consumes the publish.

Part of #273. The `infra/devbox` consumption (the actual close) lands in
a follow-up PR once the first publish has populated FlakeHub.