### PR TITLE
feat(infra/home): nix store auto-gc + optimise + min-free/max-free

### DIFF
--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -15,6 +15,23 @@
   # Required so non-root users can dispatch to the linux-builder VM.
   nix.settings.trusted-users = [ "@admin" ];
 
+  # Per-project flakes + the daily `kolohelios-nix` lock bump means every
+  # project's old dev shell becomes GC-able after the next direnv reload,
+  # easily piling up tens of GB per day. `min-free`/`max-free` is the
+  # load-bearing pair: the daemon auto-GCs mid-build when free space drops
+  # below `min-free` and reclaims up to `max-free`, so the store doesn't
+  # grow unbounded between manual sweeps. The daily timer + 7d retention
+  # bounds long-tail roots; `optimise.automatic` deduplicates identical
+  # store paths via hardlinks.
+  nix.gc = {
+    automatic = true;
+    interval.Hour = 3;
+    options = "--delete-older-than 7d";
+  };
+  nix.optimise.automatic = true;
+  nix.settings.min-free = 10 * 1024 * 1024 * 1024;
+  nix.settings.max-free = 50 * 1024 * 1024 * 1024;
+
   users.users.jedwards = {
     name = "jedwards";
     home = "/Users/jedwards";


### PR DESCRIPTION
The store grew 30–60 GB every 1–2 hours between manual sweeps because
nix-darwin wasn't running any housekeeping. Per-project flakes and the
daily kolohelios-nix lock bump together churn dev-shell generations
quickly: every project's old shell becomes GC-able after the next
direnv reload, easily piling up tens of GB per day.

min-free/max-free is the load-bearing pair — the daemon auto-GCs
mid-build when free space drops below min-free and reclaims up to
max-free, so the store stops growing unbounded between sweeps. The
daily timer plus 7-day retention bounds long-tail roots, and
optimise.automatic deduplicates identical store paths via hardlinks
for typical ~25–30% additional savings.

Closes #573