### PR TITLE
feat(blogctl): metrics collect — walk stale targets interactively

### DIFF
--- a/apps/blogctl/Cargo.lock
+++ b/apps/blogctl/Cargo.lock
@@ -107,6 +107,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "humantime",
  "mockito",
  "serde",
  "serde_json",
@@ -434,6 +435,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"

--- a/apps/blogctl/Cargo.toml
+++ b/apps/blogctl/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+humantime = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"

--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -60,6 +60,8 @@ blogctl metrics update <slug> --workdir <path> \
   --impressions N --reactions N --comments N --reposts N \
   [--sampled-at <RFC3339>]
 blogctl metrics show <slug> --workdir <path>
+blogctl metrics collect --workdir <path> --target <linkedin|blog> \
+  [--stale-after <duration>] [--batch-size N]
 blogctl backfill --workdir <path> [--import <file.json>]
 ```
 
@@ -213,6 +215,13 @@ blogctl classify the-only-way-out-is-through \
 # 5. Refresh metrics weekly. `metrics show` prints the current
 #    snapshot per target.
 blogctl metrics show the-only-way-out-is-through --workdir ~/blog-os
+
+# 5a. Or — once a daily habit kicks in — walk a rotating batch of
+#     posts whose target metrics are stale or missing.
+blogctl metrics collect --workdir ~/blog-os --target linkedin
+# (default: 10 posts per run, sampled_at older than 7d. The walker
+#  prompts for the four counts; pressing `q` partway through still
+#  commits whatever was already entered.)
 
 # 6. Once you have ~15+ measured posts, look at signals:
 blogctl analytics summary         --workdir ~/blog-os

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -343,6 +343,31 @@ pub enum MetricsAction {
         #[arg(long, value_name = "PATH")]
         workdir: Option<PathBuf>,
     },
+    /// Walk a daily batch of published posts whose target needs a
+    /// metrics refresh (no metrics, or `sampled_at` older than
+    /// `--stale-after`). Prompts interactively for each, then commits
+    /// the whole batch.
+    Collect {
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Required — picks which venue's metrics this run refreshes.
+        #[arg(long, value_enum)]
+        target: Target,
+        /// Posts with `sampled_at` older than this are eligible.
+        /// `humantime`-shaped: `7d`, `1w`, `24h`. Default: 7 days.
+        #[arg(long, value_name = "DURATION", default_value = "7d")]
+        stale_after: String,
+        /// Cap on how many posts to walk per invocation. Default 10
+        /// gives a manageable daily rotation without forcing the
+        /// whole backlog every time. Pass a large number to do all
+        /// eligible in one sitting.
+        #[arg(long, default_value_t = 10)]
+        batch_size: usize,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -582,6 +607,30 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                     slug,
                     workdir: workdir_or_pwd(workdir)?,
                 })
+            }
+            MetricsAction::Collect {
+                workdir,
+                target,
+                stale_after,
+                batch_size,
+                no_sync,
+            } => {
+                let stdin = io::stdin();
+                let stdout = io::stdout();
+                let mut input = io::BufReader::new(stdin.lock());
+                let mut output = stdout.lock();
+                commands::metrics::collect(
+                    jj,
+                    commands::metrics::CollectArgs {
+                        workdir: workdir_or_pwd(workdir)?,
+                        target,
+                        stale_after,
+                        batch_size,
+                        no_sync,
+                    },
+                    &mut input,
+                    &mut output,
+                )
             }
         },
         Command::Backfill {

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -225,13 +225,13 @@ fn merge_classifications(target: &mut Classifications, source: &Classifications)
 }
 
 #[derive(Debug, PartialEq)]
-enum MergeMetricsOutcome {
+pub(crate) enum MergeMetricsOutcome {
     Applied,
     Unchanged,
     TargetMissing,
 }
 
-fn merge_metrics(
+pub(crate) fn merge_metrics(
     targets: &mut [TargetEntry],
     target: Target,
     source: &TargetMetrics,
@@ -464,7 +464,7 @@ enum DimPick {
     Quit,
 }
 
-enum MetricsPick {
+pub(crate) enum MetricsPick {
     Values(TargetMetrics),
     Skip,
     SkipPost,
@@ -519,7 +519,7 @@ fn prompt_dimension<R: BufRead, W: Write>(
     }
 }
 
-fn prompt_metrics<R: BufRead, W: Write>(
+pub(crate) fn prompt_metrics<R: BufRead, W: Write>(
     target: Target,
     input: &mut R,
     output: &mut W,

--- a/apps/blogctl/src/commands/metrics.rs
+++ b/apps/blogctl/src/commands/metrics.rs
@@ -1,21 +1,24 @@
-//! `blogctl metrics update <slug>` / `blogctl metrics show <slug>` —
-//! per-target performance numbers.
+//! `blogctl metrics update <slug>` / `blogctl metrics show <slug>` /
+//! `blogctl metrics collect` — per-target performance numbers.
 //!
 //! Update overwrites; there's no history. `sampled_at` defaults to
-//! `now_utc()` and acts as the freshness signal — analytics will
-//! grow a "stale" notion on top, but the storage model stays a
-//! single point-in-time per target.
+//! `now_utc()` and acts as the freshness signal — `collect` uses it
+//! to decide which posts in the eligibility set are due for a
+//! refresh, oldest first.
 
 use std::fs;
+use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+use crate::commands::backfill::{merge_metrics, prompt_metrics, MergeMetricsOutcome, MetricsPick};
 use crate::error::{Error, Result};
+use crate::stage::Stage;
 use crate::storage::{Repository, Workdir};
 use crate::sync::{self, Jj, SyncOptions};
-use crate::target::{Target, TargetMetrics};
+use crate::target::{Target, TargetMetrics, TargetStatus};
 
 #[derive(Debug)]
 pub struct UpdateArgs {
@@ -114,6 +117,170 @@ pub fn show(args: ShowArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[derive(Debug)]
+pub struct CollectArgs {
+    pub workdir: PathBuf,
+    pub target: Target,
+    /// Posts whose `sampled_at` is older than this become eligible.
+    /// Parsed via `humantime` (`7d`, `1w`, `24h`, …).
+    pub stale_after: String,
+    /// Hard cap on how many posts a single run walks. The rotation
+    /// falls out of "oldest first" — capping at 10/day rotates through
+    /// the backlog without forcing the whole thing in one sitting.
+    pub batch_size: usize,
+    pub no_sync: bool,
+}
+
+/// Walk a daily batch of posts whose chosen-target metrics are stale
+/// or missing. Prompts interactively, accumulates writes, commits the
+/// whole batch in one go. Quit mid-walk preserves accumulated work.
+pub fn collect<R: BufRead, W: Write>(
+    jj: &dyn Jj,
+    args: CollectArgs,
+    input: &mut R,
+    output: &mut W,
+) -> Result<()> {
+    let stale_after = humantime::parse_duration(&args.stale_after).map_err(|source| {
+        Error::InvalidStaleAfter {
+            value: args.stale_after.clone(),
+            source,
+        }
+    })?;
+    let cutoff = OffsetDateTime::now_utc() - stale_after;
+
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let config = repo.read_config()?;
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let handles = repo.list()?;
+
+    // Build the eligible set: published posts whose chosen target is
+    // itself in `published` state, and whose metrics are either
+    // absent or older than the cutoff. `None` sorts before any
+    // `Some` so never-sampled posts naturally lead the rotation.
+    let mut eligible: Vec<(String, Option<OffsetDateTime>)> = Vec::new();
+    for handle in &handles {
+        if handle.stage != Stage::Published {
+            continue;
+        }
+        let Some(entry) = handle
+            .metadata
+            .targets
+            .iter()
+            .find(|t| t.name == args.target)
+        else {
+            continue;
+        };
+        if entry.status != TargetStatus::Published {
+            continue;
+        }
+        let sampled = entry.metrics.as_ref().map(|m| m.sampled_at);
+        let stale = match sampled {
+            None => true,
+            Some(s) => s < cutoff,
+        };
+        if stale {
+            eligible.push((handle.metadata.slug.clone(), sampled));
+        }
+    }
+    eligible.sort_by_key(|(_, sampled)| *sampled);
+
+    if eligible.is_empty() {
+        writeln!(output, "metrics collect: nothing to refresh").ok();
+        return Ok(());
+    }
+
+    let pool = eligible.len();
+    let batch_slugs: Vec<String> = eligible
+        .into_iter()
+        .take(args.batch_size)
+        .map(|(slug, _)| slug)
+        .collect();
+    writeln!(
+        output,
+        "metrics collect({}): walking {} of {} eligible post(s)",
+        args.target,
+        batch_slugs.len(),
+        pool,
+    )
+    .ok();
+
+    let mut writes: Vec<(PathBuf, String)> = Vec::new();
+    let mut quit_early = false;
+
+    for slug in &batch_slugs {
+        let (h, mut post) = repo.load_raw(slug)?;
+        print_preview(output, &post, slug, args.target);
+
+        match prompt_metrics(args.target, input, output)? {
+            MetricsPick::Values(m) => {
+                if matches!(
+                    merge_metrics(&mut post.metadata.targets, args.target, &m),
+                    MergeMetricsOutcome::Applied
+                ) {
+                    post.metadata.updated_at = OffsetDateTime::now_utc();
+                    let rendered = post.render()?;
+                    writes.push((h.path.clone(), rendered));
+                }
+            }
+            // `Skip` and `SkipPost` are equivalent here — we only
+            // prompt one target per post — but accept both so the
+            // shared prompt UX stays consistent with `backfill`.
+            MetricsPick::Skip | MetricsPick::SkipPost => continue,
+            MetricsPick::Quit => {
+                quit_early = true;
+                break;
+            }
+        }
+    }
+
+    let n = writes.len();
+    if n == 0 {
+        writeln!(output, "metrics collect: no changes recorded").ok();
+        return Ok(());
+    }
+
+    let message = format!("chore: collect metrics({}) — {n} post(s)", args.target);
+    sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        for (path, rendered) in &writes {
+            fs::write(path, rendered).map_err(|e| Error::io(path, e))?;
+        }
+        Ok(())
+    })?;
+    writeln!(output, "metrics collect: updated {n} post(s)").ok();
+    if quit_early {
+        writeln!(
+            output,
+            "  (quit early; remaining batch deferred to next run)",
+        )
+        .ok();
+    }
+    Ok(())
+}
+
+fn print_preview<W: Write>(output: &mut W, post: &crate::post::Post, slug: &str, target: Target) {
+    let entry = post.metadata.targets.iter().find(|t| t.name == target);
+    let url = entry
+        .and_then(|t| t.url.as_deref())
+        .unwrap_or("(no url recorded)");
+    writeln!(output, "---").ok();
+    writeln!(output, "{} ({slug})", post.metadata.title).ok();
+    writeln!(output, "{target}: {url}").ok();
+    match entry.and_then(|t| t.metrics.as_ref()) {
+        None => {
+            writeln!(output, "  last sampled: never").ok();
+        }
+        Some(m) => {
+            let when = m.sampled_at.format(&Rfc3339).unwrap_or_else(|_| "?".into());
+            writeln!(
+                output,
+                "  last sampled: {when} (impressions: {}, reactions: {}, comments: {}, reposts: {})",
+                m.impressions, m.reactions, m.comments, m.reposts,
+            )
+            .ok();
+        }
+    }
 }
 
 fn parse_sampled_at(raw: Option<&str>) -> Result<OffsetDateTime> {

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -256,6 +256,13 @@ pub enum Error {
 
     #[error("backfill completed with {0} warning(s) — see stderr for details")]
     BackfillPartialFailure(usize),
+
+    #[error("invalid --stale-after {value:?}: expected a humantime duration like `7d` or `24h` ({source})")]
+    InvalidStaleAfter {
+        value: String,
+        #[source]
+        source: humantime::DurationError,
+    },
 }
 
 impl Error {

--- a/apps/blogctl/tests/metrics_collect.rs
+++ b/apps/blogctl/tests/metrics_collect.rs
@@ -1,0 +1,267 @@
+//! Integration tests for `blogctl metrics collect`. Builds a real
+//! workdir, walks a stale post via canned stdin, and asserts on the
+//! resulting frontmatter — same shape as `tests/backfill.rs`.
+
+use std::fs;
+use std::io::Cursor;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use blogctl::commands;
+use blogctl::kind::Kind;
+use blogctl::sync::FakeJj;
+use blogctl::target::Target;
+
+fn add_published_linkedin_target(post_path: &Path, metrics_block: Option<&str>) {
+    let raw = fs::read_to_string(post_path).unwrap();
+    let metrics = metrics_block.unwrap_or("");
+    let injected = format!(
+        concat!(
+            "tags: []\n",
+            "targets:\n",
+            "  - name: linkedin\n",
+            "    status: published\n",
+            "    url: https://www.linkedin.com/posts/example\n",
+            "    published_at: 2026-05-08T14:32:00Z\n",
+            "{}",
+        ),
+        metrics,
+    );
+    fs::write(post_path, raw.replace("tags: []\n", &injected)).unwrap();
+}
+
+fn fresh_metrics_block_now() -> String {
+    // Sampled "now" → never stale under any reasonable `--stale-after`.
+    let now = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    format!(
+        concat!(
+            "    metrics:\n",
+            "      impressions: 100\n",
+            "      reactions: 5\n",
+            "      comments: 1\n",
+            "      reposts: 0\n",
+            "      sampled_at: {}\n",
+        ),
+        now,
+    )
+}
+
+fn old_metrics_block() -> &'static str {
+    // Sampled in 2024 → always stale under any 7d cutoff.
+    concat!(
+        "    metrics:\n",
+        "      impressions: 100\n",
+        "      reactions: 5\n",
+        "      comments: 1\n",
+        "      reposts: 0\n",
+        "      sampled_at: 2024-01-01T00:00:00Z\n",
+    )
+}
+
+/// Build a workdir with one Published post that has a `linkedin`
+/// target. Caller supplies the metrics block (or `None` for "never
+/// sampled").
+fn workdir_with_published_linkedin(slug: &str, metrics_block: Option<&str>) -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    commands::init::run(&FakeJj::new(), tmp.path().to_path_buf(), false).unwrap();
+    commands::new::run(
+        &FakeJj::new(),
+        slug.to_string(),
+        tmp.path().to_path_buf(),
+        Some(slug.to_string()),
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(
+        &tmp.path().join(format!("concepts/{slug}.md")),
+        metrics_block,
+    );
+    // concept → ideation → editing → final-editing → published
+    for _ in 0..4 {
+        commands::promote::run(
+            &FakeJj::new(),
+            slug.to_string(),
+            tmp.path().to_path_buf(),
+            false,
+        )
+        .unwrap();
+    }
+    tmp
+}
+
+fn collect_args(workdir: &Path) -> commands::metrics::CollectArgs {
+    commands::metrics::CollectArgs {
+        workdir: workdir.to_path_buf(),
+        target: Target::Linkedin,
+        stale_after: "7d".to_string(),
+        batch_size: 10,
+        no_sync: false,
+    }
+}
+
+#[test]
+fn collect_walks_stale_post_and_records_entered_metrics() {
+    let tmp = workdir_with_published_linkedin("bare-post", Some(old_metrics_block()));
+    // Prompt sequence for one post: impressions, reactions, comments, reposts.
+    let input_bytes = b"1842\n67\n14\n5\n";
+    let mut input = Cursor::new(&input_bytes[..]);
+    let mut output: Vec<u8> = Vec::new();
+
+    commands::metrics::collect(
+        &FakeJj::new(),
+        collect_args(tmp.path()),
+        &mut input,
+        &mut output,
+    )
+    .unwrap();
+
+    let raw = fs::read_to_string(tmp.path().join("published/bare-post.md")).unwrap();
+    assert!(raw.contains("impressions: 1842"), "got:\n{raw}");
+    assert!(raw.contains("reactions: 67"), "got:\n{raw}");
+    assert!(raw.contains("reposts: 5"), "got:\n{raw}");
+    // The 2024 timestamp is overwritten by `now`.
+    assert!(!raw.contains("2024-01-01T00:00:00Z"), "got:\n{raw}");
+}
+
+#[test]
+fn collect_nothing_to_refresh_when_all_fresh() {
+    let tmp = workdir_with_published_linkedin("bare-post", Some(&fresh_metrics_block_now()));
+    let mut input = Cursor::new(&b""[..]);
+    let mut output: Vec<u8> = Vec::new();
+
+    let jj = FakeJj::new();
+    commands::metrics::collect(&jj, collect_args(tmp.path()), &mut input, &mut output).unwrap();
+
+    let stdout = String::from_utf8(output).unwrap();
+    assert!(
+        stdout.contains("nothing to refresh"),
+        "expected nothing-to-refresh, got: {stdout}",
+    );
+    // No write, no commit — the FakeJj shouldn't have received any
+    // calls.
+    assert!(
+        jj.calls().is_empty(),
+        "fresh-only workdir must not invoke jj: {:?}",
+        jj.calls(),
+    );
+}
+
+#[test]
+fn collect_picks_never_sampled_before_stale_sampled() {
+    // Two eligible posts. With batch_size=1, the never-sampled one
+    // (sorts first under "None < Some") must be the one we walk.
+    let tmp = workdir_with_published_linkedin("never-sampled", None);
+    // Add a second post sampled long ago.
+    commands::new::run(
+        &FakeJj::new(),
+        "stale-sampled".to_string(),
+        tmp.path().to_path_buf(),
+        Some("stale-sampled".to_string()),
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(
+        &tmp.path().join("concepts/stale-sampled.md"),
+        Some(old_metrics_block()),
+    );
+    for _ in 0..4 {
+        commands::promote::run(
+            &FakeJj::new(),
+            "stale-sampled".to_string(),
+            tmp.path().to_path_buf(),
+            false,
+        )
+        .unwrap();
+    }
+
+    // Single-post batch, enter values for whichever the walker picks.
+    let input_bytes = b"1\n2\n3\n4\n";
+    let mut input = Cursor::new(&input_bytes[..]);
+    let mut output: Vec<u8> = Vec::new();
+    commands::metrics::collect(
+        &FakeJj::new(),
+        commands::metrics::CollectArgs {
+            batch_size: 1,
+            ..collect_args(tmp.path())
+        },
+        &mut input,
+        &mut output,
+    )
+    .unwrap();
+
+    let never_raw = fs::read_to_string(tmp.path().join("published/never-sampled.md")).unwrap();
+    let stale_raw = fs::read_to_string(tmp.path().join("published/stale-sampled.md")).unwrap();
+    // The never-sampled post got the entered values.
+    assert!(
+        never_raw.contains("impressions: 1"),
+        "never-sampled should be picked first; got:\n{never_raw}"
+    );
+    // The stale-sampled post is untouched (still has its 2024 mtime).
+    assert!(
+        stale_raw.contains("2024-01-01T00:00:00Z"),
+        "stale-sampled should be deferred; got:\n{stale_raw}"
+    );
+}
+
+#[test]
+fn collect_quit_mid_walk_commits_accumulated_writes() {
+    let tmp = workdir_with_published_linkedin("first", None);
+    commands::new::run(
+        &FakeJj::new(),
+        "second".to_string(),
+        tmp.path().to_path_buf(),
+        Some("second".to_string()),
+        Kind::Post,
+        None,
+        false,
+    )
+    .unwrap();
+    add_published_linkedin_target(&tmp.path().join("concepts/second.md"), None);
+    for _ in 0..4 {
+        commands::promote::run(
+            &FakeJj::new(),
+            "second".to_string(),
+            tmp.path().to_path_buf(),
+            false,
+        )
+        .unwrap();
+    }
+
+    // First post: real values. Second post's first prompt: `q`.
+    // Accumulated change for `first` must still land.
+    let input_bytes = b"100\n10\n2\n1\nq\n";
+    let mut input = Cursor::new(&input_bytes[..]);
+    let mut output: Vec<u8> = Vec::new();
+    commands::metrics::collect(
+        &FakeJj::new(),
+        collect_args(tmp.path()),
+        &mut input,
+        &mut output,
+    )
+    .unwrap();
+
+    let stdout = String::from_utf8(output).unwrap();
+    assert!(
+        stdout.contains("quit early"),
+        "expected quit-early notice, got: {stdout}"
+    );
+
+    // Either ordering is permissible (both are "never sampled");
+    // whichever was walked first got committed.
+    let first_raw = fs::read_to_string(tmp.path().join("published/first.md")).unwrap();
+    let second_raw = fs::read_to_string(tmp.path().join("published/second.md")).unwrap();
+    let one_committed =
+        first_raw.contains("impressions: 100") ^ second_raw.contains("impressions: 100");
+    assert!(
+        one_committed,
+        "exactly one of the two posts should have committed metrics; \
+         first:\n{first_raw}\nsecond:\n{second_raw}"
+    );
+}


### PR DESCRIPTION
The interactive metrics-prompt path in `backfill --interactive` is
about to gain a second caller (`metrics collect`, #558) that needs
exactly the same prompt UX for a single target per post. Make the
relevant pieces `pub(crate)`:

- `prompt_metrics` — drives the four-number entry loop with skip /
  skip-post / quit.
- `MetricsPick` — the prompt's return shape.
- `merge_metrics` + `MergeMetricsOutcome` — the per-target apply
  primitive (returns `Applied` / `Unchanged` / `TargetMissing`).

Visibility-only; no behavior change. The internal helpers
(`prompt_u64`, `read_line`) stay private — `prompt_metrics` is
the seam.

LinkedIn doesn't expose post analytics via API for personal profiles
(#557 confirmed and was closed for that reason). Manual entry via
`metrics update` is the realistic path, but the ergonomics — slug
lookup, four order-sensitive flags, no "what's stale" view, N
invocations for a multi-post sitting — push toward not bothering.

`metrics collect` walks a daily batch of posts whose chosen target
needs a refresh:

- **Eligibility**: published post + target with status=published + no
  metrics, or `sampled_at` older than `--stale-after` (default 7d).
- **Rotation**: sort eligible ascending by `sampled_at` (`None`
  sorts as 'never sampled', so it leads). Take top `--batch-size`
  (default 10). The rotation falls out of `sampled_at` being honest
  — no extra state file, no scheduler.
- **Prompt**: reuses `backfill::prompt_metrics` (made `pub(crate)`
  in the preceding refactor commit). Quit (`q`) mid-walk still
  commits everything accumulated so far.
- **Single batch commit** at the end (`chore: collect
  metrics(linkedin) — N post(s)`), rather than backfill's per-post
  commits — a daily collect run is one logical action.

`--target` is required (linkedin vs. blog); no implicit default.
`--stale-after` uses humantime (`7d`, `1w`, `24h`). To process
the entire eligible backlog in one sitting, pass a large
`--batch-size`.

Closes #558