### PR TITLE
fix(shaka): bump-locks re-anchors on live main before force-push

### DIFF
--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -129,6 +129,9 @@ fn run_remote(input: &str, branch: &str, slug: &str, auto_merge: bool) -> Result
     git_in(&work, &["add", "flake.lock"])?;
     let title = format!("chore(deps): bump {input} flake input");
     git_in(&work, &["commit", "-m", &title])?;
+    // Re-anchor on live `main`: previous bump's PR may have merged since the clone (#563).
+    git_in(&work, &["fetch", "--depth", "1", "origin", "main"])?;
+    git_in(&work, &["rebase", "origin/main"])?;
     git_in(&work, &["push", "--force", "origin", branch])?;
 
     if let Some(pr) = gh::pr_for_head(slug, branch).map_err(|e| e.to_string())? {


### PR DESCRIPTION
A shallow clone in run_remote captures `main` before the bump runs.
If the previous bump's PR merges in the interim, the commit we
force-push is rooted on stale main and the resulting PR opens with
a `flake.lock` conflict against the freshly-merged tip.

Fetch `origin/main` and rebase the bumped commit onto it
immediately before pushing. If a different bump of the same input
landed on main while we worked, the rebase conflicts and the run
fails fast — the next scheduled run picks up the new state.

Observed on `kolohelios/blogs-and-posts` PR #59, where bumper run
for blogctl rev `b97bd651` cloned `main` seconds before PR #58
(bumping to `f8494a20`) finished rebase-merging.

Closes #563