### PR TITLE
feat(todoist): tasks add command

### DIFF
--- a/tools/todoist/README.md
+++ b/tools/todoist/README.md
@@ -36,7 +36,23 @@ emits one raw API object per line for piping into `jq`; without it
 the output is a column table whose `id` shows the first six characters
 of the task ID for quick reference.
 
+## Adding tasks
+
+```
+todoist tasks add <content> [--project <name-or-id>] \
+                            [--due <natural-language>] \
+                            [--priority 1|2|3|4] \
+                            [--label <name>]... \
+                            [--description <text>]
+```
+
+`--due` passes through to `Todoist`'s natural-language parser
+(`tomorrow at 3pm`, `every monday`, etc.). Priority is `1` (lowest)
+through `4` (highest) — out-of-range values are rejected before the
+request reaches the server. Repeating `--label` attaches multiple
+labels at once.
+
 ## Status
 
-Auth (#476) and `tasks list` (#477) are implemented. `tasks add` (#478)
-and `tasks complete` (#479) are still stubs.
+Auth (#476), `tasks list` (#477), and `tasks add` (#478) are
+implemented. `tasks complete` (#479) is still a stub.

--- a/tools/todoist/src/api.rs
+++ b/tools/todoist/src/api.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub const API_BASE: &str = "https://api.todoist.com/rest/v2";
 
@@ -37,6 +37,21 @@ pub struct TaskListQuery {
     pub filter: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+pub struct CreateTaskBody {
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub due_string: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u8>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
 pub trait TodoistClient {
     fn list_tasks(
         &self,
@@ -45,6 +60,12 @@ pub trait TodoistClient {
     ) -> Result<Vec<serde_json::Value>, ApiError>;
 
     fn list_projects(&self, token: &str) -> Result<Vec<Project>, ApiError>;
+
+    fn create_task(
+        &self,
+        token: &str,
+        body: &CreateTaskBody,
+    ) -> Result<serde_json::Value, ApiError>;
 }
 
 pub struct RealClient {
@@ -73,18 +94,33 @@ impl TodoistClient for RealClient {
         if let Some(filter) = &query.filter {
             req = req.query("filter", filter);
         }
-        send_json(req)
+        send_json(req.call())
     }
 
     fn list_projects(&self, token: &str) -> Result<Vec<Project>, ApiError> {
         let req = ureq::get(&format!("{}/projects", self.base))
             .set("Authorization", &format!("Bearer {token}"));
-        send_json(req)
+        send_json(req.call())
+    }
+
+    fn create_task(
+        &self,
+        token: &str,
+        body: &CreateTaskBody,
+    ) -> Result<serde_json::Value, ApiError> {
+        let req = ureq::post(&format!("{}/tasks", self.base))
+            .set("Authorization", &format!("Bearer {token}"))
+            .set("Content-Type", "application/json");
+        let payload =
+            serde_json::to_value(body).map_err(|e| ApiError::Network(format!("encode: {e}")))?;
+        send_json(req.send_json(payload))
     }
 }
 
-fn send_json<T: for<'de> Deserialize<'de>>(req: ureq::Request) -> Result<T, ApiError> {
-    match req.call() {
+fn send_json<T: for<'de> Deserialize<'de>>(
+    result: Result<ureq::Response, ureq::Error>,
+) -> Result<T, ApiError> {
+    match result {
         Ok(response) => response
             .into_json::<T>()
             .map_err(|e| ApiError::Network(format!("could not parse response: {e}"))),
@@ -124,5 +160,38 @@ mod tests {
         .to_string();
         assert!(msg.contains("500"));
         assert!(msg.contains("boom"));
+    }
+
+    #[test]
+    fn create_task_body_omits_unset_fields() {
+        let body = CreateTaskBody {
+            content: "buy milk".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"content\":\"buy milk\""));
+        assert!(!json.contains("project_id"));
+        assert!(!json.contains("due_string"));
+        assert!(!json.contains("priority"));
+        assert!(!json.contains("labels"));
+        assert!(!json.contains("description"));
+    }
+
+    #[test]
+    fn create_task_body_includes_set_fields() {
+        let body = CreateTaskBody {
+            content: "x".into(),
+            project_id: Some("42".into()),
+            due_string: Some("tomorrow".into()),
+            priority: Some(3),
+            labels: vec!["errand".into()],
+            description: Some("longer".into()),
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(json.contains("\"project_id\":\"42\""));
+        assert!(json.contains("\"due_string\":\"tomorrow\""));
+        assert!(json.contains("\"priority\":3"));
+        assert!(json.contains("\"labels\":[\"errand\"]"));
+        assert!(json.contains("\"description\":\"longer\""));
     }
 }

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -133,6 +133,31 @@ fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
             }
             Ok(())
         }
+        TasksSubcommand::Add {
+            content,
+            project,
+            due,
+            priority,
+            labels,
+            description,
+        } => {
+            let token = resolve_token()?;
+            let client = api::RealClient::default();
+            let created = tasks::run_add(
+                &client,
+                &token,
+                &tasks::AddOpts {
+                    content,
+                    project,
+                    due,
+                    priority,
+                    labels,
+                    description,
+                },
+            )?;
+            println!("{}", tasks::render_added(&created));
+            Ok(())
+        }
         _ => bail!("this tasks subcommand is not yet implemented"),
     }
 }

--- a/tools/todoist/src/tasks.rs
+++ b/tools/todoist/src/tasks.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 
-use crate::api::{Project, TaskListQuery, TodoistClient};
+use crate::api::{CreateTaskBody, Project, TaskListQuery, TodoistClient};
 
 pub const ID_PREFIX_LEN: usize = 6;
 
@@ -57,6 +57,46 @@ pub fn resolve_project_id(projects: &[Project], arg: &str) -> Result<String> {
             many.len()
         )),
     }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AddOpts {
+    pub content: String,
+    pub project: Option<String>,
+    pub due: Option<String>,
+    pub priority: Option<u8>,
+    pub labels: Vec<String>,
+    pub description: Option<String>,
+}
+
+pub fn run_add(
+    client: &impl TodoistClient,
+    token: &str,
+    opts: &AddOpts,
+) -> Result<serde_json::Value> {
+    let project_id = match &opts.project {
+        Some(arg) => {
+            let projects = client.list_projects(token).map_err(|e| anyhow!(e))?;
+            Some(resolve_project_id(&projects, arg)?)
+        }
+        None => None,
+    };
+    let body = CreateTaskBody {
+        content: opts.content.clone(),
+        project_id,
+        due_string: opts.due.clone(),
+        priority: opts.priority,
+        labels: opts.labels.clone(),
+        description: opts.description.clone(),
+    };
+    client.create_task(token, &body).map_err(|e| anyhow!(e))
+}
+
+pub fn render_added(task: &serde_json::Value) -> String {
+    let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let prefix: String = id.chars().take(ID_PREFIX_LEN).collect();
+    let content = task.get("content").and_then(|v| v.as_str()).unwrap_or("");
+    format!("created {prefix} {content}")
 }
 
 pub fn render_ndjson(tasks: &[serde_json::Value]) -> String {
@@ -136,7 +176,7 @@ pub fn render_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::{ApiError, Project, TaskListQuery, TodoistClient};
+    use crate::api::{ApiError, CreateTaskBody, Project, TaskListQuery, TodoistClient};
     use std::cell::RefCell;
     use std::collections::HashMap;
 
@@ -144,6 +184,9 @@ mod tests {
         projects: Vec<Project>,
         tasks: Vec<serde_json::Value>,
         last_query: RefCell<Option<TaskListQuery>>,
+        last_create: RefCell<Option<CreateTaskBody>>,
+        create_response: serde_json::Value,
+        create_error: RefCell<Option<ApiError>>,
     }
 
     impl FakeClient {
@@ -152,7 +195,15 @@ mod tests {
                 projects,
                 tasks,
                 last_query: RefCell::new(None),
+                last_create: RefCell::new(None),
+                create_response: serde_json::json!({"id": "999abc12345", "content": "echo"}),
+                create_error: RefCell::new(None),
             }
+        }
+
+        fn with_create_error(mut self, err: ApiError) -> Self {
+            self.create_error = RefCell::new(Some(err));
+            self
         }
     }
 
@@ -168,6 +219,18 @@ mod tests {
 
         fn list_projects(&self, _token: &str) -> Result<Vec<Project>, ApiError> {
             Ok(self.projects.clone())
+        }
+
+        fn create_task(
+            &self,
+            _token: &str,
+            body: &CreateTaskBody,
+        ) -> Result<serde_json::Value, ApiError> {
+            *self.last_create.borrow_mut() = Some(body.clone());
+            if let Some(e) = self.create_error.borrow_mut().take() {
+                return Err(e);
+            }
+            Ok(self.create_response.clone())
         }
     }
 
@@ -308,5 +371,64 @@ mod tests {
     fn render_table_reports_empty_set() {
         let out = render_table(&[], &HashMap::new());
         assert_eq!(out, "no tasks");
+    }
+
+    #[test]
+    fn run_add_forwards_all_fields_to_create_body() {
+        let client = FakeClient::new(vec![project("9", "Errands")], vec![]);
+        let opts = AddOpts {
+            content: "buy milk".into(),
+            project: Some("Errands".into()),
+            due: Some("tomorrow".into()),
+            priority: Some(3),
+            labels: vec!["shopping".into()],
+            description: Some("organic".into()),
+        };
+        run_add(&client, "tok", &opts).unwrap();
+        let body = client.last_create.borrow().clone().unwrap();
+        assert_eq!(body.content, "buy milk");
+        assert_eq!(body.project_id.as_deref(), Some("9"));
+        assert_eq!(body.due_string.as_deref(), Some("tomorrow"));
+        assert_eq!(body.priority, Some(3));
+        assert_eq!(body.labels, vec!["shopping"]);
+        assert_eq!(body.description.as_deref(), Some("organic"));
+    }
+
+    #[test]
+    fn run_add_skips_project_lookup_when_unset() {
+        let client = FakeClient::new(vec![], vec![]);
+        let opts = AddOpts {
+            content: "x".into(),
+            ..Default::default()
+        };
+        run_add(&client, "tok", &opts).unwrap();
+        let body = client.last_create.borrow().clone().unwrap();
+        assert!(body.project_id.is_none());
+        assert!(body.labels.is_empty());
+    }
+
+    #[test]
+    fn run_add_surfaces_create_error() {
+        let client = FakeClient::new(vec![], vec![]).with_create_error(ApiError::Other {
+            status: 400,
+            body: "Bad content".into(),
+        });
+        let opts = AddOpts {
+            content: "x".into(),
+            ..Default::default()
+        };
+        let err = run_add(&client, "tok", &opts).unwrap_err();
+        assert!(err.to_string().contains("400"));
+        assert!(err.to_string().contains("Bad content"));
+    }
+
+    #[test]
+    fn render_added_uses_id_prefix_and_content() {
+        let task = serde_json::json!({"id": "abcdef9876543210", "content": "buy milk"});
+        let out = render_added(&task);
+        assert!(out.contains("created"));
+        assert!(out.contains("abcdef"));
+        assert!(!out.contains("9876543210"));
+        assert!(out.contains("buy milk"));
     }
 }


### PR DESCRIPTION
\`todoist tasks add <content>\` now posts a new task to the Todoist
REST API, accepting all the standard flags: \`--project\` (name or
numeric id), \`--due\` (natural language passed through verbatim),
\`--priority\` (1-4, clap rejects out-of-range before the request),
repeatable \`--label\`, and \`--description\`. On success the CLI
prints \`created <id-prefix> <content>\`.

\`CreateTaskBody\` uses \`skip_serializing_if\` on every optional
field so omitted flags don't reach the wire; the server interprets
absence as \"use default\" rather than \"clear\". The same
\`resolve_project_id\` helper that backs \`tasks list\` resolves
project names here.

Stacked on #508. Will retarget to \`main\` once that lands.

Closes #478