### PR TITLE
feat(blogctl): refine command — AI-assisted iteration on existing body

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -148,6 +148,25 @@ pub enum Command {
         #[arg(long)]
         no_sync: bool,
     },
+    /// Iterate on a post body via OpenRouter, seeded with the post's
+    /// title + current body. Post must be in the `editing` stage.
+    /// Requires `OPENROUTER_API_KEY` in the environment.
+    Refine {
+        slug: String,
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Refinement instruction to send to the model (alongside the
+        /// post's title + current body).
+        #[arg(long)]
+        prompt: String,
+        /// OpenRouter model identifier.
+        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
+        model: String,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// Set classification dimensions on a post (format, hook, tone,
     /// audience, strategic-role, theme). Missing flags leave the
     /// existing value alone; `--clear-<dim>` removes it.
@@ -394,6 +413,22 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
         } => commands::draft::run(
             jj,
             commands::draft::DraftArgs {
+                slug,
+                workdir: workdir_or_pwd(workdir)?,
+                prompt,
+                model,
+                no_sync,
+            },
+        ),
+        Command::Refine {
+            slug,
+            workdir,
+            prompt,
+            model,
+            no_sync,
+        } => commands::refine::run(
+            jj,
+            commands::refine::RefineArgs {
                 slug,
                 workdir: workdir_or_pwd(workdir)?,
                 prompt,

--- a/apps/blogctl/src/commands/draft.rs
+++ b/apps/blogctl/src/commands/draft.rs
@@ -170,6 +170,7 @@ mod tests {
                 model: "old-model".into(),
                 generated_at: OffsetDateTime::UNIX_EPOCH,
             }),
+            refine: None,
         };
         let h = merge_draft_record(
             Some(prior),

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -12,4 +12,5 @@ pub mod metrics;
 pub mod new;
 pub mod promote;
 pub mod readme;
+pub mod refine;
 pub mod show;

--- a/apps/blogctl/src/commands/refine.rs
+++ b/apps/blogctl/src/commands/refine.rs
@@ -1,0 +1,225 @@
+//! `blogctl refine <slug> --prompt <text>` — iterate on a post body via
+//! OpenRouter, seeded by the post's title + current body + a single
+//! user instruction.
+//!
+//! Operates on `Editing`-stage posts only. Other stages error; the
+//! intent is that `refine` iterates on the draft that `draft` produced.
+//! Polish-pass belongs to a future `final-edit` command (#483).
+//!
+//! Replaces the post body with the model's reply and records an audit
+//! trail in `metadata.ai.refine`. Prior `ai.draft` (and any future
+//! `ai.<other>`) records are preserved.
+//!
+//! Only the most-recent `refine` is stored; earlier passes live in `jj`
+//! history. Promoting `ai.refine` to a `Vec<AiRefineRecord>` is
+//! deliberately deferred until the audit-trail use case demands it.
+
+use std::fs;
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::openrouter;
+use crate::post::{AiHistory, AiRefineRecord};
+use crate::stage::Stage;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+
+#[derive(Debug)]
+pub struct RefineArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+    pub prompt: String,
+    pub model: String,
+    pub no_sync: bool,
+}
+
+pub fn run(jj: &dyn Jj, args: RefineArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let (handle, mut post) = repo.load_raw(&args.slug)?;
+
+    if handle.stage != Stage::Editing {
+        return Err(Error::RefineWrongStage {
+            slug: args.slug,
+            stage: handle.stage,
+        });
+    }
+
+    let llm_prompt = build_prompt(&post.metadata.title, &post.body, &args.prompt);
+    let reply = openrouter::chat(&llm_prompt, &args.model)?;
+
+    post.body = reply;
+    post.metadata.ai = Some(merge_refine_record(
+        post.metadata.ai.take(),
+        AiRefineRecord {
+            prompt: args.prompt.clone(),
+            model: args.model.clone(),
+            generated_at: OffsetDateTime::now_utc(),
+        },
+    ));
+
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let message = format!("post({}): refine via {}", args.slug, args.model);
+    let path = handle.path.clone();
+    let model = args.model.clone();
+    let slug = args.slug.clone();
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        post.metadata.updated_at = OffsetDateTime::now_utc();
+        let rendered = post.render()?;
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))?;
+        Ok(())
+    })?;
+    println!("{slug}: refined via {model}");
+    Ok(())
+}
+
+/// Compose the LLM prompt: small preamble framing the task as
+/// iteration, then the post's title and current body as context, then
+/// the user's refinement instruction. Kept as a separate fn so the
+/// shape is unit-testable without spinning up a mock server.
+fn build_prompt(title: &str, current_body: &str, user_prompt: &str) -> String {
+    let mut s = String::with_capacity(
+        // Rough size estimate; the +256 covers the boilerplate.
+        title.len() + current_body.len() + user_prompt.len() + 256,
+    );
+    s.push_str(
+        "You are iterating on an existing blog post draft. \
+         Produce the revised post body in Markdown. \
+         Do not include a title, frontmatter, or commentary about your output — \
+         only the body text the reader will see.\n\n",
+    );
+    s.push_str("Title: ");
+    s.push_str(title);
+    s.push_str("\n\n");
+    if !current_body.trim().is_empty() {
+        s.push_str("Current body:\n");
+        s.push_str(current_body.trim());
+        s.push_str("\n\n");
+    }
+    s.push_str("Author instruction: ");
+    s.push_str(user_prompt);
+    s
+}
+
+/// Fold a new `AiRefineRecord` into the post's optional `AiHistory`,
+/// preserving any other AI-history fields (notably `ai.draft` from an
+/// earlier `draft` invocation).
+fn merge_refine_record(existing: Option<AiHistory>, new_refine: AiRefineRecord) -> AiHistory {
+    let mut history = existing.unwrap_or_default();
+    history.refine = Some(new_refine);
+    history
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::post::AiDraftRecord;
+
+    #[test]
+    fn prompt_includes_title_and_user_instruction() {
+        let p = build_prompt("The Title", "draft body", "tighten paragraph two");
+        assert!(p.contains("Title: The Title"));
+        assert!(p.contains("Author instruction: tighten paragraph two"));
+    }
+
+    #[test]
+    fn prompt_includes_current_body_when_non_empty() {
+        let p = build_prompt("T", "existing draft text", "trim");
+        assert!(p.contains("Current body:"));
+        assert!(p.contains("existing draft text"));
+    }
+
+    #[test]
+    fn prompt_skips_body_block_when_empty() {
+        // Refine on an empty body is silly (use draft), but the
+        // helper handles it gracefully rather than emitting a
+        // misleading "Current body:" header over nothing.
+        let p = build_prompt("T", "", "go");
+        assert!(!p.contains("Current body:"));
+    }
+
+    #[test]
+    fn prompt_skips_body_block_when_whitespace() {
+        let p = build_prompt("T", "   \n  \t\n", "go");
+        assert!(!p.contains("Current body:"));
+    }
+
+    #[test]
+    fn prompt_specifies_markdown_and_excludes_frontmatter() {
+        let p = build_prompt("T", "draft", "go");
+        assert!(p.to_lowercase().contains("markdown"));
+        assert!(p.to_lowercase().contains("frontmatter"));
+    }
+
+    #[test]
+    fn prompt_frames_task_as_iteration_not_drafting() {
+        // Different preamble from `draft`'s — the model should know
+        // it's editing existing content, not generating from a seed.
+        let p = build_prompt("T", "draft", "polish");
+        assert!(p.to_lowercase().contains("iterating"));
+    }
+
+    #[test]
+    fn merge_creates_history_when_none_existed() {
+        let h = merge_refine_record(
+            None,
+            AiRefineRecord {
+                prompt: "p".into(),
+                model: "m".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert!(h.refine.is_some());
+        assert!(h.draft.is_none());
+    }
+
+    #[test]
+    fn merge_preserves_prior_draft_record() {
+        // A post that went through `draft` then `refine` should keep
+        // its `ai.draft` block as audit trail for the original
+        // generation — never overwrite it.
+        let prior = AiHistory {
+            draft: Some(AiDraftRecord {
+                prompt: "draft-prompt".into(),
+                model: "draft-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+            refine: None,
+        };
+        let h = merge_refine_record(
+            Some(prior),
+            AiRefineRecord {
+                prompt: "refine-prompt".into(),
+                model: "refine-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert_eq!(h.draft.unwrap().prompt, "draft-prompt");
+        assert_eq!(h.refine.unwrap().prompt, "refine-prompt");
+    }
+
+    #[test]
+    fn merge_overwrites_prior_refine_record() {
+        let prior = AiHistory {
+            draft: None,
+            refine: Some(AiRefineRecord {
+                prompt: "old".into(),
+                model: "old-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+        };
+        let h = merge_refine_record(
+            Some(prior),
+            AiRefineRecord {
+                prompt: "new".into(),
+                model: "new-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert_eq!(h.refine.unwrap().prompt, "new");
+    }
+}

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -45,6 +45,11 @@ pub enum Error {
     )]
     DraftWrongStage { slug: String, stage: Stage },
 
+    #[error(
+        "cannot refine post {slug:?} from stage {stage}: refining requires the post to be in the `editing` stage"
+    )]
+    RefineWrongStage { slug: String, stage: Stage },
+
     #[error("cannot demote from {0}: already at the first workflow stage")]
     DemoteFromInitial(Stage),
 

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -62,10 +62,23 @@ pub struct PostMetadata {
 pub struct AiHistory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub draft: Option<AiDraftRecord>,
+    /// Most-recent `blogctl refine` invocation. Overwrites on each
+    /// run — multi-pass history (a `Vec<AiRefineRecord>`) is deferred
+    /// per #506's scope. Earlier refines live in `jj` history.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refine: Option<AiRefineRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AiDraftRecord {
+    pub prompt: String,
+    pub model: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub generated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AiRefineRecord {
     pub prompt: String,
     pub model: String,
     #[serde(with = "time::serde::rfc3339")]

--- a/apps/blogctl/tests/workflow.rs
+++ b/apps/blogctl/tests/workflow.rs
@@ -6,12 +6,12 @@
 //! directory rename, taxonomy mismatch) — gaps unit tests miss because
 //! each one stays inside one module's contract.
 //!
-//! The AI-touching path lands here too via `lifecycle_with_draft`,
-//! which drives `commands::draft` against a `mockito` server using the
-//! `OPENROUTER_API_BASE` seam (#474). Once the rest of the
-//! AI-integrated commands tracked in #483 land (`refine`,
-//! `final-edit`), they'll extend the same test rather than spawning
-//! new ones.
+//! The AI-touching path lands here too via `lifecycle_with_ai_commands`,
+//! which drives `commands::draft` and `commands::refine` against a
+//! `mockito` server using the `OPENROUTER_API_BASE` seam (#474). The
+//! `mock_chat_completion` helper makes adding the next AI command
+//! (`final-edit`, ... tracked in #483) one more line, not a copy of
+//! the JSON envelope.
 
 use std::env;
 use std::path::PathBuf;
@@ -19,7 +19,9 @@ use std::sync::Mutex;
 
 use tempfile::TempDir;
 
-use blogctl::commands::{self, classify::ClassifyArgs, draft::DraftArgs, metrics::UpdateArgs};
+use blogctl::commands::{
+    self, classify::ClassifyArgs, draft::DraftArgs, metrics::UpdateArgs, refine::RefineArgs,
+};
 use blogctl::error::Error;
 use blogctl::kind::Kind;
 use blogctl::stage::Stage;
@@ -34,29 +36,41 @@ use blogctl::target::{Target, TargetEntry, TargetStatus};
 // interfere with each other.
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-const CANNED_DRAFT_REPLY: &str =
-    "## Drafted body\n\nFirst paragraph from the mock.\n\nSecond paragraph from the mock.\n";
-
-const CANNED_OPENROUTER_RESPONSE: &str = r###"{
-  "id": "gen-test-001",
-  "object": "chat.completion",
-  "model": "test-model",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "## Drafted body\n\nFirst paragraph from the mock.\n\nSecond paragraph from the mock.\n"
-      },
-      "finish_reason": "stop"
-    }
-  ]
-}"###;
-
 fn fresh_workdir() -> (TempDir, PathBuf) {
     let tmp = TempDir::new().expect("tempdir");
     let path = tmp.path().to_path_buf();
     (tmp, path)
+}
+
+/// Register a one-shot `/chat/completions` mock that returns `content`
+/// wrapped in an OpenRouter chat-completion envelope. Each call queues
+/// one canned reply; sequential AI commands consume them in
+/// registration order. Adding a new AI-touching command to the
+/// lifecycle test is one more `mock_chat_completion(&mut server, ...)`
+/// call rather than a new JSON literal.
+fn mock_chat_completion(server: &mut mockito::Server, content: &str) -> mockito::Mock {
+    let body = format!(
+        r###"{{
+  "id": "gen-test",
+  "object": "chat.completion",
+  "model": "test-model",
+  "choices": [
+    {{
+      "index": 0,
+      "message": {{ "role": "assistant", "content": {content_json} }},
+      "finish_reason": "stop"
+    }}
+  ]
+}}"###,
+        content_json = serde_json::to_string(content).expect("content is utf-8")
+    );
+    server
+        .mock("POST", "/chat/completions")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .expect(1)
+        .create()
 }
 
 fn promote_to_published(workdir: &PathBuf, slug: &str) {
@@ -180,20 +194,22 @@ fn lifecycle_init_new_classify_promote_metrics() {
     assert_eq!(m.reposts, 3);
 }
 
-/// Drive an `Ideation`-stage post through `commands::draft` against a
-/// `mockito` server. Asserts the body was replaced with the mock's
-/// reply and the `ai.draft` audit block was populated. Also asserts
-/// that drafting from a non-`Ideation` stage errors cleanly.
+const DRAFT_REPLY: &str =
+    "## Drafted body\n\nFirst paragraph from the mock.\n\nSecond paragraph from the mock.\n";
+const REFINE_REPLY: &str =
+    "## Refined body\n\nTighter first paragraph.\n\nTighter second paragraph.\n";
+
+/// Drive the AI-touching path of the lifecycle end-to-end against a
+/// `mockito` server: draft into an Ideation post, promote to Editing,
+/// refine. Asserts on body replacement and the `ai.draft` / `ai.refine`
+/// audit blocks. Also exercises the negative paths (draft from Concept,
+/// refine from Ideation) so the stage-gating regressions land here too.
 #[test]
-fn lifecycle_with_draft_uses_mocked_openrouter() {
+fn lifecycle_with_ai_commands_uses_mocked_openrouter() {
     let _guard = ENV_LOCK.lock().unwrap();
     let mut server = mockito::Server::new();
-    let mock = server
-        .mock("POST", "/chat/completions")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(CANNED_OPENROUTER_RESPONSE)
-        .create();
+    let mock_draft = mock_chat_completion(&mut server, DRAFT_REPLY);
+    let mock_refine = mock_chat_completion(&mut server, REFINE_REPLY);
 
     let prev_base = env::var("OPENROUTER_API_BASE").ok();
     let prev_key = env::var("OPENROUTER_API_KEY").ok();
@@ -203,7 +219,7 @@ fn lifecycle_with_draft_uses_mocked_openrouter() {
     );
     env::set_var("OPENROUTER_API_KEY", "test-key");
 
-    let result = run_draft_lifecycle();
+    let result = run_ai_lifecycle();
 
     match prev_base {
         Some(v) => env::set_var("OPENROUTER_API_BASE", v),
@@ -214,27 +230,28 @@ fn lifecycle_with_draft_uses_mocked_openrouter() {
         None => env::remove_var("OPENROUTER_API_KEY"),
     }
 
-    result.expect("draft lifecycle should succeed");
-    mock.assert();
+    result.expect("ai lifecycle should succeed");
+    mock_draft.assert();
+    mock_refine.assert();
 }
 
-fn run_draft_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
+fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp, workdir) = fresh_workdir();
     commands::init::run(&FakeJj::new(), workdir.clone(), true)?;
     commands::new::run(
         &FakeJj::new(),
-        "Draft test post".into(),
+        "Ai test post".into(),
         workdir.clone(),
         None,
         Kind::Post,
         None,
         true,
     )?;
-    let slug = "draft-test-post";
+    let slug = "ai-test-post";
 
-    // Trying to draft at Concept must fail with DraftWrongStage. Catch
-    // before promoting so the negative path is exercised inside the
-    // same lifecycle test instead of a tiny standalone case.
+    // Draft at Concept must fail with DraftWrongStage. Catch the
+    // negative path here so the stage-gating regression doesn't need
+    // its own standalone test.
     let err = commands::draft::run(
         &FakeJj::new(),
         DraftArgs {
@@ -251,8 +268,8 @@ fn run_draft_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
         "expected DraftWrongStage, got: {err:?}"
     );
 
+    // Concept → Ideation, then draft.
     commands::promote::run(&FakeJj::new(), slug.to_string(), workdir.clone(), true)?;
-
     commands::draft::run(
         &FakeJj::new(),
         DraftArgs {
@@ -268,12 +285,64 @@ fn run_draft_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
     let (_, post) = repo.load(slug)?;
     assert_eq!(
         post.body.trim(),
-        CANNED_DRAFT_REPLY.trim(),
-        "body should match the canned mock reply"
+        DRAFT_REPLY.trim(),
+        "body should match the canned draft reply"
     );
-    let ai = post.metadata.ai.as_ref().expect("ai block populated");
-    let draft = ai.draft.as_ref().expect("ai.draft populated");
+    let ai = post
+        .metadata
+        .ai
+        .as_ref()
+        .expect("ai block populated post-draft");
+    assert!(ai.draft.is_some(), "ai.draft set post-draft");
+    assert!(ai.refine.is_none(), "ai.refine not set yet");
+
+    // Refine at Ideation must fail with RefineWrongStage. Same
+    // pattern as the draft check above.
+    let err = commands::refine::run(
+        &FakeJj::new(),
+        RefineArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: "tighten".into(),
+            model: "test-model".into(),
+            no_sync: true,
+        },
+    )
+    .expect_err("refine at Ideation must error");
+    assert!(
+        matches!(err, Error::RefineWrongStage { .. }),
+        "expected RefineWrongStage, got: {err:?}"
+    );
+
+    // Ideation → Editing, then refine.
+    commands::promote::run(&FakeJj::new(), slug.to_string(), workdir.clone(), true)?;
+    commands::refine::run(
+        &FakeJj::new(),
+        RefineArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: "tighten paragraphs".into(),
+            model: "test-model".into(),
+            no_sync: true,
+        },
+    )?;
+
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let (_, post) = repo.load(slug)?;
+    assert_eq!(
+        post.body.trim(),
+        REFINE_REPLY.trim(),
+        "body should match the canned refine reply"
+    );
+    let ai = post
+        .metadata
+        .ai
+        .as_ref()
+        .expect("ai block populated post-refine");
+    let draft = ai.draft.as_ref().expect("ai.draft preserved across refine");
     assert_eq!(draft.prompt, "write me three paragraphs about mocking");
-    assert_eq!(draft.model, "test-model");
+    let refine = ai.refine.as_ref().expect("ai.refine set post-refine");
+    assert_eq!(refine.prompt, "tighten paragraphs");
+    assert_eq!(refine.model, "test-model");
     Ok(())
 }


### PR DESCRIPTION
Second slice of the AI-integrated content workflow tracked in #483,
following `draft` (#494). `blogctl refine <slug> --prompt <text>` runs
OpenRouter against a post that's already been drafted, replacing the
body with the model's iterated version.

Gates on `Editing` stage. Drafting belongs to `Ideation`, refining to
`Editing`, and the future `final-edit` will gate on `FinalEditing` —
each stage maps to one AI-touching command in the lifecycle.

Records an audit trail in `metadata.ai.refine` alongside the existing
`ai.draft`. The merge helper preserves `ai.draft` across refine
invocations so a future reader can see both the original generation
prompt and the most-recent refine prompt. Multi-pass refine history
(a `Vec<AiRefineRecord>`) is deferred per #506's scope; earlier
refines live in `jj` history.

`tests/workflow.rs` grows a `mock_chat_completion(&mut server,
content)` helper so each AI-touching command's mock is one line, not
a copy of the OpenRouter response envelope. The new `lifecycle_with_
ai_commands_uses_mocked_openrouter` test exercises draft → promote →
refine end-to-end and covers both wrong-stage error paths
(`DraftWrongStage` from `Concept`, `RefineWrongStage` from
`Ideation`). The pre-existing `lifecycle_with_draft_*` test is
absorbed into it — same coverage, no fragmentation.

Closes #506