### PR TITLE
feat(claude-hooks): publish to FlakeHub on push to main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       base_ref: ${{ steps.base.outputs.ref }}
       blogctl: ${{ steps.filter.outputs.blogctl }}
+      claude-hooks: ${{ steps.filter.outputs.claude-hooks }}
       home: ${{ steps.filter.outputs.home }}
       image: ${{ steps.filter.outputs.image }}
       nix-lib: ${{ steps.filter.outputs.nix-lib }}
@@ -51,6 +52,8 @@ jobs:
             - 'infra/home/**'
           nix-lib:
             - 'nix/kolohelios-nix/**'
+          claude-hooks:
+            - 'tools/claude-hooks/**'
           shaka:
             - 'tools/shaka/**'
   preflight:
@@ -207,6 +210,31 @@ jobs:
         name: kolohelios/kolohelios-nix
         rolling: true
         visibility: public
+  build-claude-hooks:
+    name: Build claude-hooks
+    needs:
+    - preflight
+    - changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.claude-hooks == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - uses: DeterminateSystems/nix-installer-action@main
+      with:
+        determinate: true
+        flakehub: true
+    - uses: DeterminateSystems/flakehub-cache-action@v3
+    - run: nix build ./tools/claude-hooks
+    - uses: DeterminateSystems/flakehub-push@main
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      with:
+        directory: tools/claude-hooks
+        name: kolohelios/claude-hooks
+        rolling: true
+        visibility: public
   build-shaka:
     name: Build shaka
     needs:
@@ -241,6 +269,7 @@ jobs:
     - build-image
     - build-home
     - build-nix-lib
+    - build-claude-hooks
     - build-shaka
     if: always()
     runs-on: ubuntu-latest

--- a/tools/claude-hooks/project.cue
+++ b/tools/claude-hooks/project.cue
@@ -11,4 +11,17 @@ package project
 			fail: 0
 		}
 	}
+	ci: {
+		build: {
+			filterKey:   "claude-hooks"
+			jobId:       "claude-hooks"
+			displayName: "claude-hooks"
+			publish: {
+				kind:       "flakehub"
+				name:       "kolohelios/claude-hooks"
+				visibility: "public"
+				rolling:    true
+			}
+		}
+	}
 }


### PR DESCRIPTION
Adds a `ci.build` block to `tools/claude-hooks/project.cue` and
regenerates `.github/workflows/main.yaml`. The new
`build-claude-hooks` job mirrors `build-shaka` / `build-blogctl` /
`build-nix-lib` — same path-filter, same nix build + flakehub-push
shape.

Scope cut from #545: this PR ships only the publish half. The
`infra/home` consumption half (the second half of #545's body) was
deferred to #548 because the chicken-egg made one PR impossible —
the first CI run can't resolve `claude-hooks` from FlakeHub
because the publish hasn't happened yet. Two-step landing instead:
this PR lands → post-merge publish lands → #548 lands the
consumption.

Closes #545