### PR TITLE
refactor(infra/home): cede nix management to Determinate

### DIFF
--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -6,31 +6,13 @@
   nixpkgs.hostPlatform = "aarch64-darwin";
   nixpkgs.config.allowUnfree = true;
 
-  nix.settings.experimental-features = [
-    "nix-command"
-    "flakes"
-  ];
-
-  nix.linux-builder.enable = true;
-  # Required so non-root users can dispatch to the linux-builder VM.
-  nix.settings.trusted-users = [ "@admin" ];
-
-  # Per-project flakes + the daily `kolohelios-nix` lock bump means every
-  # project's old dev shell becomes GC-able after the next direnv reload,
-  # easily piling up tens of GB per day. `min-free`/`max-free` is the
-  # load-bearing pair: the daemon auto-GCs mid-build when free space drops
-  # below `min-free` and reclaims up to `max-free`, so the store doesn't
-  # grow unbounded between manual sweeps. The daily timer + 7d retention
-  # bounds long-tail roots; `optimise.automatic` deduplicates identical
-  # store paths via hardlinks.
-  nix.gc = {
-    automatic = true;
-    interval.Hour = 3;
-    options = "--delete-older-than 7d";
-  };
-  nix.optimise.automatic = true;
-  nix.settings.min-free = 10 * 1024 * 1024 * 1024;
-  nix.settings.max-free = 50 * 1024 * 1024 * 1024;
+  # Determinate Nix manages the daemon and store on this host; nix-darwin
+  # aborts activation otherwise. With `nix.enable = false`, every `nix.*`
+  # option (gc, optimise, settings, linux-builder, experimental-features,
+  # trusted-users) becomes unreachable here and must be configured on the
+  # Determinate side instead — see `/etc/nix/nix.custom.conf` and
+  # `determinate-nixd`. Tracked in #631.
+  nix.enable = false;
 
   users.users.jedwards = {
     name = "jedwards";


### PR DESCRIPTION
Determinate Nix is installed on the laptop and refuses to coexist with
nix-darwin's daemon management:

    error: Determinate detected, aborting activation

The fix is `nix.enable = false`, which makes every `nix.*` option in
nix-darwin unreachable. Removes the now-dead config from #574 (gc,
optimise, min-free/max-free) along with `linux-builder.enable`,
`settings.experimental-features`, and `settings.trusted-users` — all
of which need Determinate-side equivalents instead.

No-op for the running system since `darwin-rebuild switch` was never
the activation path here; future activations can now proceed. The GC
behavior we wanted via #573 is unsolved on this host until #632 lands
it in `/etc/nix/nix.custom.conf`. #633 audits whether home-manager
activation should stay routed through nix-darwin at all.

Closes #631