### PR TITLE
fix(blogctl): check workdir initialization before sync orchestration

### DIFF
--- a/apps/blogctl/src/commands/init.rs
+++ b/apps/blogctl/src/commands/init.rs
@@ -1,10 +1,18 @@
 use std::path::PathBuf;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::storage::{Repository, Workdir};
 use crate::sync::{self, Jj, SyncOptions};
 
 pub fn run(jj: &dyn Jj, workdir: PathBuf, no_sync: bool) -> Result<()> {
+    // Short-circuit before the sync orchestration so the user sees
+    // `WorkdirAlreadyInitialized` rather than whatever jj precheck
+    // happens to fail first (conflicted bookmark, missing remote, …).
+    let wd = Workdir::new(&workdir);
+    if wd.config_path().exists() {
+        return Err(Error::WorkdirAlreadyInitialized(wd.root().to_path_buf()));
+    }
+
     // `init` creates `.blog-os.toml`, so we have no config to read
     // SyncConfig from yet. Use the built-in defaults; if the user
     // wants different sync settings they can edit the file after.

--- a/apps/blogctl/tests/cli.rs
+++ b/apps/blogctl/tests/cli.rs
@@ -207,6 +207,26 @@ fn new_accepts_explicit_slug_override() {
 }
 
 #[test]
+fn init_on_already_initialized_workdir_short_circuits() {
+    // The fast-path must fire before any jj orchestration — so this
+    // test deliberately does NOT call `jj_init` on the tempdir. If the
+    // sync layer ran, it would short-circuit on `NotAJjRepo` and we'd
+    // never reach (or observe) the `WorkdirAlreadyInitialized` path.
+    let tmp = TempDir::new().unwrap();
+    let wd = workdir_arg(tmp.path());
+
+    assert_success(&run(&["init", "--workdir", &wd]), "first init");
+
+    let out = run(&["init", "--workdir", &wd]);
+    assert!(!out.status.success(), "second init should fail");
+    let err = stderr(&out);
+    assert!(
+        err.contains("already initialized"),
+        "expected `already initialized` in stderr, got: {err}"
+    );
+}
+
+#[test]
 fn init_writes_readme_template() {
     let tmp = TempDir::new().unwrap();
     let wd = workdir_arg(tmp.path());


### PR DESCRIPTION
`blogctl init` ran the full jj `commit_and_push` flow before the
`WorkdirAlreadyInitialized` check fired (the latter lived inside the
write closure via `Repository::init`). Any sync-layer precheck failure —
conflicted bookmark, missing remote, rebase conflict — would preempt the
clearer error.

Hoist the `<workdir>/.blog-os.toml` existence check to the top of
`init::run` so re-running `init` against an already-initialized workdir
returns the actionable error without touching jj.

Closes #542