### PR TITLE
feat(blogctl): accept date-only --published-at/--sampled-at values

### DIFF
--- a/apps/blogctl/src/commands/import.rs
+++ b/apps/blogctl/src/commands/import.rs
@@ -19,9 +19,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
-use time::format_description::well_known::Rfc3339;
-use time::OffsetDateTime;
-
+use crate::datetime::{self, Flag};
 use crate::error::Result;
 use crate::kind::Kind;
 use crate::post::{Post, PostMetadata};
@@ -55,12 +53,7 @@ pub fn run(jj: &dyn Jj, args: ImportArgs) -> Result<()> {
         None => slug::slugify(&args.title)?,
     };
 
-    let published_at = OffsetDateTime::parse(&args.published_at, &Rfc3339).map_err(|source| {
-        Error::InvalidPublishedAt {
-            value: args.published_at.clone(),
-            source,
-        }
-    })?;
+    let published_at = datetime::parse_timestamp(&args.published_at, Flag::PublishedAt)?;
 
     let body = read_body(&args.body_file)?;
 

--- a/apps/blogctl/src/commands/metrics.rs
+++ b/apps/blogctl/src/commands/metrics.rs
@@ -14,6 +14,7 @@ use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::commands::backfill::{merge_metrics, prompt_metrics, MergeMetricsOutcome, MetricsPick};
+use crate::datetime::{self, Flag};
 use crate::error::{Error, Result};
 use crate::stage::Stage;
 use crate::storage::{Repository, Workdir};
@@ -286,10 +287,7 @@ fn print_preview<W: Write>(output: &mut W, post: &crate::post::Post, slug: &str,
 fn parse_sampled_at(raw: Option<&str>) -> Result<OffsetDateTime> {
     match raw {
         None => Ok(OffsetDateTime::now_utc()),
-        Some(s) => OffsetDateTime::parse(s, &Rfc3339).map_err(|source| Error::InvalidSampledAt {
-            value: s.to_string(),
-            source,
-        }),
+        Some(s) => datetime::parse_timestamp(s, Flag::SampledAt),
     }
 }
 

--- a/apps/blogctl/src/datetime.rs
+++ b/apps/blogctl/src/datetime.rs
@@ -1,0 +1,107 @@
+//! Shared timestamp-flag parser. `--published-at` (on `import`) and
+//! `--sampled-at` (on `metrics update`) both want the same shape:
+//! accept full RFC 3339, but also accept a bare `YYYY-MM-DD` (treated
+//! as `T00:00:00Z`) since backfill from URLs like LinkedIn's typically
+//! carries only the date.
+
+use time::format_description::well_known::Rfc3339;
+use time::macros::format_description;
+use time::{Date, OffsetDateTime, PrimitiveDateTime, Time};
+
+use crate::error::{Error, Result};
+
+/// Which CLI flag we're parsing for — used to route to the right
+/// `Error::Invalid*` variant so the user sees the actual flag name in
+/// the error.
+#[derive(Debug, Clone, Copy)]
+pub enum Flag {
+    PublishedAt,
+    SampledAt,
+}
+
+/// Parse a timestamp string. Accepts:
+///   - full RFC 3339 (`2026-05-09T14:32:00Z`, `2026-05-09T14:32:00-07:00`)
+///   - bare date (`2026-05-09`), interpreted as `2026-05-09T00:00:00Z`
+///
+/// Anything else returns the matching `Error::Invalid*` variant with
+/// the original input and the RFC 3339 parse error as the source — the
+/// date-only path falls through to RFC 3339, so the surfaced error is
+/// always the RFC 3339 parser's diagnostic.
+pub fn parse_timestamp(value: &str, flag: Flag) -> Result<OffsetDateTime> {
+    if let Ok(date) = Date::parse(value, &format_description!("[year]-[month]-[day]")) {
+        return Ok(PrimitiveDateTime::new(date, Time::MIDNIGHT).assume_utc());
+    }
+    OffsetDateTime::parse(value, &Rfc3339).map_err(|source| match flag {
+        Flag::PublishedAt => Error::InvalidPublishedAt {
+            value: value.to_string(),
+            source,
+        },
+        Flag::SampledAt => Error::InvalidSampledAt {
+            value: value.to_string(),
+            source,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    #[test]
+    fn date_only_is_midnight_utc() {
+        let parsed = parse_timestamp("2026-05-09", Flag::PublishedAt).unwrap();
+        assert_eq!(parsed, datetime!(2026-05-09 00:00:00 UTC));
+    }
+
+    #[test]
+    fn full_rfc3339_utc_parses() {
+        let parsed = parse_timestamp("2026-05-09T14:32:00Z", Flag::PublishedAt).unwrap();
+        assert_eq!(parsed, datetime!(2026-05-09 14:32:00 UTC));
+    }
+
+    #[test]
+    fn full_rfc3339_with_offset_parses() {
+        let parsed = parse_timestamp("2026-05-09T14:32:00-07:00", Flag::SampledAt).unwrap();
+        assert_eq!(parsed, datetime!(2026-05-09 14:32:00 -7:00));
+    }
+
+    #[test]
+    fn natural_language_rejected_as_published_at() {
+        let err = parse_timestamp("yesterday", Flag::PublishedAt).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidPublishedAt { ref value, .. } if value == "yesterday"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn natural_language_rejected_as_sampled_at() {
+        let err = parse_timestamp("yesterday", Flag::SampledAt).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidSampledAt { ref value, .. } if value == "yesterday"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn out_of_range_date_rejected() {
+        // 2026-13-40 isn't a real calendar date — the date-only path
+        // fails and the RFC 3339 fallback also rejects it.
+        let err = parse_timestamp("2026-13-40", Flag::PublishedAt).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidPublishedAt { ref value, .. } if value == "2026-13-40"),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn partial_date_rejected() {
+        // Year-month with no day — neither parser accepts it.
+        let err = parse_timestamp("2026-05", Flag::PublishedAt).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidPublishedAt { ref value, .. } if value == "2026-05"),
+            "got: {err:?}"
+        );
+    }
+}

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -2,6 +2,7 @@ pub mod analytics;
 pub mod classifications;
 pub mod cli;
 pub mod commands;
+pub mod datetime;
 pub mod error;
 pub mod kind;
 pub mod openrouter;


### PR DESCRIPTION
Backfilling a post from a LinkedIn URL gives you the date but rarely
the time-of-day. Forcing every invocation to pad `T00:00:00Z` onto
`--published-at` (on `import`) and `--sampled-at` (on `metrics
update`) is friction with no signal.

Lift the parser into a shared `datetime` module that accepts both
shapes — bare `YYYY-MM-DD` (interpreted as `T00:00:00Z`) and full RFC
3339 — and route the `Invalid*` error variant per the caller's flag
so the user sees the actual flag name in the error.

Closes #570