### PR TITLE
ci(blogctl): build via FlakeHub URL for consumer cache hits

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,6 +120,9 @@ jobs:
         name: kolohelios/blogctl
         rolling: true
         visibility: public
+    - name: Build blogctl from FlakeHub URL (populate consumer cache)
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      run: nix build 'https://flakehub.com/f/kolohelios/blogctl/*.tar.gz'
     - uses: actions/create-github-app-token@v3
       id: bot-token
       if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/apps/blogctl/project.cue
+++ b/apps/blogctl/project.cue
@@ -26,6 +26,11 @@ package project
 				name:       "kolohelios/blogctl"
 				visibility: "public"
 				rolling:    true
+				// Consumers (e.g. kolohelios/blogs-and-posts) build
+				// blogctl from this FlakeHub URL; without the second
+				// build step, our local-path build's closure misses
+				// their cache lookups. See #591.
+				populateConsumerCache: true
 			}
 			// Notify the blogs-and-posts repo of a fresh publish so its
 			// bump-blogctl workflow runs immediately rather than waiting

--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -54,6 +54,18 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	name:       string & =~"^[a-z][a-z0-9-]+/[a-z][a-z0-9-]+$"
 	visibility: "public" | "private"
 	rolling:    bool
+
+	// After `flakehub-push` registers this revision, also run
+	// `nix build https://flakehub.com/f/<name>/*.tar.gz`. The closure
+	// produced by that second build has a different `.drv` than the
+	// `nix build <local-path>` we already did (source-store-hash
+	// differs between path and tarball inputs), so it lands a *new*
+	// entry in FlakeHub Cache — the one downstream consumers will
+	// look up when they evaluate this flake. Set to `true` for
+	// flakes consumed by other repos as `nix build`-able derivations;
+	// leave `false` for libs (where there's no built output) or
+	// flakes whose only consumer is this repo itself.
+	populateConsumerCache: *false | bool
 }
 
 #PublishArtifact: {

--- a/tools/shaka/src/ci/main_workflow.rs
+++ b/tools/shaka/src/ci/main_workflow.rs
@@ -59,10 +59,13 @@ pub enum Publish {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct PublishFlakehub {
     pub name: String,
     pub visibility: String,
     pub rolling: bool,
+    #[serde(default)]
+    pub populate_consumer_cache: bool,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -418,6 +421,25 @@ fn build_job(spec: &MainBuildSpec) -> InlineJob {
                 with,
                 env: BTreeMap::new(),
             }));
+            // After flakehub-push registers the new revision, rebuild
+            // from the FlakeHub URL so the closure pushed to FlakeHub
+            // Cache matches what downstream consumers will ask for.
+            // The local-path `nix build` above produces a different
+            // `.drv` (different source-store-hash for path vs tarball
+            // inputs), so its cached output never satisfies consumer
+            // lookups. See kolohelios/kolohelios#591.
+            if fh.populate_consumer_cache {
+                steps.push(Step::Run(RunStep {
+                    id: None,
+                    name: Some(format!(
+                        "Build {} from FlakeHub URL (populate consumer cache)",
+                        spec.build.display_name
+                    )),
+                    if_: Some(publish_if.to_string()),
+                    run: format!("nix build 'https://flakehub.com/f/{}/*.tar.gz'", fh.name),
+                    env: BTreeMap::new(),
+                }));
+            }
         }
         Publish::Artifact(art) => {
             let mut with: BTreeMap<String, Value> = BTreeMap::new();


### PR DESCRIPTION
Two commits:

1. **`feat(shaka)`** — Add `populateConsumerCache` to `#PublishFlakehub`. When set, the generator emits a second `nix build https://flakehub.com/f/<name>/*.tar.gz` step after `flakehub-push`. No-op by default — opt in per publish target.
2. **`ci(blogctl)`** — Opt blogctl in. The local-path `nix build ./apps/blogctl` we already do produces a closure with a different `.drv` than what FlakeHub consumers ask for (different source-store-hash for path vs tarball inputs), so our cached closure never satisfies their lookups — they rebuild from source on every PR and roll the `crates.io` dice. The new step rebuilds from the FlakeHub URL after `flakehub-push` registers the new revision, landing a closure consumers actually hit.

Cost: ~1-3 min added to `Build blogctl` per main push. Acceptable for "every consumer hits cache forever after."

Closes #591