### PR TITLE
feat(infra/home): consume claude-hooks from FlakeHub

### DIFF
--- a/infra/home/flake.lock
+++ b/infra/home/flake.lock
@@ -1,5 +1,28 @@
 {
   "nodes": {
+    "claude-hooks": {
+      "inputs": {
+        "kolohelios-nix": [
+          "kolohelios-nix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1779817997,
+        "narHash": "sha256-Xtg4c0R1sVKjQJEbl74siGNlJL1qk2CcOotRVKNNGLM=",
+        "rev": "a5369a9620456c3fa4df19d9bca7e2fb979f68d4",
+        "revCount": 379,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/claude-hooks/0.1.379%2Brev-a5369a9620456c3fa4df19d9bca7e2fb979f68d4/019e656e-b29c-7b01-bb8a-9ff9c546134c/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/kolohelios/claude-hooks/%2A.tar.gz"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -7,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777851538,
-        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
+        "lastModified": 1779506708,
+        "narHash": "sha256-QOD/CNm196nCJRheux/URi4/HE66fthdOMqCJoPP1Y0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
+        "rev": "3ee51fbdac8c8bdfe1e7e1fcaba6520a563f394f",
         "type": "github"
       },
       "original": {
@@ -26,12 +49,12 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1779755646,
+        "lastModified": 1779817997,
         "narHash": "sha256-aDrScWklbRGN2L3eMOJ7EA7d6vcwQejbU7S3xN//c00=",
-        "rev": "d862df9e3337833f65e40dcb57c05d45ab7e8843",
-        "revCount": 367,
+        "rev": "a5369a9620456c3fa4df19d9bca7e2fb979f68d4",
+        "revCount": 379,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.367%2Brev-d862df9e3337833f65e40dcb57c05d45ab7e8843/019e61b9-1b60-78a1-b493-2c5b21b7552b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.379%2Brev-a5369a9620456c3fa4df19d9bca7e2fb979f68d4/019e656e-b2b4-78b0-bc4a-fca7ba37c1f1/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -75,6 +98,7 @@
     },
     "root": {
       "inputs": {
+        "claude-hooks": "claude-hooks",
         "home-manager": "home-manager",
         "kolohelios-nix": "kolohelios-nix",
         "nix-darwin": "nix-darwin",
@@ -82,6 +106,27 @@
           "kolohelios-nix",
           "nixpkgs"
         ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "claude-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779765539,
+        "narHash": "sha256-2QxuD5gJcfCFsnqv54LGEHQKvd+K+DW/ecERwAvuA7w=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "09889992e640378f7008c3302b9d4892579df610",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/infra/home/flake.nix
+++ b/infra/home/flake.nix
@@ -18,6 +18,17 @@
       url = "github:LnL7/nix-darwin/nix-darwin-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Portable Claude Code hooks — installed globally so the
+    # duplicate-issue-create gate (#515) fires in any working
+    # directory, not just inside the kolohelios checkout. Follows
+    # the shared kolohelios-nix / nixpkgs pins so its closure
+    # stays in lockstep with the rest of the toolchain here.
+    claude-hooks = {
+      url = "https://flakehub.com/f/kolohelios/claude-hooks/*.tar.gz";
+      inputs.kolohelios-nix.follows = "kolohelios-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -27,6 +38,7 @@
       nixpkgs,
       home-manager,
       nix-darwin,
+      claude-hooks,
       ...
     }:
     let
@@ -35,6 +47,7 @@
     {
       darwinConfigurations.Jons-MacBook-Pro = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
+        specialArgs = { inherit claude-hooks; };
         modules = [
           home-manager.darwinModules.home-manager
           ./modules/darwin.nix
@@ -43,11 +56,15 @@
 
       # NixOS module — imported by `infra/devbox` to apply this user's
       # home-manager profile to the `jon` account on the devbox.
+      # `_module.args.claude-hooks` is the NixOS equivalent of the
+      # `specialArgs` plumbing above so `infra/devbox` doesn't have
+      # to know about it.
       nixosModules.home = {
         imports = [
           home-manager.nixosModules.home-manager
           ./modules/linux.nix
         ];
+        _module.args = { inherit claude-hooks; };
       };
 
       devShells = forEachSupportedSystem (

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -2,22 +2,28 @@
 # (via nix-darwin) and Linux (via NixOS). `home.username` and
 # `home.homeDirectory` are set by the host system's user list; this
 # module stays platform-agnostic.
-{ pkgs, ... }:
+{ pkgs, claude-hooks, ... }:
 
 {
   home.stateVersion = "25.05";
 
   # CLI toolchain. Tools managed via `programs.*` (git, jujutsu, helix,
   # direnv, zsh) install their own binaries; only list the rest here.
-  home.packages = with pkgs; [
-    ripgrep
-    fd
-    jq
-    curl
-    bat
-    eza
-    zellij
-    claude-code
+  home.packages = [
+    pkgs.ripgrep
+    pkgs.fd
+    pkgs.jq
+    pkgs.curl
+    pkgs.bat
+    pkgs.eza
+    pkgs.zellij
+    pkgs.claude-code
+    # Portable Claude Code harness hooks. The duplicate-issue-create
+    # gate (#515) calls `claude-hooks pre-issue-create` from
+    # `~/.claude/settings.json` (wired in #534); having it on PATH
+    # globally lets the hook fire in any working directory, not just
+    # inside the kolohelios checkout.
+    claude-hooks.packages.${pkgs.stdenv.hostPlatform.system}.default
   ];
 
   programs.git = {

--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ claude-hooks, ... }:
 
 {
   system.stateVersion = 5;
@@ -24,5 +24,6 @@
 
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
+  home-manager.extraSpecialArgs = { inherit claude-hooks; };
   home-manager.users.jedwards = import ./common.nix;
 }

--- a/infra/home/modules/linux.nix
+++ b/infra/home/modules/linux.nix
@@ -1,7 +1,8 @@
-{ ... }:
+{ claude-hooks, ... }:
 
 {
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
+  home-manager.extraSpecialArgs = { inherit claude-hooks; };
   home-manager.users.jon = import ./common.nix;
 }


### PR DESCRIPTION
Picks up the FlakeHub-published `claude-hooks` from #549, threads it
through `darwinSystem`'s `specialArgs` / the NixOS module's
`_module.args` and `home-manager.extraSpecialArgs` into common.nix,
and adds the binary to `home.packages`.

Now that the binary is on PATH globally, the `~/.claude/settings.json`
wiring (#534) can call plain `claude-hooks pre-issue-create` from
any working directory — not just inside the kolohelios checkout.

kolohelios's project-local `.claude/settings.json` still calls
`tools/shaka/bin/shaka claude hook pre-issue-create`; switching that
to `claude-hooks pre-issue-create` is deferred until #534 lands and
the global hook is exercised in practice — both work today.

Closes #548