### PR TITLE
feat(infra/home): version-controlled ~/.claude/CLAUDE.md

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -33,3 +33,10 @@ BasedOnStyles =
 # linted — only the deliverable .md is exempt.
 [**/tools/resume/resume.md]
 BasedOnStyles =
+
+# Personal Claude Code directives — first-person voice ("I", "my",
+# "me"), tech-name spellings (Jujutsu, jj, dotfiles), and a casual
+# register that's the whole point of a personal-prefs file. Google's
+# tech-writing rules don't apply.
+[**/infra/home/dotfiles/claude/CLAUDE.md]
+BasedOnStyles =

--- a/infra/home/dotfiles/claude/CLAUDE.md
+++ b/infra/home/dotfiles/claude/CLAUDE.md
@@ -1,0 +1,26 @@
+# Personal Claude Code Directives
+
+## Version Control
+- **Always use Jujutsu (jj)** instead of git for all version control operations
+- Use jj commands for commits, branches, and all VCS operations
+- **Use Conventional Commits format** for all commit messages:
+  - Format: `<type>(<scope>): <subject>` (title max 70 chars)
+  - Optional body wrapped at 80 chars per line
+  - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, `build`
+  - Always include scope when applicable
+  - Body should explain the "why" not the "what"
+
+## Output Guidelines
+- **NEVER include Claude attribution** in commits, code, documentation, or any other output
+- No "Generated with Claude Code" messages
+- No "Co-Authored-By: Claude" attributions
+- Focus on clean, professional output without AI meta-commentary
+
+## Memory and persistence
+- **Don't use the auto-memory system as a substitute for writing things down where I can see them.** Memory files at `~/.claude/projects/.../memory/` are private to you and invisible to me — I can't grep them, version them in dotfiles, or take them with me if I switch tools. From my perspective, anything in memory is not durable.
+- **Durable knowledge belongs in files I own and can see:**
+  - Cross-project behavioral rules / preferences: this file (`~/.claude/CLAUDE.md`)
+  - Project-specific conventions: the project's `CLAUDE.md`
+  - Project runbooks, snippets, architecture notes, inventories: a `docs/` folder in the relevant project, or a GitHub issue
+- **Memory is only appropriate for** ephemeral within-session/within-project state that genuinely doesn't need to be surfaced to me — and even then, prefer surfacing.
+- When you catch yourself reaching for memory to "make something durable," that's the signal to instead propose an edit to one of the files above and let me approve it.

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -101,4 +101,10 @@
   # `programs.git.ignores` above so it never gets committed); Claude
   # merges the two with `.local.json` taking precedence.
   home.file.".claude/settings.json".source = ../dotfiles/claude/settings.json;
+
+  # Cross-project personal directives for Claude Code. Used to be
+  # hand-maintained at `~/.claude/CLAUDE.md`; now version-controlled
+  # so a clean-machine rebuild reproduces the same behavioral rules
+  # (per the "devboxes are ephemeral" tenet).
+  home.file.".claude/CLAUDE.md".source = ../dotfiles/claude/CLAUDE.md;
 }


### PR DESCRIPTION
Lifts the hand-maintained `~/.claude/CLAUDE.md` (jj-only VCS rule,
no-Claude-attribution rule, memory-vs-files rule) into
`infra/home/dotfiles/claude/CLAUDE.md` and wires it via
`home.file`. Same shape as #518 (file-issue skill), #534
(settings.json), and #551 (claude-hooks consumption): clean-machine
rebuild reproduces the same directives, no manual config bootstrap.

Vale's tech-doc styles fight every line of personal directives
(first-person voice, tech-name spellings — `Jujutsu`, `jj`,
`dotfiles` — casual register). Adds a vale exemption for this
specific file, following the resume.md precedent. The kolohelios
CLAUDE.md is still linted; only this user-personal directives file
is exempt.

## Migration note

On the dev machine, manually `rm ~/.claude/CLAUDE.md` before
`darwin-rebuild switch` — home-manager errors on existing files
when it wants to symlink. Content is already folded into the
managed source verbatim.

Closes #537