### PR TITLE
feat(shaka): issue create with enforced scope + conv-commit title

### DIFF
--- a/tools/shaka/src/commit.rs
+++ b/tools/shaka/src/commit.rs
@@ -5,11 +5,12 @@ use clap::Subcommand;
 
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
-const TYPES: &[&str] = &[
-    "feat", "fix", "docs", "chore", "refactor", "test", "style", "perf", "ci", "build",
-];
+pub mod title;
+
+use title::TitleError;
+
 const SLOTS: &[&str] = &["apps", "infra", "packages", "services", "tools"];
-const TITLE_MAX: usize = 70;
+pub(crate) const TITLE_MAX: usize = 70;
 const BODY_LINE_MAX: usize = 80;
 
 #[derive(Subcommand)]
@@ -235,13 +236,10 @@ fn lint_commit(commit: &Commit) -> Vec<Finding> {
     let mut lines = desc.lines();
     let title = lines.next().unwrap_or("");
 
-    if !title_matches_format(title) {
+    if let Err(e) = title::validate(title) {
         findings.push(Finding {
             severity: Severity::Error,
-            message: format!(
-                "title does not match `<type>(<scope>): <subject>` (type ∈ {{{}}})",
-                TYPES.join(", ")
-            ),
+            message: title_finding_message(&e),
         });
     }
 
@@ -278,45 +276,19 @@ fn lint_commit(commit: &Commit) -> Vec<Finding> {
     findings
 }
 
-fn title_matches_format(title: &str) -> bool {
-    let Some(colon_idx) = title.find(": ") else {
-        return false;
-    };
-    let prefix = &title[..colon_idx];
-    let subject = &title[colon_idx + 2..];
-
-    if subject.is_empty() {
-        return false;
+/// Render a `TitleError` into the human-facing string `commit lint`
+/// surfaces. The grammar errors get a uniform `does not match` prefix
+/// (since the structural reason is usually less interesting than
+/// "title format is wrong"); type / scope errors carry their detail
+/// from the validator directly.
+fn title_finding_message(err: &TitleError) -> String {
+    match err {
+        TitleError::MissingSeparator | TitleError::EmptySubject => format!(
+            "title does not match `<type>(<scope>): <subject>` (type ∈ {{{}}})",
+            title::TYPES.join(", ")
+        ),
+        TitleError::UnknownType { .. } | TitleError::InvalidScope { .. } => err.to_string(),
     }
-
-    let (type_part, scope_part) = match prefix.find('(') {
-        Some(open) => {
-            if !prefix.ends_with(')') {
-                return false;
-            }
-            let close = prefix.len() - 1;
-            (&prefix[..open], Some(&prefix[open + 1..close]))
-        }
-        None => (prefix, None),
-    };
-
-    if !TYPES.contains(&type_part) {
-        return false;
-    }
-
-    if let Some(scope) = scope_part {
-        if scope.is_empty() {
-            return false;
-        }
-        if !scope
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '/')
-        {
-            return false;
-        }
-    }
-
-    true
 }
 
 fn check_atomicity(files: &[String]) -> Option<Finding> {
@@ -370,39 +342,32 @@ mod tests {
         lint_commit(&commit)
     }
 
+    // Grammar-level coverage lives in `commit::title::tests`. The lint
+    // tests below only assert that lint_commit composes the validator
+    // correctly with the other checks (length, body wrap, atomicity).
+
     #[test]
-    fn title_format_matches_simple_type() {
-        assert!(title_matches_format("feat: add a thing"));
-        assert!(title_matches_format("fix: handle edge case"));
+    fn lint_flags_unknown_type_with_specific_message() {
+        let findings = lint_desc("frob: do thing");
+        assert!(
+            findings.iter().any(|f| f.message.contains("frob")),
+            "expected message to name the bad type, got: {findings:?}"
+        );
     }
 
     #[test]
-    fn title_format_matches_type_with_scope() {
-        assert!(title_matches_format("feat(shaka): add command"));
-        assert!(title_matches_format("ci(infra/devbox): scope job"));
-    }
-
-    #[test]
-    fn title_format_rejects_unknown_type() {
-        assert!(!title_matches_format("foo: do thing"));
-        assert!(!title_matches_format("FEAT: capital"));
-    }
-
-    #[test]
-    fn title_format_rejects_missing_subject() {
-        assert!(!title_matches_format("feat: "));
-        assert!(!title_matches_format("feat:"));
-    }
-
-    #[test]
-    fn title_format_rejects_missing_colon_space() {
-        assert!(!title_matches_format("feat:add thing"));
-    }
-
-    #[test]
-    fn title_format_rejects_empty_or_unclosed_scope() {
-        assert!(!title_matches_format("feat(): bad"));
-        assert!(!title_matches_format("feat(scope: bad"));
+    fn lint_flags_grammar_error_with_format_hint() {
+        // MissingSeparator / EmptySubject collapse to the uniform
+        // "does not match `<type>(<scope>): <subject>`" message so the
+        // hint stays the same regardless of which structural rule
+        // failed first.
+        let findings = lint_desc("feat add thing");
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.message.contains("does not match")),
+            "got: {findings:?}"
+        );
     }
 
     #[test]

--- a/tools/shaka/src/commit/title.rs
+++ b/tools/shaka/src/commit/title.rs
@@ -1,0 +1,182 @@
+//! Shared conventional-commit title validator. Used by `shaka commit
+//! lint` to gate commits and by `shaka issue create` to gate issue
+//! titles (so an issue's title can be used as a commit title later
+//! without re-editing).
+//!
+//! The grammar accepted is `<type>(<scope>): <subject>` or
+//! `<type>: <subject>`, with `<type>` drawn from `TYPES` and `<scope>`
+//! a non-empty string of `[A-Za-z0-9_/-]`. Errors are structured so
+//! both call sites can surface a specific reason and the valid set.
+//!
+//! The leading parsing is colon-anchored rather than regex-driven so
+//! that the error path can pinpoint *which* component is bad. The
+//! length cap (`TITLE_MAX`) lives in `commit.rs` since it's policy,
+//! not grammar.
+
+/// Conventional commit types accepted across the repo. Anything outside
+/// this set fails validation; expanding the set is intentionally a
+/// code-change rather than config so all consumers stay in lockstep.
+pub const TYPES: &[&str] = &[
+    "feat", "fix", "docs", "chore", "refactor", "test", "style", "perf", "ci", "build",
+];
+
+/// Why a conventional-commit title failed validation. Variants are
+/// exhaustive of the structural failure modes the validator can
+/// produce; callers `match` on this to render the error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TitleError {
+    /// No `": "` separator was found between the prefix and the subject.
+    MissingSeparator,
+    /// The subject (the text after `": "`) was empty.
+    EmptySubject,
+    /// A parenthesized scope was present but malformed (unclosed parens,
+    /// empty scope, or disallowed characters).
+    InvalidScope { scope: String },
+    /// The type prefix (before `(` or `:`) was not in `TYPES`.
+    UnknownType { found: String },
+}
+
+impl std::fmt::Display for TitleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingSeparator => write!(
+                f,
+                "title does not match `<type>(<scope>): <subject>`: missing `: ` separator"
+            ),
+            Self::EmptySubject => write!(
+                f,
+                "title does not match `<type>(<scope>): <subject>`: subject is empty"
+            ),
+            Self::InvalidScope { scope } => write!(
+                f,
+                "scope `{scope}` is invalid (must be a non-empty `[A-Za-z0-9_/-]+`)"
+            ),
+            Self::UnknownType { found } => {
+                write!(f, "type `{found}` is not one of {{{}}}", TYPES.join(", "))
+            }
+        }
+    }
+}
+
+/// Validate `title` against the conventional-commit shape. Returns
+/// `Ok(())` when the title is acceptable; otherwise the first failure
+/// encountered (in parse order, so the message points at the first
+/// thing that didn't match).
+pub fn validate(title: &str) -> Result<(), TitleError> {
+    let Some(colon_idx) = title.find(": ") else {
+        return Err(TitleError::MissingSeparator);
+    };
+    let prefix = &title[..colon_idx];
+    let subject = &title[colon_idx + 2..];
+
+    if subject.is_empty() {
+        return Err(TitleError::EmptySubject);
+    }
+
+    let (type_part, scope_part) = match prefix.find('(') {
+        Some(open) => {
+            if !prefix.ends_with(')') {
+                return Err(TitleError::InvalidScope {
+                    scope: prefix[open..].to_string(),
+                });
+            }
+            let close = prefix.len() - 1;
+            (&prefix[..open], Some(&prefix[open + 1..close]))
+        }
+        None => (prefix, None),
+    };
+
+    if !TYPES.contains(&type_part) {
+        return Err(TitleError::UnknownType {
+            found: type_part.to_string(),
+        });
+    }
+
+    if let Some(scope) = scope_part {
+        if scope.is_empty() {
+            return Err(TitleError::InvalidScope {
+                scope: String::new(),
+            });
+        }
+        if !scope
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '/')
+        {
+            return Err(TitleError::InvalidScope {
+                scope: scope.to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_canonical_shapes() {
+        assert!(validate("feat: add thing").is_ok());
+        assert!(validate("feat(shaka): add thing").is_ok());
+        assert!(validate("ci(infra/devbox): tweak").is_ok());
+        assert!(validate("chore(deps): bump x").is_ok());
+    }
+
+    #[test]
+    fn rejects_missing_separator() {
+        assert_eq!(
+            validate("feat add thing"),
+            Err(TitleError::MissingSeparator)
+        );
+    }
+
+    #[test]
+    fn rejects_empty_subject() {
+        assert_eq!(validate("feat: "), Err(TitleError::EmptySubject));
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        assert_eq!(
+            validate("frob: x"),
+            Err(TitleError::UnknownType {
+                found: "frob".into()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_empty_scope() {
+        assert_eq!(
+            validate("feat(): x"),
+            Err(TitleError::InvalidScope {
+                scope: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unclosed_scope() {
+        assert!(matches!(
+            validate("feat(shaka: x"),
+            Err(TitleError::InvalidScope { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_scope_with_disallowed_chars() {
+        assert!(matches!(
+            validate("feat(scope with spaces): x"),
+            Err(TitleError::InvalidScope { .. })
+        ));
+    }
+
+    #[test]
+    fn display_lists_valid_types() {
+        let err = validate("frob: x").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("feat"));
+        assert!(msg.contains("chore"));
+    }
+}

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -434,6 +434,105 @@ pub fn issue_title(n: u64) -> Result<String, GhError> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreatedIssue {
+    pub number: u64,
+    pub url: String,
+}
+
+/// Run `gh issue create` and return the created issue's number + URL.
+///
+/// `labels` and `milestone` are optional; both may be empty / `None`.
+/// `--repo` is always passed so this works from inside a jj workspace.
+pub fn issue_create(
+    repo: &str,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    milestone: Option<&str>,
+) -> Result<CreatedIssue, GhError> {
+    let mut args: Vec<String> = vec![
+        "issue".into(),
+        "create".into(),
+        "--repo".into(),
+        repo.into(),
+        "--title".into(),
+        title.into(),
+        "--body".into(),
+        body.into(),
+    ];
+    for label in labels {
+        args.push("--label".into());
+        args.push(label.clone());
+    }
+    if let Some(m) = milestone {
+        args.push("--milestone".into());
+        args.push(m.to_string());
+    }
+
+    let output = Command::new("gh")
+        .args(&args)
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: "gh issue create".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let number = parse_issue_number_from_url(&url).with_context(|| SchemaSnafu {
+        message: format!("could not parse issue number from gh URL: {url}"),
+    })?;
+    Ok(CreatedIssue { number, url })
+}
+
+pub(crate) fn parse_issue_number_from_url(url: &str) -> Option<u64> {
+    url.rsplit('/').next().and_then(|s| s.parse().ok())
+}
+
+/// Fetch an issue's integer database id (distinct from its user-facing
+/// number). The sub-issues API expects this id, not the number.
+pub fn issue_db_id(repo: &str, number: u64) -> Result<u64, GhError> {
+    let endpoint = format!("/repos/{repo}/issues/{number}");
+    let value = api_get(&endpoint)?;
+    value["id"].as_u64().with_context(|| SchemaSnafu {
+        message: format!("issue {repo}#{number} response missing integer 'id'"),
+    })
+}
+
+/// Link `sub_id` (the integer db id of an existing issue) as a sub-issue
+/// of `{repo}#{parent_number}` via GitHub's native sub-issues API.
+///
+/// Retries up to 3 times with 1s then 3s backoff on any failure —
+/// distinguishing transient 5xx/network errors from permanent 4xx via
+/// `gh` stderr is brittle, and a permanent error wastes at most ~4s
+/// of backoff before surfacing.
+pub fn add_sub_issue(repo: &str, parent_number: u64, sub_id: u64) -> Result<(), GhError> {
+    let endpoint = format!("/repos/{repo}/issues/{parent_number}/sub_issues");
+    let body = serde_json::json!({ "sub_issue_id": sub_id });
+
+    let backoffs = [
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(3),
+    ];
+    let mut last_err: Option<GhError> = None;
+    for attempt in 0..=backoffs.len() {
+        match api_post(&endpoint, &body) {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                last_err = Some(e);
+                if attempt < backoffs.len() {
+                    std::thread::sleep(backoffs[attempt]);
+                }
+            }
+        }
+    }
+    Err(last_err.expect("loop ran at least once"))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenPr {
     pub number: u64,
     pub head_ref: String,

--- a/tools/shaka/src/issue.rs
+++ b/tools/shaka/src/issue.rs
@@ -1,10 +1,11 @@
 mod audit;
 mod brief;
+mod create;
 mod label;
 mod labels;
 mod list;
 
-use clap::{Subcommand, ValueEnum};
+use clap::{ArgGroup, Subcommand, ValueEnum};
 
 use crate::gh::ListState;
 
@@ -46,6 +47,40 @@ pub enum IssueCommand {
         /// Emit structured JSON instead of the human-readable tree
         #[arg(long)]
         json: bool,
+    },
+    /// Create a GitHub issue with enforced scope label + conv-commit title
+    #[command(group(ArgGroup::new("body_src").required(true).args(["body", "body_file"])))]
+    Create {
+        /// Repository in owner/repo format (auto-detected from git remote if omitted)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Issue title — must match `<type>(<scope>): <subject>`
+        /// (`shaka commit lint`'s validator)
+        #[arg(long)]
+        title: String,
+        /// Issue body text
+        #[arg(long)]
+        body: Option<String>,
+        /// Path to a file containing the issue body
+        #[arg(long, value_name = "PATH")]
+        body_file: Option<String>,
+        /// Scope label — must be one of the canonical scope labels
+        /// declared in `.shaka/labels.cue`
+        #[arg(long)]
+        scope: String,
+        /// Parent issue number; links via GitHub's native sub-issue
+        /// API (no freeform `Sub-issue of #N` body text)
+        #[arg(long)]
+        parent: Option<u64>,
+        /// Milestone title
+        #[arg(long)]
+        milestone: Option<String>,
+        /// Extra labels beyond `--scope` (repeatable)
+        #[arg(long = "label")]
+        labels: Vec<String>,
+        /// Print the planned `gh` calls without executing them
+        #[arg(long)]
+        dry_run: bool,
     },
     /// List issues with optional filters
     List {
@@ -100,6 +135,27 @@ pub fn run(cmd: IssueCommand) {
             no_fetch,
             json,
         } => brief::run(number, no_fetch, json),
+        IssueCommand::Create {
+            repo,
+            title,
+            body,
+            body_file,
+            scope,
+            parent,
+            milestone,
+            labels,
+            dry_run,
+        } => create::run(create::CreateArgs {
+            repo,
+            title,
+            body,
+            body_file,
+            scope,
+            parent,
+            milestone,
+            labels,
+            dry_run,
+        }),
         IssueCommand::Label(LabelCommand::Sync {
             repo,
             apply,

--- a/tools/shaka/src/issue/create.rs
+++ b/tools/shaka/src/issue/create.rs
@@ -1,0 +1,277 @@
+//! `shaka issue create` — gated wrapper around `gh issue create` that
+//! enforces:
+//!
+//! - title matches the conventional-commit shape (shared validator
+//!   with `shaka commit lint`)
+//! - `--scope <label>` is one of the canonical scope labels declared
+//!   in `.shaka/labels.cue`
+//! - native sub-issue link is set via the GitHub sub-issues API when
+//!   `--parent <N>` is supplied (no freeform `Sub-issue of #N` body text)
+//!
+//! All validation happens *before* any GitHub call, so a bad scope or
+//! malformed title fails locally without polluting the issue list with
+//! a half-created issue.
+
+use std::path::Path;
+
+use crate::commit::title;
+use crate::gh::{self, GhError};
+use crate::issue::labels::{self, LabelSet};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET};
+
+pub struct CreateArgs {
+    pub repo: Option<String>,
+    pub title: String,
+    pub body: Option<String>,
+    pub body_file: Option<String>,
+    pub scope: String,
+    pub parent: Option<u64>,
+    pub milestone: Option<String>,
+    pub labels: Vec<String>,
+    pub dry_run: bool,
+}
+
+pub fn run(args: CreateArgs) {
+    if let Err(e) = run_inner(args, Path::new(".")) {
+        eprintln!("{RED}{BOLD}error:{RESET} {e}");
+        std::process::exit(1);
+    }
+}
+
+/// Plan that `run_inner` builds before any GitHub call. Returned in
+/// dry-run mode for tests / debugging; in normal mode it's executed
+/// immediately.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Plan {
+    repo: String,
+    title: String,
+    body: String,
+    labels: Vec<String>,
+    milestone: Option<String>,
+    parent: Option<u64>,
+}
+
+fn run_inner(args: CreateArgs, cwd: &Path) -> Result<(), String> {
+    // 1. Title format — same validator as `shaka commit lint`.
+    title::validate(&args.title).map_err(|e| e.to_string())?;
+
+    // 2. Body — exactly one of --body / --body-file. clap's ArgGroup
+    //    enforces the structural rule; this resolves the file path.
+    let body = resolve_body(&args.body, &args.body_file)?;
+
+    // 3. Scope — must be one of the canonical scope labels.
+    let label_set = labels::load(cwd)?;
+    validate_scope(&args.scope, &label_set)?;
+
+    // 4. Repo — explicit flag wins; otherwise infer.
+    let repo = match args.repo {
+        Some(r) => r,
+        None => gh::detect_repo_or_env().map_err(|e| format!("could not detect repo: {e}"))?,
+    };
+
+    // Scope label goes first, extra `--label` flags append. Dedup so
+    // a redundant `--label <scope>` doesn't double-up.
+    let mut all_labels = vec![args.scope.clone()];
+    for l in args.labels {
+        if !all_labels.contains(&l) {
+            all_labels.push(l);
+        }
+    }
+
+    let plan = Plan {
+        repo,
+        title: args.title,
+        body,
+        labels: all_labels,
+        milestone: args.milestone,
+        parent: args.parent,
+    };
+
+    if args.dry_run {
+        print_plan(&plan);
+        return Ok(());
+    }
+
+    execute(&plan).map_err(|e| e.to_string())
+}
+
+fn resolve_body(body: &Option<String>, body_file: &Option<String>) -> Result<String, String> {
+    match (body, body_file) {
+        (Some(b), None) => Ok(b.clone()),
+        (None, Some(p)) => {
+            std::fs::read_to_string(p).map_err(|e| format!("could not read --body-file {p}: {e}"))
+        }
+        // clap's ArgGroup(required=true) makes neither/both unreachable
+        // in practice, but we keep the runtime check so the function
+        // is correct in isolation (and so tests don't depend on clap
+        // setup).
+        (None, None) => Err("exactly one of --body / --body-file is required".into()),
+        (Some(_), Some(_)) => Err("--body and --body-file are mutually exclusive".into()),
+    }
+}
+
+fn validate_scope(scope: &str, set: &LabelSet) -> Result<(), String> {
+    let valid: Vec<&str> = set.scope_names();
+    if valid.contains(&scope) {
+        return Ok(());
+    }
+    Err(format!(
+        "scope `{scope}` is not a canonical scope label; valid: {}",
+        valid.join(", ")
+    ))
+}
+
+fn execute(plan: &Plan) -> Result<(), GhError> {
+    let created = gh::issue_create(
+        &plan.repo,
+        &plan.title,
+        &plan.body,
+        &plan.labels,
+        plan.milestone.as_deref(),
+    )?;
+    println!(
+        "{GREEN}{BOLD}created{RESET} #{} {}",
+        created.number, created.url
+    );
+
+    if let Some(parent) = plan.parent {
+        // Sub-issue API needs the child's *internal* id, not its
+        // user-facing number.
+        let child_id = gh::issue_db_id(&plan.repo, created.number)?;
+        gh::add_sub_issue(&plan.repo, parent, child_id)?;
+        println!("{DIM}linked as sub-issue of #{parent}{RESET}");
+    }
+
+    Ok(())
+}
+
+fn print_plan(plan: &Plan) {
+    println!("{BOLD}shaka issue create{RESET} {DIM}(dry-run){RESET}");
+    println!("{DIM}├──{RESET} repo:      {}", plan.repo);
+    println!("{DIM}├──{RESET} title:     {}", plan.title);
+    println!("{DIM}├──{RESET} labels:    {}", plan.labels.join(", "));
+    if let Some(m) = &plan.milestone {
+        println!("{DIM}├──{RESET} milestone: {m}");
+    }
+    if let Some(p) = plan.parent {
+        println!("{DIM}├──{RESET} parent:    #{p}");
+    }
+    let body_preview = if plan.body.len() > 80 {
+        format!("{}…", &plan.body[..80])
+    } else {
+        plan.body.clone()
+    };
+    println!(
+        "{DIM}└──{RESET} body:      {body_preview:?} ({} chars)",
+        plan.body.len()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn args(title: &str, scope: &str) -> CreateArgs {
+        CreateArgs {
+            repo: Some("o/r".into()),
+            title: title.into(),
+            body: Some("body text".into()),
+            body_file: None,
+            scope: scope.into(),
+            parent: None,
+            milestone: None,
+            labels: vec![],
+            dry_run: true,
+        }
+    }
+
+    fn workdir_with_labels(canonical: &[&str]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        let mut entries = String::from("package labels\n\n#LabelSet & {\n    labels: [\n");
+        for name in canonical {
+            entries.push_str(&format!(
+                "        {{name: {name:?}, color: \"5319e7\", description: \"\", scope: true}},\n"
+            ));
+        }
+        entries.push_str("    ]\n}\n");
+        std::fs::create_dir_all(tmp.path().join(".shaka")).unwrap();
+        std::fs::write(tmp.path().join(".shaka/labels.cue"), entries).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn rejects_bad_title_before_loading_labels() {
+        // Title validation runs before label loading — confirmed by
+        // *not* planting a labels file. If the validator fired second,
+        // we'd hit "no .shaka/labels.cue found" first.
+        let tmp = TempDir::new().unwrap();
+        let err = run_inner(args("not conventional", "shaka"), tmp.path()).unwrap_err();
+        assert!(
+            err.contains("missing `: ` separator") || err.contains("does not match"),
+            "expected title error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_scope_with_valid_list() {
+        let tmp = workdir_with_labels(&["shaka", "ci"]);
+        let err = run_inner(args("feat(shaka): add x", "blogctl"), tmp.path()).unwrap_err();
+        assert!(err.contains("blogctl"), "should name the bad scope: {err}");
+        assert!(err.contains("shaka"), "should list valid scopes: {err}");
+        assert!(err.contains("ci"), "should list valid scopes: {err}");
+    }
+
+    #[test]
+    fn accepts_valid_scope_and_title_in_dry_run() {
+        let tmp = workdir_with_labels(&["shaka"]);
+        run_inner(args("feat(shaka): add x", "shaka"), tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn dedups_scope_when_also_passed_via_label_flag() {
+        // A common slip is `--scope shaka --label shaka`. Don't pass
+        // duplicate labels to gh — confirmed via the dry-run plan's
+        // label vector (no behavioral effect on gh, but cleaner output).
+        let tmp = workdir_with_labels(&["shaka"]);
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.labels = vec!["shaka".into(), "bug".into()];
+        // Execute through to plan-building by calling run_inner with
+        // dry-run; assertion on stdout is brittle, so call the plan
+        // builder directly via a small refactor in a future iteration
+        // if this proves needed. For now, just exercise the path.
+        run_inner(a, tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn rejects_neither_body_nor_body_file() {
+        let tmp = workdir_with_labels(&["shaka"]);
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.body = None;
+        a.body_file = None;
+        let err = run_inner(a, tmp.path()).unwrap_err();
+        assert!(err.contains("--body"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_both_body_and_body_file() {
+        let tmp = workdir_with_labels(&["shaka"]);
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.body_file = Some("/nonexistent".into());
+        let err = run_inner(a, tmp.path()).unwrap_err();
+        assert!(err.contains("mutually exclusive"), "got: {err}");
+    }
+
+    #[test]
+    fn reads_body_from_file_when_set() {
+        let tmp = workdir_with_labels(&["shaka"]);
+        let body_path = tmp.path().join("body.md");
+        std::fs::write(&body_path, "from-file body").unwrap();
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.body = None;
+        a.body_file = Some(body_path.to_string_lossy().into());
+        // Reaching dry-run without an error is the assertion — file
+        // was readable and resolved.
+        run_inner(a, tmp.path()).unwrap();
+    }
+}


### PR DESCRIPTION
Adds `shaka issue create` — a gated wrapper around `gh issue create`
that enforces three rules locally before any GitHub call:

1. Title matches the conventional-commit shape (`<type>(<scope>):
   <subject>`). The validator is shared with `shaka commit lint` via
   a new `commit::title` module that returns structured `TitleError`
   variants, so both call sites surface specific reasons rather than
   a bare "format invalid".
2. `--scope <label>` must be one of the canonical scope labels
   declared in `.shaka/labels.cue` (loaded via `issue::labels::load`,
   landed in #539). Unknown scope errors list the valid set.
3. Body comes from exactly one of `--body` / `--body-file`; clap's
   `ArgGroup(required = true)` enforces structurally, with a runtime
   check so the function is correct in isolation.

When `--parent <N>` is set, the new issue is linked via GitHub's
native sub-issue API (`POST /repos/.../issues/<parent>/sub_issues`)
using the child's internal database id — no freeform "Sub-issue of
#N" body text. Sub-issue link retries with 1s/3s backoff to ride out
transient API failures.

`--dry-run` prints the planned `gh` calls without executing, giving
a deterministic test surface and a debug affordance for catching
malformed invocations before they create a half-baked issue.

Closes #540