### PR TITLE
feat(shaka): surface workspace staleness in status + sync

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -227,12 +227,14 @@ pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
 ///
 /// Returns `Ok(None)` if the issue is open, has no closing PR reference, or
 /// the issue does not exist. Returns the first referenced PR if multiple.
-pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
+pub fn merged_pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError> {
     let output = Command::new("gh")
         .args([
             "issue",
             "view",
             &n.to_string(),
+            "--repo",
+            repo,
             "--json",
             "state,closedByPullRequestsReferences",
         ])
@@ -242,7 +244,7 @@ pub fn merged_pr_for_issue(n: u64) -> Result<Option<PrInfo>, GhError> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return GhCommandSnafu {
-            command: format!("gh issue view {n}"),
+            command: format!("gh issue view {n} --repo {repo}"),
             stderr: stderr.trim().to_string(),
         }
         .fail();

--- a/tools/shaka/src/repo.rs
+++ b/tools/shaka/src/repo.rs
@@ -29,6 +29,10 @@ pub enum RepoCommand {
         /// Print the commands that would run without executing them
         #[arg(long)]
         dry_run: bool,
+        /// Suppress the post-sync hint listing workspaces eligible for
+        /// `shaka workspace cleanup`. The sync itself runs unchanged.
+        #[arg(long)]
+        no_cleanup_hint: bool,
     },
     /// Refresh an in-flight PR's bookmark onto the latest main@origin
     ///
@@ -168,7 +172,10 @@ pub enum RepoCommand {
 pub fn run(cmd: RepoCommand) {
     match cmd {
         RepoCommand::Audit { repo, fix } => audit::run(repo, fix),
-        RepoCommand::Sync { dry_run } => sync::run(dry_run),
+        RepoCommand::Sync {
+            dry_run,
+            no_cleanup_hint,
+        } => sync::run(dry_run, no_cleanup_hint),
         RepoCommand::Bump { bookmark, dry_run } => bump::run(bookmark, dry_run),
         RepoCommand::Send {
             bookmark,

--- a/tools/shaka/src/repo/sync.rs
+++ b/tools/shaka/src/repo/sync.rs
@@ -1,7 +1,9 @@
+use crate::gh;
 use crate::jj;
-use crate::term::{BOLD, GREEN, RED, RESET};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+use crate::workspace::staleness::{self, Staleness};
 
-pub fn run(dry_run: bool) {
+pub fn run(dry_run: bool, no_cleanup_hint: bool) {
     if dry_run {
         println!("would run: jj git fetch");
         println!("would run: jj rebase -b @ -d main@origin");
@@ -21,4 +23,48 @@ pub fn run(dry_run: bool) {
     }
 
     println!("{GREEN}{BOLD}synced{RESET}");
+
+    if !no_cleanup_hint {
+        print_cleanup_hint();
+    }
+}
+
+/// Walk every workspace, classify each via the shared staleness module,
+/// and print a one-line hint per stale workspace. Errors are swallowed
+/// — the hint is a side-info; failing to query GitHub shouldn't break
+/// a sync that already succeeded.
+fn print_cleanup_hint() {
+    let repo_root = match jj::repo_root() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let repo = match gh::detect_repo() {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+
+    let classified = staleness::classify_all(&repo_root, &repo);
+    let stale: Vec<&(String, Staleness)> = classified
+        .iter()
+        .filter(|(_, s)| !matches!(s, Staleness::Active))
+        .collect();
+
+    if stale.is_empty() {
+        return;
+    }
+
+    let plural = if stale.len() == 1 { "" } else { "s" };
+    println!(
+        "{YELLOW}hint: {} workspace{plural} look stale; run shaka workspace cleanup{RESET}",
+        stale.len()
+    );
+    for (name, s) in &stale {
+        match s {
+            Staleness::Merged { pr_url } => {
+                println!("  {BOLD}{name}{RESET} {DIM}(merged: {pr_url}){RESET}")
+            }
+            Staleness::Orphan => println!("  {BOLD}{name}{RESET} {DIM}(orphan){RESET}"),
+            Staleness::Active => unreachable!("filtered above"),
+        }
+    }
 }

--- a/tools/shaka/src/workspace.rs
+++ b/tools/shaka/src/workspace.rs
@@ -3,6 +3,7 @@ mod forget;
 mod issue_link;
 mod list;
 mod new;
+pub(crate) mod staleness;
 mod status;
 
 use std::path::{Path, PathBuf};

--- a/tools/shaka/src/workspace/cleanup.rs
+++ b/tools/shaka/src/workspace/cleanup.rs
@@ -1,4 +1,5 @@
 use super::issue_link;
+use super::staleness;
 use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET};
 use crate::{gh, jj};
 use std::fs;
@@ -115,43 +116,17 @@ pub fn run(dry_run: bool) {
 }
 
 /// Try each detection strategy in order and return the merged-PR URL on the
-/// first hit.
+/// first hit. Thin wrapper that bridges `cleanup`'s pre-existing call site
+/// to `staleness::resolve_merged_pr` (the shared implementation).
 fn resolve_merged_pr(repo_root: &Path, repo: &str, name: &str) -> Option<String> {
-    // 1. Persisted issue link.
     let issue_from_link = issue_link::read(repo_root, name)
         .map_err(|e| eprintln!("{DIM}warn:{RESET} reading issue link for {name}: {e}"))
         .ok()
         .flatten()
         .map(|l| l.issue);
 
-    // 2. Name inference: i<N>.
-    let issue_from_name = name
-        .strip_prefix('i')
-        .and_then(|s| s.parse::<u64>().ok())
-        .filter(|_| issue_from_link.is_none());
-
-    if let Some(issue) = issue_from_link.or(issue_from_name) {
-        match gh::merged_pr_for_issue(issue) {
-            Ok(Some(pr)) => return Some(pr.url),
-            Ok(None) => {} // issue not yet closed by a merged PR
-            Err(e) => {
-                eprintln!("{DIM}warn:{RESET} could not query PR for issue #{issue}: {e}");
-            }
-        }
-    }
-
-    // 3. Bookmark scan (legacy path; works only pre-sync).
     let revset = format!("main@origin..{name}@");
     let bookmarks = jj::bookmarks_on(&revset).unwrap_or_default();
-    for bookmark in &bookmarks {
-        match gh::pr_for_head(repo, bookmark) {
-            Ok(Some(pr)) if pr.state == gh::PrState::Merged => return Some(pr.url),
-            Ok(_) => {}
-            Err(e) => {
-                eprintln!("{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}");
-            }
-        }
-    }
 
-    None
+    staleness::resolve_merged_pr(repo, name, &bookmarks, issue_from_link)
 }

--- a/tools/shaka/src/workspace/staleness.rs
+++ b/tools/shaka/src/workspace/staleness.rs
@@ -1,0 +1,157 @@
+//! Workspace staleness classification — shared between `shaka workspace
+//! status` (annotates each workspace inline) and `shaka repo sync`
+//! (appends a cleanup hint).
+//!
+//! Three categories:
+//!
+//! - **`Active`** — has WIP somewhere (bookmark, ahead of main, or dirty
+//!   working copy). No action implied.
+//! - **`Merged`** — bookmark or persisted issue link points at a PR that
+//!   has merged on the remote. Carries the PR URL so consumers can
+//!   surface it without re-querying.
+//! - **`Orphan`** — no bookmarks, 0 commits ahead, clean working copy.
+//!   The workspace's purpose is unrecoverable from VCS state.
+//!
+//! `Orphan` is computed locally with no network. `Merged` requires at
+//! least one GitHub API call; `classify` skips the network entirely
+//! when a workspace has no bookmarks and no persisted issue link
+//! (in that case it can only be `Orphan` or `Active`).
+
+use std::path::Path;
+
+use super::issue_link;
+use crate::gh;
+use crate::jj;
+use crate::term::{DIM, RESET};
+
+/// Why a workspace is considered stale — or that it isn't. `Active`
+/// is the no-action default; the two stale variants name a specific
+/// reason that maps to a recovery action.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Staleness {
+    Active,
+    Merged { pr_url: String },
+    Orphan,
+}
+
+/// Classify a workspace from its already-fetched state. `bookmarks`,
+/// `ahead`, and `dirty` are the same signals `shaka workspace status`
+/// already computes; this function avoids re-querying jj.
+///
+/// `repo` is the GitHub `owner/repo` — needed only for the bookmark-scan
+/// fallback path when neither a persisted issue link nor an `i<N>` name
+/// resolves the merged PR.
+pub fn classify(
+    repo_root: &Path,
+    repo: &str,
+    name: &str,
+    bookmarks: &[String],
+    ahead: usize,
+    dirty: bool,
+) -> Staleness {
+    let issue_link = issue_link::read(repo_root, name)
+        .map_err(|e| eprintln!("{DIM}warn:{RESET} reading issue link for {name}: {e}"))
+        .ok()
+        .flatten();
+
+    // Cheap path: if there's no bookmark, no issue link, and the
+    // workspace is at main with a clean working copy, it's orphan.
+    // Avoids API calls for the common "I forgot to forget" case.
+    if bookmarks.is_empty() && issue_link.is_none() && ahead == 0 && !dirty {
+        return Staleness::Orphan;
+    }
+
+    if let Some(pr_url) = resolve_merged_pr(repo, name, bookmarks, issue_link.map(|l| l.issue)) {
+        return Staleness::Merged { pr_url };
+    }
+
+    Staleness::Active
+}
+
+/// Walk every workspace and classify each. Default workspace is omitted
+/// since it has no meaningful staleness (it carries no specific work).
+/// Returns `(name, staleness)` pairs in workspace order.
+pub fn classify_all(repo_root: &Path, repo: &str) -> Vec<(String, Staleness)> {
+    let workspaces = jj::workspaces().unwrap_or_default();
+    let mut out = Vec::with_capacity(workspaces.len());
+    for ws in &workspaces {
+        if ws.name == "default" {
+            continue;
+        }
+        let bookmarks = jj::bookmarks_on_workspace(&ws.name).unwrap_or_default();
+        let counts = jj::dirty_counts_for(&ws.name).unwrap_or_default();
+        let dirty = counts.total() > 0;
+        let ahead = jj::ahead_count_for(&ws.name, "main@origin").unwrap_or(0);
+        let staleness = classify(repo_root, repo, &ws.name, &bookmarks, ahead, dirty);
+        out.push((ws.name.clone(), staleness));
+    }
+    out
+}
+
+/// Try each detection strategy in order and return the merged-PR URL on
+/// the first hit. Lifted from `cleanup::resolve_merged_pr` so both the
+/// cleanup command and the staleness classifier share one implementation.
+pub(super) fn resolve_merged_pr(
+    repo: &str,
+    name: &str,
+    bookmarks: &[String],
+    issue_from_link: Option<u64>,
+) -> Option<String> {
+    let issue_from_name = name
+        .strip_prefix('i')
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|_| issue_from_link.is_none());
+
+    if let Some(issue) = issue_from_link.or(issue_from_name) {
+        match gh::merged_pr_for_issue(repo, issue) {
+            Ok(Some(pr)) => return Some(pr.url),
+            Ok(None) => {}
+            Err(e) => {
+                eprintln!("{DIM}warn:{RESET} could not query PR for issue #{issue}: {e}");
+            }
+        }
+    }
+
+    for bookmark in bookmarks {
+        match gh::pr_for_head(repo, bookmark) {
+            Ok(Some(pr)) if pr.state == gh::PrState::Merged => return Some(pr.url),
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("{DIM}warn:{RESET} could not query PR for bookmark {bookmark}: {e}");
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn root() -> PathBuf {
+        PathBuf::from("/tmp/shaka-staleness-test")
+    }
+
+    #[test]
+    fn orphan_when_no_signal_and_clean() {
+        // No bookmarks, no issue link (read returns None for a
+        // tempdir-less root), 0 ahead, clean. Skips the network path.
+        let s = classify(&root(), "o/r", "ad-hoc", &[], 0, false);
+        assert_eq!(s, Staleness::Orphan);
+    }
+
+    #[test]
+    fn active_when_dirty_with_no_other_signal() {
+        let s = classify(&root(), "o/r", "ad-hoc", &[], 0, true);
+        assert_eq!(s, Staleness::Active);
+    }
+
+    #[test]
+    fn active_when_ahead_with_no_other_signal() {
+        let s = classify(&root(), "o/r", "ad-hoc", &[], 3, false);
+        assert_eq!(s, Staleness::Active);
+    }
+}

--- a/tools/shaka/src/workspace/status.rs
+++ b/tools/shaka/src/workspace/status.rs
@@ -1,7 +1,8 @@
 use serde::Serialize;
 
+use super::staleness::{self, Staleness};
 use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET, YELLOW};
-use crate::jj;
+use crate::{gh, jj};
 
 #[derive(Serialize)]
 struct WorkspaceStatus {
@@ -13,6 +14,7 @@ struct WorkspaceStatus {
     ahead: usize,
     dirty: bool,
     dirty_counts: DirtyCounts,
+    staleness: Staleness,
 }
 
 #[derive(Serialize)]
@@ -34,6 +36,12 @@ pub fn run(json: bool) {
         Err(e) => die(&e.to_string()),
     };
 
+    // Detect the GitHub repo for the merged-PR lookup. Failure here is
+    // non-fatal — we just classify every workspace as `active` rather
+    // than refusing to render. A local-only repo (no remote) should
+    // still produce a useful status table.
+    let repo = gh::detect_repo().ok();
+
     let mut statuses: Vec<WorkspaceStatus> = Vec::new();
 
     for ws in &workspaces {
@@ -52,6 +60,17 @@ pub fn run(json: bool) {
         // fall back to 0 so status still renders.
         let ahead = jj::ahead_count_for(&ws.name, "main@origin").unwrap_or(0);
 
+        // Default workspace never carries issue-shaped work — it's the
+        // primary tree, always `active` for our purposes. Skip the
+        // network probe for it.
+        let staleness = if ws.name == "default" {
+            Staleness::Active
+        } else if let Some(r) = &repo {
+            staleness::classify(&repo_root, r, &ws.name, &bookmarks, ahead, dirty)
+        } else {
+            Staleness::Active
+        };
+
         statuses.push(WorkspaceStatus {
             name: ws.name.clone(),
             path: path.display().to_string(),
@@ -66,6 +85,7 @@ pub fn run(json: bool) {
                 deleted: counts.deleted,
                 total: counts.total(),
             },
+            staleness,
         });
     }
 
@@ -84,8 +104,13 @@ pub fn run(json: bool) {
 
 fn render_human(statuses: &[WorkspaceStatus]) {
     for ws in statuses {
-        // Header: name + path
-        println!("{BOLD}{}{RESET}  {DIM}{}{RESET}", ws.name, ws.path);
+        // Header: name + path + (optional) staleness flag
+        let flag = match &ws.staleness {
+            Staleness::Active => String::new(),
+            Staleness::Merged { .. } => format!("  {GREEN}[merged]{RESET}"),
+            Staleness::Orphan => format!("  {YELLOW}[orphan]{RESET}"),
+        };
+        println!("{BOLD}{}{RESET}  {DIM}{}{RESET}{flag}", ws.name, ws.path);
 
         // Current @: change id + description
         let desc = if ws.description.is_empty() {
@@ -122,6 +147,33 @@ fn render_human(statuses: &[WorkspaceStatus]) {
         };
         println!("  {BOLD}working copy:{RESET} {dirty_label}");
 
+        // For merged workspaces, surface the PR URL so the user can
+        // verify before running cleanup. Orphans get nothing because
+        // there's nothing to verify against.
+        if let Staleness::Merged { pr_url } = &ws.staleness {
+            println!("  {BOLD}merged:{RESET}     {DIM}{pr_url}{RESET}");
+        }
+
         println!();
+    }
+
+    // Trailing summary if any workspaces are stale. Matches the
+    // wording from the cleanup-hint side of #204 so the two surfaces
+    // teach the same lesson.
+    let merged = statuses
+        .iter()
+        .filter(|s| matches!(s.staleness, Staleness::Merged { .. }))
+        .count();
+    let orphan = statuses
+        .iter()
+        .filter(|s| matches!(s.staleness, Staleness::Orphan))
+        .count();
+    let stale = merged + orphan;
+    if stale > 0 {
+        let plural = if stale == 1 { "" } else { "s" };
+        println!(
+            "{YELLOW}{stale} workspace{plural} stale ({merged} merged, {orphan} orphan); \
+             run shaka workspace cleanup{RESET}"
+        );
     }
 }


### PR DESCRIPTION
Adds a shared `workspace::staleness` classifier with three
categories: `Active`, `Merged { pr_url }`, `Orphan`. `Merged` reuses
the cleanup module's multi-strategy lookup (persisted issue link →
i<N> name → bookmark scan); `Orphan` is "no bookmarks, 0 ahead,
clean" and stays purely local. The pre-existing `cleanup` command
now goes through the shared resolver, dropping a duplicated
~30-line copy.

`shaka workspace status` annotates each non-default workspace with
an inline `[merged]` or `[orphan]` flag in the human-readable
header, includes the structured staleness in JSON (tagged enum:
`{"type": "merged", "pr_url": "..."}`), shows the PR URL for
merged workspaces, and prints a trailing summary like
`2 workspaces stale (1 merged, 1 orphan); run shaka workspace
cleanup` when there's anything to act on.

`shaka repo sync` adds a post-sync cleanup hint listing stale
workspaces by name and reason, suppressible via `--no-cleanup-hint`.
Errors querying GitHub silently skip the hint — a transient API
issue shouldn't break a sync that already succeeded. The cheap-path
short-circuit (no bookmarks + no issue link + clean + at main =
`Orphan`, no API call) keeps the common case fast.

The hint surface mirrors what `cleanup --dry-run` would print so
the two paths teach the same lesson, just at different moments.

Closes #203
Closes #204