### PR TITLE
feat(blogctl): import command for already-published posts

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -252,6 +252,50 @@ pub enum Command {
         #[arg(long)]
         no_sync: bool,
     },
+    /// Import an already-published post directly into `published/`,
+    /// pre-populating a `targets:` entry with the venue URL and
+    /// publish date. Used to backfill posts that went out on another
+    /// surface (LinkedIn, an external blog) before the workdir existed.
+    Import {
+        /// Post title — slug is derived from this unless `--slug` is given.
+        #[arg(long)]
+        title: String,
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Override the auto-derived slug.
+        #[arg(long)]
+        slug: Option<String>,
+        /// Surface this targets: `post` (short-form feed) or `article`
+        /// (long-form).
+        #[arg(long, value_enum, default_value_t = Kind::Post)]
+        kind: Kind,
+        /// Narrative theme. Defaults to the workdir's
+        /// `defaults.theme`; must be declared in `[themes.*]`.
+        #[arg(long)]
+        theme: Option<String>,
+        /// Distribution venue this post was published to.
+        #[arg(long, value_enum)]
+        target: Target,
+        /// URL of the already-published post on `--target`.
+        #[arg(long)]
+        url: String,
+        /// RFC 3339 timestamp the post went live on `--target`.
+        /// Also used as the post's `created_at` and `updated_at`.
+        #[arg(long, value_name = "RFC3339")]
+        published_at: String,
+        /// Path to a file containing the post body. Use `-` to read
+        /// from stdin. Body is written verbatim — no formatting
+        /// munging.
+        #[arg(long, value_name = "PATH")]
+        body_file: PathBuf,
+        /// Free-form tag for the post. Repeatable.
+        #[arg(long = "tag", value_name = "TAG")]
+        tags: Vec<String>,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
     /// Per-target performance metrics (impressions, reactions,
     /// comments, reposts).
     Metrics {
@@ -577,6 +621,34 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 no_sync,
             },
         ),
+        Command::Import {
+            title,
+            workdir,
+            slug,
+            kind,
+            theme,
+            target,
+            url,
+            published_at,
+            body_file,
+            tags,
+            no_sync,
+        } => commands::import::run(
+            jj,
+            commands::import::ImportArgs {
+                title,
+                workdir: workdir_or_pwd(workdir)?,
+                slug,
+                kind,
+                theme,
+                target,
+                url,
+                published_at,
+                body_file,
+                tags,
+                no_sync,
+            },
+        ),
         Command::Metrics { action } => match action {
             MetricsAction::Update {
                 slug,
@@ -871,6 +943,50 @@ mod tests {
                 "--workdir",
                 "/tmp/wd",
             ],
+            // import — backfill an already-published post.
+            vec![
+                "blogctl",
+                "import",
+                "--title",
+                "Hello",
+                "--workdir",
+                "/tmp/wd",
+                "--target",
+                "linkedin",
+                "--url",
+                "https://www.linkedin.com/posts/x",
+                "--published-at",
+                "2026-05-08T14:32:00Z",
+                "--body-file",
+                "/tmp/body.md",
+            ],
+            vec![
+                "blogctl",
+                "import",
+                "--title",
+                "Hello",
+                "--workdir",
+                "/tmp/wd",
+                "--slug",
+                "custom-slug",
+                "--kind",
+                "article",
+                "--theme",
+                "parable",
+                "--target",
+                "blog",
+                "--url",
+                "https://example.com/x",
+                "--published-at",
+                "2026-05-08T14:32:00Z",
+                "--body-file",
+                "-",
+                "--tag",
+                "rust",
+                "--tag",
+                "blogctl",
+                "--no-sync",
+            ],
             // backfill — interactive + import.
             vec!["blogctl", "backfill", "--workdir", "/tmp/wd"],
             vec![
@@ -1059,6 +1175,20 @@ mod tests {
                 "0",
             ],
             vec!["blogctl", "metrics", "show", "hello"],
+            vec![
+                "blogctl",
+                "import",
+                "--title",
+                "Hello",
+                "--target",
+                "linkedin",
+                "--url",
+                "https://www.linkedin.com/posts/x",
+                "--published-at",
+                "2026-05-08T14:32:00Z",
+                "--body-file",
+                "/tmp/body.md",
+            ],
             vec!["blogctl", "backfill"],
             vec!["blogctl", "analytics", "summary"],
             vec!["blogctl", "analytics", "compare", "format", "hook"],

--- a/apps/blogctl/src/commands.rs
+++ b/apps/blogctl/src/commands.rs
@@ -8,6 +8,7 @@ pub mod doctor;
 pub mod draft;
 pub mod final_edit;
 pub mod fix;
+pub mod import;
 pub mod init;
 pub mod list;
 pub mod metrics;

--- a/apps/blogctl/src/commands/import.rs
+++ b/apps/blogctl/src/commands/import.rs
@@ -1,0 +1,121 @@
+//! `blogctl import` — backfill a post that was already published on
+//! another surface (LinkedIn, an external blog) before the workdir
+//! existed.
+//!
+//! The editorial pipeline (`new` → `promote` × 4) is the wrong shape
+//! for this case: there's no drafting to do, the body is already
+//! written, and the post already has a URL and a publish date. This
+//! command writes straight to `published/` and seeds a `targets:`
+//! entry recording the venue, URL, and publish time — the same shape
+//! `add-target` would produce if it accepted `--status published` /
+//! `--url` / `--published-at` (deferred from #527).
+//!
+//! Out of scope: classifications and metrics (covered by
+//! `blogctl backfill`, #435), multi-target single invocation (call
+//! `import` once per surface), body cleanup or LinkedIn-format
+//! munging (body is written verbatim from `--body-file`).
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+
+use crate::error::Result;
+use crate::kind::Kind;
+use crate::post::{Post, PostMetadata};
+use crate::stage::Stage;
+use crate::storage::{Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+use crate::target::{Target, TargetEntry, TargetStatus};
+use crate::{slug, Error};
+
+#[derive(Debug)]
+pub struct ImportArgs {
+    pub title: String,
+    pub workdir: PathBuf,
+    pub slug: Option<String>,
+    pub kind: Kind,
+    pub theme: Option<String>,
+    pub target: Target,
+    pub url: String,
+    pub published_at: String,
+    pub body_file: PathBuf,
+    pub tags: Vec<String>,
+    pub no_sync: bool,
+}
+
+pub fn run(jj: &dyn Jj, args: ImportArgs) -> Result<()> {
+    if args.title.trim().is_empty() {
+        return Err(Error::EmptyTitle(args.title));
+    }
+    let resolved_slug = match args.slug {
+        Some(s) => slug::validate(&s)?.to_string(),
+        None => slug::slugify(&args.title)?,
+    };
+
+    let published_at = OffsetDateTime::parse(&args.published_at, &Rfc3339).map_err(|source| {
+        Error::InvalidPublishedAt {
+            value: args.published_at.clone(),
+            source,
+        }
+    })?;
+
+    let body = read_body(&args.body_file)?;
+
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let config = repo.read_config()?;
+    let resolved_theme = args.theme.unwrap_or_else(|| config.defaults.theme.clone());
+    if !config.themes.contains_key(&resolved_theme) {
+        let known: Vec<String> = config.themes.keys().cloned().collect();
+        return Err(Error::UnknownTheme {
+            theme: resolved_theme,
+            known,
+        });
+    }
+
+    let message = format!("post({}): import from {}", resolved_slug, args.target);
+    let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+    let target_name = args.target;
+
+    let path = sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+        let metadata = PostMetadata {
+            title: args.title,
+            slug: resolved_slug,
+            kind: args.kind,
+            theme: resolved_theme,
+            status: Stage::Published,
+            created_at: published_at,
+            updated_at: published_at,
+            tags: args.tags,
+            todoist_task_id: None,
+            history_checked: false,
+            targets: vec![TargetEntry {
+                name: target_name,
+                status: TargetStatus::Published,
+                url: Some(args.url),
+                published_at: Some(published_at),
+                metrics: None,
+            }],
+            classifications: Default::default(),
+            ai: None,
+        };
+        let post = Post::new(metadata, body);
+        repo.create_post(&post)
+    })?;
+    println!("imported {} (target: {})", path.display(), target_name);
+    Ok(())
+}
+
+fn read_body(path: &Path) -> Result<String> {
+    if path == Path::new("-") {
+        let mut buf = String::new();
+        io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| Error::io(PathBuf::from("<stdin>"), e))?;
+        Ok(buf)
+    } else {
+        fs::read_to_string(path).map_err(|e| Error::io(path, e))
+    }
+}

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -251,6 +251,13 @@ pub enum Error {
         source: time::error::Parse,
     },
 
+    #[error("invalid --published-at {value:?}: expected RFC 3339 timestamp ({source})")]
+    InvalidPublishedAt {
+        value: String,
+        #[source]
+        source: time::error::Parse,
+    },
+
     #[error("could not parse backfill import file: {0}")]
     BackfillImportParse(#[source] serde_json::Error),
 

--- a/apps/blogctl/tests/fixtures/import/linkedin-sample.md
+++ b/apps/blogctl/tests/fixtures/import/linkedin-sample.md
@@ -1,0 +1,7 @@
+Most teams treat backfill as a one-time chore. That's a mistake.
+
+The shape of "import an existing artifact" is *also* the shape of
+"recover from a botched export," "rebuild after a schema migration,"
+and "onboard a new contributor's existing work."
+
+Build the importer once. Reuse it forever.

--- a/apps/blogctl/tests/import.rs
+++ b/apps/blogctl/tests/import.rs
@@ -1,0 +1,145 @@
+//! Integration tests for `blogctl import`. The happy path goes
+//! through `commands::import::run` against a fresh tempdir workdir;
+//! the body comes from the canonical fixture under
+//! `tests/fixtures/import/`. The slug-collision path goes through the
+//! same command run twice to confirm the existing `DuplicateSlug`
+//! invariant fires.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use blogctl::commands::{self, import::ImportArgs};
+use blogctl::error::Error;
+use blogctl::kind::Kind;
+use blogctl::stage::Stage;
+use blogctl::storage::{Repository, Workdir};
+use blogctl::sync::FakeJj;
+use blogctl::target::{Target, TargetStatus};
+
+fn fresh_workdir() -> (TempDir, PathBuf) {
+    let tmp = TempDir::new().expect("tempdir");
+    let path = tmp.path().to_path_buf();
+    (tmp, path)
+}
+
+fn fixture_body_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/import/linkedin-sample.md")
+}
+
+fn import_args(workdir: &Path) -> ImportArgs {
+    ImportArgs {
+        title: "Backfill is the shape".into(),
+        workdir: workdir.to_path_buf(),
+        slug: None,
+        kind: Kind::Post,
+        theme: None,
+        target: Target::Linkedin,
+        url: "https://www.linkedin.com/posts/example".into(),
+        published_at: "2026-05-08T14:32:00Z".into(),
+        body_file: fixture_body_path(),
+        tags: vec!["meta".into(), "tooling".into()],
+        no_sync: true,
+    }
+}
+
+#[test]
+fn import_writes_published_post_with_target_entry() {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true).expect("init");
+
+    commands::import::run(&FakeJj::new(), import_args(&workdir)).expect("import");
+
+    let repo = Repository::open(Workdir::new(&workdir)).expect("reopen");
+    let (handle, post) = repo
+        .load("backfill-is-the-shape")
+        .expect("load imported post");
+
+    assert_eq!(handle.stage, Stage::Published);
+    assert_eq!(post.metadata.status, Stage::Published);
+    assert_eq!(post.metadata.title, "Backfill is the shape");
+    assert_eq!(post.metadata.slug, "backfill-is-the-shape");
+    assert_eq!(post.metadata.kind, Kind::Post);
+    assert_eq!(post.metadata.tags, vec!["meta", "tooling"]);
+    assert_eq!(post.metadata.targets.len(), 1);
+
+    let entry = &post.metadata.targets[0];
+    assert_eq!(entry.name, Target::Linkedin);
+    assert_eq!(entry.status, TargetStatus::Published);
+    assert_eq!(
+        entry.url.as_deref(),
+        Some("https://www.linkedin.com/posts/example")
+    );
+    assert!(entry.published_at.is_some());
+
+    // created_at == updated_at == --published-at: the editorial pipeline
+    // never touched this post, so timestamps should collapse to the
+    // moment it actually went live on LinkedIn.
+    assert_eq!(post.metadata.created_at, post.metadata.updated_at);
+    assert_eq!(Some(post.metadata.created_at), entry.published_at);
+
+    assert!(post.body.contains("Most teams treat backfill"));
+    assert!(post.body.contains("Build the importer once"));
+}
+
+#[test]
+fn import_with_slug_override_uses_provided_slug() {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true).expect("init");
+
+    let mut args = import_args(&workdir);
+    args.slug = Some("custom-name".into());
+    commands::import::run(&FakeJj::new(), args).expect("import");
+
+    let repo = Repository::open(Workdir::new(&workdir)).expect("reopen");
+    let (_handle, post) = repo.load("custom-name").expect("load custom-named post");
+    assert_eq!(post.metadata.slug, "custom-name");
+}
+
+#[test]
+fn import_refuses_when_slug_already_exists() {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true).expect("init");
+
+    commands::import::run(&FakeJj::new(), import_args(&workdir)).expect("first import");
+    let second = commands::import::run(&FakeJj::new(), import_args(&workdir));
+
+    match second {
+        Err(Error::DuplicateSlug(slug, _)) => {
+            assert_eq!(slug, "backfill-is-the-shape");
+        }
+        other => panic!("expected DuplicateSlug, got {other:?}"),
+    }
+}
+
+#[test]
+fn import_rejects_malformed_published_at() {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true).expect("init");
+
+    let mut args = import_args(&workdir);
+    args.published_at = "not-a-date".into();
+    let result = commands::import::run(&FakeJj::new(), args);
+
+    match result {
+        Err(Error::InvalidPublishedAt { value, .. }) => {
+            assert_eq!(value, "not-a-date");
+        }
+        other => panic!("expected InvalidPublishedAt, got {other:?}"),
+    }
+}
+
+#[test]
+fn import_rejects_unknown_theme() {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true).expect("init");
+
+    let mut args = import_args(&workdir);
+    args.theme = Some("noir".into());
+    let result = commands::import::run(&FakeJj::new(), args);
+
+    match result {
+        Err(Error::UnknownTheme { theme, .. }) => assert_eq!(theme, "noir"),
+        other => panic!("expected UnknownTheme, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Backfilling a post that already went out on LinkedIn or an external
blog used to take six steps: `new` to land in `concept`, four
`promote`s through the editorial pipeline, then a hand-edit of
frontmatter to add a `targets:` entry — because `add-target`
(introduced in #527) explicitly deferred `--url` / `--published-at`
support. With twenty-plus posts to backfill, that flow doesn't scale.

`blogctl import` writes straight into `published/`, populating the
`targets:` entry with the venue URL and publish time in one shot.
Body comes from `--body-file` (or stdin via `-`), so building the
post is a separate manual step but the file write is one command.
Classifications and metrics stay out of scope: `blogctl backfill`
(#435) already covers that pass.

Reuses the existing `Repository::create_post` invariant for slug
uniqueness rather than adding a parallel `ImportSlugExists` variant —
the existing `DuplicateSlug` catches collisions across every stage
directory, which is stricter and right.

Closes #567