### PR TITLE
feat(blogctl): add-target command for distribution target entries

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -226,6 +226,20 @@ pub enum Command {
         #[arg(long)]
         no_sync: bool,
     },
+    /// Register a distribution target on a post. v1 fixes the new
+    /// entry's status at `planned`; `published` / `retracted` (which
+    /// require `--url` / `--published-at`) are deferred.
+    AddTarget {
+        slug: String,
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        #[arg(long, value_enum)]
+        target: Target,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// Per-target performance metrics (impressions, reactions,
     /// comments, reposts).
     Metrics {
@@ -506,6 +520,20 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 clear_audience,
                 clear_strategic_role,
                 clear_theme,
+                no_sync,
+            },
+        ),
+        Command::AddTarget {
+            slug,
+            workdir,
+            target,
+            no_sync,
+        } => commands::add_target::run(
+            jj,
+            commands::add_target::AddTargetArgs {
+                slug,
+                workdir: workdir_or_pwd(workdir)?,
+                target,
                 no_sync,
             },
         ),

--- a/apps/blogctl/src/commands/add_target.rs
+++ b/apps/blogctl/src/commands/add_target.rs
@@ -1,0 +1,72 @@
+//! `blogctl add-target <slug> --target <name>` — register a
+//! distribution target on a post.
+//!
+//! Replaces the "hand-edit the frontmatter" gap that surfaced during
+//! #474 (the e2e workflow test had to manually inject a `linkedin`
+//! `TargetEntry` so `metrics update` had something to update).
+//!
+//! v1 fixes the new entry's status at `Planned`. `Published` and
+//! `Retracted` are deferred because they legitimately require `url`
+//! / `published_at` fields and the use case for "add-as-already-
+//! published" hasn't appeared yet; rare cases can hand-edit
+//! frontmatter for now. When that flow shows up, add `--status`
+//! plus `--url` / `--published-at` alongside.
+
+use std::fs;
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+use crate::target::{Target, TargetEntry, TargetStatus};
+
+#[derive(Debug)]
+pub struct AddTargetArgs {
+    pub slug: String,
+    pub workdir: PathBuf,
+    pub target: Target,
+    pub no_sync: bool,
+}
+
+pub fn run(jj: &dyn Jj, args: AddTargetArgs) -> Result<()> {
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let (handle, mut post) = repo.load_raw(&args.slug)?;
+
+    // Per the parse-time `validate_targets` invariant, each `Target`
+    // appears at most once per post. Refuse early with the existing
+    // duplicate-target error so the user knows to use `metrics
+    // update` (or a future `set-target-status` command) instead of
+    // adding a second entry.
+    if post.metadata.targets.iter().any(|t| t.name == args.target) {
+        return Err(Error::DuplicateTarget {
+            path: handle.path.clone(),
+            name: args.target,
+        });
+    }
+
+    post.metadata.targets.push(TargetEntry {
+        name: args.target,
+        status: TargetStatus::Planned,
+        url: None,
+        published_at: None,
+        metrics: None,
+    });
+
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let message = format!("post({}): add-target {}", args.slug, args.target);
+    let path = handle.path.clone();
+    let target_name = args.target;
+    let slug = args.slug.clone();
+
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        post.metadata.updated_at = OffsetDateTime::now_utc();
+        let rendered = post.render()?;
+        fs::write(&path, rendered).map_err(|e| Error::io(&path, e))?;
+        Ok(())
+    })?;
+    println!("{slug}: add-target {target_name} (planned)");
+    Ok(())
+}

--- a/apps/blogctl/src/commands/mod.rs
+++ b/apps/blogctl/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod add_target;
 pub mod ai;
 pub mod analytics;
 pub mod backfill;

--- a/apps/blogctl/tests/workflow.rs
+++ b/apps/blogctl/tests/workflow.rs
@@ -20,15 +20,15 @@ use std::sync::Mutex;
 use tempfile::TempDir;
 
 use blogctl::commands::{
-    self, classify::ClassifyArgs, draft::DraftArgs, final_edit::FinalEditArgs, metrics::UpdateArgs,
-    refine::RefineArgs,
+    self, add_target::AddTargetArgs, classify::ClassifyArgs, draft::DraftArgs,
+    final_edit::FinalEditArgs, metrics::UpdateArgs, refine::RefineArgs,
 };
 use blogctl::error::Error;
 use blogctl::kind::Kind;
 use blogctl::stage::Stage;
 use blogctl::storage::{Repository, Workdir};
 use blogctl::sync::FakeJj;
-use blogctl::target::{Target, TargetEntry, TargetStatus};
+use blogctl::target::Target;
 
 // `tests/ai_endpoint.rs` also touches OPENROUTER_API_BASE; both
 // processes run in parallel by default. Process-level mutex keeps the
@@ -147,22 +147,21 @@ fn lifecycle_init_new_classify_promote_metrics() {
     // 4. promote — walk Concept → Published, four hops.
     promote_to_published(&workdir, slug);
 
-    // 5. metrics — `update` requires a target already in the post's
-    // targets[]. Adding a target is currently a manual frontmatter edit
-    // (no `add-target` command exists; tracked in #483 as part of the
-    // AI-integrated workflow gap survey). We rewrite the post directly
-    // to seed a `planned` linkedin target so metrics has something to
-    // update.
-    let repo = Repository::open(Workdir::new(&workdir)).expect("reopen pre-metrics");
-    let (handle, mut post) = repo.load_raw(slug).expect("load_raw pre-metrics");
-    post.metadata.targets.push(TargetEntry {
-        name: Target::Linkedin,
-        status: TargetStatus::Planned,
-        url: None,
-        published_at: None,
-        metrics: None,
-    });
-    std::fs::write(&handle.path, post.render().expect("render")).expect("write seeded target");
+    // 5. add-target → metrics update. `metrics update` requires a
+    // target already in the post's targets[]; `add-target` (added in
+    // #527) is how that target gets there. Before #527 this test
+    // hand-injected a TargetEntry via Post::render; now the same path
+    // exercises the real command.
+    commands::add_target::run(
+        &FakeJj::new(),
+        AddTargetArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            target: Target::Linkedin,
+            no_sync: true,
+        },
+    )
+    .expect("add-target");
 
     commands::metrics::update(
         &FakeJj::new(),


### PR DESCRIPTION
Replaces the "hand-edit the frontmatter" gap that surfaced during
#474 — the e2e workflow test was injecting a `linkedin` TargetEntry
directly via Post::render because `metrics update` requires the
target to already exist on the post. Now `add-target` is the
command that fills that gap, and the workflow test calls it instead
of hand-injecting.

v1 fixes the new entry's status at `Planned`. `Published` and
`Retracted` legitimately require `url` / `published_at` (per the
existing `validate_targets` invariant) and the use case for
"add-as-already-published" hasn't appeared yet; rare cases can
hand-edit frontmatter for now. When that flow shows up, add
`--status` plus `--url` / `--published-at` alongside.

Duplicate registration of an existing target fails early with the
existing `Error::DuplicateTarget` variant — the parse-time
`validate_targets` invariant says each `Target` appears at most
once per post, so a second entry would be rejected on the next
load anyway. Refusing up-front keeps the error site close to the
user's intent.

Closes #527