### PR TITLE
feat(todoist): tasks list command

### DIFF
--- a/tools/todoist/Cargo.lock
+++ b/tools/todoist/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,7 +44,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +55,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -59,10 +65,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -117,6 +139,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -139,10 +181,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -179,10 +257,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -227,6 +408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +426,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +446,21 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "prettyplease"
@@ -285,6 +497,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,7 +520,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -356,10 +617,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -373,16 +664,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -392,8 +704,10 @@ dependencies = [
  "anyhow",
  "clap",
  "serde",
+ "serde_json",
  "tempfile",
  "toml",
+ "ureq",
 ]
 
 [[package]]
@@ -450,10 +764,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -508,10 +870,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -521,6 +910,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -623,6 +1076,95 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/tools/todoist/Cargo.toml
+++ b/tools/todoist/Cargo.toml
@@ -13,7 +13,9 @@ path = "src/main.rs"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
+ureq = { version = "2", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/tools/todoist/README.md
+++ b/tools/todoist/README.md
@@ -22,7 +22,21 @@ the reference — never the token. `auth login` rejects a reference
 that `op read` cannot resolve, so a bad ref fails fast instead of
 turning into a surprise 401 later.
 
+## Listing tasks
+
+```
+todoist tasks list [--project <name-or-id>] [--filter <todoist-filter>] \
+                   [--limit <N>] [--json]
+```
+
+`--project` accepts either a project name (resolved via `/projects`)
+or a numeric ID. `--filter` passes through the `Todoist` filter query
+language verbatim (`today`, `overdue`, `@waiting`, etc.). `--json`
+emits one raw API object per line for piping into `jq`; without it
+the output is a column table whose `id` shows the first six characters
+of the task ID for quick reference.
+
 ## Status
 
-Auth is implemented (#476). Task operations are still stubs;
-follow-up issues (#477–#479) fill them in.
+Auth (#476) and `tasks list` (#477) are implemented. `tasks add` (#478)
+and `tasks complete` (#479) are still stubs.

--- a/tools/todoist/README.md
+++ b/tools/todoist/README.md
@@ -36,7 +36,23 @@ emits one raw API object per line for piping into `jq`; without it
 the output is a column table whose `id` shows the first six characters
 of the task ID for quick reference.
 
+## Adding tasks
+
+```
+todoist tasks add <content> [--project <name-or-id>] \
+                            [--due <natural-language>] \
+                            [--priority 1|2|3|4] \
+                            [--label <name>]... \
+                            [--description <text>]
+```
+
+`--due` passes through to `Todoist`'s natural-language parser
+(`tomorrow at 3pm`, `every monday`, etc.). Priority is `1` (lowest)
+through `4` (highest) — out-of-range values are rejected before the
+request reaches the server. Repeating `--label` attaches multiple
+labels at once.
+
 ## Status
 
-Auth (#476) and `tasks list` (#477) are implemented. `tasks add` (#478)
-and `tasks complete` (#479) are still stubs.
+Auth (#476), `tasks list` (#477), and `tasks add` (#478) are
+implemented. `tasks complete` (#479) is still a stub.

--- a/tools/todoist/deny.toml
+++ b/tools/todoist/deny.toml
@@ -8,6 +8,7 @@ allow = [
     "MIT",
     "Apache-2.0",
     "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
     "ISC",
     "Unicode-3.0",
     "Unicode-DFS-2016",

--- a/tools/todoist/src/api.rs
+++ b/tools/todoist/src/api.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub const API_BASE: &str = "https://api.todoist.com/rest/v2";
 
@@ -37,6 +37,21 @@ pub struct TaskListQuery {
     pub filter: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct CreateTaskBody {
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub due_string: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u8>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
 pub trait TodoistClient {
     fn list_tasks(
         &self,
@@ -45,6 +60,12 @@ pub trait TodoistClient {
     ) -> Result<Vec<serde_json::Value>, ApiError>;
 
     fn list_projects(&self, token: &str) -> Result<Vec<Project>, ApiError>;
+
+    fn create_task(
+        &self,
+        token: &str,
+        body: &CreateTaskBody,
+    ) -> Result<serde_json::Value, ApiError>;
 }
 
 pub struct RealClient {
@@ -73,18 +94,33 @@ impl TodoistClient for RealClient {
         if let Some(filter) = &query.filter {
             req = req.query("filter", filter);
         }
-        send_json(req)
+        send_json(req.call())
     }
 
     fn list_projects(&self, token: &str) -> Result<Vec<Project>, ApiError> {
         let req = ureq::get(&format!("{}/projects", self.base))
             .set("Authorization", &format!("Bearer {token}"));
-        send_json(req)
+        send_json(req.call())
+    }
+
+    fn create_task(
+        &self,
+        token: &str,
+        body: &CreateTaskBody,
+    ) -> Result<serde_json::Value, ApiError> {
+        let req = ureq::post(&format!("{}/tasks", self.base))
+            .set("Authorization", &format!("Bearer {token}"))
+            .set("Content-Type", "application/json");
+        let payload =
+            serde_json::to_value(body).map_err(|e| ApiError::Network(format!("encode: {e}")))?;
+        send_json(req.send_json(payload))
     }
 }
 
-fn send_json<T: for<'de> Deserialize<'de>>(req: ureq::Request) -> Result<T, ApiError> {
-    match req.call() {
+fn send_json<T: for<'de> Deserialize<'de>>(
+    result: Result<ureq::Response, ureq::Error>,
+) -> Result<T, ApiError> {
+    match result {
         Ok(response) => response
             .into_json::<T>()
             .map_err(|e| ApiError::Network(format!("could not parse response: {e}"))),
@@ -124,5 +160,38 @@ mod tests {
         .to_string();
         assert!(msg.contains("500"));
         assert!(msg.contains("boom"));
+    }
+
+    #[test]
+    fn create_task_body_omits_unset_fields() {
+        let body = CreateTaskBody {
+            content: "buy milk".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"content\":\"buy milk\""));
+        assert!(!json.contains("project_id"));
+        assert!(!json.contains("due_string"));
+        assert!(!json.contains("priority"));
+        assert!(!json.contains("labels"));
+        assert!(!json.contains("description"));
+    }
+
+    #[test]
+    fn create_task_body_includes_set_fields() {
+        let body = CreateTaskBody {
+            content: "x".into(),
+            project_id: Some("42".into()),
+            due_string: Some("tomorrow".into()),
+            priority: Some(3),
+            labels: vec!["errand".into()],
+            description: Some("longer".into()),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"project_id\":\"42\""));
+        assert!(json.contains("\"due_string\":\"tomorrow\""));
+        assert!(json.contains("\"priority\":3"));
+        assert!(json.contains("\"labels\":[\"errand\"]"));
+        assert!(json.contains("\"description\":\"longer\""));
     }
 }

--- a/tools/todoist/src/api.rs
+++ b/tools/todoist/src/api.rs
@@ -1,0 +1,128 @@
+use serde::Deserialize;
+
+pub const API_BASE: &str = "https://api.todoist.com/rest/v2";
+
+#[derive(Debug)]
+pub enum ApiError {
+    Unauthorized,
+    Network(String),
+    Other { status: u16, body: String },
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unauthorized => {
+                write!(f, "token invalid; run `todoist auth login` to refresh")
+            }
+            Self::Network(msg) => write!(f, "network error: {msg}"),
+            Self::Other { status, body } => {
+                write!(f, "Todoist API returned {status}: {body}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
+pub struct Project {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TaskListQuery {
+    pub project_id: Option<String>,
+    pub filter: Option<String>,
+}
+
+pub trait TodoistClient {
+    fn list_tasks(
+        &self,
+        token: &str,
+        query: &TaskListQuery,
+    ) -> Result<Vec<serde_json::Value>, ApiError>;
+
+    fn list_projects(&self, token: &str) -> Result<Vec<Project>, ApiError>;
+}
+
+pub struct RealClient {
+    pub base: String,
+}
+
+impl Default for RealClient {
+    fn default() -> Self {
+        Self {
+            base: API_BASE.to_string(),
+        }
+    }
+}
+
+impl TodoistClient for RealClient {
+    fn list_tasks(
+        &self,
+        token: &str,
+        query: &TaskListQuery,
+    ) -> Result<Vec<serde_json::Value>, ApiError> {
+        let mut req = ureq::get(&format!("{}/tasks", self.base))
+            .set("Authorization", &format!("Bearer {token}"));
+        if let Some(pid) = &query.project_id {
+            req = req.query("project_id", pid);
+        }
+        if let Some(filter) = &query.filter {
+            req = req.query("filter", filter);
+        }
+        send_json(req)
+    }
+
+    fn list_projects(&self, token: &str) -> Result<Vec<Project>, ApiError> {
+        let req = ureq::get(&format!("{}/projects", self.base))
+            .set("Authorization", &format!("Bearer {token}"));
+        send_json(req)
+    }
+}
+
+fn send_json<T: for<'de> Deserialize<'de>>(req: ureq::Request) -> Result<T, ApiError> {
+    match req.call() {
+        Ok(response) => response
+            .into_json::<T>()
+            .map_err(|e| ApiError::Network(format!("could not parse response: {e}"))),
+        Err(ureq::Error::Status(401, _)) => Err(ApiError::Unauthorized),
+        Err(ureq::Error::Status(status, response)) => {
+            let body = response
+                .into_string()
+                .unwrap_or_else(|_| "<unreadable>".into());
+            Err(ApiError::Other { status, body })
+        }
+        Err(ureq::Error::Transport(t)) => Err(ApiError::Network(t.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unauthorized_message_directs_to_auth_login() {
+        let msg = ApiError::Unauthorized.to_string();
+        assert!(msg.contains("todoist auth login"));
+    }
+
+    #[test]
+    fn network_message_includes_detail() {
+        let msg = ApiError::Network("dns failed".into()).to_string();
+        assert!(msg.contains("dns failed"));
+    }
+
+    #[test]
+    fn other_message_includes_status_and_body() {
+        let msg = ApiError::Other {
+            status: 500,
+            body: "boom".into(),
+        }
+        .to_string();
+        assert!(msg.contains("500"));
+        assert!(msg.contains("boom"));
+    }
+}

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -133,6 +133,31 @@ fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
             }
             Ok(())
         }
+        TasksSubcommand::Add {
+            content,
+            project,
+            due,
+            priority,
+            labels,
+            description,
+        } => {
+            let token = resolve_token()?;
+            let client = api::RealClient::default();
+            let created = tasks::run_add(
+                &client,
+                &token,
+                &tasks::AddOpts {
+                    content,
+                    project,
+                    due,
+                    priority,
+                    labels,
+                    description,
+                },
+            )?;
+            println!("{}", tasks::render_added(&created));
+            Ok(())
+        }
         _ => bail!("this tasks subcommand is not yet implemented"),
     }
 }

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -1,7 +1,11 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
 
+mod api;
 mod auth;
+mod tasks;
+
+use auth::OpRunner;
 
 #[derive(Parser)]
 #[command(name = "todoist", version, about = "Command-line client for Todoist")]
@@ -96,8 +100,56 @@ fn main() -> Result<()> {
 fn dispatch(command: Command) -> Result<()> {
     match command {
         Command::Auth(AuthCmd { command }) => handle_auth(command),
-        Command::Tasks(_) => bail!("tasks subcommands are not yet implemented"),
+        Command::Tasks(TasksCmd { command }) => handle_tasks(command),
     }
+}
+
+fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
+    match cmd {
+        TasksSubcommand::List {
+            project,
+            filter,
+            limit,
+            json,
+        } => {
+            let token = resolve_token()?;
+            let client = api::RealClient::default();
+            let outcome = tasks::run_list(
+                &client,
+                &token,
+                &tasks::ListOpts {
+                    project,
+                    filter,
+                    limit,
+                },
+            )?;
+            if json {
+                println!("{}", tasks::render_ndjson(&outcome.tasks));
+            } else {
+                println!(
+                    "{}",
+                    tasks::render_table(&outcome.tasks, &outcome.projects_by_id)
+                );
+            }
+            Ok(())
+        }
+        _ => bail!("this tasks subcommand is not yet implemented"),
+    }
+}
+
+fn resolve_token() -> Result<String> {
+    let path = auth::default_config_path()?;
+    let op = auth::RealOp;
+    let raw = std::fs::read_to_string(&path).with_context(|| {
+        format!(
+            "could not read {} — run `todoist auth login` first",
+            path.display()
+        )
+    })?;
+    let config: auth::Config =
+        toml::from_str(&raw).context("could not parse stored auth config")?;
+    op.read(&config.token_op_ref)
+        .map_err(|e| anyhow!("could not resolve token from 1Password: {e}"))
 }
 
 fn handle_auth(cmd: AuthSubcommand) -> Result<()> {

--- a/tools/todoist/src/tasks.rs
+++ b/tools/todoist/src/tasks.rs
@@ -1,0 +1,312 @@
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+
+use crate::api::{Project, TaskListQuery, TodoistClient};
+
+pub const ID_PREFIX_LEN: usize = 6;
+
+#[derive(Debug, Clone)]
+pub struct ListOpts {
+    pub project: Option<String>,
+    pub filter: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub struct ListOutcome {
+    pub tasks: Vec<serde_json::Value>,
+    pub projects_by_id: HashMap<String, String>,
+}
+
+pub fn run_list(client: &impl TodoistClient, token: &str, opts: &ListOpts) -> Result<ListOutcome> {
+    let projects = client.list_projects(token).map_err(|e| anyhow!(e))?;
+    let project_id = match &opts.project {
+        Some(arg) => Some(resolve_project_id(&projects, arg)?),
+        None => None,
+    };
+    let query = TaskListQuery {
+        project_id,
+        filter: opts.filter.clone(),
+    };
+    let mut tasks = client.list_tasks(token, &query).map_err(|e| anyhow!(e))?;
+    if let Some(n) = opts.limit {
+        tasks.truncate(n);
+    }
+    let projects_by_id = projects.into_iter().map(|p| (p.id, p.name)).collect();
+    Ok(ListOutcome {
+        tasks,
+        projects_by_id,
+    })
+}
+
+pub fn resolve_project_id(projects: &[Project], arg: &str) -> Result<String> {
+    if arg.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(arg.to_string());
+    }
+    let matches: Vec<&Project> = projects.iter().filter(|p| p.name == arg).collect();
+    match matches.as_slice() {
+        [] => {
+            let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
+            Err(anyhow!(
+                "no project named {arg:?} (known: {})",
+                names.join(", ")
+            ))
+        }
+        [hit] => Ok(hit.id.clone()),
+        many => Err(anyhow!(
+            "{} projects named {arg:?} — disambiguate by id",
+            many.len()
+        )),
+    }
+}
+
+pub fn render_ndjson(tasks: &[serde_json::Value]) -> String {
+    tasks
+        .iter()
+        .map(|t| serde_json::to_string(t).unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn render_table(
+    tasks: &[serde_json::Value],
+    projects_by_id: &HashMap<String, String>,
+) -> String {
+    if tasks.is_empty() {
+        return "no tasks".to_string();
+    }
+    let rows: Vec<[String; 5]> = tasks
+        .iter()
+        .map(|t| {
+            let id = t.get("id").and_then(|v| v.as_str()).unwrap_or("");
+            let id_short = id.chars().take(ID_PREFIX_LEN).collect::<String>();
+            let content = t
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let project_id = t.get("project_id").and_then(|v| v.as_str()).unwrap_or("");
+            let project = projects_by_id
+                .get(project_id)
+                .cloned()
+                .unwrap_or_else(|| project_id.to_string());
+            let due = t
+                .get("due")
+                .and_then(|d| d.get("string"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let priority = t
+                .get("priority")
+                .and_then(|v| v.as_u64())
+                .map(|p| p.to_string())
+                .unwrap_or_default();
+            [id_short, content, project, due, priority]
+        })
+        .collect();
+
+    let headers = ["id", "content", "project", "due", "priority"];
+    let mut widths = headers.map(str::len);
+    for row in &rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+
+    let format_row = |cells: &[String; 5]| -> String {
+        cells
+            .iter()
+            .enumerate()
+            .map(|(i, c)| format!("{:width$}", c, width = widths[i]))
+            .collect::<Vec<_>>()
+            .join("  ")
+    };
+
+    let header_row = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| format!("{:width$}", h, width = widths[i]))
+        .collect::<Vec<_>>()
+        .join("  ");
+
+    let mut lines = vec![header_row];
+    lines.extend(rows.iter().map(format_row));
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{ApiError, Project, TaskListQuery, TodoistClient};
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    struct FakeClient {
+        projects: Vec<Project>,
+        tasks: Vec<serde_json::Value>,
+        last_query: RefCell<Option<TaskListQuery>>,
+    }
+
+    impl FakeClient {
+        fn new(projects: Vec<Project>, tasks: Vec<serde_json::Value>) -> Self {
+            Self {
+                projects,
+                tasks,
+                last_query: RefCell::new(None),
+            }
+        }
+    }
+
+    impl TodoistClient for FakeClient {
+        fn list_tasks(
+            &self,
+            _token: &str,
+            query: &TaskListQuery,
+        ) -> Result<Vec<serde_json::Value>, ApiError> {
+            *self.last_query.borrow_mut() = Some(query.clone());
+            Ok(self.tasks.clone())
+        }
+
+        fn list_projects(&self, _token: &str) -> Result<Vec<Project>, ApiError> {
+            Ok(self.projects.clone())
+        }
+    }
+
+    fn project(id: &str, name: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            name: name.to_string(),
+        }
+    }
+
+    fn task(
+        id: &str,
+        content: &str,
+        project_id: &str,
+        priority: u64,
+        due: Option<&str>,
+    ) -> serde_json::Value {
+        let mut obj = serde_json::json!({
+            "id": id,
+            "content": content,
+            "project_id": project_id,
+            "priority": priority,
+        });
+        if let Some(d) = due {
+            obj["due"] = serde_json::json!({ "string": d, "date": "2026-05-25" });
+        }
+        obj
+    }
+
+    #[test]
+    fn resolve_project_id_passes_numeric_through() {
+        let id = resolve_project_id(&[], "12345").unwrap();
+        assert_eq!(id, "12345");
+    }
+
+    #[test]
+    fn resolve_project_id_finds_exact_name_match() {
+        let projects = vec![project("1", "Inbox"), project("2", "Errands")];
+        let id = resolve_project_id(&projects, "Errands").unwrap();
+        assert_eq!(id, "2");
+    }
+
+    #[test]
+    fn resolve_project_id_errors_on_unknown_name() {
+        let projects = vec![project("1", "Inbox")];
+        let err = resolve_project_id(&projects, "Missing").unwrap_err();
+        assert!(err.to_string().contains("no project named"));
+        assert!(err.to_string().contains("Inbox"));
+    }
+
+    #[test]
+    fn resolve_project_id_errors_on_ambiguous_name() {
+        let projects = vec![project("1", "Dup"), project("2", "Dup")];
+        let err = resolve_project_id(&projects, "Dup").unwrap_err();
+        assert!(err.to_string().contains("disambiguate"));
+    }
+
+    #[test]
+    fn run_list_forwards_project_name_to_query_as_id() {
+        let client = FakeClient::new(vec![project("9", "Errands")], vec![]);
+        let opts = ListOpts {
+            project: Some("Errands".into()),
+            filter: None,
+            limit: None,
+        };
+        run_list(&client, "tok", &opts).unwrap();
+        let q = client.last_query.borrow();
+        assert_eq!(q.as_ref().unwrap().project_id.as_deref(), Some("9"));
+    }
+
+    #[test]
+    fn run_list_forwards_filter_unchanged() {
+        let client = FakeClient::new(vec![], vec![]);
+        let opts = ListOpts {
+            project: None,
+            filter: Some("today".into()),
+            limit: None,
+        };
+        run_list(&client, "tok", &opts).unwrap();
+        assert_eq!(
+            client
+                .last_query
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .filter
+                .as_deref(),
+            Some("today")
+        );
+    }
+
+    #[test]
+    fn run_list_truncates_to_limit() {
+        let tasks = vec![task("a", "1", "1", 1, None), task("b", "2", "1", 1, None)];
+        let client = FakeClient::new(vec![], tasks);
+        let opts = ListOpts {
+            project: None,
+            filter: None,
+            limit: Some(1),
+        };
+        let outcome = run_list(&client, "tok", &opts).unwrap();
+        assert_eq!(outcome.tasks.len(), 1);
+    }
+
+    #[test]
+    fn render_ndjson_emits_one_object_per_line() {
+        let tasks = vec![
+            task("a", "first", "1", 1, None),
+            task("b", "second", "1", 1, None),
+        ];
+        let out = render_ndjson(&tasks);
+        assert_eq!(out.lines().count(), 2);
+        assert!(out.contains("\"content\":\"first\""));
+        assert!(out.contains("\"content\":\"second\""));
+    }
+
+    #[test]
+    fn render_table_truncates_id_and_shows_project_name() {
+        let tasks = vec![task("abcdef1234567890", "buy milk", "42", 3, Some("today"))];
+        let mut projects_by_id = HashMap::new();
+        projects_by_id.insert("42".into(), "Errands".into());
+        let out = render_table(&tasks, &projects_by_id);
+        assert!(out.contains("abcdef"));
+        assert!(!out.contains("1234567890"));
+        assert!(out.contains("buy milk"));
+        assert!(out.contains("Errands"));
+        assert!(out.contains("today"));
+    }
+
+    #[test]
+    fn render_table_falls_back_to_id_when_project_unknown() {
+        let tasks = vec![task("x", "y", "99", 1, None)];
+        let out = render_table(&tasks, &HashMap::new());
+        assert!(out.contains("99"));
+    }
+
+    #[test]
+    fn render_table_reports_empty_set() {
+        let out = render_table(&[], &HashMap::new());
+        assert_eq!(out, "no tasks");
+    }
+}

--- a/tools/todoist/src/tasks.rs
+++ b/tools/todoist/src/tasks.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 
-use crate::api::{Project, TaskListQuery, TodoistClient};
+use crate::api::{CreateTaskBody, Project, TaskListQuery, TodoistClient};
 
 pub const ID_PREFIX_LEN: usize = 6;
 
@@ -57,6 +57,46 @@ pub fn resolve_project_id(projects: &[Project], arg: &str) -> Result<String> {
             many.len()
         )),
     }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AddOpts {
+    pub content: String,
+    pub project: Option<String>,
+    pub due: Option<String>,
+    pub priority: Option<u8>,
+    pub labels: Vec<String>,
+    pub description: Option<String>,
+}
+
+pub fn run_add(
+    client: &impl TodoistClient,
+    token: &str,
+    opts: &AddOpts,
+) -> Result<serde_json::Value> {
+    let project_id = match &opts.project {
+        Some(arg) => {
+            let projects = client.list_projects(token).map_err(|e| anyhow!(e))?;
+            Some(resolve_project_id(&projects, arg)?)
+        }
+        None => None,
+    };
+    let body = CreateTaskBody {
+        content: opts.content.clone(),
+        project_id,
+        due_string: opts.due.clone(),
+        priority: opts.priority,
+        labels: opts.labels.clone(),
+        description: opts.description.clone(),
+    };
+    client.create_task(token, &body).map_err(|e| anyhow!(e))
+}
+
+pub fn render_added(task: &serde_json::Value) -> String {
+    let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let prefix: String = id.chars().take(ID_PREFIX_LEN).collect();
+    let content = task.get("content").and_then(|v| v.as_str()).unwrap_or("");
+    format!("created {prefix} {content}")
 }
 
 pub fn render_ndjson(tasks: &[serde_json::Value]) -> String {
@@ -136,7 +176,7 @@ pub fn render_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::{ApiError, Project, TaskListQuery, TodoistClient};
+    use crate::api::{ApiError, CreateTaskBody, Project, TaskListQuery, TodoistClient};
     use std::cell::RefCell;
     use std::collections::HashMap;
 
@@ -144,6 +184,9 @@ mod tests {
         projects: Vec<Project>,
         tasks: Vec<serde_json::Value>,
         last_query: RefCell<Option<TaskListQuery>>,
+        last_create: RefCell<Option<CreateTaskBody>>,
+        create_response: serde_json::Value,
+        create_error: RefCell<Option<ApiError>>,
     }
 
     impl FakeClient {
@@ -152,7 +195,15 @@ mod tests {
                 projects,
                 tasks,
                 last_query: RefCell::new(None),
+                last_create: RefCell::new(None),
+                create_response: serde_json::json!({"id": "999abc12345", "content": "echo"}),
+                create_error: RefCell::new(None),
             }
+        }
+
+        fn with_create_error(mut self, err: ApiError) -> Self {
+            self.create_error = RefCell::new(Some(err));
+            self
         }
     }
 
@@ -168,6 +219,18 @@ mod tests {
 
         fn list_projects(&self, _token: &str) -> Result<Vec<Project>, ApiError> {
             Ok(self.projects.clone())
+        }
+
+        fn create_task(
+            &self,
+            _token: &str,
+            body: &CreateTaskBody,
+        ) -> Result<serde_json::Value, ApiError> {
+            *self.last_create.borrow_mut() = Some(body.clone());
+            if let Some(e) = self.create_error.borrow_mut().take() {
+                return Err(e);
+            }
+            Ok(self.create_response.clone())
         }
     }
 
@@ -308,5 +371,64 @@ mod tests {
     fn render_table_reports_empty_set() {
         let out = render_table(&[], &HashMap::new());
         assert_eq!(out, "no tasks");
+    }
+
+    #[test]
+    fn run_add_forwards_all_fields_to_create_body() {
+        let client = FakeClient::new(vec![project("9", "Errands")], vec![]);
+        let opts = AddOpts {
+            content: "buy milk".into(),
+            project: Some("Errands".into()),
+            due: Some("tomorrow".into()),
+            priority: Some(3),
+            labels: vec!["shopping".into()],
+            description: Some("organic".into()),
+        };
+        run_add(&client, "tok", &opts).unwrap();
+        let body = client.last_create.borrow().clone().unwrap();
+        assert_eq!(body.content, "buy milk");
+        assert_eq!(body.project_id.as_deref(), Some("9"));
+        assert_eq!(body.due_string.as_deref(), Some("tomorrow"));
+        assert_eq!(body.priority, Some(3));
+        assert_eq!(body.labels, vec!["shopping"]);
+        assert_eq!(body.description.as_deref(), Some("organic"));
+    }
+
+    #[test]
+    fn run_add_skips_project_lookup_when_unset() {
+        let client = FakeClient::new(vec![], vec![]);
+        let opts = AddOpts {
+            content: "x".into(),
+            ..Default::default()
+        };
+        run_add(&client, "tok", &opts).unwrap();
+        let body = client.last_create.borrow().clone().unwrap();
+        assert!(body.project_id.is_none());
+        assert!(body.labels.is_empty());
+    }
+
+    #[test]
+    fn run_add_surfaces_create_error() {
+        let client = FakeClient::new(vec![], vec![]).with_create_error(ApiError::Other {
+            status: 400,
+            body: "Bad content".into(),
+        });
+        let opts = AddOpts {
+            content: "x".into(),
+            ..Default::default()
+        };
+        let err = run_add(&client, "tok", &opts).unwrap_err();
+        assert!(err.to_string().contains("400"));
+        assert!(err.to_string().contains("Bad content"));
+    }
+
+    #[test]
+    fn render_added_uses_id_prefix_and_content() {
+        let task = serde_json::json!({"id": "abcdef9876543210", "content": "buy milk"});
+        let out = render_added(&task);
+        assert!(out.contains("created"));
+        assert!(out.contains("abcdef"));
+        assert!(!out.contains("9876543210"));
+        assert!(out.contains("buy milk"));
     }
 }


### PR DESCRIPTION
\`todoist tasks list\` now fetches active tasks via the Todoist REST API
and renders them as either a column table (default) or ndjson
(\`--json\`, for piping into \`jq\`). The default table truncates each
task ID to the first six characters; full IDs remain canonical
everywhere else.

A new \`api\` module wraps \`ureq\` behind a \`TodoistClient\` trait, so
tests fake the HTTP layer. The 401 path surfaces an actionable
\"token invalid; run \`todoist auth login\`\" rather than a raw status
code, and transport errors render as \"network error: <detail>\".

\`--project\` accepts either a numeric ID or a project name; names are
resolved by \`GET /projects\` and exact-matched (case-sensitive).
Unknown names list the known projects in the error; ambiguous names
ask the caller to disambiguate by ID. The resolver lives in \`tasks\`
so #478 can reuse it.

Closes #477