### PR TITLE
feat(shaka): enforce native sub-issue links in audit and create

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -502,6 +502,49 @@ pub fn issue_db_id(repo: &str, number: u64) -> Result<u64, GhError> {
     })
 }
 
+/// Fetch the native parent issue number for `{repo}#{number}`, if any.
+///
+/// GitHub's REST issue endpoint exposes `.parent` (object or null) for
+/// issues linked via the native sub-issue API. Freeform `Sub-issue of #N`
+/// body text does *not* populate this field — which is exactly the drift
+/// `shaka issue audit` flags.
+pub fn issue_parent(repo: &str, number: u64) -> Result<Option<u64>, GhError> {
+    let endpoint = format!("/repos/{repo}/issues/{number}");
+    let value = api_get(&endpoint)?;
+    Ok(value
+        .get("parent")
+        .and_then(|p| p.get("number"))
+        .and_then(|n| n.as_u64()))
+}
+
+/// Returns `Ok(true)` if `{repo}#{number}` resolves, `Ok(false)` on 404,
+/// or propagates any other error. Used to flag freeform references to
+/// nonexistent issues.
+pub fn issue_exists(repo: &str, number: u64) -> Result<bool, GhError> {
+    let endpoint = format!("/repos/{repo}/issues/{number}");
+    let output = Command::new("gh")
+        .args([
+            "api",
+            &endpoint,
+            "-H",
+            "Accept: application/vnd.github+json",
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("HTTP 404") || stderr.contains("Not Found") {
+        return Ok(false);
+    }
+    GhCommandSnafu {
+        command: format!("gh api {endpoint}"),
+        stderr: stderr.trim().to_string(),
+    }
+    .fail()
+}
+
 /// Link `sub_id` (the integer db id of an existing issue) as a sub-issue
 /// of `{repo}#{parent_number}` via GitHub's native sub-issues API.
 ///

--- a/tools/shaka/src/issue/audit.rs
+++ b/tools/shaka/src/issue/audit.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 
 use serde_json::Value;
@@ -40,37 +41,201 @@ pub fn run(repo_arg: Option<String>) {
         }
     };
 
-    let mut violators: Vec<(u64, String)> = Vec::new();
+    let mut scope_violators: Vec<(u64, String)> = Vec::new();
+    let mut missing_native_link: Vec<MissingLink> = Vec::new();
+    let mut nonexistent_refs: Vec<NonexistentRef> = Vec::new();
+
+    // Cache `gh::issue_exists` lookups so a parent referenced by N
+    // children only costs one round trip.
+    let mut existence_cache: BTreeMap<u64, bool> = BTreeMap::new();
+
     for issue in &issues {
+        let number = issue["number"].as_u64().unwrap_or(0);
+        let title = issue["title"].as_str().unwrap_or("").to_string();
+        let body = issue["body"].as_str().unwrap_or("");
+
         let labels: Vec<&str> = issue["labels"]
             .as_array()
             .map(|arr| arr.iter().filter_map(|l| l["name"].as_str()).collect())
             .unwrap_or_default();
         let has_scope = labels.iter().any(|l| scope_labels.contains(l));
         if !has_scope {
-            let n = issue["number"].as_u64().unwrap_or(0);
-            let title = issue["title"].as_str().unwrap_or("").to_string();
-            violators.push((n, title));
+            scope_violators.push((number, title.clone()));
+        }
+
+        let refs = extract_parent_refs(body);
+        if refs.is_empty() {
+            continue;
+        }
+
+        // Only call /issues/{N} when there's a freeform ref to verify.
+        let native_parent = match gh::issue_parent(&repo, number) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("{RED}{BOLD}warn:{RESET} could not load #{number} parent: {e}");
+                None
+            }
+        };
+
+        for r in &refs {
+            let exists = *existence_cache.entry(r.parent).or_insert_with(|| {
+                gh::issue_exists(&repo, r.parent).unwrap_or_else(|e| {
+                    eprintln!("{RED}{BOLD}warn:{RESET} could not check #{}: {e}", r.parent);
+                    // Treat lookup failure as "assume exists" so we don't
+                    // false-positive a noisy network blip into a violation.
+                    true
+                })
+            });
+            if !exists {
+                nonexistent_refs.push(NonexistentRef {
+                    child: number,
+                    child_title: title.clone(),
+                    parent: r.parent,
+                    phrase: r.phrase.clone(),
+                });
+            }
+        }
+
+        let referenced_parents: BTreeSet<u64> = refs.iter().map(|r| r.parent).collect();
+        if !referenced_parents.contains(&native_parent.unwrap_or(0)) {
+            let phrase = refs.first().map(|r| r.phrase.clone()).unwrap_or_default();
+            missing_native_link.push(MissingLink {
+                child: number,
+                child_title: title.clone(),
+                referenced_parents: referenced_parents.into_iter().collect(),
+                phrase,
+            });
         }
     }
 
-    if violators.is_empty() {
+    let mut violations = 0;
+
+    if !scope_violators.is_empty() {
+        println!("{BOLD}Open issues missing a scope label:{RESET}");
+        for (n, title) in &scope_violators {
+            println!("  {RED}#{n}{RESET}  {title}");
+        }
+        println!();
+        violations += scope_violators.len();
+    }
+
+    if !missing_native_link.is_empty() {
+        println!("{BOLD}Issues with freeform parent reference but no native link:{RESET}");
+        for v in &missing_native_link {
+            let parents: Vec<String> = v
+                .referenced_parents
+                .iter()
+                .map(|p| format!("#{p}"))
+                .collect();
+            println!(
+                "  {RED}#{}{RESET}  {} {RED}→{RESET} {:?} (link to {})",
+                v.child,
+                v.child_title,
+                v.phrase,
+                parents.join(", ")
+            );
+        }
+        println!();
+        violations += missing_native_link.len();
+    }
+
+    if !nonexistent_refs.is_empty() {
+        println!("{BOLD}Issues referencing nonexistent issues:{RESET}");
+        for v in &nonexistent_refs {
+            println!(
+                "  {RED}#{}{RESET}  {} {RED}→{RESET} {:?} (#{} not found)",
+                v.child, v.child_title, v.phrase, v.parent
+            );
+        }
+        println!();
+        violations += nonexistent_refs.len();
+    }
+
+    if violations == 0 {
         println!(
-            "{GREEN}{BOLD}All {} open issue(s) carry a scope label{RESET}",
+            "{GREEN}{BOLD}All {} open issue(s) pass audit{RESET}",
             issues.len()
         );
         return;
     }
 
-    println!("{BOLD}Open issues missing a scope label:{RESET}");
-    for (n, title) in &violators {
-        println!("  {RED}#{n}{RESET}  {title}");
-    }
     println!(
-        "\n{RED}{BOLD}{} issue(s) need attention{RESET}",
-        violators.len()
+        "{RED}{BOLD}{} violation(s) across {} open issue(s){RESET}",
+        violations,
+        issues.len()
     );
     std::process::exit(1);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParentRef {
+    pub(crate) parent: u64,
+    /// The matched phrase (e.g. `"Sub-issue of #15"`), surfaced in
+    /// audit output so the user can grep the body for it.
+    pub(crate) phrase: String,
+}
+
+#[derive(Debug)]
+struct MissingLink {
+    child: u64,
+    child_title: String,
+    referenced_parents: Vec<u64>,
+    phrase: String,
+}
+
+#[derive(Debug)]
+struct NonexistentRef {
+    child: u64,
+    child_title: String,
+    parent: u64,
+    phrase: String,
+}
+
+/// Scan an issue body for freeform parent-pointer phrases. Returns one
+/// `ParentRef` per match (so two phrases pointing to different parents
+/// both surface).
+///
+/// Recognized phrases:
+/// - `Sub-issue of #N`
+/// - `Tracked in #N`
+///
+/// Both are case-sensitive and match the canonical form used in this
+/// repo's existing issue bodies. PR-side close keywords (`Closes`,
+/// `Fixes`, `Resolves`) and sibling relationships (`Blocked on`,
+/// `Depends on`) are intentionally excluded — see issue #541 for
+/// rationale.
+pub(crate) fn extract_parent_refs(body: &str) -> Vec<ParentRef> {
+    const PHRASES: &[&str] = &["Sub-issue of", "Tracked in"];
+    let mut out: Vec<ParentRef> = Vec::new();
+    let mut seen: BTreeSet<(u64, String)> = BTreeSet::new();
+
+    for phrase in PHRASES {
+        let needle = format!("{phrase} #");
+        let mut search_from = 0usize;
+        while let Some(idx) = body[search_from..].find(&needle) {
+            let abs = search_from + idx + needle.len();
+            // Read digits until non-digit.
+            let digits: String = body[abs..]
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if !digits.is_empty() {
+                if let Ok(n) = digits.parse::<u64>() {
+                    let phrase_str = format!("{phrase} #{digits}");
+                    if seen.insert((n, phrase_str.clone())) {
+                        out.push(ParentRef {
+                            parent: n,
+                            phrase: phrase_str,
+                        });
+                    }
+                }
+                search_from = abs + digits.len();
+            } else {
+                search_from = abs;
+            }
+        }
+    }
+    out
 }
 
 // `gh issue list` rather than the REST API directly, since the REST API
@@ -89,7 +254,7 @@ fn list_open_issues(repo: &str) -> Result<Vec<Value>, gh::GhError> {
             "--limit",
             "1000",
             "--json",
-            "number,title,labels",
+            "number,title,labels,body",
         ])
         .output()
         .context(gh::SpawnSnafu)?;
@@ -109,4 +274,74 @@ fn list_open_issues(repo: &str) -> Result<Vec<Value>, gh::GhError> {
     })?;
 
     Ok(parsed.as_array().cloned().unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_sub_issue_of_phrase() {
+        let refs = extract_parent_refs("Sub-issue of #15. Closes the loophole.");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].parent, 15);
+        assert_eq!(refs[0].phrase, "Sub-issue of #15");
+    }
+
+    #[test]
+    fn extracts_tracked_in_phrase() {
+        let refs = extract_parent_refs("Slice tracked in #209: `shaka issue audit`.");
+        // "Tracked in #209" appears as " tracked in #209" — case-sensitive
+        // pattern requires capital T at start-of-phrase. Confirm: lower-
+        // case "tracked in" *does not* match (matches comment style only).
+        assert!(refs.is_empty(), "lowercase 'tracked in' should not match");
+    }
+
+    #[test]
+    fn extracts_capital_tracked_in() {
+        let refs = extract_parent_refs("Tracked in #209: see context.");
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].parent, 209);
+    }
+
+    #[test]
+    fn extracts_multiple_phrases() {
+        let refs = extract_parent_refs("Sub-issue of #15. Tracked in #209 for slicing.");
+        assert_eq!(refs.len(), 2);
+        let parents: Vec<u64> = refs.iter().map(|r| r.parent).collect();
+        assert!(parents.contains(&15));
+        assert!(parents.contains(&209));
+    }
+
+    #[test]
+    fn dedupes_repeated_phrase_for_same_parent() {
+        let refs = extract_parent_refs(
+            "Sub-issue of #15. Reiterated: Sub-issue of #15 in next paragraph.",
+        );
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].parent, 15);
+    }
+
+    #[test]
+    fn ignores_pr_close_keywords() {
+        let refs = extract_parent_refs("Closes #100. Fixes #200. Resolves #300.");
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn ignores_blocked_on_and_depends_on() {
+        let refs = extract_parent_refs("Blocked on #100. Depends on #200.");
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn handles_empty_body() {
+        assert!(extract_parent_refs("").is_empty());
+    }
+
+    #[test]
+    fn handles_phrase_without_number() {
+        // "Sub-issue of #" followed by non-digit — no match.
+        assert!(extract_parent_refs("Sub-issue of #notanumber").is_empty());
+    }
 }

--- a/tools/shaka/src/issue/create.rs
+++ b/tools/shaka/src/issue/create.rs
@@ -59,11 +59,18 @@ fn run_inner(args: CreateArgs, cwd: &Path) -> Result<(), String> {
     //    enforces the structural rule; this resolves the file path.
     let body = resolve_body(&args.body, &args.body_file)?;
 
-    // 3. Scope — must be one of the canonical scope labels.
+    // 3. No freeform parent references. `--parent <N>` is the only way
+    //    to set a parent (uses GitHub's native sub-issue API); freeform
+    //    `Sub-issue of #N` / `Tracked in #N` body text rots silently
+    //    and is what `shaka issue audit` flags. Refuse at create time
+    //    so we never write the freeform shape in the first place.
+    reject_freeform_parent_refs(&body, args.parent)?;
+
+    // 4. Scope — must be one of the canonical scope labels.
     let label_set = labels::load(cwd)?;
     validate_scope(&args.scope, &label_set)?;
 
-    // 4. Repo — explicit flag wins; otherwise infer.
+    // 5. Repo — explicit flag wins; otherwise infer.
     let repo = match args.repo {
         Some(r) => r,
         None => gh::detect_repo_or_env().map_err(|e| format!("could not detect repo: {e}"))?,
@@ -118,6 +125,28 @@ fn validate_scope(scope: &str, set: &LabelSet) -> Result<(), String> {
     Err(format!(
         "scope `{scope}` is not a canonical scope label; valid: {}",
         valid.join(", ")
+    ))
+}
+
+/// Reject bodies that contain freeform parent-pointer phrases (`Sub-issue
+/// of #N`, `Tracked in #N`). `--parent <N>` is the only sanctioned way
+/// to set a parent — it uses GitHub's native sub-issue API, which is
+/// what `shaka issue audit` enforces. The text-only shape rots silently
+/// and is exactly what audit flags; refusing here keeps new issues from
+/// being born in the bad state.
+///
+/// `_parent` is accepted but ignored — even with `--parent N` set, the
+/// freeform body text is still wrong (it duplicates the link in a
+/// brittle form). One canonical signal, no second source of truth.
+fn reject_freeform_parent_refs(body: &str, _parent: Option<u64>) -> Result<(), String> {
+    let refs = super::audit::extract_parent_refs(body);
+    if refs.is_empty() {
+        return Ok(());
+    }
+    let phrases: Vec<String> = refs.iter().map(|r| r.phrase.clone()).collect();
+    Err(format!(
+        "body contains freeform parent reference(s) {phrases:?} — use `--parent <N>` \
+         instead (sets GitHub's native sub-issue link) and drop the freeform text"
     ))
 }
 
@@ -273,5 +302,37 @@ mod tests {
         // Reaching dry-run without an error is the assertion — file
         // was readable and resolved.
         run_inner(a, tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn rejects_body_with_sub_issue_of() {
+        let tmp = workdir_with_labels(&["shaka"]);
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.body = Some("Sub-issue of #15. Adds a thing.".into());
+        let err = run_inner(a, tmp.path()).unwrap_err();
+        assert!(err.contains("Sub-issue of #15"), "got: {err}");
+        assert!(err.contains("--parent"), "should hint at --parent: {err}");
+    }
+
+    #[test]
+    fn rejects_body_with_tracked_in() {
+        let tmp = workdir_with_labels(&["shaka"]);
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.body = Some("Tracked in #209.".into());
+        let err = run_inner(a, tmp.path()).unwrap_err();
+        assert!(err.contains("Tracked in #209"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_freeform_even_with_parent_set() {
+        // --parent N doesn't whitelist freeform body text; the two
+        // would duplicate the link in incompatible shapes. One source
+        // of truth (the native API), no freeform.
+        let tmp = workdir_with_labels(&["shaka"]);
+        let mut a = args("feat(shaka): add x", "shaka");
+        a.body = Some("Sub-issue of #15".into());
+        a.parent = Some(15);
+        let err = run_inner(a, tmp.path()).unwrap_err();
+        assert!(err.contains("Sub-issue of #15"), "got: {err}");
     }
 }


### PR DESCRIPTION
Closes the freeform-reference loophole on both sides.

**Audit side.** Extends `shaka issue audit` with two new checks beyond
the existing scope-label policy:

1. *Missing native parent link.* An issue whose body says
   `Sub-issue of #N` or `Tracked in #N` but whose `.parent` field in
   GitHub's REST issue endpoint is `null` is flagged. The native
   sub-issue API populates `.parent` (and the parent's
   `sub_issues_summary` count) symmetrically, so this single check
   covers drift in both directions — the output names both the child
   and the orphaned parent so it can be fixed from either side.
2. *Stale reference.* A freeform reference to an issue that returns
   404 surfaces as a separate violation category. Closed parents are
   not flagged — closed umbrellas are normal.

Only two parent-pointer phrases are recognized (`Sub-issue of`,
`Tracked in`). PR-side close keywords (`Closes`, `Fixes`, `Resolves`)
are excluded — #146 covers the PR → issue side — and
sibling/dependency phrasing (`Blocked on`, `Depends on`) doesn't
imply parent-child structure.

**Create side.** `shaka issue create` now refuses any body containing
the same freeform phrases, even when `--parent <N>` is also set. One
canonical signal lives in GitHub's native sub-issue API; the prose
shape can't be a second source of truth.

**New helpers.** `gh::issue_parent` returns the native parent number
(or `None`); `gh::issue_exists` is a `gh api` wrapper that maps 404
to `Ok(false)`. The existence check is cached per parent so an
umbrella referenced by N children only costs one round trip.

The audit flags two existing freeform-only sub-issues (#541 → #15,
#290 → #289). Per the issue's "manual migration only" stance, this
PR doesn't auto-link them.

Closes #541