### PR TITLE
feat(aof): areas-of-focus CUE schema + example fixture

### DIFF
--- a/tools/aof/data/example.cue
+++ b/tools/aof/data/example.cue
@@ -1,0 +1,20 @@
+// Minimal fixture demonstrating the `#Area` shape. Personal data —
+// the actual areas-of-focus tree — lives in `kolohelios/personal-os`
+// (#620), not here. This file exists so `cue vet` has something to
+// validate against the schema locally.
+package areas
+
+example: #Area & {
+	name:        "Example"
+	description: "Minimal fixture; real tree lives in kolohelios/personal-os."
+	children: [
+		{name: "Work"},
+		{
+			name: "Personal"
+			children: [
+				{name: "Health"},
+				{name: "Family"},
+			]
+		},
+	]
+}

--- a/tools/aof/data/schema.cue
+++ b/tools/aof/data/schema.cue
@@ -1,0 +1,11 @@
+// Areas of focus: a strict tree of life domains. Parent-child only —
+// no cross-area references, so cycles are impossible by construction.
+// If cross-links ever become load-bearing, add them as a separate edge
+// list and implement cycle detection in `aof`, don't pollute this shape.
+package areas
+
+#Area: {
+	name:         string & !=""
+	description?: string & !=""
+	children?: [...#Area]
+}


### PR DESCRIPTION
Adds `tools/aof/data/schema.cue` defining `#Area` as a strict
parent-child tree (name, optional description, optional children list
of `#Area`). No cross-area references — cycles are impossible by
construction, so the engine doesn't need cycle-detection logic.

`data/example.cue` holds a minimal fixture so `cue vet` has something
to validate locally and so the schema has a concrete usage reference.
The actual areas-of-focus tree — the personal data the screenshot
in the planning conversation showed — lives in `kolohelios/personal-os`
(#620), not here. This rename (`areas.cue` → `example.cue`) reflects
that split, which we settled on after #605 was filed.

`cue vet` wiring into the per-project `validate` recipe lands in
#606.

Closes #605