### PR TITLE
feat(infra/home): managed ~/.claude/settings.json with global hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,18 +17,5 @@
       "Bash(shaka *)",
       "Bash(tools/shaka/bin/shaka *)"
     ]
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "tools/shaka/bin/shaka claude hook pre-issue-create"
-          }
-        ]
-      }
-    ]
   }
 }

--- a/infra/home/dotfiles/claude/settings.json
+++ b/infra/home/dotfiles/claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "enabledPlugins": {
+    "swift-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true
+  },
+  "agentPushNotifEnabled": true,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "claude-hooks pre-issue-create"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -92,4 +92,13 @@
   # (`/ship`, `/start` — both call `shaka`) stay in kolohelios's
   # `.claude/commands/`.
   home.file.".claude/commands/file-issue.md".source = ../dotfiles/claude/commands/file-issue.md;
+
+  # Cross-machine Claude Code harness config. Carries the
+  # `PreToolUse` duplicate-issue-create hook (#515 → #524 → #549 →
+  # #551) plus stable personal preferences (experimental agent
+  # teams, LSP plugins, push notifications). Per-machine overrides
+  # go to `~/.claude/settings.local.json` (already in
+  # `programs.git.ignores` above so it never gets committed); Claude
+  # merges the two with `.local.json` taking precedence.
+  home.file.".claude/settings.json".source = ../dotfiles/claude/settings.json;
 }


### PR DESCRIPTION
Closes the meta-tooling chain that started with #515. The portable
`claude-hooks` binary (#535 → #551) is now on PATH globally;
`~/.claude/settings.json` calls `claude-hooks pre-issue-create` as
a `PreToolUse` hook on `Bash`, so the duplicate-issue-create gate
fires in any claude session — not just inside the kolohelios
checkout.

Carries the previously hand-maintained personal settings
(experimental agent teams env var, LSP plugin enablement, push
notifications) into the managed source. The intent is to commit to
the shared file as the personal file too;
`~/.claude/settings.local.json` stays available as a per-machine
override but isn't expected to grow content.

The kolohelios project-local `.claude/settings.json` loses its
redundant `hooks` block — the global hook now covers kolohelios
too, and having both would double-search every `gh issue create`.
The `allow` list stays (cargo/jj/shaka patterns are project-
specific).

## Migration note

On the dev machine, manually rm `~/.claude/settings.json` before
`darwin-rebuild switch` — home-manager's symlink-into-place errors
if the file already exists. The content the user cares about is
already folded into the managed source.

Closes #534