### PR TITLE
feat(apps/pollen-alert): scheduled cron entrypoint wires the pipeline

### DIFF
--- a/apps/pollen-alert/src/lib.rs
+++ b/apps/pollen-alert/src/lib.rs
@@ -1,17 +1,186 @@
 pub mod alert;
 pub mod forecast;
 pub mod notify;
+pub mod pipeline;
 pub mod scoring;
 
-use worker::{event, Context, Env, Request, Response, Result, ScheduleContext, ScheduledEvent};
+// Worker runtime — scheduled cron + fetch handler, env reading,
+// HTTP adapters. Cfg-gated to `wasm32` because all of this depends
+// on `worker::Fetch` / `worker::Env`, which only exist on the
+// Cloudflare Worker target. Native `cargo test` exercises the
+// pure modules above through their own unit tests.
+#[cfg(target_arch = "wasm32")]
+mod worker_runtime {
+    use async_trait::async_trait;
+    use worker::{event, Context, Env, Request, Response, Result, ScheduleContext, ScheduledEvent};
 
-#[event(scheduled)]
-async fn scheduled(_event: ScheduledEvent, _env: Env, _ctx: ScheduleContext) {
-    // Stub. Pipeline lands in #409 (scheduled handler) reading from
-    // wrangler.toml [vars] and dispatching to the notifier.
-}
+    use crate::forecast::{ForecastError, ForecastProvider, OpenMeteoProvider};
+    use crate::notify::{HttpPoster, LogNotifier, Notifier, NotifyError, PushoverNotifier};
+    use crate::pipeline::decide;
 
-#[event(fetch)]
-async fn fetch(_req: Request, _env: Env, _ctx: Context) -> Result<Response> {
-    Response::error("Not Found", 404)
+    /// Cron entrypoint. Reads env, fetches the forecast for the
+    /// configured location, finds the overnight alert window, and
+    /// dispatches to the notifier. Errors are logged (so a single
+    /// bad run shows up in `wrangler tail`) and swallowed — the next
+    /// cron retries on its own schedule.
+    #[event(scheduled)]
+    pub async fn scheduled(_event: ScheduledEvent, env: Env, _ctx: ScheduleContext) {
+        if let Err(e) = run(&env).await {
+            worker::console_error!("pollen-alert run failed: {e}");
+        }
+    }
+
+    #[event(fetch)]
+    pub async fn fetch(_req: Request, _env: Env, _ctx: Context) -> Result<Response> {
+        Response::error("Not Found", 404)
+    }
+
+    #[derive(Debug)]
+    enum RunError {
+        Env(String),
+        Forecast(ForecastError),
+        Notify(NotifyError),
+    }
+
+    impl std::fmt::Display for RunError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Env(e) => write!(f, "env: {e}"),
+                Self::Forecast(e) => write!(f, "{e}"),
+                Self::Notify(e) => write!(f, "{e}"),
+            }
+        }
+    }
+
+    impl From<ForecastError> for RunError {
+        fn from(e: ForecastError) -> Self {
+            Self::Forecast(e)
+        }
+    }
+
+    impl From<NotifyError> for RunError {
+        fn from(e: NotifyError) -> Self {
+            Self::Notify(e)
+        }
+    }
+
+    async fn run(env: &Env) -> std::result::Result<(), RunError> {
+        let cfg = Config::from_env(env)?;
+        let provider = OpenMeteoProvider::new(crate::forecast::WorkerFetcher);
+        let hours = provider.fetch(cfg.lat, cfg.lon, &cfg.tz).await?;
+
+        match decide(&hours, cfg.threshold, cfg.min_consecutive) {
+            Some(alert) => {
+                worker::console_log!(
+                    "pollen-alert: window {start} – {end} (score {score})",
+                    start = alert.window_start,
+                    end = alert.window_end,
+                    score = alert.score,
+                );
+                if cfg.dry_run {
+                    LogNotifier.send(&alert).await?;
+                } else {
+                    let notifier = PushoverNotifier {
+                        app_token: cfg.pushover_app_token.unwrap_or_default(),
+                        user_key: cfg.pushover_user_key.unwrap_or_default(),
+                        http: WorkerPoster,
+                    };
+                    notifier.send(&alert).await?;
+                }
+            }
+            None => {
+                worker::console_log!("pollen-alert: no overnight window crossed threshold");
+            }
+        }
+        Ok(())
+    }
+
+    struct Config {
+        lat: f32,
+        lon: f32,
+        tz: String,
+        threshold: u8,
+        min_consecutive: usize,
+        dry_run: bool,
+        pushover_app_token: Option<String>,
+        pushover_user_key: Option<String>,
+    }
+
+    impl Config {
+        fn from_env(env: &Env) -> std::result::Result<Self, RunError> {
+            let lat = parse_var(env, "LAT")?;
+            let lon = parse_var(env, "LON")?;
+            let tz = var(env, "TZ")?;
+            let threshold = parse_var(env, "THRESHOLD")?;
+            let min_consecutive = parse_var(env, "MIN_CONSECUTIVE_HOURS")?;
+            let dry_run = var(env, "DRY_RUN")?.eq_ignore_ascii_case("true");
+            // Secrets are optional in dry-run mode so a staging deploy
+            // can come up before `wrangler secret put` runs. In live
+            // mode `run` reaches for them and a missing value surfaces
+            // as a Pushover `Rejected` from an empty token.
+            let pushover_app_token = env.secret("PUSHOVER_APP_TOKEN").ok().map(|s| s.to_string());
+            let pushover_user_key = env.secret("PUSHOVER_USER_KEY").ok().map(|s| s.to_string());
+            Ok(Self {
+                lat,
+                lon,
+                tz,
+                threshold,
+                min_consecutive,
+                dry_run,
+                pushover_app_token,
+                pushover_user_key,
+            })
+        }
+    }
+
+    fn var(env: &Env, key: &str) -> std::result::Result<String, RunError> {
+        env.var(key)
+            .map(|v| v.to_string())
+            .map_err(|e| RunError::Env(format!("{key}: {e}")))
+    }
+
+    fn parse_var<T: std::str::FromStr>(env: &Env, key: &str) -> std::result::Result<T, RunError>
+    where
+        T::Err: std::fmt::Display,
+    {
+        var(env, key)?
+            .parse::<T>()
+            .map_err(|e| RunError::Env(format!("{key}: {e}")))
+    }
+
+    /// `worker::Fetch`-backed form-encoded POST for the Pushover
+    /// notifier. The GET adapter for the forecast lives in
+    /// `forecast::WorkerFetcher` (also wasm-only); separate adapters
+    /// keep each trait independently mockable.
+    struct WorkerPoster;
+
+    #[async_trait(?Send)]
+    impl HttpPoster for WorkerPoster {
+        async fn post_form(
+            &self,
+            url: &str,
+            body: &str,
+        ) -> std::result::Result<String, NotifyError> {
+            use worker::{wasm_bindgen::JsValue, Fetch, Headers, Method, Request, RequestInit};
+            let headers = Headers::new();
+            headers
+                .set("content-type", "application/x-www-form-urlencoded")
+                .map_err(|e| NotifyError::Http(e.to_string()))?;
+            let req = Request::new_with_init(
+                url,
+                RequestInit::new()
+                    .with_method(Method::Post)
+                    .with_headers(headers)
+                    .with_body(Some(JsValue::from_str(body))),
+            )
+            .map_err(|e| NotifyError::Http(e.to_string()))?;
+            let mut resp = Fetch::Request(req)
+                .send()
+                .await
+                .map_err(|e| NotifyError::Http(e.to_string()))?;
+            resp.text()
+                .await
+                .map_err(|e| NotifyError::Http(e.to_string()))
+        }
+    }
 }

--- a/apps/pollen-alert/src/pipeline.rs
+++ b/apps/pollen-alert/src/pipeline.rs
@@ -1,0 +1,146 @@
+//! Glue that turns a forecast into an alert decision.
+//!
+//! Kept out of `lib.rs` so the pipeline is unit-testable against
+//! synthetic forecast hours without requiring the Worker runtime.
+//! `lib.rs` reads env, constructs the trait objects, and calls
+//! `decide` with what it gathered.
+
+use crate::alert::{find_alert, Alert};
+use crate::scoring::{in_tree_season, score_hour, ForecastHour};
+
+/// Filter `hours` to the first contiguous overnight window
+/// (19:00–07:00 local) and search for a qualifying alert. Returns
+/// `None` if no window crosses threshold for `min_consecutive`
+/// hours, or if the forecast contained no overnight hours at all.
+pub fn decide(hours: &[ForecastHour], threshold: u8, min_consecutive: usize) -> Option<Alert> {
+    let window = overnight_window(hours);
+    if window.is_empty() {
+        return None;
+    }
+    let season = window
+        .first()
+        .map(|h| in_tree_season(h.local_time.date()))
+        .unwrap_or(false);
+    let scored: Vec<_> = window
+        .iter()
+        .cloned()
+        .map(|h| {
+            let s = score_hour(&h, season);
+            (h, s)
+        })
+        .collect();
+    find_alert(&scored, threshold, min_consecutive)
+}
+
+/// First contiguous run of hours whose local time falls inside
+/// the overnight window `[19:00, 07:00)`. The cron fires at 02:00
+/// UTC (≈ 19:00 PDT / 18:00 PST), so the first qualifying hour in
+/// Open-Meteo's response is the start of the user's evening.
+fn overnight_window(hours: &[ForecastHour]) -> Vec<ForecastHour> {
+    use chrono::Timelike;
+    let mut started = false;
+    let mut window = Vec::new();
+    for h in hours {
+        let hr = h.local_time.hour();
+        let in_window = !(7..19).contains(&hr);
+        if in_window {
+            started = true;
+            window.push(h.clone());
+        } else if started {
+            break;
+        }
+    }
+    window
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scoring::Sky;
+    use chrono::{NaiveDate, NaiveTime};
+
+    fn hr(date: (i32, u32, u32), hour: u32) -> ForecastHour {
+        ForecastHour {
+            local_time: NaiveDate::from_ymd_opt(date.0, date.1, date.2)
+                .unwrap()
+                .and_time(NaiveTime::from_hms_opt(hour, 0, 0).unwrap()),
+            humidity_pct: 90.0,
+            wind_mph: 2.0,
+            precip_prob_pct: 10.0,
+            sky: Some(Sky::Clear),
+        }
+    }
+
+    fn safe(date: (i32, u32, u32), hour: u32) -> ForecastHour {
+        ForecastHour {
+            humidity_pct: 50.0,
+            wind_mph: 15.0,
+            precip_prob_pct: 80.0,
+            sky: Some(Sky::Overcast),
+            ..hr(date, hour)
+        }
+    }
+
+    #[test]
+    fn overnight_window_picks_19_to_06() {
+        let hours = vec![
+            hr((2026, 4, 15), 19),
+            hr((2026, 4, 15), 20),
+            hr((2026, 4, 15), 21),
+            hr((2026, 4, 16), 6),
+            hr((2026, 4, 16), 7),  // out
+            hr((2026, 4, 16), 19), // next evening — stops at first break
+        ];
+        let w = overnight_window(&hours);
+        assert_eq!(w.len(), 4);
+        assert_eq!(w[0].local_time.format("%H").to_string(), "19");
+        assert_eq!(w[3].local_time.format("%H").to_string(), "06");
+    }
+
+    #[test]
+    fn overnight_window_skips_leading_daytime_hours() {
+        let hours = vec![
+            hr((2026, 4, 15), 14), // skipped
+            hr((2026, 4, 15), 15), // skipped
+            hr((2026, 4, 15), 19), // start
+            hr((2026, 4, 15), 20),
+        ];
+        let w = overnight_window(&hours);
+        assert_eq!(w.len(), 2);
+        assert_eq!(w[0].local_time.format("%H").to_string(), "19");
+    }
+
+    #[test]
+    fn decide_returns_alert_when_overnight_qualifies() {
+        let hours = vec![
+            hr((2026, 4, 15), 19),
+            hr((2026, 4, 15), 20),
+            hr((2026, 4, 15), 21),
+            hr((2026, 4, 15), 22),
+        ];
+        let alert = decide(&hours, 5, 3).expect("alert");
+        assert!(alert.score >= 5);
+    }
+
+    #[test]
+    fn decide_returns_none_when_overnight_is_safe() {
+        let hours = vec![
+            safe((2026, 4, 15), 19),
+            safe((2026, 4, 15), 20),
+            safe((2026, 4, 15), 21),
+            safe((2026, 4, 15), 22),
+        ];
+        assert!(decide(&hours, 5, 3).is_none());
+    }
+
+    #[test]
+    fn decide_returns_none_when_no_overnight_hours() {
+        // All daytime — no window to score.
+        let hours = vec![
+            hr((2026, 4, 15), 10),
+            hr((2026, 4, 15), 11),
+            hr((2026, 4, 15), 12),
+        ];
+        assert!(decide(&hours, 5, 3).is_none());
+    }
+}

--- a/apps/pollen-alert/wrangler.toml
+++ b/apps/pollen-alert/wrangler.toml
@@ -15,3 +15,22 @@ command = "cargo install -q worker-build --locked && worker-build --release"
 # UTC value stable rather than tracking local time).
 [triggers]
 crons = ["0 2 * * *"]
+
+# Non-secret runtime config. Latitude/longitude pin Bainbridge Island,
+# WA; `TZ` is what Open-Meteo uses to return local-time hours.
+# `THRESHOLD` and `MIN_CONSECUTIVE_HOURS` match the v1 rules in
+# `scoring`/`alert`. `DRY_RUN=true` swaps the Pushover notifier for
+# `LogNotifier` so the pipeline can be exercised end-to-end without
+# sending real notifications — useful for staging before secrets are
+# wired or after a wrangler.toml change.
+#
+# Secrets live outside this file. Set via:
+#   wrangler secret put PUSHOVER_APP_TOKEN
+#   wrangler secret put PUSHOVER_USER_KEY
+[vars]
+LAT = "47.625"
+LON = "-122.5"
+TZ = "America/Los_Angeles"
+THRESHOLD = "5"
+MIN_CONSECUTIVE_HOURS = "3"
+DRY_RUN = "true"


### PR DESCRIPTION
Replaces the stub `scheduled` handler with the real cron pipeline:
reads env vars, fetches the forecast, decides on an alert window,
dispatches to the notifier.

Env (declared in `wrangler.toml [vars]`):
- `LAT`, `LON`, `TZ` — Bainbridge Island / America/Los_Angeles.
- `THRESHOLD = 5`, `MIN_CONSECUTIVE_HOURS = 3` — v1 rules.
- `DRY_RUN = true` — defaults dry-run so the pipeline can prove
  itself end-to-end before secrets are wired. `wrangler secret put`
  for `PUSHOVER_APP_TOKEN` / `PUSHOVER_USER_KEY` plus flipping
  `DRY_RUN = false` flips it live.

Pipeline module (`src/pipeline.rs`) wraps `decide(hours, threshold,
min_consecutive) → Option<Alert>` with `overnight_window` filtering
to the first contiguous `[19:00, 07:00)` run. Pure, native-
unit-testable; the worker entrypoint is just the glue.

Worker runtime (handlers, env reader, `WorkerPoster` HTTP adapter)
lives in a `#[cfg(target_arch = "wasm32")]` module so native
`cargo test` exercises only the pure modules — `worker::Fetch`,
`worker::Env`, and friends don't need to compile off-target.

Errors inside `run` are logged via `console_error!` and swallowed
so a single bad cron run shows up in `wrangler tail` without
fighting the scheduled trigger semantics. The next cron retries on
its own schedule.

Closes #409.