### PR TITLE
feat(apps/pollen-alert): forecast provider trait + Open-Meteo impl

### DIFF
--- a/apps/pollen-alert/Cargo.lock
+++ b/apps/pollen-alert/Cargo.lock
@@ -344,7 +344,11 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 name = "pollen-alert"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
+ "serde",
+ "serde_json",
+ "tokio",
  "worker",
 ]
 
@@ -531,6 +535,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/pollen-alert/Cargo.toml
+++ b/apps/pollen-alert/Cargo.toml
@@ -9,12 +9,25 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+# Async trait methods. Worker callbacks are async; the forecast trait
+# is `async fn fetch` so the natural impl works with `worker::Fetch`
+# without `Pin<Box<...>>` boilerplate.
+async-trait = "0.1"
 # `default-features = false` drops chrono's default `clock` feature
 # (which pulls in libc time functions unavailable on
-# `wasm32-unknown-unknown`); the scoring module only needs
-# `NaiveDate` / `NaiveDateTime` arithmetic.
+# `wasm32-unknown-unknown`). The forecast parser captures Open-Meteo
+# timestamps as `String` and uses `NaiveDateTime::parse_from_str` to
+# handle the seconds-less format — no chrono `serde` feature needed.
 chrono = { version = "0.4", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 worker = "0.8"
+
+[dev-dependencies]
+# `tokio = { rt, macros }` lets native integration tests run async
+# code via `#[tokio::test]`. The Worker runtime doesn't need tokio
+# (worker has its own executor); this is host-side only.
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [profile.release]
 opt-level = "s"

--- a/apps/pollen-alert/src/forecast.rs
+++ b/apps/pollen-alert/src/forecast.rs
@@ -1,0 +1,231 @@
+//! Forecast access for the scoring pipeline.
+//!
+//! `ForecastProvider` is the trait the worker entrypoint depends on;
+//! `OpenMeteoProvider` is the only implementation today (Open-Meteo
+//! is free + key-less + exposes the four fields scoring needs on an
+//! hourly grid). HTTP is abstracted behind `HttpFetcher` so native
+//! tests can replay fixture JSON without hitting the network.
+
+use async_trait::async_trait;
+use chrono::NaiveDateTime;
+use serde::Deserialize;
+
+use crate::scoring::{ForecastHour, Sky};
+
+#[derive(Debug)]
+pub enum ForecastError {
+    Http(String),
+    Parse(String),
+    /// The provider returned arrays whose lengths don't line up;
+    /// usually a sign of a partial response.
+    LengthMismatch {
+        hours: usize,
+        field: &'static str,
+    },
+}
+
+impl std::fmt::Display for ForecastError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "forecast http: {e}"),
+            Self::Parse(e) => write!(f, "forecast parse: {e}"),
+            Self::LengthMismatch { hours, field } => {
+                write!(f, "forecast: {field} has wrong length vs hours ({hours})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ForecastError {}
+
+/// Thin HTTP boundary the provider depends on. The worker impl wraps
+/// `worker::Fetch`; native tests use a fixture-replaying fake so the
+/// parser is exercised without a real network round-trip.
+#[async_trait(?Send)]
+pub trait HttpFetcher {
+    async fn get(&self, url: &str) -> Result<String, ForecastError>;
+}
+
+#[async_trait(?Send)]
+pub trait ForecastProvider {
+    async fn fetch(&self, lat: f32, lon: f32, tz: &str)
+        -> Result<Vec<ForecastHour>, ForecastError>;
+}
+
+pub struct OpenMeteoProvider<F: HttpFetcher> {
+    pub fetcher: F,
+}
+
+impl<F: HttpFetcher> OpenMeteoProvider<F> {
+    pub fn new(fetcher: F) -> Self {
+        Self { fetcher }
+    }
+}
+
+#[async_trait(?Send)]
+impl<F: HttpFetcher> ForecastProvider for OpenMeteoProvider<F> {
+    async fn fetch(
+        &self,
+        lat: f32,
+        lon: f32,
+        tz: &str,
+    ) -> Result<Vec<ForecastHour>, ForecastError> {
+        let url = format!(
+            "https://api.open-meteo.com/v1/forecast?\
+             latitude={lat}&longitude={lon}\
+             &hourly=relative_humidity_2m,wind_speed_10m,\
+             precipitation_probability,cloud_cover\
+             &wind_speed_unit=mph&timezone={tz}"
+        );
+        let body = self.fetcher.get(&url).await?;
+        parse_open_meteo(&body)
+    }
+}
+
+/// Open-Meteo response shape (subset we care about). Hourly fields
+/// come back as parallel arrays — `time[i]` lines up with
+/// `relative_humidity_2m[i]` and so on. The parser walks the indices
+/// and builds `ForecastHour` rows; mismatched lengths fail loudly
+/// instead of producing garbage.
+#[derive(Debug, Deserialize)]
+struct OpenMeteoResponse {
+    hourly: OpenMeteoHourly,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenMeteoHourly {
+    // Open-Meteo returns times without seconds (`2026-04-15T22:00`),
+    // which chrono's default `NaiveDateTime` deserializer rejects.
+    // Capture as strings and parse with an explicit format below.
+    time: Vec<String>,
+    relative_humidity_2m: Vec<f32>,
+    wind_speed_10m: Vec<f32>,
+    precipitation_probability: Vec<f32>,
+    cloud_cover: Vec<f32>,
+}
+
+const OPEN_METEO_TIME_FMT: &str = "%Y-%m-%dT%H:%M";
+
+fn parse_open_meteo(body: &str) -> Result<Vec<ForecastHour>, ForecastError> {
+    let resp: OpenMeteoResponse =
+        serde_json::from_str(body).map_err(|e| ForecastError::Parse(e.to_string()))?;
+    let h = &resp.hourly;
+    let n = h.time.len();
+    if h.relative_humidity_2m.len() != n {
+        return Err(ForecastError::LengthMismatch {
+            hours: n,
+            field: "relative_humidity_2m",
+        });
+    }
+    if h.wind_speed_10m.len() != n {
+        return Err(ForecastError::LengthMismatch {
+            hours: n,
+            field: "wind_speed_10m",
+        });
+    }
+    if h.precipitation_probability.len() != n {
+        return Err(ForecastError::LengthMismatch {
+            hours: n,
+            field: "precipitation_probability",
+        });
+    }
+    if h.cloud_cover.len() != n {
+        return Err(ForecastError::LengthMismatch {
+            hours: n,
+            field: "cloud_cover",
+        });
+    }
+
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let local_time = NaiveDateTime::parse_from_str(&h.time[i], OPEN_METEO_TIME_FMT)
+            .map_err(|e| ForecastError::Parse(format!("time[{i}]: {e}")))?;
+        out.push(ForecastHour {
+            local_time,
+            humidity_pct: h.relative_humidity_2m[i],
+            wind_mph: h.wind_speed_10m[i],
+            precip_prob_pct: h.precipitation_probability[i],
+            sky: Some(cloud_cover_to_sky(h.cloud_cover[i])),
+        });
+    }
+    Ok(out)
+}
+
+/// Map Open-Meteo's continuous cloud-cover percent into the categorical
+/// `Sky` the scorer accepts. Boundaries are NWS-ish ("clear" through
+/// 25%, "scattered" 26-50%, etc.); refine if false-positives in the
+/// scoring side bite.
+fn cloud_cover_to_sky(pct: f32) -> Sky {
+    match pct as u8 {
+        0..=25 => Sky::Clear,
+        26..=50 => Sky::PartlyCloudy,
+        51..=75 => Sky::MostlyCloudy,
+        _ => Sky::Overcast,
+    }
+}
+
+/// `worker::Fetch`-backed HTTP fetcher for the Cloudflare Worker
+/// runtime. Compiled out on native targets so `cargo test` doesn't
+/// need to depend on the wasm runtime.
+#[cfg(target_arch = "wasm32")]
+pub struct WorkerFetcher;
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait(?Send)]
+impl HttpFetcher for WorkerFetcher {
+    async fn get(&self, url: &str) -> Result<String, ForecastError> {
+        use worker::{Fetch, Method, Request, RequestInit};
+        let req = Request::new_with_init(url, RequestInit::new().with_method(Method::Get))
+            .map_err(|e| ForecastError::Http(e.to_string()))?;
+        let mut resp = Fetch::Request(req)
+            .send()
+            .await
+            .map_err(|e| ForecastError::Http(e.to_string()))?;
+        resp.text()
+            .await
+            .map_err(|e| ForecastError::Http(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cloud_cover_boundaries() {
+        assert_eq!(cloud_cover_to_sky(0.0), Sky::Clear);
+        assert_eq!(cloud_cover_to_sky(25.0), Sky::Clear);
+        assert_eq!(cloud_cover_to_sky(26.0), Sky::PartlyCloudy);
+        assert_eq!(cloud_cover_to_sky(50.0), Sky::PartlyCloudy);
+        assert_eq!(cloud_cover_to_sky(51.0), Sky::MostlyCloudy);
+        assert_eq!(cloud_cover_to_sky(75.0), Sky::MostlyCloudy);
+        assert_eq!(cloud_cover_to_sky(76.0), Sky::Overcast);
+        assert_eq!(cloud_cover_to_sky(100.0), Sky::Overcast);
+    }
+
+    #[test]
+    fn parser_rejects_mismatched_array_lengths() {
+        let body = r#"{
+            "hourly": {
+                "time": ["2026-04-15T22:00"],
+                "relative_humidity_2m": [80.0, 85.0],
+                "wind_speed_10m": [2.0],
+                "precipitation_probability": [10.0],
+                "cloud_cover": [20.0]
+            }
+        }"#;
+        let err = parse_open_meteo(body).expect_err("length mismatch");
+        match err {
+            ForecastError::LengthMismatch { field, .. } => {
+                assert_eq!(field, "relative_humidity_2m");
+            }
+            other => panic!("expected LengthMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parser_rejects_malformed_json() {
+        let err = parse_open_meteo("not json").expect_err("parse error");
+        assert!(matches!(err, ForecastError::Parse(_)));
+    }
+}

--- a/apps/pollen-alert/src/lib.rs
+++ b/apps/pollen-alert/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod alert;
+pub mod forecast;
 pub mod scoring;
 
 use worker::{event, Context, Env, Request, Response, Result, ScheduleContext, ScheduledEvent};

--- a/apps/pollen-alert/tests/fixtures/open-meteo/bainbridge-overnight.json
+++ b/apps/pollen-alert/tests/fixtures/open-meteo/bainbridge-overnight.json
@@ -1,0 +1,32 @@
+{
+  "latitude": 47.625,
+  "longitude": -122.5,
+  "generationtime_ms": 0.1,
+  "utc_offset_seconds": -25200,
+  "timezone": "America/Los_Angeles",
+  "timezone_abbreviation": "PDT",
+  "elevation": 18.0,
+  "hourly_units": {
+    "time": "iso8601",
+    "relative_humidity_2m": "%",
+    "wind_speed_10m": "mp/h",
+    "precipitation_probability": "%",
+    "cloud_cover": "%"
+  },
+  "hourly": {
+    "time": [
+      "2026-04-15T19:00",
+      "2026-04-15T20:00",
+      "2026-04-15T21:00",
+      "2026-04-15T22:00",
+      "2026-04-15T23:00",
+      "2026-04-16T00:00",
+      "2026-04-16T01:00",
+      "2026-04-16T02:00"
+    ],
+    "relative_humidity_2m": [78.0, 82.0, 86.0, 90.0, 92.0, 91.0, 88.0, 84.0],
+    "wind_speed_10m": [5.5, 3.8, 2.4, 1.9, 1.6, 1.8, 2.5, 3.2],
+    "precipitation_probability": [15.0, 12.0, 10.0, 8.0, 7.0, 8.0, 10.0, 14.0],
+    "cloud_cover": [60.0, 40.0, 20.0, 10.0, 5.0, 8.0, 22.0, 35.0]
+  }
+}

--- a/apps/pollen-alert/tests/forecast.rs
+++ b/apps/pollen-alert/tests/forecast.rs
@@ -1,0 +1,109 @@
+//! Integration test for the Open-Meteo forecast provider. Runs the
+//! parser against a real-shape captured response (see
+//! `tests/fixtures/open-meteo/`); no network round-trip.
+//!
+//! The fixture is a Bainbridge Island overnight window — eight
+//! consecutive hours from 7 PM to 2 AM local. Trends across the
+//! fixture: humidity climbs into the 90s, wind drops below 2 mph,
+//! sky clears, precip stays low. The middle hours score high under
+//! the v1 rules (this is the input shape the scoring + alert
+//! pipeline will see in production).
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use chrono::{NaiveDate, NaiveTime};
+
+use pollen_alert::forecast::{ForecastError, ForecastProvider, HttpFetcher, OpenMeteoProvider};
+use pollen_alert::scoring::Sky;
+
+struct FixtureFetcher {
+    body: String,
+}
+
+#[async_trait(?Send)]
+impl HttpFetcher for FixtureFetcher {
+    async fn get(&self, _url: &str) -> Result<String, ForecastError> {
+        Ok(self.body.clone())
+    }
+}
+
+fn fixture(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/open-meteo")
+        .join(name);
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", path.display()))
+}
+
+#[tokio::test]
+async fn parses_bainbridge_overnight_fixture() {
+    let provider = OpenMeteoProvider::new(FixtureFetcher {
+        body: fixture("bainbridge-overnight.json"),
+    });
+    let hours = provider
+        .fetch(47.625, -122.5, "America/Los_Angeles")
+        .await
+        .expect("fetch ok");
+
+    assert_eq!(hours.len(), 8);
+
+    let first = &hours[0];
+    assert_eq!(
+        first.local_time,
+        NaiveDate::from_ymd_opt(2026, 4, 15)
+            .unwrap()
+            .and_time(NaiveTime::from_hms_opt(19, 0, 0).unwrap())
+    );
+    assert_eq!(first.humidity_pct, 78.0);
+    assert_eq!(first.wind_mph, 5.5);
+    assert_eq!(first.precip_prob_pct, 15.0);
+    assert_eq!(first.sky, Some(Sky::MostlyCloudy));
+
+    // 23:00 — the peak risky hour: humidity 92, wind 1.6, precip 7,
+    // cloud cover 5 → Clear.
+    let peak = &hours[4];
+    assert_eq!(peak.humidity_pct, 92.0);
+    assert_eq!(peak.wind_mph, 1.6);
+    assert_eq!(peak.sky, Some(Sky::Clear));
+}
+
+#[tokio::test]
+async fn fixture_drives_scoring_above_threshold() {
+    use pollen_alert::alert::find_alert;
+    use pollen_alert::scoring::score_hour;
+
+    let provider = OpenMeteoProvider::new(FixtureFetcher {
+        body: fixture("bainbridge-overnight.json"),
+    });
+    let hours = provider
+        .fetch(47.625, -122.5, "America/Los_Angeles")
+        .await
+        .expect("fetch ok");
+
+    // Drive the full pipeline: score each hour (April → tree season),
+    // then ask `find_alert` for the first 5-point ≥ 3-hour window.
+    let scored: Vec<_> = hours
+        .iter()
+        .cloned()
+        .map(|h| {
+            let s = score_hour(&h, true);
+            (h, s)
+        })
+        .collect();
+    let alert = find_alert(&scored, 5, 3).expect("alert");
+    assert!(
+        alert.score >= 5,
+        "alert score {} below threshold",
+        alert.score
+    );
+    // The risky run starts at 20:00 (humidity hits 82, wind drops to
+    // 3.8, sky clears to PartlyCloudy) and continues through the
+    // overnight peak.
+    assert_eq!(
+        alert.window_start,
+        NaiveDate::from_ymd_opt(2026, 4, 15)
+            .unwrap()
+            .and_time(NaiveTime::from_hms_opt(20, 0, 0).unwrap())
+    );
+}


### PR DESCRIPTION
`ForecastProvider` is the trait the worker entrypoint will depend on;
`OpenMeteoProvider` is the only impl today. Open-Meteo is free,
key-less, and exposes the four fields scoring needs
(`relative_humidity_2m`, `wind_speed_10m`, `precipitation_probability`,
`cloud_cover`) on an hourly grid.

`HttpFetcher` abstracts the HTTP boundary so native integration tests
replay a fixture without hitting the network. The Worker impl
(`WorkerFetcher`, cfg-gated to `wasm32`) wraps `worker::Fetch`;
the test fake reads from disk.

`OPEN_METEO_TIME_FMT` (`%Y-%m-%dT%H:%M`) handles the seconds-less
timestamps Open-Meteo returns — chrono's default `NaiveDateTime`
deserializer rejects that shape, so the parser captures times as
`String` and converts explicitly with a clear error path.

`cloud_cover_to_sky` maps the provider's continuous percent into
the categorical `Sky` the scorer takes (boundaries 25/50/75
chosen NWS-style).

Fixture-based integration test in `tests/forecast.rs` reads
`tests/fixtures/open-meteo/bainbridge-overnight.json` (8-hour
overnight window for Bainbridge Island) — exercises the parser end-
to-end and drives the full scoring + alert pipeline to verify the
fixture's peak-risky run crosses threshold.

Adds dev-dep `tokio = { rt, macros }` for `#[tokio::test]` on the
native side; the Worker runtime has its own executor and doesn't
pull tokio in.

Closes #407.