### PR TITLE
feat(aof): publish to FlakeHub for consumer use

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      aof: ${{ steps.filter.outputs.aof }}
       base_ref: ${{ steps.base.outputs.ref }}
       blogctl: ${{ steps.filter.outputs.blogctl }}
       claude-hooks: ${{ steps.filter.outputs.claude-hooks }}
@@ -52,6 +53,8 @@ jobs:
             - 'infra/home/**'
           nix-lib:
             - 'nix/kolohelios-nix/**'
+          aof:
+            - 'tools/aof/**'
           claude-hooks:
             - 'tools/claude-hooks/**'
           shaka:
@@ -213,6 +216,49 @@ jobs:
         name: kolohelios/kolohelios-nix
         rolling: true
         visibility: public
+  build-aof:
+    name: Build aof
+    needs:
+    - preflight
+    - changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.aof == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+    - uses: DeterminateSystems/nix-installer-action@main
+      with:
+        determinate: true
+        flakehub: true
+    - uses: DeterminateSystems/flakehub-cache-action@v3
+    - run: nix build ./tools/aof
+    - uses: DeterminateSystems/flakehub-push@main
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      with:
+        directory: tools/aof
+        name: kolohelios/aof
+        rolling: true
+        visibility: public
+    - name: Build aof from FlakeHub URL (populate consumer cache)
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      run: nix build 'https://flakehub.com/f/kolohelios/aof/*.tar.gz'
+    - uses: actions/create-github-app-token@v3
+      id: bot-token
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      with:
+        client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
+        owner: kolohelios
+        private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
+        repositories: personal-os
+    - name: Notify personal-os of new aof publish
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      run: |
+        gh api -X POST repos/kolohelios/personal-os/dispatches \
+          -f event_type=aof-published
+      env:
+        GH_TOKEN: ${{ steps.bot-token.outputs.token }}
   build-claude-hooks:
     name: Build claude-hooks
     needs:
@@ -272,6 +318,7 @@ jobs:
     - build-image
     - build-home
     - build-nix-lib
+    - build-aof
     - build-claude-hooks
     - build-shaka
     if: always()

--- a/tools/aof/flake.nix
+++ b/tools/aof/flake.nix
@@ -48,6 +48,28 @@
         };
     in
     {
+      packages = forEachSupportedSystem (
+        { pkgs, ... }:
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "aof";
+            version = "0.1.0";
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+          };
+        }
+      );
+
+      apps = forEachSupportedSystem (
+        { system, ... }:
+        {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/aof";
+          };
+        }
+      );
+
       devShells = forEachSupportedSystem (
         { pkgs, ... }:
         {

--- a/tools/aof/project.cue
+++ b/tools/aof/project.cue
@@ -5,9 +5,7 @@ package project
 	kind: "rust-cli"
 	cli: {
 		binaryName: "aof"
-		// devShell-only project today; no `nix build ./tools/aof`
-		// consumer, so the package emission is off.
-		package: false
+		package:    true
 	}
 	coverage: {
 		line: {
@@ -15,6 +13,34 @@ package project
 		}
 		branch: {
 			fail: 0
+		}
+	}
+	ci: {
+		build: {
+			filterKey:   "aof"
+			jobId:       "aof"
+			displayName: "aof"
+			publish: {
+				kind:       "flakehub"
+				name:       "kolohelios/aof"
+				visibility: "public"
+				rolling:    true
+				// kolohelios/personal-os (#620) consumes aof from
+				// FlakeHub; without the second build step, the
+				// consumer-side .drv lookup misses our cache. See #591
+				// for the pattern this preempts.
+				populateConsumerCache: true
+			}
+			// Notify personal-os of a fresh publish so its bump
+			// workflow runs immediately rather than waiting for cron.
+			// The repo doesn't exist yet (#620); until it does, this
+			// dispatch step 404s while the publish itself succeeds.
+			dispatch: [
+				{
+					repo:      "kolohelios/personal-os"
+					eventType: "aof-published"
+				},
+			]
 		}
 	}
 }


### PR DESCRIPTION
Adds a `ci.build` block to `tools/aof/project.cue` that pushes `aof`
to FlakeHub on every merge to main, populates the consumer-side cache
(same `.drv`-mismatch preempt as `blogctl` learned in #591), and
dispatches an `aof-published` event to `kolohelios/personal-os` so the
consumer's lock-bump workflow runs immediately instead of waiting for
its daily cron.

Mirrors the `apps/blogctl/project.cue` ↔ `kolohelios/blogs-and-posts`
pattern. The generated `build-aof` job in `.github/workflows/main.yaml`
follows the same shape as `build-blogctl`.

`kolohelios/personal-os` doesn't exist yet — #620 tracks creating it.
Until then the dispatch step will 404 on each publish; the publish
itself succeeds. Self-resolves the moment `personal-os` lands.

Closes #622