### PR TITLE
feat(infra/devbox): consume infra/home via FlakeHub

### DIFF
--- a/infra/devbox/flake.lock
+++ b/infra/devbox/flake.lock
@@ -1,5 +1,51 @@
 {
   "nodes": {
+    "home-env": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "kolohelios-nix": [
+          "kolohelios-nix"
+        ],
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779745897,
+        "narHash": "sha256-0TbWMK9dJufKwLrVuUURRqgw9bKBtgSmc1QDvad0/0k=",
+        "rev": "dc0b6a8b7911ccea6ef5eaa7a230c56e61c9f0a3",
+        "revCount": 349,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/home/0.1.349%2Brev-dc0b6a8b7911ccea6ef5eaa7a230c56e61c9f0a3/019e6129-22cb-7a52-9300-76d2c11cea43/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/kolohelios/home/%2A.tar.gz"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "home-env",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-25.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "kolohelios-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -15,6 +61,28 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/kolohelios/kolohelios-nix/%2A.tar.gz"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "home-env",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772129556,
+        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "ref": "nix-darwin-25.11",
+        "repo": "nix-darwin",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -33,6 +101,7 @@
     },
     "root": {
       "inputs": {
+        "home-env": "home-env",
         "kolohelios-nix": "kolohelios-nix",
         "nixpkgs": [
           "kolohelios-nix",

--- a/infra/devbox/flake.nix
+++ b/infra/devbox/flake.nix
@@ -4,6 +4,10 @@
   inputs = {
     kolohelios-nix.url = "https://flakehub.com/f/kolohelios/kolohelios-nix/*.tar.gz";
     nixpkgs.follows = "kolohelios-nix/nixpkgs";
+
+    home-env.url = "https://flakehub.com/f/kolohelios/home/*.tar.gz";
+    home-env.inputs.kolohelios-nix.follows = "kolohelios-nix";
+    home-env.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -11,6 +15,7 @@
       self,
       kolohelios-nix,
       nixpkgs,
+      home-env,
       ...
     }:
     let
@@ -21,12 +26,18 @@
       # invoking this flake.
       devboxConfig = lib.nixosSystem {
         system = "x86_64-linux";
-        modules = [ ./nixos/configuration.nix ];
+        modules = [
+          ./nixos/configuration.nix
+          home-env.nixosModules.home
+        ];
       };
 
       imageConfig = lib.nixosSystem {
         system = "x86_64-linux";
-        modules = [ ./nixos/image.nix ];
+        modules = [
+          ./nixos/image.nix
+          home-env.nixosModules.home
+        ];
       };
 
       x86Pkgs = import nixpkgs {

--- a/infra/devbox/nixos/configuration.nix
+++ b/infra/devbox/nixos/configuration.nix
@@ -14,6 +14,11 @@
 
   system.stateVersion = "25.05";
 
+  # `home-env.nixosModules.home` installs `claude-code` (unfree) for the
+  # `jon` user via home-manager. Mirror `infra/home/modules/darwin.nix`
+  # so eval succeeds on both platforms.
+  nixpkgs.config.allowUnfree = true;
+
   # ── Nix settings ──────────────────────────────────────────────
   nix = {
     settings = {
@@ -74,23 +79,14 @@
   services.tailscale.enable = true;
 
   # ── Core packages ─────────────────────────────────────────────
+  # `git`, `jujutsu`, `curl`, `jq`, `direnv` (with `nix-direnv`) are
+  # installed for the `jon` user by `home-env.nixosModules.home`
+  # (`infra/home/modules/common.nix`). Only system-level tools stay here.
   environment.systemPackages = with pkgs; [
-    git
-    jujutsu
     tmux
     neovim
     htop
-    curl
-    jq
-    direnv
-    nix-direnv
   ];
-
-  # ── direnv integration ────────────────────────────────────────
-  programs.direnv = {
-    enable = true;
-    nix-direnv.enable = true;
-  };
 
   # ── Persist symlinks ──────────────────────────────────────────
   # Symlink directories that should survive instance rebuilds.


### PR DESCRIPTION
Wires `infra/devbox` to consume `infra/home` via the FlakeHub publish
that landed in #504, satisfying the last open acceptance criterion of #9 — the
Linux output integrating with the existing devbox image.

- Adds `home-env` input pointing at `kolohelios/home` on FlakeHub with
  `kolohelios-nix` and `nixpkgs` follows so the inputs are unified.
- Includes `home-env.nixosModules.home` in both `devboxConfig` and
  `imageConfig` so the `jon` user gets the shared home-manager profile
  on both the live config and the Linode disk image build.
- Drops the now-duplicate `git`/`jujutsu`/`direnv`/`nix-direnv`/`jq`/`curl`
  from `environment.systemPackages` and the system-level
  `programs.direnv` block in `configuration.nix`.
- Sets `nixpkgs.config.allowUnfree = true` on devbox to match
  `infra/home/modules/darwin.nix` (the shared profile includes
  `claude-code`).

Closes #273.