### PR TITLE
feat(infra/home): home-manager-managed /file-issue skill

### DIFF
--- a/infra/home/dotfiles/claude/commands/file-issue.md
+++ b/infra/home/dotfiles/claude/commands/file-issue.md
@@ -1,12 +1,13 @@
 ---
-description: File a new GitHub issue with a duplicate-search gate (the well-lit path; the PreToolUse hook is the safety net)
-allowed-tools: Bash(gh issue *), Bash(shaka *), Bash(tools/shaka/bin/shaka *), Read
+description: File a new GitHub issue with a duplicate-search gate (the well-lit path; a PreToolUse hook may also be configured per-repo as the safety net)
+allowed-tools: Bash(gh issue *), Read
 ---
 
-File a new GitHub issue. The `PreToolUse` hook on `gh issue create`
-catches duplicates as a safety net; this skill is the well-lit path
-that runs the search up front so you see candidates before drafting
-a body.
+File a new GitHub issue. This skill is the well-lit path that runs the
+search up front so you see candidates before drafting a body. Some
+repos also configure a `PreToolUse` hook on `gh issue create` as a
+safety net (kolohelios is one); the skill works the same with or
+without the hook.
 
 ## Workflow
 
@@ -19,8 +20,8 @@ gh issue list --state open --search "<keywords>" --limit 10
 ```
 
 Pick keywords from the topic — typically the project scope plus the
-distinguishing nouns/verbs (for example, `blogctl refine command`
-or `shaka issue list search`).
+distinguishing nouns/verbs (for example, `analytics summary` or
+`auth token storage`).
 
 ### 2. Show candidates
 
@@ -41,8 +42,8 @@ to confirm one of:
 
 ### 3. Draft the issue body
 
-Once the user confirms "file as new," draft a body using this repo's
-standard issue shape:
+Once the user confirms "file as new," draft a body using a standard
+issue shape:
 
 - `## Problem` — what's broken or missing
 - `## Proposed implementation` — the shape, not every detail
@@ -55,10 +56,11 @@ Stop, show the draft, and wait for the user to confirm or tweak.
 
 Run `gh issue create --title "<title>" --body "<body>" [--label ...]`.
 
-The `PreToolUse` hook will re-run the search and block if it finds
-matches that this skill missed. That's fine — it's the safety net.
-If the hook blocks but the user has already confirmed in step 2 that
-filing is intended, re-run with `BYPASS_ISSUE_DUP_CHECK=1` prefix:
+If the repo has a `PreToolUse` hook configured, it will re-run the
+search and block on matches. If the hook blocks but the user has
+already confirmed in step 2 that filing is intended, re-run with a
+`BYPASS_ISSUE_DUP_CHECK=1` prefix (kolohelios convention; other repos
+may use a different bypass mechanism):
 
 ```
 BYPASS_ISSUE_DUP_CHECK=1 gh issue create --title ... --body ...

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -79,4 +79,11 @@
   # Zellij's keybind tree is too elaborate to express idiomatically in
   # nix. Ship the kdl file as-is and let home-manager symlink it.
   xdg.configFile."zellij/config.kdl".source = ../dotfiles/zellij/config.kdl;
+
+  # Claude Code skills that aren't tied to a specific project. Lifted
+  # from `kolohelios/.claude/commands/` so they apply to claude
+  # sessions in any working directory. Project-specific skills
+  # (`/ship`, `/start` — both call `shaka`) stay in kolohelios's
+  # `.claude/commands/`.
+  home.file.".claude/commands/file-issue.md".source = ../dotfiles/claude/commands/file-issue.md;
 }


### PR DESCRIPTION
Lifts the `/file-issue` skill from kolohelios's `.claude/commands/`
to `infra/home/dotfiles/claude/commands/`, wired into `common.nix`
via `home.file`. Now propagates to every claude session — not just
ones run from inside the kolohelios checkout.

Light cleanup on the way: dropped the kolohelios-specific
`Bash(shaka *)` and `Bash(tools/shaka/bin/shaka *)` from
`allowed-tools`, generalized the example keywords away from
shaka-specific terms. The skill itself only needs `gh issue *`; the
shaka tool calls were leftover from when this lived alongside
shaka-aware code.

The companion `PreToolUse` hook from #524 still calls
`tools/shaka/bin/shaka claude hook pre-issue-create`, which is
kolohelios-specific — so the hook stays in `.claude/settings.json`
where it can't fire from non-kolohelios working directories. The
skill works the same with or without the hook; updated wording
makes that explicit.

Follow-ups for the remaining #518 acceptance criteria (managed
`~/.claude/settings.json`, portable hook, version-controlled
`~/.claude/CLAUDE.md`) get filed as separate issues — each is its
own design discussion.

Closes #518