### PR TITLE
feat(blogctl): update command — recover workdir without manual jj ops

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -122,6 +122,18 @@ pub enum Command {
         #[arg(long)]
         no_sync: bool,
     },
+    /// Bring the workdir into a known-good shape against the remote:
+    /// fetch, move `@` directly onto `<bookmark>@<remote>`, fast-forward
+    /// the local bookmark. Refuses if `@` has uncommitted edits or the
+    /// local bookmark has unpushed commits.
+    Update {
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Refuse to run (sync is the whole point of `update`).
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// LLM interaction subcommands.
     Ai {
         #[command(subcommand)]
@@ -436,6 +448,9 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             dry_run,
             no_sync,
         } => commands::fix::run(jj, workdir_or_pwd(workdir)?, dry_run, no_sync),
+        Command::Update { workdir, no_sync } => {
+            commands::update::run(jj, workdir_or_pwd(workdir)?, no_sync)
+        }
         Command::Ai { action } => match action {
             AiAction::Ping { prompt, model } => commands::ai::ping(prompt, model),
         },
@@ -706,6 +721,8 @@ mod tests {
             vec!["blogctl", "fix", "--workdir", "/tmp/wd"],
             vec!["blogctl", "fix", "--workdir", "/tmp/wd", "--dry-run"],
             vec!["blogctl", "fix", "--workdir", "/tmp/wd", "--no-sync"],
+            vec!["blogctl", "update", "--workdir", "/tmp/wd"],
+            vec!["blogctl", "update", "--workdir", "/tmp/wd", "--no-sync"],
             vec!["blogctl", "ai", "ping", "hello"],
             vec![
                 "blogctl",
@@ -974,6 +991,7 @@ mod tests {
             vec!["blogctl", "readme", "regenerate"],
             vec!["blogctl", "doctor"],
             vec!["blogctl", "fix"],
+            vec!["blogctl", "update"],
             vec!["blogctl", "classify", "hello"],
             vec![
                 "blogctl",

--- a/apps/blogctl/src/commands.rs
+++ b/apps/blogctl/src/commands.rs
@@ -16,3 +16,4 @@ pub mod promote;
 pub mod readme;
 pub mod refine;
 pub mod show;
+pub mod update;

--- a/apps/blogctl/src/commands/update.rs
+++ b/apps/blogctl/src/commands/update.rs
@@ -1,0 +1,200 @@
+//! `blogctl update` — recovery command that brings the workdir into a
+//! known-good shape against the remote without the writer ever touching
+//! `jj` directly. Pairs with the #516 guardrail in `sync::commit_and_push`
+//! (which surfaces the side-branch state this command recovers from).
+//!
+//! The sequence:
+//! 1. Open the repo (refuse if not initialized).
+//! 2. Check `jj.status` — hard-fail if jj missing or workdir isn't a repo.
+//! 3. Refuse if `@` has uncommitted edits (would be stranded).
+//! 4. Fetch remote.
+//! 5. Refuse if local `<bookmark>` has unpushed commits.
+//! 6. `jj new <bookmark>@<remote>` — position `@` directly on the remote tip.
+//! 7. `jj bookmark set <bookmark> -r <bookmark>@<remote>` — fast-forward
+//!    the local bookmark.
+//!
+//! Each step prints a one-line progress note so it's obvious what
+//! happened if a write-shaped command later trips on something else.
+
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::storage::{Repository, Workdir};
+use crate::sync::{Jj, Status, SyncOptions};
+
+pub fn run(jj: &dyn Jj, workdir: PathBuf, no_sync: bool) -> Result<()> {
+    let wd = Workdir::new(&workdir);
+    let repo = Repository::open(wd)?;
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, no_sync);
+
+    if !opts.is_active() {
+        return Err(Error::UpdateRequiresSyncEnabled);
+    }
+
+    match jj.status(&workdir)? {
+        Status::Ok => {}
+        Status::JjNotInstalled | Status::NotAJjRepo => {
+            return Err(Error::UpdateRequiresJj);
+        }
+    }
+
+    if !jj.change_is_empty(&workdir, "@")? {
+        return Err(Error::UpdateHasUncommittedEdits);
+    }
+
+    println!("fetching {}", opts.config.remote);
+    jj.fetch(&workdir, &opts.config.remote)?;
+
+    if let Some(summary) = jj.unpushed_summary(
+        &workdir,
+        &opts.config.bookmark,
+        &opts.config.remote,
+        OffsetDateTime::now_utc(),
+    )? {
+        if summary.count > 0 {
+            return Err(Error::UpdateHasUnpushedCommits {
+                bookmark: opts.config.bookmark.clone(),
+                count: summary.count,
+            });
+        }
+    }
+
+    let remote_ref = format!("{}@{}", opts.config.bookmark, opts.config.remote);
+
+    println!("moving @ onto {remote_ref}");
+    jj.new_change_at(&workdir, &remote_ref, None)?;
+
+    println!("advancing {} to {remote_ref}", opts.config.bookmark);
+    jj.set_bookmark_at(&workdir, &opts.config.bookmark, &remote_ref)?;
+
+    println!("updated: @ is now on top of {remote_ref}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use crate::storage::Repository;
+    use crate::sync::{Call, FakeJj, Status, UnpushedSummary};
+
+    fn fresh_workdir() -> (TempDir, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        Repository::unchecked(Workdir::new(&path)).init().unwrap();
+        (tmp, path)
+    }
+
+    #[test]
+    fn run_drives_full_sequence_on_happy_path() {
+        let (_tmp, path) = fresh_workdir();
+        let jj = FakeJj::new();
+        run(&jj, path.clone(), false).unwrap();
+        let calls = jj.calls();
+        // Status → ChangeIsEmpty(@) → Fetch → UnpushedSummary
+        // → NewChangeAt(main@origin, None) → SetBookmarkAt(main, main@origin)
+        assert_eq!(calls.len(), 6, "got: {calls:?}");
+        assert!(matches!(calls[0], Call::Status { .. }));
+        assert!(matches!(
+            calls[1],
+            Call::ChangeIsEmpty { ref change, .. } if change == "@"
+        ));
+        assert!(matches!(
+            calls[2],
+            Call::Fetch { ref remote, .. } if remote == "origin"
+        ));
+        assert!(matches!(calls[3], Call::UnpushedSummary { .. }));
+        assert!(matches!(
+            &calls[4],
+            Call::NewChangeAt { parent, message, .. }
+                if parent == "main@origin" && message.is_none()
+        ));
+        assert!(matches!(
+            &calls[5],
+            Call::SetBookmarkAt { bookmark, target, .. }
+                if bookmark == "main" && target == "main@origin"
+        ));
+    }
+
+    #[test]
+    fn run_refuses_when_no_sync_flag_set() {
+        let (_tmp, path) = fresh_workdir();
+        let jj = FakeJj::new();
+        let err = run(&jj, path, true).unwrap_err();
+        assert!(matches!(err, Error::UpdateRequiresSyncEnabled));
+        // Refused before touching jj.
+        assert!(jj.calls().is_empty());
+    }
+
+    #[test]
+    fn run_refuses_when_sync_disabled_in_config() {
+        let (_tmp, path) = fresh_workdir();
+        // Rewrite .blog-os.toml with sync disabled.
+        fs::write(
+            path.join(".blog-os.toml"),
+            "version = 1\n[sync]\nenabled = false\n",
+        )
+        .unwrap();
+        let jj = FakeJj::new();
+        let err = run(&jj, path, false).unwrap_err();
+        assert!(matches!(err, Error::UpdateRequiresSyncEnabled));
+        assert!(jj.calls().is_empty());
+    }
+
+    #[test]
+    fn run_refuses_when_jj_not_installed() {
+        let (_tmp, path) = fresh_workdir();
+        let jj = FakeJj::new().with_status(Status::JjNotInstalled);
+        let err = run(&jj, path, false).unwrap_err();
+        assert!(matches!(err, Error::UpdateRequiresJj));
+    }
+
+    #[test]
+    fn run_refuses_when_not_a_jj_repo() {
+        let (_tmp, path) = fresh_workdir();
+        let jj = FakeJj::new().with_status(Status::NotAJjRepo);
+        let err = run(&jj, path, false).unwrap_err();
+        assert!(matches!(err, Error::UpdateRequiresJj));
+    }
+
+    #[test]
+    fn run_refuses_when_at_has_uncommitted_edits() {
+        let (_tmp, path) = fresh_workdir();
+        let jj = FakeJj::new().with_change_is_empty(false);
+        let err = run(&jj, path, false).unwrap_err();
+        assert!(matches!(err, Error::UpdateHasUncommittedEdits));
+        // Refused before fetch.
+        let calls = jj.calls();
+        assert!(!calls.iter().any(|c| matches!(c, Call::Fetch { .. })));
+    }
+
+    #[test]
+    fn run_refuses_when_local_bookmark_has_unpushed_commits() {
+        let (_tmp, path) = fresh_workdir();
+        let jj = FakeJj::new().with_unpushed_summary(Some(UnpushedSummary {
+            count: 3,
+            oldest_age_hours: 12,
+        }));
+        let err = run(&jj, path, false).unwrap_err();
+        match err {
+            Error::UpdateHasUnpushedCommits { bookmark, count } => {
+                assert_eq!(bookmark, "main");
+                assert_eq!(count, 3);
+            }
+            other => panic!("expected UpdateHasUnpushedCommits, got {other:?}"),
+        }
+        // Refused before NewChangeAt — fetch did fire (we need the
+        // unpushed-summary input to be authoritative).
+        let calls = jj.calls();
+        assert!(!calls.iter().any(|c| matches!(c, Call::NewChangeAt { .. })));
+        assert!(!calls
+            .iter()
+            .any(|c| matches!(c, Call::SetBookmarkAt { .. })));
+    }
+}

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -181,13 +181,31 @@ pub enum Error {
     SyncRebaseConflict { bookmark: String, remote: String },
 
     #[error(
-        "@ has commits from side branch(es) {} below it; bring @ on top of {bookmark} before writing",
+        "@ has commits from side branch(es) {} below it; run `blogctl update` to bring @ on top of {bookmark}",
         side_bookmarks.join(", "),
     )]
     WorkdirOnSideBranch {
         bookmark: String,
         side_bookmarks: Vec<String>,
     },
+
+    #[error(
+        "@ has uncommitted changes; commit via a blogctl write command (or `jj describe @`) before running `blogctl update`"
+    )]
+    UpdateHasUncommittedEdits,
+
+    #[error(
+        "local {bookmark} has {count} unpushed commit(s); resolve via `jj git push --bookmark {bookmark}` before running `blogctl update`"
+    )]
+    UpdateHasUnpushedCommits { bookmark: String, count: usize },
+
+    #[error("`blogctl update` requires sync to be enabled (config: `sync.enabled = true`, and don't pass `--no-sync`)")]
+    UpdateRequiresSyncEnabled,
+
+    #[error(
+        "`blogctl update` needs `jj`: install it (and run `jj git init --colocate` in the workdir)"
+    )]
+    UpdateRequiresJj,
 
     #[error(
         "`blogctl {0}` is not yet implemented (CLI surface only; behavior lands in a follow-up)"

--- a/apps/blogctl/src/sync.rs
+++ b/apps/blogctl/src/sync.rs
@@ -133,6 +133,20 @@ pub trait Jj: Send + Sync {
         remote: &str,
         now: OffsetDateTime,
     ) -> Result<Option<UnpushedSummary>>;
+
+    /// Whether the named change has no diff against its parent. Used
+    /// by `blogctl update` to refuse moving `@` when doing so would
+    /// strand uncommitted edits.
+    fn change_is_empty(&self, workdir: &Path, change: &str) -> Result<bool>;
+
+    /// Create a new empty change with `parent` as its parent. `message`
+    /// is optional — `None` leaves the new change without a description.
+    /// Companion to `new_change`, which always parents on `@`.
+    fn new_change_at(&self, workdir: &Path, parent: &str, message: Option<&str>) -> Result<()>;
+
+    /// Move (or create) `bookmark` to point at the revision `target`.
+    /// Companion to `set_bookmark_to_head`, which always targets `@`.
+    fn set_bookmark_at(&self, workdir: &Path, bookmark: &str, target: &str) -> Result<()>;
 }
 
 /// Real `jj` binary. Each method shells out via `std::process::Command`;
@@ -391,6 +405,42 @@ impl Jj for RealJj {
             oldest_age_hours: age.whole_hours(),
         }))
     }
+
+    fn change_is_empty(&self, workdir: &Path, change: &str) -> Result<bool> {
+        // `jj diff --summary -r <change>` lists one path per line for
+        // any add/modify/delete/rename. Empty stdout = no diff.
+        let command_str = format!("{JJ} diff --summary -r {change}");
+        let out = Command::new(JJ)
+            .args(["diff", "--summary", "-r", change])
+            .current_dir(workdir)
+            .output()
+            .map_err(|source| Error::JjInvoke {
+                command: command_str.clone(),
+                source,
+            })?;
+        if !out.status.success() {
+            return Err(Error::JjCommandFailed {
+                command: command_str,
+                status: out.status.code().unwrap_or(-1),
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            });
+        }
+        Ok(out.stdout.iter().all(u8::is_ascii_whitespace))
+    }
+
+    fn new_change_at(&self, workdir: &Path, parent: &str, message: Option<&str>) -> Result<()> {
+        let mut args: Vec<&str> = vec!["new", parent];
+        if let Some(m) = message {
+            args.extend(["-m", m]);
+        }
+        run_strict(workdir, &args)?;
+        Ok(())
+    }
+
+    fn set_bookmark_at(&self, workdir: &Path, bookmark: &str, target: &str) -> Result<()> {
+        run_strict(workdir, &["bookmark", "set", bookmark, "-r", target])?;
+        Ok(())
+    }
 }
 
 /// Per-invocation sync state: a `SyncConfig` (from `.blog-os.toml`)
@@ -597,6 +647,7 @@ struct FakeState {
     push_outcome: Option<PushOutcome>,
     unpushed_summary: Option<Option<UnpushedSummary>>,
     other_bookmarks: Option<Vec<String>>,
+    change_is_empty: Option<bool>,
 }
 
 /// One recorded call against `FakeJj`. Tests pop these and assert.
@@ -635,6 +686,20 @@ pub enum Call {
     OtherBookmarksInRange {
         workdir: PathBuf,
         bookmark: String,
+    },
+    ChangeIsEmpty {
+        workdir: PathBuf,
+        change: String,
+    },
+    NewChangeAt {
+        workdir: PathBuf,
+        parent: String,
+        message: Option<String>,
+    },
+    SetBookmarkAt {
+        workdir: PathBuf,
+        bookmark: String,
+        target: String,
     },
 }
 
@@ -676,6 +741,13 @@ impl FakeJj {
     /// an empty vec (no side branches in range) when unset.
     pub fn with_other_bookmarks(self, names: Vec<String>) -> Self {
         self.inner.lock().unwrap().other_bookmarks = Some(names);
+        self
+    }
+
+    /// Force `change_is_empty()` to return `is_empty`. Default is
+    /// `true` (matches the common case: an empty `@` between writes).
+    pub fn with_change_is_empty(self, is_empty: bool) -> Self {
+        self.inner.lock().unwrap().change_is_empty = Some(is_empty);
         self
     }
 
@@ -766,6 +838,33 @@ impl Jj for FakeJj {
             remote: remote.to_string(),
         });
         Ok(s.unpushed_summary.clone().unwrap_or(None))
+    }
+
+    fn change_is_empty(&self, workdir: &Path, change: &str) -> Result<bool> {
+        let mut s = self.inner.lock().unwrap();
+        s.calls.push(Call::ChangeIsEmpty {
+            workdir: workdir.to_path_buf(),
+            change: change.to_string(),
+        });
+        Ok(s.change_is_empty.unwrap_or(true))
+    }
+
+    fn new_change_at(&self, workdir: &Path, parent: &str, message: Option<&str>) -> Result<()> {
+        self.inner.lock().unwrap().calls.push(Call::NewChangeAt {
+            workdir: workdir.to_path_buf(),
+            parent: parent.to_string(),
+            message: message.map(str::to_string),
+        });
+        Ok(())
+    }
+
+    fn set_bookmark_at(&self, workdir: &Path, bookmark: &str, target: &str) -> Result<()> {
+        self.inner.lock().unwrap().calls.push(Call::SetBookmarkAt {
+            workdir: workdir.to_path_buf(),
+            bookmark: bookmark.to_string(),
+            target: target.to_string(),
+        });
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Pairs with #516's `WorkdirOnSideBranch` guardrail: when a writer's `@`
gets parked on a side branch (or the local bookmark lags behind the
remote, or a stray empty `@` is dangling), `blogctl update` brings
the workdir back to a known-good shape — fetch, move `@` directly
onto `<bookmark>@<remote>`, fast-forward the local bookmark — without
the writer ever touching `jj`.

Refuses loudly rather than guessing in the cases that need writer
judgement:
- `@` has uncommitted edits (would be stranded when `@` moves)
- local `<bookmark>` has unpushed commits (would be silently dropped
  by the bookmark fast-forward)
- sync is disabled / `--no-sync` passed (sync is the whole point)
- jj missing or workdir isn't a jj repo

Each step prints a one-line progress note so a downstream surprise
makes it obvious where things diverged. The #516 `WorkdirOnSideBranch`
error message now points at `blogctl update` directly, closing the
loop the issue called out.

Implementation surface in `sync.rs` is three additive `Jj` trait
methods (`change_is_empty`, `new_change_at`, `set_bookmark_at`) — the
existing `new_change` / `set_bookmark_to_head` keep their `@`-only
shape so `commit_and_push` callers don't churn.

Closes #522