### PR TITLE
feat(blogctl): final-edit command for the FinalEditing stage

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -167,6 +167,27 @@ pub enum Command {
         #[arg(long)]
         no_sync: bool,
     },
+    /// Polish-pass a post body via OpenRouter. Post must be in the
+    /// `final-editing` stage. Without `--prompt`, applies a baked-in
+    /// LinkedIn-flavored polish prompt (strip LLMisms, cap at 500
+    /// words, plain text only). Requires `OPENROUTER_API_KEY`.
+    FinalEdit {
+        slug: String,
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Override the default polish instruction. Use this for
+        /// non-LinkedIn surfaces (articles, etc.) where the baked-in
+        /// LinkedIn rules don't apply.
+        #[arg(long)]
+        prompt: Option<String>,
+        /// OpenRouter model identifier.
+        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
+        model: String,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// Set classification dimensions on a post (format, hook, tone,
     /// audience, strategic-role, theme). Missing flags leave the
     /// existing value alone; `--clear-<dim>` removes it.
@@ -429,6 +450,22 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
         } => commands::refine::run(
             jj,
             commands::refine::RefineArgs {
+                slug,
+                workdir: workdir_or_pwd(workdir)?,
+                prompt,
+                model,
+                no_sync,
+            },
+        ),
+        Command::FinalEdit {
+            slug,
+            workdir,
+            prompt,
+            model,
+            no_sync,
+        } => commands::final_edit::run(
+            jj,
+            commands::final_edit::FinalEditArgs {
                 slug,
                 workdir: workdir_or_pwd(workdir)?,
                 prompt,

--- a/apps/blogctl/src/commands/draft.rs
+++ b/apps/blogctl/src/commands/draft.rs
@@ -171,6 +171,7 @@ mod tests {
                 generated_at: OffsetDateTime::UNIX_EPOCH,
             }),
             refine: None,
+            final_edit: None,
         };
         let h = merge_draft_record(
             Some(prior),

--- a/apps/blogctl/src/commands/final_edit.rs
+++ b/apps/blogctl/src/commands/final_edit.rs
@@ -1,0 +1,256 @@
+//! `blogctl final-edit <slug> [--prompt <text>]` — last-pass polish on
+//! a `FinalEditing`-stage post via OpenRouter.
+//!
+//! Operates on `FinalEditing`-stage posts only — the polish pass runs
+//! after `draft` and `refine` have produced something the author is
+//! happy with structurally.
+//!
+//! Without `--prompt`, the polish guidance is baked in and aimed at
+//! LinkedIn-format posts: strip LLMisms, drop em-dashes and staccato
+//! sequences, cap at 500 words, no Markdown (LinkedIn doesn't render
+//! it), only words and blank lines for structure. Override with
+//! `--prompt` for non-LinkedIn targets (articles, other surfaces).
+//!
+//! Replaces the post body with the model's reply and records the audit
+//! block in `metadata.ai.final_edit`. Prior `ai.draft` and `ai.refine`
+//! records are preserved.
+
+use std::fs;
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::openrouter;
+use crate::post::{AiFinalEditRecord, AiHistory};
+use crate::stage::Stage;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+
+/// Default polish instruction used when `--prompt` is omitted. Aimed at
+/// LinkedIn feed posts (`Kind::Post`); pass `--prompt` to polish an
+/// article or other surface with different rules.
+const DEFAULT_POLISH_PROMPT: &str = "Remove the LLMisms, staccato sequences, em-dashes. \
+The post should be for LinkedIn, 500 words or less. \
+We should use words and whitespace (new double line breaks) as our only means of expression. \
+There is no markdown support.";
+
+#[derive(Debug)]
+pub struct FinalEditArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+    pub prompt: Option<String>,
+    pub model: String,
+    pub no_sync: bool,
+}
+
+pub fn run(jj: &dyn Jj, args: FinalEditArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let (handle, mut post) = repo.load_raw(&args.slug)?;
+
+    if handle.stage != Stage::FinalEditing {
+        return Err(Error::FinalEditWrongStage {
+            slug: args.slug,
+            stage: handle.stage,
+        });
+    }
+
+    let instruction = args
+        .prompt
+        .clone()
+        .unwrap_or_else(|| DEFAULT_POLISH_PROMPT.to_string());
+    let llm_prompt = build_prompt(&post.metadata.title, &post.body, &instruction);
+    let reply = openrouter::chat(&llm_prompt, &args.model)?;
+
+    post.body = reply;
+    post.metadata.ai = Some(merge_final_edit_record(
+        post.metadata.ai.take(),
+        AiFinalEditRecord {
+            prompt: instruction,
+            model: args.model.clone(),
+            generated_at: OffsetDateTime::now_utc(),
+        },
+    ));
+
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let message = format!("post({}): final-edit via {}", args.slug, args.model);
+    let path = handle.path.clone();
+    let model = args.model.clone();
+    let slug = args.slug.clone();
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        post.metadata.updated_at = OffsetDateTime::now_utc();
+        let rendered = post.render()?;
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))?;
+        Ok(())
+    })?;
+    println!("{slug}: final-edited via {model}");
+    Ok(())
+}
+
+/// Compose the LLM prompt. The preamble frames the task as a polish
+/// pass and tells the model to emit only the body text — no title, no
+/// frontmatter, no meta-commentary. Crucially, it does NOT instruct
+/// the model to use Markdown; the default polish prompt explicitly
+/// targets LinkedIn, which doesn't render Markdown, and a `--prompt`
+/// override can re-introduce Markdown if needed.
+fn build_prompt(title: &str, current_body: &str, instruction: &str) -> String {
+    let mut s = String::with_capacity(title.len() + current_body.len() + instruction.len() + 256);
+    s.push_str(
+        "You are performing a final polish pass on a blog post draft. \
+         Produce the revised post body only — no title, no frontmatter, \
+         no commentary about your output.\n\n",
+    );
+    s.push_str("Title: ");
+    s.push_str(title);
+    s.push_str("\n\n");
+    if !current_body.trim().is_empty() {
+        s.push_str("Current body:\n");
+        s.push_str(current_body.trim());
+        s.push_str("\n\n");
+    }
+    s.push_str("Author instruction: ");
+    s.push_str(instruction);
+    s
+}
+
+/// Fold a new `AiFinalEditRecord` into the post's optional `AiHistory`,
+/// preserving any prior `ai.draft` and `ai.refine` records.
+fn merge_final_edit_record(
+    existing: Option<AiHistory>,
+    new_record: AiFinalEditRecord,
+) -> AiHistory {
+    let mut history = existing.unwrap_or_default();
+    history.final_edit = Some(new_record);
+    history
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::post::{AiDraftRecord, AiRefineRecord};
+
+    #[test]
+    fn prompt_includes_title_and_instruction() {
+        let p = build_prompt("The Title", "polished body", "tighten");
+        assert!(p.contains("Title: The Title"));
+        assert!(p.contains("Author instruction: tighten"));
+    }
+
+    #[test]
+    fn prompt_includes_current_body_when_non_empty() {
+        let p = build_prompt("T", "some body text", "polish");
+        assert!(p.contains("Current body:"));
+        assert!(p.contains("some body text"));
+    }
+
+    #[test]
+    fn prompt_skips_body_block_when_empty() {
+        let p = build_prompt("T", "", "go");
+        assert!(!p.contains("Current body:"));
+    }
+
+    #[test]
+    fn prompt_skips_body_block_when_whitespace() {
+        let p = build_prompt("T", "   \n\t\n", "go");
+        assert!(!p.contains("Current body:"));
+    }
+
+    #[test]
+    fn prompt_does_not_instruct_markdown_output() {
+        // The default polish target is LinkedIn, which doesn't render
+        // Markdown. The preamble must stay format-agnostic — the user's
+        // (or default) instruction decides the output format.
+        let p = build_prompt("T", "body", DEFAULT_POLISH_PROMPT);
+        assert!(
+            !p.to_lowercase().contains("in markdown"),
+            "preamble should not impose Markdown on the model: {p}"
+        );
+    }
+
+    #[test]
+    fn prompt_frames_task_as_polish_not_drafting() {
+        let p = build_prompt("T", "body", "polish");
+        assert!(p.to_lowercase().contains("polish"));
+    }
+
+    #[test]
+    fn default_polish_prompt_targets_linkedin_constraints() {
+        // Smoke-test the baked-in default so a future edit that loses
+        // the LinkedIn focus is caught — this is the primary use case
+        // and the prompt is load-bearing.
+        assert!(DEFAULT_POLISH_PROMPT.to_lowercase().contains("linkedin"));
+        assert!(DEFAULT_POLISH_PROMPT.contains("500"));
+        assert!(DEFAULT_POLISH_PROMPT.to_lowercase().contains("markdown"));
+    }
+
+    #[test]
+    fn merge_creates_history_when_none_existed() {
+        let h = merge_final_edit_record(
+            None,
+            AiFinalEditRecord {
+                prompt: "p".into(),
+                model: "m".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert!(h.final_edit.is_some());
+        assert!(h.draft.is_none());
+        assert!(h.refine.is_none());
+    }
+
+    #[test]
+    fn merge_preserves_prior_draft_and_refine_records() {
+        // A post that went through draft → refine → final-edit should
+        // keep all three audit blocks — final-edit must never clobber
+        // its predecessors.
+        let prior = AiHistory {
+            draft: Some(AiDraftRecord {
+                prompt: "draft-prompt".into(),
+                model: "draft-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+            refine: Some(AiRefineRecord {
+                prompt: "refine-prompt".into(),
+                model: "refine-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+            final_edit: None,
+        };
+        let h = merge_final_edit_record(
+            Some(prior),
+            AiFinalEditRecord {
+                prompt: "polish-prompt".into(),
+                model: "polish-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert_eq!(h.draft.unwrap().prompt, "draft-prompt");
+        assert_eq!(h.refine.unwrap().prompt, "refine-prompt");
+        assert_eq!(h.final_edit.unwrap().prompt, "polish-prompt");
+    }
+
+    #[test]
+    fn merge_overwrites_prior_final_edit_record() {
+        let prior = AiHistory {
+            draft: None,
+            refine: None,
+            final_edit: Some(AiFinalEditRecord {
+                prompt: "old".into(),
+                model: "old-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            }),
+        };
+        let h = merge_final_edit_record(
+            Some(prior),
+            AiFinalEditRecord {
+                prompt: "new".into(),
+                model: "new-model".into(),
+                generated_at: OffsetDateTime::UNIX_EPOCH,
+            },
+        );
+        assert_eq!(h.final_edit.unwrap().prompt, "new");
+    }
+}

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod classify;
 pub mod demote;
 pub mod doctor;
 pub mod draft;
+pub mod final_edit;
 pub mod fix;
 pub mod init;
 pub mod list;

--- a/apps/blogctl/src/commands/refine.rs
+++ b/apps/blogctl/src/commands/refine.rs
@@ -189,6 +189,7 @@ mod tests {
                 generated_at: OffsetDateTime::UNIX_EPOCH,
             }),
             refine: None,
+            final_edit: None,
         };
         let h = merge_refine_record(
             Some(prior),
@@ -211,6 +212,7 @@ mod tests {
                 model: "old-model".into(),
                 generated_at: OffsetDateTime::UNIX_EPOCH,
             }),
+            final_edit: None,
         };
         let h = merge_refine_record(
             Some(prior),

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -50,6 +50,11 @@ pub enum Error {
     )]
     RefineWrongStage { slug: String, stage: Stage },
 
+    #[error(
+        "cannot final-edit post {slug:?} from stage {stage}: the polish pass requires the post to be in the `final-editing` stage"
+    )]
+    FinalEditWrongStage { slug: String, stage: Stage },
+
     #[error("cannot demote from {0}: already at the first workflow stage")]
     DemoteFromInitial(Stage),
 

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -67,6 +67,10 @@ pub struct AiHistory {
     /// per #506's scope. Earlier refines live in `jj` history.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refine: Option<AiRefineRecord>,
+    /// Most-recent `blogctl final-edit` invocation. Same single-slot
+    /// shape as `refine` — earlier polish passes live in `jj` history.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_edit: Option<AiFinalEditRecord>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -79,6 +83,14 @@ pub struct AiDraftRecord {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AiRefineRecord {
+    pub prompt: String,
+    pub model: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub generated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AiFinalEditRecord {
     pub prompt: String,
     pub model: String,
     #[serde(with = "time::serde::rfc3339")]

--- a/apps/blogctl/tests/workflow.rs
+++ b/apps/blogctl/tests/workflow.rs
@@ -20,7 +20,8 @@ use std::sync::Mutex;
 use tempfile::TempDir;
 
 use blogctl::commands::{
-    self, classify::ClassifyArgs, draft::DraftArgs, metrics::UpdateArgs, refine::RefineArgs,
+    self, classify::ClassifyArgs, draft::DraftArgs, final_edit::FinalEditArgs, metrics::UpdateArgs,
+    refine::RefineArgs,
 };
 use blogctl::error::Error;
 use blogctl::kind::Kind;
@@ -198,18 +199,23 @@ const DRAFT_REPLY: &str =
     "## Drafted body\n\nFirst paragraph from the mock.\n\nSecond paragraph from the mock.\n";
 const REFINE_REPLY: &str =
     "## Refined body\n\nTighter first paragraph.\n\nTighter second paragraph.\n";
+const FINAL_EDIT_REPLY: &str =
+    "Polished body from the mock.\n\nNo markdown, just words and double line breaks.\n";
 
 /// Drive the AI-touching path of the lifecycle end-to-end against a
 /// `mockito` server: draft into an Ideation post, promote to Editing,
-/// refine. Asserts on body replacement and the `ai.draft` / `ai.refine`
-/// audit blocks. Also exercises the negative paths (draft from Concept,
-/// refine from Ideation) so the stage-gating regressions land here too.
+/// refine, promote to FinalEditing, final-edit. Asserts on body
+/// replacement and the `ai.draft` / `ai.refine` / `ai.final_edit`
+/// audit blocks. Also exercises the negative paths (draft from
+/// Concept, refine from Ideation, final-edit from Editing) so the
+/// stage-gating regressions land here too.
 #[test]
 fn lifecycle_with_ai_commands_uses_mocked_openrouter() {
     let _guard = ENV_LOCK.lock().unwrap();
     let mut server = mockito::Server::new();
     let mock_draft = mock_chat_completion(&mut server, DRAFT_REPLY);
     let mock_refine = mock_chat_completion(&mut server, REFINE_REPLY);
+    let mock_final_edit = mock_chat_completion(&mut server, FINAL_EDIT_REPLY);
 
     let prev_base = env::var("OPENROUTER_API_BASE").ok();
     let prev_key = env::var("OPENROUTER_API_KEY").ok();
@@ -233,6 +239,7 @@ fn lifecycle_with_ai_commands_uses_mocked_openrouter() {
     result.expect("ai lifecycle should succeed");
     mock_draft.assert();
     mock_refine.assert();
+    mock_final_edit.assert();
 }
 
 fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
@@ -344,5 +351,72 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
     let refine = ai.refine.as_ref().expect("ai.refine set post-refine");
     assert_eq!(refine.prompt, "tighten paragraphs");
     assert_eq!(refine.model, "test-model");
+
+    // FinalEdit at Editing must fail with FinalEditWrongStage. Same
+    // stage-gating pattern as the draft/refine checks above.
+    let err = commands::final_edit::run(
+        &FakeJj::new(),
+        FinalEditArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: None,
+            model: "test-model".into(),
+            no_sync: true,
+        },
+    )
+    .expect_err("final-edit at Editing must error");
+    assert!(
+        matches!(err, Error::FinalEditWrongStage { .. }),
+        "expected FinalEditWrongStage, got: {err:?}"
+    );
+
+    // Editing → FinalEditing, then final-edit (using the baked-in
+    // LinkedIn polish prompt since --prompt is None).
+    commands::promote::run(&FakeJj::new(), slug.to_string(), workdir.clone(), true)?;
+    commands::final_edit::run(
+        &FakeJj::new(),
+        FinalEditArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: None,
+            model: "test-model".into(),
+            no_sync: true,
+        },
+    )?;
+
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let (_, post) = repo.load(slug)?;
+    assert_eq!(
+        post.body.trim(),
+        FINAL_EDIT_REPLY.trim(),
+        "body should match the canned final-edit reply"
+    );
+    let ai = post
+        .metadata
+        .ai
+        .as_ref()
+        .expect("ai block populated post-final-edit");
+    let draft = ai
+        .draft
+        .as_ref()
+        .expect("ai.draft preserved across final-edit");
+    assert_eq!(draft.prompt, "write me three paragraphs about mocking");
+    let refine = ai
+        .refine
+        .as_ref()
+        .expect("ai.refine preserved across final-edit");
+    assert_eq!(refine.prompt, "tighten paragraphs");
+    let fe = ai
+        .final_edit
+        .as_ref()
+        .expect("ai.final_edit set post-final-edit");
+    // The default polish prompt should have been recorded in the audit
+    // block since --prompt was None.
+    assert!(
+        fe.prompt.to_lowercase().contains("linkedin"),
+        "default polish prompt should be stored in ai.final_edit: {}",
+        fe.prompt
+    );
+    assert_eq!(fe.model, "test-model");
     Ok(())
 }


### PR DESCRIPTION
Third slice of the AI-integrated content workflow tracked in #483.
`blogctl final-edit <slug>` runs a polish-pass prompt against a
`FinalEditing`-stage post via OpenRouter and writes the reply back into
the post body, recording the audit block in `metadata.ai.final_edit`.

Shape mirrors `refine` (#506): `FinalEditArgs`, `--model` flag with
the OpenRouter default, stage-gate that errors loudly via
`Error::FinalEditWrongStage`. The audit field `ai.final_edit` joins
`ai.draft` and `ai.refine` in `AiHistory`; final-edit preserves both
of its predecessors so a published post carries the full draft → refine →
final-edit chain.

The difference from `refine`: `--prompt` is optional. Without it, the
command applies a baked-in LinkedIn-flavored polish (strip LLMisms,
em-dashes, staccato sequences; cap at 500 words; plain text only — no
markdown, since LinkedIn doesn't render it). Override with `--prompt`
for articles or other surfaces. The default prompt is recorded in
`ai.final_edit.prompt` so the audit trail reflects what the model
actually saw.

Unit tests mirror refine's set (prompt construction, merge semantics)
plus two final-edit-specific guards: the preamble must not impose
markdown on the model (the default target doesn't render it), and the
default polish prompt must keep its LinkedIn-shaped constraints.
`tests/workflow.rs` extends `lifecycle_with_ai_commands_uses_mocked_openrouter`
with the final-edit step alongside draft and refine, including the
negative path (final-edit from `Editing` → `FinalEditWrongStage`).

Closes #511.