### PR TITLE
feat(claude): /audit-workflow skill for periodic friction review

### DIFF
--- a/.claude/commands/audit-workflow.md
+++ b/.claude/commands/audit-workflow.md
@@ -1,0 +1,139 @@
+---
+description: Audit recent Claude sessions for friction patterns worth fixing with tooling
+allowed-tools: Bash(gh issue list:*), Bash(gh issue create:*), Bash(find:*), Read, Grep, Glob, Agent
+---
+
+Audit recent Claude Code sessions on this machine for **churn loops**
+and **friction points**, then surface them as a triage table the user
+can turn into GitHub issues.
+
+Run this every few days or weekly. The output is ephemeral — the
+durable artifact is the issues filed from it.
+
+## Workflow
+
+### 1. Pick the window
+
+Default: sessions modified in the last 7 days. If the user passed
+`--since <N>d` (for example `--since 14d`, `--since 3d`), use that
+window instead.
+
+List candidate session files across **all** project directories on the
+machine (friction patterns surface anywhere Claude runs, not just
+kolohelios):
+
+```
+find ~/.claude/projects -maxdepth 2 -name '*.jsonl' -mtime -<N>
+```
+
+Report the count before delegating ("scanning N sessions across M
+projects"). If zero, stop and report "no sessions to audit."
+
+### 2. Delegate to one Explore agent
+
+Spawn a single Explore agent with the prompt below (verbatim — the
+taxonomy and evidence rules are load-bearing):
+
+> Analyze the listed Claude Code session JSONL files for churn loops
+> and friction patterns. Each line in a JSONL is one turn (user
+> message, assistant message, or tool result).
+>
+> **Taxonomy — look for:**
+>
+> - Push → CI-fail → fix → push loops
+> - `just validate` failures after a "final tweak" (validate pass →
+>   edit → push without re-validate → CI/local fail)
+> - User corrections ("no," "don't," "stop," "actually," "wait,")
+>   that redirect a chosen path
+> - Permission prompts for the same read-only command across sessions
+>   (allowlist candidates for `.claude/settings.json`)
+> - Multi-step manual sequences that recur (new `shaka` subcommand or
+>   `/skill` candidates)
+> - Searches that took 3+ greps/reads to land the right answer
+> - Sub-agent briefing gaps (sub-agent forgot a rule the parent should
+>   have stated up front)
+> - `nix develop`/`direnv` failures that triggered a retry
+>
+> **Evidence rules — this is the critical guardrail:**
+>
+> - **Mention counts are NOT evidence.** A finding must cite at least
+>   one **failure→fix→retry triple** in the session log:
+>   1. A `tool_result` with `is_error: true` (or non-zero exit, or a
+>      clear error string in stderr/stdout)
+>   2. An edit or decision turn responding to that error
+>   3. Another invocation of the same command (or a closely related
+>      one) that reflects the fix
+>
+>   Without that triple, the pattern is dropped.
+> - **Sample size:** a finding needs evidence from **≥2 distinct
+>   sessions** before it's worth surfacing.
+> - **Skip prior audit output:** exclude turns whose `<command-name>`
+>   tag contains `audit-workflow` (otherwise we reinforce prior runs).
+> - **Sessions are large (multi-MB).** Don't full-read; grep for
+>   `"is_error":true`, error keywords, and the user's correction
+>   phrases above, then read the surrounding turns.
+>
+> **Output format** — one row per pattern with these fields:
+>
+> - Pattern: one-sentence description
+> - Evidence: 2-3 session ID prefixes + approximate turn number + the
+>   triggering command/error
+> - Proposed fix shape: new `shaka <subcommand>`, CLAUDE.md hint,
+>   `/skill` addition, `settings.json` allowlist entry, or hook
+> - Priority: high / medium / low (frequency × time-cost per
+>   occurrence)
+>
+> Cap at **≤10 findings**. Prefer 5 strong ones over 10 weak ones.
+
+### 3. Cross-check against existing issues
+
+For each finding the agent surfaces, search GitHub:
+
+```
+gh issue list --state all --limit 30 --search "<keywords from finding>"
+```
+
+Annotate each row with a **Dup-Check** column:
+
+- `none` — no overlap
+- `extends #N` — related open issue, this would build on it
+- `duplicates #N` — already covered; surface for visibility, don't
+  file
+- `reopens #N` — was closed but the pattern recurs, worth reopening
+
+**Do not silently drop duplicates** — surface them so the user can
+decide whether the closed work was sufficient.
+
+If `gh` fails (auth, rate limit), present the table anyway with
+Dup-Check set to `unchecked` and tell the user to verify before
+filing.
+
+### 4. Present and offer to file
+
+Output the triage table:
+
+| Pattern | Evidence | Proposed Fix | Dup-Check | Priority |
+|---------|----------|--------------|-----------|----------|
+
+Ask which rows the user wants to file. For each pick, draft a title in
+conventional commit format (`<type>(<scope>): <subject>`) and a body
+that includes context (which sessions, what the friction looked like),
+scope / out of scope, and acceptance criteria. Then call
+`gh issue create`. **Never auto-file** — always wait for the user's
+selection.
+
+## Conventions
+
+- This skill runs from the **primary tree**. It's read-only against
+  the repo; no workspace needed.
+- Findings without a failure→fix→retry triple are dropped silently,
+  not surfaced as "weak signal."
+- The skill identifies opportunities; it doesn't fix them. Each filed
+  issue is downstream work.
+
+## Stop conditions
+
+- No sessions in the window → report and exit.
+- Explore agent returns zero findings → report and exit (success).
+- `gh issue list` fails → present findings with `unchecked` dup
+  column.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,18 @@ restate two rules that `/start` and `/ship` would otherwise enforce:
   and forget to re-run; the resulting CI failure cycle is far more
   expensive than the local validate.
 
+## Periodic maintenance
+
+A few tasks pay off when run on a cadence rather than per-PR:
+
+- **`/audit-workflow`** — every few days or weekly. Scans recent
+  Claude session JSONL files across all `~/.claude/projects/*/`
+  directories for churn loops (push→CI-fail→fix→push, repeated user
+  corrections, multi-step sequences ripe for one `shaka` subcommand)
+  and surfaces them as a triage table for new issues. Findings without
+  a failure→fix→retry triple are dropped, so the output stays
+  signal-heavy. Defined in `.claude/commands/audit-workflow.md`.
+
 ## Things to avoid
 
 - **Don't edit code in the primary tree.** Issue work belongs in a


### PR DESCRIPTION
Adds .claude/commands/audit-workflow.md — a slash command that scans
recent Claude session JSONL files for churn loops (push→CI-fail→fix
loops, repeated user corrections, multi-step sequences worth a shaka
subcommand, permission-prompt repetition, sub-agent briefing gaps) and
surfaces them as a triage table the user can turn into GitHub issues.

The first ad-hoc run of this audit (manual Explore agent) produced a
plausible-looking report whose evidence was mostly keyword frequency —
most findings duplicated already-closed issues. So the skill bakes in
a sharper filter:

- Findings must cite a failure→fix→retry triple in the session log,
  not just word mentions. Patterns without that triple are dropped.
- Evidence must span ≥2 distinct sessions.
- Prior /audit-workflow output is excluded from analysis to avoid
  reinforcement.
- Each finding gets a dup-check pass against gh issue list (open
  and closed), surfaced as 'extends #N' / 'duplicates #N' /
  'reopens #N' so the user can see prior coverage rather than
  silently filing dups.

Output is a markdown triage table; the skill never auto-files — the
user picks which rows to turn into issues. Auto-file is a possible
v2 gated on a --file flag.

Also adds a 'Periodic maintenance' section to CLAUDE.md pointing at
the skill, so it's discoverable in the same place /start and /ship
live.

Closes #618