### PR TITLE
feat(shaka): issue label sync reconciles GitHub labels with CUE

### DIFF
--- a/.shaka/labels.cue
+++ b/.shaka/labels.cue
@@ -1,0 +1,32 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		// Scope labels — every open issue must carry at least one,
+		// per `shaka issue audit`.
+		{name: "blogctl", color:      "1f77b4", description: "blogctl CLI / blog post workflow tooling", scope: true},
+		{name: "ci", color:           "fbca04", description: "CI pipeline / GitHub Actions / preflight gates", scope: true},
+		{name: "claude", color:       "d4c5f9", description: "claude-code config, hooks, settings", scope: true},
+		{name: "infra/devbox", color: "0052cc", description: "Devbox / dev-environment infrastructure", scope: true},
+		{name: "meta", color:         "ededed", description: "Cross-cutting repo / monorepo policy issues", scope: true},
+		{name: "nix", color:          "5277c3", description: "Nix flakes, kolohelios-nix shared lib", scope: true},
+		{name: "pollen-alert", color: "0e8a16", description: "Pollen alert worker", scope: true},
+		{name: "portfolio", color:    "1d76db", description: "Personal portfolio site at kolohelios.com", scope: true},
+		{name: "shaka", color:        "5319e7", description: "shaka CLI / repo tooling", scope: true},
+		{name: "todoist", color:      "e60023", description: "Todoist CLI tool", scope: true},
+
+		// Type / housekeeping / category labels — not scope labels.
+		{name: "bug", color:              "d73a4a", description: "Something isn't working", scope: false},
+		{name: "dependencies", color:     "0366d6", description: "Pull requests that update a dependency file", scope: false},
+		{name: "documentation", color:    "0075ca", description: "Improvements or additions to documentation", scope: false},
+		{name: "duplicate", color:        "cfd3d7", description: "This issue or pull request already exists", scope: false},
+		{name: "enhancement", color:      "a2eeef", description: "New feature or request", scope: false},
+		{name: "github_actions", color:   "000000", description: "Pull requests that update GitHub Actions code", scope: false},
+		{name: "good first issue", color: "7057ff", description: "Good for newcomers", scope: false},
+		{name: "help wanted", color:      "008672", description: "Extra attention is needed", scope: false},
+		{name: "invalid", color:          "e4e669", description: "This doesn't seem right", scope: false},
+		{name: "question", color:         "d876e3", description: "Further information is requested", scope: false},
+		{name: "rust", color:             "000000", description: "Pull requests that update rust code", scope: false},
+		{name: "wontfix", color:          "ffffff", description: "This will not be worked on", scope: false},
+	]
+}

--- a/tools/shaka/schema/labels-schema.cue
+++ b/tools/shaka/schema/labels-schema.cue
@@ -1,0 +1,16 @@
+package labels
+
+#Label: {
+	name:        string & !=""
+	color:       =~"^[0-9a-f]{6}$"
+	description: string
+	// `true` if this label counts toward the scope-label policy
+	// enforced by `shaka issue audit`. Type labels (e.g. `bug`,
+	// `enhancement`), housekeeping labels (`duplicate`, `wontfix`),
+	// and Dependabot category labels are all `false`.
+	scope: bool
+}
+
+#LabelSet: {
+	labels: [...#Label]
+}

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -684,6 +684,139 @@ pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError>
         .collect()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteLabel {
+    pub name: String,
+    pub color: String,
+    pub description: String,
+}
+
+/// List all labels in `repo` via `gh label list --json name,color,description`.
+pub fn list_labels(repo: &str) -> Result<Vec<RemoteLabel>, GhError> {
+    let output = Command::new("gh")
+        .args([
+            "label",
+            "list",
+            "--repo",
+            repo,
+            "--limit",
+            "1000",
+            "--json",
+            "name,color,description",
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: "gh label list".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    let body = String::from_utf8_lossy(&output.stdout);
+    parse_label_list(&body)
+}
+
+pub(crate) fn parse_label_list(body: &str) -> Result<Vec<RemoteLabel>, GhError> {
+    let value: Value = serde_json::from_str(body).context(JsonParseSnafu {
+        context: "failed to parse gh label list JSON".to_string(),
+    })?;
+    let arr = value.as_array().context(SchemaSnafu {
+        message: "gh label list did not return an array",
+    })?;
+    arr.iter()
+        .map(|v| {
+            let name = v["name"]
+                .as_str()
+                .context(SchemaSnafu {
+                    message: "label missing 'name'",
+                })?
+                .to_string();
+            let color = v["color"]
+                .as_str()
+                .with_context(|| SchemaSnafu {
+                    message: format!("label '{name}' missing 'color'"),
+                })?
+                .to_string();
+            let description = v["description"].as_str().unwrap_or("").to_string();
+            Ok(RemoteLabel {
+                name,
+                color,
+                description,
+            })
+        })
+        .collect()
+}
+
+pub fn label_create(repo: &str, name: &str, color: &str, description: &str) -> Result<(), GhError> {
+    let output = Command::new("gh")
+        .args([
+            "label",
+            "create",
+            name,
+            "--repo",
+            repo,
+            "--color",
+            color,
+            "--description",
+            description,
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: format!("gh label create {name}"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
+pub fn label_edit(repo: &str, name: &str, color: &str, description: &str) -> Result<(), GhError> {
+    let output = Command::new("gh")
+        .args([
+            "label",
+            "edit",
+            name,
+            "--repo",
+            repo,
+            "--color",
+            color,
+            "--description",
+            description,
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: format!("gh label edit {name}"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
+pub fn label_delete(repo: &str, name: &str) -> Result<(), GhError> {
+    let output = Command::new("gh")
+        .args(["label", "delete", name, "--repo", repo, "--yes"])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: format!("gh label delete {name}"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
 /// Detect owner/repo. Prefers `$GITHUB_REPOSITORY` (set in GitHub Actions),
 /// falling back to [`detect_repo`] for local invocations.
 pub fn detect_repo_or_env() -> Result<String, GhError> {
@@ -910,5 +1043,36 @@ mod tests {
             "labels": [], "url": "u", "createdAt": "", "updatedAt": ""
         }]"#;
         assert!(parse_issue_list(body).is_err());
+    }
+
+    #[test]
+    fn parse_label_list_extracts_fields() {
+        let body = r#"[
+            {"name": "shaka", "color": "5319e7", "description": "shaka CLI"},
+            {"name": "bug",   "color": "d73a4a", "description": "broken"}
+        ]"#;
+        let labels = parse_label_list(body).unwrap();
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].name, "shaka");
+        assert_eq!(labels[0].color, "5319e7");
+        assert_eq!(labels[1].description, "broken");
+    }
+
+    #[test]
+    fn parse_label_list_empty_description_ok() {
+        let body = r#"[{"name": "x", "color": "abcdef", "description": ""}]"#;
+        let labels = parse_label_list(body).unwrap();
+        assert_eq!(labels[0].description, "");
+    }
+
+    #[test]
+    fn parse_label_list_missing_color_errors() {
+        let body = r#"[{"name": "x", "description": ""}]"#;
+        assert!(parse_label_list(body).is_err());
+    }
+
+    #[test]
+    fn parse_label_list_empty() {
+        assert!(parse_label_list("[]").unwrap().is_empty());
     }
 }

--- a/tools/shaka/src/issue.rs
+++ b/tools/shaka/src/issue.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod brief;
+mod labels;
 mod list;
 
 use clap::{Subcommand, ValueEnum};

--- a/tools/shaka/src/issue.rs
+++ b/tools/shaka/src/issue.rs
@@ -1,5 +1,6 @@
 mod audit;
 mod brief;
+mod label;
 mod labels;
 mod list;
 
@@ -32,6 +33,9 @@ pub enum IssueCommand {
         #[arg(long)]
         repo: Option<String>,
     },
+    /// Manage the canonical GitHub label set declared in .shaka/labels.cue
+    #[command(subcommand)]
+    Label(LabelCommand),
     /// Fetch + view + comments for an issue in one shot
     Brief {
         /// GitHub issue number
@@ -71,6 +75,23 @@ pub enum IssueCommand {
     },
 }
 
+#[derive(Subcommand)]
+pub enum LabelCommand {
+    /// Diff canonical .shaka/labels.cue against GitHub; reconcile with --apply
+    Sync {
+        /// Repository in owner/repo format (auto-detected from git remote if omitted)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Apply create + edit operations; otherwise report drift only
+        #[arg(long)]
+        apply: bool,
+        /// Also delete labels present on GitHub but not in .shaka/labels.cue
+        /// (requires --apply)
+        #[arg(long)]
+        delete: bool,
+    },
+}
+
 pub fn run(cmd: IssueCommand) {
     match cmd {
         IssueCommand::Audit { repo } => audit::run(repo),
@@ -79,6 +100,11 @@ pub fn run(cmd: IssueCommand) {
             no_fetch,
             json,
         } => brief::run(number, no_fetch, json),
+        IssueCommand::Label(LabelCommand::Sync {
+            repo,
+            apply,
+            delete,
+        }) => label::run(repo, apply, delete),
         IssueCommand::List {
             repo,
             state,

--- a/tools/shaka/src/issue/audit.rs
+++ b/tools/shaka/src/issue/audit.rs
@@ -3,20 +3,8 @@ use std::process::Command;
 use serde_json::Value;
 
 use crate::gh;
+use crate::issue::labels;
 use crate::term::{BOLD, GREEN, RED, RESET};
-
-// Every open issue must carry at least one of these labels. New scope
-// labels must be added here AND created in the repo (`gh label create`).
-const SCOPE_LABELS: &[&str] = &[
-    "ci",
-    "claude",
-    "infra/devbox",
-    "meta",
-    "nix",
-    "pollen-alert",
-    "portfolio",
-    "shaka",
-];
 
 pub fn run(repo_arg: Option<String>) {
     let repo = match repo_arg {
@@ -31,8 +19,18 @@ pub fn run(repo_arg: Option<String>) {
         },
     };
 
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let label_set = match labels::load(&cwd) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    let scope_labels: Vec<&str> = label_set.scope_names();
+
     println!("{BOLD}Auditing {repo}{RESET}");
-    println!("Scope labels: {}\n", SCOPE_LABELS.join(", "));
+    println!("Scope labels: {}\n", scope_labels.join(", "));
 
     let issues = match list_open_issues(&repo) {
         Ok(v) => v,
@@ -48,7 +46,7 @@ pub fn run(repo_arg: Option<String>) {
             .as_array()
             .map(|arr| arr.iter().filter_map(|l| l["name"].as_str()).collect())
             .unwrap_or_default();
-        let has_scope = labels.iter().any(|l| SCOPE_LABELS.contains(l));
+        let has_scope = labels.iter().any(|l| scope_labels.contains(l));
         if !has_scope {
             let n = issue["number"].as_u64().unwrap_or(0);
             let title = issue["title"].as_str().unwrap_or("").to_string();

--- a/tools/shaka/src/issue/label.rs
+++ b/tools/shaka/src/issue/label.rs
@@ -1,0 +1,307 @@
+//! `shaka issue label sync` — reconciles GitHub's live label set
+//! against the canonical declaration in `.shaka/labels.cue`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::gh::{self, RemoteLabel};
+use crate::issue::labels::{self, Label};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Plan {
+    pub to_create: Vec<Label>,
+    pub to_edit: Vec<EditDiff>,
+    pub to_delete: Vec<RemoteLabel>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EditDiff {
+    pub name: String,
+    pub remote_color: String,
+    pub canonical_color: String,
+    pub remote_description: String,
+    pub canonical_description: String,
+}
+
+impl Plan {
+    pub fn is_clean(&self) -> bool {
+        self.to_create.is_empty() && self.to_edit.is_empty() && self.to_delete.is_empty()
+    }
+}
+
+/// Compute the diff between the canonical label set and what GitHub
+/// currently reports. Pure function — no side effects — so it stays
+/// easy to unit-test without shelling out to `gh`.
+pub fn compute_plan(canonical: &[Label], remote: &[RemoteLabel]) -> Plan {
+    let canonical_by_name: HashMap<&str, &Label> =
+        canonical.iter().map(|l| (l.name.as_str(), l)).collect();
+    let remote_by_name: HashMap<&str, &RemoteLabel> =
+        remote.iter().map(|l| (l.name.as_str(), l)).collect();
+
+    let mut to_create: Vec<Label> = canonical
+        .iter()
+        .filter(|l| !remote_by_name.contains_key(l.name.as_str()))
+        .cloned()
+        .collect();
+    to_create.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut to_edit: Vec<EditDiff> = canonical
+        .iter()
+        .filter_map(|c| {
+            let r = remote_by_name.get(c.name.as_str())?;
+            if r.color == c.color && r.description == c.description {
+                None
+            } else {
+                Some(EditDiff {
+                    name: c.name.clone(),
+                    remote_color: r.color.clone(),
+                    canonical_color: c.color.clone(),
+                    remote_description: r.description.clone(),
+                    canonical_description: c.description.clone(),
+                })
+            }
+        })
+        .collect();
+    to_edit.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut to_delete: Vec<RemoteLabel> = remote
+        .iter()
+        .filter(|r| !canonical_by_name.contains_key(r.name.as_str()))
+        .cloned()
+        .collect();
+    to_delete.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Plan {
+        to_create,
+        to_edit,
+        to_delete,
+    }
+}
+
+pub fn run(repo_arg: Option<String>, apply: bool, delete: bool) {
+    let repo = match repo_arg {
+        Some(r) => r,
+        None => match gh::detect_repo() {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                eprintln!("Hint: pass --repo owner/repo explicitly");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
+    let canonical = match labels::load(&cwd) {
+        Ok(set) => set.labels,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let remote = match gh::list_labels(&repo) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let plan = compute_plan(&canonical, &remote);
+    print!("{}", render_plan(&repo, &plan, apply, delete));
+
+    if !apply {
+        if plan.is_clean() {
+            std::process::exit(0);
+        } else {
+            std::process::exit(1);
+        }
+    }
+
+    let mut errors = 0;
+    for label in &plan.to_create {
+        match gh::label_create(&repo, &label.name, &label.color, &label.description) {
+            Ok(()) => println!("  {GREEN}+{RESET} created {}", label.name),
+            Err(e) => {
+                eprintln!("  {RED}!{RESET} create {}: {e}", label.name);
+                errors += 1;
+            }
+        }
+    }
+    for diff in &plan.to_edit {
+        match gh::label_edit(
+            &repo,
+            &diff.name,
+            &diff.canonical_color,
+            &diff.canonical_description,
+        ) {
+            Ok(()) => println!("  {GREEN}~{RESET} edited {}", diff.name),
+            Err(e) => {
+                eprintln!("  {RED}!{RESET} edit {}: {e}", diff.name);
+                errors += 1;
+            }
+        }
+    }
+    if delete {
+        for label in &plan.to_delete {
+            match gh::label_delete(&repo, &label.name) {
+                Ok(()) => println!("  {YELLOW}-{RESET} deleted {}", label.name),
+                Err(e) => {
+                    eprintln!("  {RED}!{RESET} delete {}: {e}", label.name);
+                    errors += 1;
+                }
+            }
+        }
+    }
+
+    if errors > 0 {
+        eprintln!("\n{RED}{BOLD}{errors} operation(s) failed{RESET}");
+        std::process::exit(1);
+    }
+}
+
+fn render_plan(repo: &str, plan: &Plan, apply: bool, delete: bool) -> String {
+    let mut out = String::new();
+    let mode = match (apply, delete) {
+        (true, true) => "apply (with deletes)",
+        (true, false) => "apply (skip deletes)",
+        (false, _) => "dry-run",
+    };
+    out.push_str(&format!("{BOLD}shaka issue label sync{RESET}\n"));
+    out.push_str(&format!("{DIM}├── repo: {repo}  mode: {mode}{RESET}\n"));
+
+    if plan.is_clean() {
+        out.push_str(&format!(
+            "{GREEN}└── clean — canonical and remote agree{RESET}\n"
+        ));
+        return out;
+    }
+
+    out.push_str(&format!(
+        "├── {GREEN}create{RESET}: {}\n",
+        plan.to_create.len()
+    ));
+    for l in &plan.to_create {
+        out.push_str(&format!("│     {GREEN}+{RESET} {} #{}\n", l.name, l.color));
+    }
+    out.push_str(&format!(
+        "├── {YELLOW}edit{RESET}: {}\n",
+        plan.to_edit.len()
+    ));
+    for d in &plan.to_edit {
+        if d.remote_color != d.canonical_color {
+            out.push_str(&format!(
+                "│     {YELLOW}~{RESET} {} color #{} → #{}\n",
+                d.name, d.remote_color, d.canonical_color
+            ));
+        }
+        if d.remote_description != d.canonical_description {
+            out.push_str(&format!(
+                "│     {YELLOW}~{RESET} {} description {:?} → {:?}\n",
+                d.name, d.remote_description, d.canonical_description
+            ));
+        }
+    }
+    let delete_label = if delete || !apply {
+        "delete"
+    } else {
+        "delete (skipped without --delete)"
+    };
+    out.push_str(&format!(
+        "└── {RED}{}{RESET}: {}\n",
+        delete_label,
+        plan.to_delete.len()
+    ));
+    for l in &plan.to_delete {
+        out.push_str(&format!("      {RED}-{RESET} {}\n", l.name));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn label(name: &str, color: &str, description: &str, scope: bool) -> Label {
+        Label {
+            name: name.to_string(),
+            color: color.to_string(),
+            description: description.to_string(),
+            scope,
+        }
+    }
+
+    fn remote(name: &str, color: &str, description: &str) -> RemoteLabel {
+        RemoteLabel {
+            name: name.to_string(),
+            color: color.to_string(),
+            description: description.to_string(),
+        }
+    }
+
+    #[test]
+    fn clean_when_canonical_and_remote_agree() {
+        let canonical = vec![label("shaka", "5319e7", "shaka CLI", true)];
+        let remote = vec![remote("shaka", "5319e7", "shaka CLI")];
+        let plan = compute_plan(&canonical, &remote);
+        assert!(plan.is_clean());
+    }
+
+    #[test]
+    fn detects_missing_label_for_create() {
+        let canonical = vec![label("new", "abcdef", "new", true)];
+        let remote: Vec<RemoteLabel> = vec![];
+        let plan = compute_plan(&canonical, &remote);
+        assert_eq!(plan.to_create.len(), 1);
+        assert_eq!(plan.to_create[0].name, "new");
+        assert!(plan.to_edit.is_empty());
+        assert!(plan.to_delete.is_empty());
+    }
+
+    #[test]
+    fn detects_color_drift_for_edit() {
+        let canonical = vec![label("shaka", "5319e7", "shaka CLI", true)];
+        let remote = vec![remote("shaka", "000000", "shaka CLI")];
+        let plan = compute_plan(&canonical, &remote);
+        assert!(plan.to_create.is_empty());
+        assert_eq!(plan.to_edit.len(), 1);
+        assert_eq!(plan.to_edit[0].remote_color, "000000");
+        assert_eq!(plan.to_edit[0].canonical_color, "5319e7");
+        assert!(plan.to_delete.is_empty());
+    }
+
+    #[test]
+    fn detects_description_drift_for_edit() {
+        let canonical = vec![label("shaka", "5319e7", "shaka CLI", true)];
+        let remote = vec![remote("shaka", "5319e7", "old description")];
+        let plan = compute_plan(&canonical, &remote);
+        assert_eq!(plan.to_edit.len(), 1);
+        assert_eq!(plan.to_edit[0].remote_description, "old description");
+        assert_eq!(plan.to_edit[0].canonical_description, "shaka CLI");
+    }
+
+    #[test]
+    fn detects_extra_remote_label_for_delete() {
+        let canonical: Vec<Label> = vec![];
+        let remote = vec![remote("stale", "ffffff", "")];
+        let plan = compute_plan(&canonical, &remote);
+        assert!(plan.to_create.is_empty());
+        assert!(plan.to_edit.is_empty());
+        assert_eq!(plan.to_delete.len(), 1);
+        assert_eq!(plan.to_delete[0].name, "stale");
+    }
+
+    #[test]
+    fn sorts_diff_buckets_by_name() {
+        let canonical = vec![
+            label("zeta", "ffffff", "", false),
+            label("alpha", "ffffff", "", false),
+        ];
+        let remote: Vec<RemoteLabel> = vec![];
+        let plan = compute_plan(&canonical, &remote);
+        assert_eq!(plan.to_create[0].name, "alpha");
+        assert_eq!(plan.to_create[1].name, "zeta");
+    }
+}

--- a/tools/shaka/src/issue/labels.rs
+++ b/tools/shaka/src/issue/labels.rs
@@ -1,0 +1,152 @@
+//! Loader for `.shaka/labels.cue` — the canonical GitHub label set
+//! that drives `shaka issue label sync` and `shaka issue audit`.
+//!
+//! `load(start)` walks upward from `start` looking for
+//! `.shaka/labels.cue`, validates and exports it via `cue export`
+//! against the embedded `labels-schema.cue`, and returns a typed
+//! `LabelSet`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+
+pub const SCHEMA: &str = include_str!("../../schema/labels-schema.cue");
+
+const LABELS_FILE_REL: &str = ".shaka/labels.cue";
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Label {
+    pub name: String,
+    pub color: String,
+    pub description: String,
+    pub scope: bool,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LabelSet {
+    pub labels: Vec<Label>,
+}
+
+impl LabelSet {
+    pub fn scope_names(&self) -> Vec<&str> {
+        self.labels
+            .iter()
+            .filter(|l| l.scope)
+            .map(|l| l.name.as_str())
+            .collect()
+    }
+}
+
+pub fn find_labels_file(start: &Path) -> Option<PathBuf> {
+    let mut current: PathBuf = start.canonicalize().ok()?;
+    loop {
+        let candidate = current.join(LABELS_FILE_REL);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        let parent = current.parent()?;
+        current = parent.to_path_buf();
+    }
+}
+
+pub fn load(start: &Path) -> Result<LabelSet, String> {
+    let labels_path = find_labels_file(start).ok_or_else(|| {
+        format!(
+            "no {LABELS_FILE_REL} found in {} or any ancestor",
+            start.display()
+        )
+    })?;
+    let cue = std::fs::read_to_string(&labels_path)
+        .map_err(|e| format!("could not read {}: {e}", labels_path.display()))?;
+    load_from_string(&cue).map_err(|e| format!("{}: {e}", labels_path.display()))
+}
+
+pub fn load_from_string(cue: &str) -> Result<LabelSet, String> {
+    let tmp = tempfile::TempDir::new().map_err(|e| format!("could not create tempdir: {e}"))?;
+    let schema_path = tmp.path().join("schema.cue");
+    std::fs::write(&schema_path, SCHEMA)
+        .map_err(|e| format!("could not write labels schema: {e}"))?;
+    let labels_path = tmp.path().join("labels.cue");
+    std::fs::write(&labels_path, cue)
+        .map_err(|e| format!("could not write temp labels file: {e}"))?;
+
+    let output = Command::new("cue")
+        .arg("export")
+        .arg("--out")
+        .arg("json")
+        .arg(&schema_path)
+        .arg(&labels_path)
+        .output()
+        .map_err(|e| format!("failed to spawn cue: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(format!("cue export failed: {detail}"));
+    }
+
+    serde_json::from_slice(&output.stdout).map_err(|e| format!("could not parse labels: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn find_labels_file_finds_at_start() {
+        let tmp = TempDir::new().unwrap();
+        write(&tmp.path().join(".shaka/labels.cue"), "");
+        let found = find_labels_file(tmp.path()).unwrap();
+        assert!(found.ends_with(".shaka/labels.cue"));
+    }
+
+    #[test]
+    fn find_labels_file_walks_up() {
+        let tmp = TempDir::new().unwrap();
+        write(&tmp.path().join(".shaka/labels.cue"), "");
+        let nested = tmp.path().join("a/b/c");
+        fs::create_dir_all(&nested).unwrap();
+        let found = find_labels_file(&nested).unwrap();
+        assert!(found.ends_with(".shaka/labels.cue"));
+    }
+
+    #[test]
+    fn find_labels_file_returns_none_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        assert!(find_labels_file(tmp.path()).is_none());
+    }
+
+    // Schema-level acceptance/rejection coverage lives in
+    // `tests/labels_schema.rs` via fixture files. This smoke test
+    // exists to exercise the Rust deserialization path end-to-end.
+    #[test]
+    fn load_from_string_parses_label_set() {
+        let cue = r#"package labels
+
+#LabelSet & {
+    labels: [
+        {name: "shaka", color: "5319e7", description: "shaka CLI", scope: true},
+        {name: "bug",   color: "d73a4a", description: "broken",    scope: false},
+    ]
+}
+"#;
+        let set = load_from_string(cue).expect("parses");
+        assert_eq!(set.labels.len(), 2);
+        assert_eq!(set.labels[0].name, "shaka");
+        assert!(set.labels[0].scope);
+        assert_eq!(set.labels[1].name, "bug");
+        assert!(!set.labels[1].scope);
+        assert_eq!(set.scope_names(), vec!["shaka"]);
+    }
+}

--- a/tools/shaka/tests/fixtures/labels/invalid/bad-color.cue
+++ b/tools/shaka/tests/fixtures/labels/invalid/bad-color.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "not-a-hex", description: "bad hex", scope: true},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/invalid/empty-name.cue
+++ b/tools/shaka/tests/fixtures/labels/invalid/empty-name.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "", color: "5319e7", description: "no name", scope: true},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/invalid/missing-scope.cue
+++ b/tools/shaka/tests/fixtures/labels/invalid/missing-scope.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "5319e7", description: "scope is required"},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/invalid/short-color.cue
+++ b/tools/shaka/tests/fixtures/labels/invalid/short-color.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "abc", description: "needs 6 chars", scope: true},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/invalid/unknown-field.cue
+++ b/tools/shaka/tests/fixtures/labels/invalid/unknown-field.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "5319e7", description: "", scope: true, surprise: "hello"},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/invalid/uppercase-color.cue
+++ b/tools/shaka/tests/fixtures/labels/invalid/uppercase-color.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "5319E7", description: "must be lowercase", scope: true},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/valid/empty-set.cue
+++ b/tools/shaka/tests/fixtures/labels/valid/empty-set.cue
@@ -1,0 +1,5 @@
+package labels
+
+#LabelSet & {
+	labels: []
+}

--- a/tools/shaka/tests/fixtures/labels/valid/minimal.cue
+++ b/tools/shaka/tests/fixtures/labels/valid/minimal.cue
@@ -1,0 +1,7 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "5319e7", description: "shaka CLI", scope: true},
+	]
+}

--- a/tools/shaka/tests/fixtures/labels/valid/scope-and-type.cue
+++ b/tools/shaka/tests/fixtures/labels/valid/scope-and-type.cue
@@ -1,0 +1,9 @@
+package labels
+
+#LabelSet & {
+	labels: [
+		{name: "shaka", color: "5319e7", description: "shaka CLI", scope: true},
+		{name: "bug", color:   "d73a4a", description: "broken", scope:    false},
+		{name: "good first issue", color: "7057ff", description: "newcomer-friendly", scope: false},
+	]
+}

--- a/tools/shaka/tests/labels_schema.rs
+++ b/tools/shaka/tests/labels_schema.rs
@@ -1,0 +1,66 @@
+//! Integration tests for the labels.cue schema.
+//!
+//! Runs `cue vet -c` against fixtures in `tests/fixtures/labels/{valid,invalid}/`.
+//! Each fixture is a complete `labels.cue` that should be accepted or rejected
+//! by the shipped schema. The test walks both directories and asserts every
+//! fixture in `valid/` passes and every fixture in `invalid/` fails — adding a
+//! new fixture is enough to extend coverage.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SCHEMA_PATH: &str = "schema/labels-schema.cue";
+
+fn cue_vet(schema: &Path, labels: &Path) -> bool {
+    Command::new("cue")
+        .arg("vet")
+        .arg("-c")
+        .arg(schema)
+        .arg(labels)
+        .output()
+        .expect("failed to spawn cue (is it on PATH?)")
+        .status
+        .success()
+}
+
+fn fixtures_in(subdir: &str) -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/labels")
+        .join(subdir);
+    let mut out: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|_| panic!("missing fixture dir: {}", dir.display()))
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|x| x == "cue").unwrap_or(false))
+        .collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn every_valid_fixture_is_accepted() {
+    let schema = Path::new(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_PATH);
+    let fixtures = fixtures_in("valid");
+    assert!(!fixtures.is_empty(), "no valid fixtures found");
+    for fixture in fixtures {
+        assert!(
+            cue_vet(&schema, &fixture),
+            "expected {} to pass cue vet but it failed",
+            fixture.display()
+        );
+    }
+}
+
+#[test]
+fn every_invalid_fixture_is_rejected() {
+    let schema = Path::new(env!("CARGO_MANIFEST_DIR")).join(SCHEMA_PATH);
+    let fixtures = fixtures_in("invalid");
+    assert!(!fixtures.is_empty(), "no invalid fixtures found");
+    for fixture in fixtures {
+        assert!(
+            !cue_vet(&schema, &fixture),
+            "expected {} to fail cue vet but it passed",
+            fixture.display()
+        );
+    }
+}


### PR DESCRIPTION
Canonical GitHub label set now lives in `.shaka/labels.cue`, validated
by `tools/shaka/schema/labels-schema.cue` (same shape as the existing
`.shaka/repo.cue` policy file). Each entry carries name, color,
description, and a `scope` flag that marks it as load-bearing for the
audit policy.

`shaka issue audit` reads `scope: true` labels from the file instead of
the hardcoded `SCOPE_LABELS` const, so scope policy is now version
controlled and inspectable rather than buried in source. The audit set
also picks up `blogctl` and `todoist` — both already existed as labels
in the repo but had drifted out of the const.

Schema-acceptance fixtures live under
`tools/shaka/tests/fixtures/labels/{valid,invalid}/` and are walked by
`tests/labels_schema.rs`, matching the pattern set by the project and
repo-policy schemas. The Rust loader mirrors `src/repo/policy.rs`.

The follow-up commit will add `shaka issue label sync` to reconcile
GitHub's live label set against this canonical source.

Adds `shaka issue label sync` to reconcile the live GitHub label set
against the canonical declaration in `.shaka/labels.cue`. Dry-run by
default — prints a tree-formatted diff (create / edit / delete) and
exits non-zero when drift exists, so it fits cleanly into a future CI
gate. `--apply` performs create + edit operations; deletes require
`--apply --delete` together, keeping accidentally-divergent labels
safe by default.

`gh.rs` gains `list_labels`, `label_create`, `label_edit`, and
`label_delete` helpers plus a `RemoteLabel` struct, with parser
coverage on `parse_label_list`. The diff itself lives in
`issue::label::compute_plan` as a pure function — unit-testable
without shelling out to `gh`.

Closes #539