### PR TITLE
feat(shaka): issue list --search for full-text issue search

### DIFF
--- a/tools/shaka/src/claude.rs
+++ b/tools/shaka/src/claude.rs
@@ -15,12 +15,11 @@
 //! exit 0 cheaply for tool calls it doesn't care about.
 
 use std::io::Read;
-use std::process::Command;
 
 use clap::Subcommand;
 use serde::Deserialize;
 
-use crate::gh;
+use crate::gh::{self, ListState};
 use crate::term::{BOLD, DIM, RED, RESET, YELLOW};
 
 /// Env-var prefix that lets the user opt out of the duplicate-check
@@ -32,7 +31,7 @@ const BYPASS_VAR: &str = "BYPASS_ISSUE_DUP_CHECK";
 /// Cap on the number of candidate matches we surface. Keeps the
 /// error output skimmable; if there are more, the user can re-run
 /// the search manually.
-const MAX_CANDIDATES: usize = 5;
+const MAX_CANDIDATES: u32 = 5;
 
 #[derive(Subcommand)]
 pub enum ClaudeCommand {
@@ -138,7 +137,7 @@ fn pre_issue_create() {
         "{RED}{BOLD}blocked:{RESET} duplicate-check found {} open issue(s) matching {title:?}:",
         candidates.len()
     );
-    for c in candidates.iter().take(MAX_CANDIDATES) {
+    for c in candidates.iter().take(MAX_CANDIDATES as usize) {
         eprintln!("  {BOLD}#{}{RESET} {}", c.number, c.title);
     }
     eprintln!();
@@ -208,34 +207,22 @@ fn search_open_issues(title: &str) -> Result<Vec<Candidate>, String> {
     // detection fails there. shaka's `detect_repo_or_env` reads the
     // remote via `jj git remote list`, which works in any workspace.
     let repo = gh::detect_repo_or_env().map_err(|e| format!("could not detect repo: {e}"))?;
-    let output = Command::new("gh")
-        .args([
-            "issue",
-            "list",
-            "--repo",
-            &repo,
-            "--state",
-            "open",
-            "--search",
-            title,
-            "--limit",
-            &MAX_CANDIDATES.to_string(),
-            "--json",
-            "number,title",
-        ])
-        .output()
-        .map_err(|e| format!("could not invoke gh: {e}"))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "gh exited with status {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-
-    serde_json::from_slice::<Vec<Candidate>>(&output.stdout)
-        .map_err(|e| format!("could not parse gh output: {e}"))
+    let issues = gh::list_issues(
+        &repo,
+        ListState::Open,
+        &[],
+        None,
+        Some(title),
+        MAX_CANDIDATES,
+    )
+    .map_err(|e| format!("could not search issues: {e}"))?;
+    Ok(issues
+        .into_iter()
+        .map(|i| Candidate {
+            number: i.number,
+            title: i.title,
+        })
+        .collect())
 }
 
 #[cfg(test)]

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -571,12 +571,15 @@ pub struct IssueSummary {
 /// List GitHub issues from `repo` matching the given filters.
 ///
 /// Shells out to `gh issue list --json number,title,state,labels,url,createdAt,updatedAt`.
-/// `labels` are AND-combined when more than one is supplied.
+/// `labels` are AND-combined when more than one is supplied. When
+/// `search` is `Some`, the query is passed through verbatim as GitHub
+/// search syntax (combinable with the other filters).
 pub fn list_issues(
     repo: &str,
     state: ListState,
     labels: &[String],
     milestone: Option<&str>,
+    search: Option<&str>,
     limit: u32,
 ) -> Result<Vec<IssueSummary>, GhError> {
     let limit = limit.to_string();
@@ -599,6 +602,10 @@ pub fn list_issues(
     if let Some(m) = milestone {
         args.push("--milestone".into());
         args.push(m.to_string());
+    }
+    if let Some(q) = search {
+        args.push("--search".into());
+        args.push(q.to_string());
     }
 
     let output = Command::new("gh")

--- a/tools/shaka/src/issue.rs
+++ b/tools/shaka/src/issue.rs
@@ -56,6 +56,11 @@ pub enum IssueCommand {
         /// Filter by milestone title
         #[arg(long)]
         milestone: Option<String>,
+        /// Full-text search query, passed through to GitHub's issue
+        /// search syntax. Combinable with `--state`, `--label`, and
+        /// `--milestone`.
+        #[arg(long)]
+        search: Option<String>,
         /// Maximum number of issues to return
         #[arg(long, default_value_t = 30)]
         limit: u32,
@@ -78,8 +83,9 @@ pub fn run(cmd: IssueCommand) {
             state,
             labels,
             milestone,
+            search,
             limit,
             json,
-        } => list::run(repo, state.into(), labels, milestone, limit, json),
+        } => list::run(repo, state.into(), labels, milestone, search, limit, json),
     }
 }

--- a/tools/shaka/src/issue/list.rs
+++ b/tools/shaka/src/issue/list.rs
@@ -8,6 +8,7 @@ pub fn run(
     state: ListState,
     labels: Vec<String>,
     milestone: Option<String>,
+    search: Option<String>,
     limit: u32,
     json_out: bool,
 ) {
@@ -23,7 +24,14 @@ pub fn run(
         },
     };
 
-    let issues = match gh::list_issues(&repo, state, &labels, milestone.as_deref(), limit) {
+    let issues = match gh::list_issues(
+        &repo,
+        state,
+        &labels,
+        milestone.as_deref(),
+        search.as_deref(),
+        limit,
+    ) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("{RED}{BOLD}error:{RESET} {e}");
@@ -32,7 +40,14 @@ pub fn run(
     };
 
     if json_out {
-        let payload = build_payload(&repo, state, &labels, milestone.as_deref(), &issues);
+        let payload = build_payload(
+            &repo,
+            state,
+            &labels,
+            milestone.as_deref(),
+            search.as_deref(),
+            &issues,
+        );
         match serde_json::to_string_pretty(&payload) {
             Ok(s) => println!("{s}"),
             Err(e) => {
@@ -41,15 +56,24 @@ pub fn run(
             }
         }
     } else {
-        print!("{}", render_tree(&repo, state, &issues));
+        print!("{}", render_tree(&repo, state, search.as_deref(), &issues));
     }
 }
 
-fn render_tree(repo: &str, state: ListState, issues: &[IssueSummary]) -> String {
+fn render_tree(
+    repo: &str,
+    state: ListState,
+    search: Option<&str>,
+    issues: &[IssueSummary],
+) -> String {
     let mut out = String::new();
     out.push_str(&format!("{BOLD}shaka issue list{RESET}\n"));
+    let search_suffix = match search {
+        Some(q) => format!("  search: {q:?}"),
+        None => String::new(),
+    };
     out.push_str(&format!(
-        "{DIM}├── repo: {repo}  state: {}  count: {}{RESET}\n",
+        "{DIM}├── repo: {repo}  state: {}{search_suffix}  count: {}{RESET}\n",
         state_arg_str(state),
         issues.len()
     ));
@@ -93,6 +117,7 @@ fn build_payload(
     state: ListState,
     labels: &[String],
     milestone: Option<&str>,
+    search: Option<&str>,
     issues: &[IssueSummary],
 ) -> Value {
     let issues_value: Vec<Value> = issues
@@ -115,6 +140,7 @@ fn build_payload(
             "state": state_arg_str(state),
             "labels": labels,
             "milestone": milestone,
+            "search": search,
         },
         "count": issues.len(),
         "issues": issues_value,
@@ -179,7 +205,7 @@ mod tests {
 
     #[test]
     fn renders_empty_list_with_summary_branch() {
-        let out = strip_ansi(&render_tree("o/r", ListState::Open, &[]));
+        let out = strip_ansi(&render_tree("o/r", ListState::Open, None, &[]));
         assert!(out.contains("shaka issue list"));
         assert!(out.contains("├── repo: o/r  state: open  count: 0"));
         assert!(out.contains("└── (no issues)"));
@@ -192,7 +218,7 @@ mod tests {
             issue(244, IssueState::Open, &["shaka"], "list slice"),
             issue(209, IssueState::Closed, &[], "audit slice"),
         ];
-        let out = strip_ansi(&render_tree("o/r", ListState::All, &issues));
+        let out = strip_ansi(&render_tree("o/r", ListState::All, None, &issues));
         assert!(out.contains("├── repo: o/r  state: all  count: 3"));
         // numbers right-padded to width 3 (longest is "244")
         assert!(out.contains("├── #15   OPEN  umbrella"));
@@ -204,6 +230,21 @@ mod tests {
     }
 
     #[test]
+    fn renders_search_in_header_when_present() {
+        let issues = vec![issue(7, IssueState::Open, &["shaka"], "found it")];
+        let out = strip_ansi(&render_tree(
+            "o/r",
+            ListState::Open,
+            Some("foo bar"),
+            &issues,
+        ));
+        assert!(
+            out.contains("├── repo: o/r  state: open  search: \"foo bar\"  count: 1"),
+            "header missing search segment: {out}"
+        );
+    }
+
+    #[test]
     fn payload_shape_is_normalized() {
         let issues = vec![issue(1, IssueState::Open, &["shaka"], "t")];
         let payload = build_payload(
@@ -211,12 +252,14 @@ mod tests {
             ListState::Open,
             &["shaka".to_string()],
             Some("v1"),
+            None,
             &issues,
         );
         assert_eq!(payload["repo"], "o/r");
         assert_eq!(payload["filters"]["state"], "open");
         assert_eq!(payload["filters"]["labels"], json!(["shaka"]));
         assert_eq!(payload["filters"]["milestone"], "v1");
+        assert!(payload["filters"]["search"].is_null());
         assert_eq!(payload["count"], 1);
         assert_eq!(payload["issues"][0]["number"], 1);
         assert_eq!(payload["issues"][0]["state"], "OPEN");
@@ -228,11 +271,18 @@ mod tests {
     }
 
     #[test]
-    fn payload_milestone_null_when_absent() {
-        let payload = build_payload("o/r", ListState::Open, &[], None, &[]);
+    fn payload_milestone_and_search_null_when_absent() {
+        let payload = build_payload("o/r", ListState::Open, &[], None, None, &[]);
         assert!(payload["filters"]["milestone"].is_null());
+        assert!(payload["filters"]["search"].is_null());
         assert_eq!(payload["filters"]["labels"], json!([]));
         assert_eq!(payload["count"], 0);
+    }
+
+    #[test]
+    fn payload_includes_search_when_set() {
+        let payload = build_payload("o/r", ListState::Open, &[], None, Some("blogctl sync"), &[]);
+        assert_eq!(payload["filters"]["search"], "blogctl sync");
     }
 
     #[test]


### PR DESCRIPTION
Adds `--search <query>` to `shaka issue list`, passing the query
through to GitHub's issue search syntax. Combinable with the
existing `--state`, `--label`, and `--milestone` filters. The header
line of the human-readable tree gains a `search: "<query>"` segment
when set; the JSON payload gets a `filters.search` field
(`null` when omitted) so callers can identify search-driven results.

Migrates the in-shaka `pre-issue-create` hook
(`tools/shaka/src/claude.rs`) from a raw `gh issue list --search`
shell-out to `gh::list_issues(..., Some(title), MAX_CANDIDATES)`, so
the hook and `shaka issue list` share one code path. The portable
`tools/claude-hooks` binary deliberately stays on its direct `gh`
shell-out per #535's no-shaka-dependency design.

Closes #519