### PR TITLE
feat(blogctl): enforce tags max via doctor

### DIFF
--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -53,8 +53,7 @@ Classifying posts and recording per-venue performance:
 ```text
 blogctl classify <slug> --workdir <path> \
   [--format X] [--hook X] [--tone X] [--audience X] \
-  [--strategic-role X] [--theme A,B,...] \
-  [--clear-<dim>]
+  [--theme A,B,...] [--clear-<dim>]
 blogctl metrics update <slug> --workdir <path> \
   --target <linkedin|blog> \
   --impressions N --reactions N --comments N --reposts N \
@@ -102,7 +101,6 @@ classifications:
   hook: contradiction
   tone: sharp
   audience: engineering
-  strategic_role: career-brand
   theme:
     - ambiguity
     - delivery
@@ -161,10 +159,6 @@ values = ["gentle", "sharp", "vulnerable", "reflective", "provocative"]
 [classifications.audience]
 values = ["engineering", "product", "leadership", "founders", "general"]
 
-[classifications.strategic_role]
-values = ["salal-positioning", "career-brand", "recruiting",
-          "writing-practice", "consulting-signal"]
-
 [classifications.theme]
 multi = true
 values = ["ambiguity", "delivery", "interfaces", "leadership", "ai",
@@ -208,7 +202,6 @@ blogctl classify the-only-way-out-is-through \
   --hook contradiction \
   --tone sharp \
   --audience engineering \
-  --strategic-role career-brand \
   --theme ambiguity,delivery \
   --workdir ~/blog-os
 

--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -52,7 +52,12 @@ Classifying posts and recording per-venue performance:
 
 ```text
 blogctl classify <slug> --workdir <path> \
-  [--format X] [--hook X] [--tone X] [--audience X] \
+  [--format X] [--hook X] [--tone X] \
+  [--audience A,B,...] [--topic A,B,...] \
+  [--narrative-structure A,B,...] \
+  [--call-to-action X] [--visual-type X] \
+  [--complexity X] [--vulnerability X] \
+  [--outcome-prediction X] \
   [--theme A,B,...] [--clear-<dim>]
 blogctl metrics update <slug> --workdir <path> \
   --target <linkedin|blog> \
@@ -100,7 +105,17 @@ classifications:
   format: thesis
   hook: contradiction
   tone: sharp
-  audience: engineering
+  audience:
+    - engineering
+  topic:
+    - leadership
+  narrative_structure:
+    - analogy
+  call_to_action: reflection
+  visual_type: text-only
+  complexity: moderate
+  vulnerability: low
+  outcome_prediction: medium
   theme:
     - ambiguity
     - delivery
@@ -157,12 +172,38 @@ values = ["proverb", "contradiction", "direct-claim",
 values = ["gentle", "sharp", "vulnerable", "reflective", "provocative"]
 
 [classifications.audience]
+multi = true
 values = ["engineering", "product", "leadership", "founders", "general"]
+
+[classifications.topic]
+multi = true
+values = ["engineering", "leadership", "product", "career", "general"]
+
+[classifications.narrative_structure]
+multi = true
+values = ["direct-statement", "personal-anecdote", "metaphor",
+          "analogy", "contrast"]
+
+[classifications.call_to_action]
+values = ["none", "reflection", "discussion"]
+
+[classifications.visual_type]
+values = ["text-only", "diagram", "illustration", "screenshot"]
+
+[classifications.complexity]
+values = ["simple", "moderate", "dense"]
+
+[classifications.vulnerability]
+values = ["none", "low", "medium", "high"]
+
+[classifications.outcome_prediction]
+values = ["low", "medium", "high"]
 
 [classifications.theme]
 multi = true
 values = ["ambiguity", "delivery", "interfaces", "leadership", "ai",
-          "engineering-culture", "product", "organizational-psychology"]
+          "engineering-culture", "product", "organizational-psychology",
+          "adaptation", "tradeoffs", "learning", "community"]
 ```
 
 `init` seeds these tables with the v1 defaults shown above. Adding a
@@ -201,7 +242,8 @@ blogctl classify the-only-way-out-is-through \
   --format thesis \
   --hook contradiction \
   --tone sharp \
-  --audience engineering \
+  --audience engineering,leadership \
+  --topic leadership \
   --theme ambiguity,delivery \
   --workdir ~/blog-os
 

--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -213,7 +213,18 @@ with values outside the declared list refuse to load — `blogctl
 doctor` surfaces the offenders.
 
 `multi = false` is the default (single-valued); `multi = true` accepts
-a list. `theme` is the only multi-valued dimension in v1.
+a list.
+
+`tags` (the free-form list on each post, separate from classifications)
+is uncapped by default. To enforce a per-workdir cap, declare:
+
+```toml
+[tags]
+max = 10
+```
+
+`blogctl doctor` then flags any post whose tag list overruns the cap;
+fix it by pruning the post's `tags` or raising `max`.
 
 ## Analytics workflow
 

--- a/apps/blogctl/src/analytics/compare.rs
+++ b/apps/blogctl/src/analytics/compare.rs
@@ -206,7 +206,6 @@ fn dimension_values(c: &Classifications, dim: &str) -> Vec<String> {
         "hook" => c.hook.iter().cloned().collect(),
         "tone" => c.tone.iter().cloned().collect(),
         "audience" => c.audience.iter().cloned().collect(),
-        "strategic_role" => c.strategic_role.iter().cloned().collect(),
         "theme" => c.theme.clone(),
         _ => vec![], // unknown dimension — no samples contribute
     }

--- a/apps/blogctl/src/analytics/compare.rs
+++ b/apps/blogctl/src/analytics/compare.rs
@@ -205,7 +205,14 @@ fn dimension_values(c: &Classifications, dim: &str) -> Vec<String> {
         "format" => c.format.iter().cloned().collect(),
         "hook" => c.hook.iter().cloned().collect(),
         "tone" => c.tone.iter().cloned().collect(),
-        "audience" => c.audience.iter().cloned().collect(),
+        "call_to_action" => c.call_to_action.iter().cloned().collect(),
+        "visual_type" => c.visual_type.iter().cloned().collect(),
+        "complexity" => c.complexity.iter().cloned().collect(),
+        "vulnerability" => c.vulnerability.iter().cloned().collect(),
+        "outcome_prediction" => c.outcome_prediction.iter().cloned().collect(),
+        "audience" => c.audience.clone(),
+        "topic" => c.topic.clone(),
+        "narrative_structure" => c.narrative_structure.clone(),
         "theme" => c.theme.clone(),
         _ => vec![], // unknown dimension — no samples contribute
     }

--- a/apps/blogctl/src/analytics/summary.rs
+++ b/apps/blogctl/src/analytics/summary.rs
@@ -175,9 +175,6 @@ fn classification_entries(c: &Classifications) -> Vec<(&'static str, String)> {
     if let Some(v) = &c.audience {
         out.push(("audience", v.clone()));
     }
-    if let Some(v) = &c.strategic_role {
-        out.push(("strategic_role", v.clone()));
-    }
     for v in &c.theme {
         out.push(("theme", v.clone()));
     }

--- a/apps/blogctl/src/analytics/summary.rs
+++ b/apps/blogctl/src/analytics/summary.rs
@@ -172,8 +172,29 @@ fn classification_entries(c: &Classifications) -> Vec<(&'static str, String)> {
     if let Some(v) = &c.tone {
         out.push(("tone", v.clone()));
     }
-    if let Some(v) = &c.audience {
+    if let Some(v) = &c.call_to_action {
+        out.push(("call_to_action", v.clone()));
+    }
+    if let Some(v) = &c.visual_type {
+        out.push(("visual_type", v.clone()));
+    }
+    if let Some(v) = &c.complexity {
+        out.push(("complexity", v.clone()));
+    }
+    if let Some(v) = &c.vulnerability {
+        out.push(("vulnerability", v.clone()));
+    }
+    if let Some(v) = &c.outcome_prediction {
+        out.push(("outcome_prediction", v.clone()));
+    }
+    for v in &c.audience {
         out.push(("audience", v.clone()));
+    }
+    for v in &c.topic {
+        out.push(("topic", v.clone()));
+    }
+    for v in &c.narrative_structure {
+        out.push(("narrative_structure", v.clone()));
     }
     for v in &c.theme {
         out.push(("theme", v.clone()));

--- a/apps/blogctl/src/classifications.rs
+++ b/apps/blogctl/src/classifications.rs
@@ -1,7 +1,9 @@
 //! Structured tag dimensions for analytics. Sits alongside the
 //! free-form `tags: Vec<String>` on `PostMetadata`: each named field
 //! captures one dimension of the post's intent (format, hook, tone,
-//! audience) plus a multi-valued `theme` list.
+//! audience, topic, narrative-structure, call-to-action, visual-type,
+//! complexity, vulnerability, outcome-prediction) plus a multi-valued
+//! `theme` list.
 //!
 //! Values stay `Option<String>` / `Vec<String>` rather than enums so
 //! the taxonomy can evolve in `.blog-os.toml` without touching code.
@@ -9,7 +11,7 @@
 //! the `classify` command + workdir-config taxonomy issue) — this
 //! module is the storage shape only.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::taxonomy::{Taxonomy, Violation};
 
@@ -18,29 +20,70 @@ use crate::taxonomy::{Taxonomy, Violation};
 /// via `#[serde(default)]` on `PostMetadata::classifications`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Classifications {
-    /// `parable`, `thesis`, `essay`, `observation`, `personal-reflection`,
+    /// What kind of writing this is — e.g. `parable`, `essay`,
     /// `framework`. Single-valued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
 
-    /// `proverb`, `contradiction`, `direct-claim`, `story-title`,
-    /// `question`, `analogy`. Single-valued.
+    /// The opening move — what gets a reader in. Single-valued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hook: Option<String>,
 
-    /// `gentle`, `sharp`, `vulnerable`, `reflective`, `provocative`.
+    /// Emotional register — e.g. `reflective`, `playful`, `cautionary`.
     /// Single-valued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tone: Option<String>,
 
-    /// `engineering`, `product`, `leadership`, `founders`, `general`.
-    /// Single-valued.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub audience: Option<String>,
+    /// Who the post is most likely to engage. Multi-valued (a post can
+    /// land for more than one audience). Accepts a single string on
+    /// the input side too, transparently promoted to a one-element
+    /// list — keeps older posts from breaking when this field was
+    /// `Option<String>`.
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "string_or_vec"
+    )]
+    pub audience: Vec<String>,
 
-    /// `ambiguity`, `delivery`, `interfaces`, `leadership`, `ai`,
-    /// `engineering-culture`, `product`, `organizational-psychology`.
-    /// Multi-valued — a post can sit in several themes.
+    /// What the post is about — e.g. `ai`, `leadership`, `engineering`.
+    /// Multi-valued.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub topic: Vec<String>,
+
+    /// How the idea is delivered — e.g. `direct-statement`,
+    /// `animal-parable`, `venn-diagram`. Multi-valued so a piece can
+    /// combine devices.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub narrative_structure: Vec<String>,
+
+    /// What the reader is invited to do — e.g. `reflection`,
+    /// `discussion`, `attend-event`. Single-valued; `none` is a real
+    /// option.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call_to_action: Option<String>,
+
+    /// Dominant visual artifact — e.g. `text-only`, `diagram`,
+    /// `carousel`. Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visual_type: Option<String>,
+
+    /// Cognitive load — `simple`, `moderate`, `dense`. Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub complexity: Option<String>,
+
+    /// How much of the author is in the piece — `none`, `low`,
+    /// `medium`, `high`. Single-valued.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vulnerability: Option<String>,
+
+    /// Pre-publish engagement guess — `low`, `medium`, `high`. Set
+    /// before publishing to compare against actual performance later.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome_prediction: Option<String>,
+
+    /// Recurring conceptual threads — e.g. `adaptation`, `tradeoffs`,
+    /// `community`. Multi-valued.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub theme: Vec<String>,
 }
@@ -53,7 +96,14 @@ impl Classifications {
         self.format.is_none()
             && self.hook.is_none()
             && self.tone.is_none()
-            && self.audience.is_none()
+            && self.audience.is_empty()
+            && self.topic.is_empty()
+            && self.narrative_structure.is_empty()
+            && self.call_to_action.is_none()
+            && self.visual_type.is_none()
+            && self.complexity.is_none()
+            && self.vulnerability.is_none()
+            && self.outcome_prediction.is_none()
             && self.theme.is_empty()
     }
 
@@ -107,17 +157,47 @@ impl Classifications {
         }
     }
 
-    fn single_valued_entries(&self) -> [(&'static str, Option<&str>); 4] {
+    fn single_valued_entries(&self) -> [(&'static str, Option<&str>); 8] {
         [
             ("format", self.format.as_deref()),
             ("hook", self.hook.as_deref()),
             ("tone", self.tone.as_deref()),
-            ("audience", self.audience.as_deref()),
+            ("call_to_action", self.call_to_action.as_deref()),
+            ("visual_type", self.visual_type.as_deref()),
+            ("complexity", self.complexity.as_deref()),
+            ("vulnerability", self.vulnerability.as_deref()),
+            ("outcome_prediction", self.outcome_prediction.as_deref()),
         ]
     }
 
-    fn multi_valued_entries(&self) -> [(&'static str, &[String]); 1] {
-        [("theme", &self.theme)]
+    fn multi_valued_entries(&self) -> [(&'static str, &[String]); 4] {
+        [
+            ("audience", &self.audience),
+            ("topic", &self.topic),
+            ("narrative_structure", &self.narrative_structure),
+            ("theme", &self.theme),
+        ]
+    }
+}
+
+/// Deserialize a field that may be a single string OR a list of
+/// strings into `Vec<String>`. Lets `audience: engineering` and
+/// `audience: [engineering]` both parse — kept for forward
+/// compatibility with posts written before `audience` was promoted
+/// to multi-valued.
+fn string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        One(String),
+        Many(Vec<String>),
+    }
+    match Repr::deserialize(deserializer)? {
+        Repr::One(s) => Ok(vec![s]),
+        Repr::Many(v) => Ok(v),
     }
 }
 
@@ -130,7 +210,14 @@ mod tests {
             format: Some("thesis".into()),
             hook: Some("contradiction".into()),
             tone: Some("sharp".into()),
-            audience: Some("engineering".into()),
+            audience: vec!["engineering".into()],
+            topic: vec!["leadership".into()],
+            narrative_structure: vec!["analogy".into()],
+            call_to_action: Some("reflection".into()),
+            visual_type: Some("text-only".into()),
+            complexity: Some("moderate".into()),
+            vulnerability: Some("low".into()),
+            outcome_prediction: Some("medium".into()),
             theme: vec!["ambiguity".into(), "delivery".into()],
         }
     }
@@ -161,6 +248,11 @@ mod tests {
         assert!(!yaml.contains("hook"), "hook must be skipped: {yaml}");
         assert!(!yaml.contains("tone"), "tone must be skipped: {yaml}");
         assert!(!yaml.contains("theme"), "theme must be skipped: {yaml}");
+        assert!(!yaml.contains("topic"), "topic must be skipped: {yaml}");
+        assert!(
+            !yaml.contains("visual_type"),
+            "visual_type must be skipped: {yaml}",
+        );
     }
 
     #[test]
@@ -171,6 +263,8 @@ mod tests {
         assert_eq!(c.format.as_deref(), Some("thesis"));
         assert!(c.hook.is_none());
         assert!(c.theme.is_empty());
+        assert!(c.topic.is_empty());
+        assert!(c.call_to_action.is_none());
     }
 
     #[test]
@@ -199,6 +293,34 @@ mod tests {
         // The common case: one theme, written as a single-element list.
         let c = Classifications {
             theme: vec!["ambiguity".into()],
+            ..Default::default()
+        };
+        let yaml = serde_yaml_ng::to_string(&c).unwrap();
+        let back: Classifications = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(back, c);
+    }
+
+    #[test]
+    fn audience_accepts_single_string_for_back_compat() {
+        // Pre-promotion frontmatter: `audience: engineering` (string).
+        // Must parse cleanly into a one-element Vec so old posts don't
+        // break when `audience` flipped from Option<String> to Vec<String>.
+        let raw = "audience: engineering\n";
+        let c: Classifications = serde_yaml_ng::from_str(raw).unwrap();
+        assert_eq!(c.audience, vec!["engineering"]);
+    }
+
+    #[test]
+    fn audience_accepts_list_form() {
+        let raw = "audience:\n  - engineering\n  - leadership\n";
+        let c: Classifications = serde_yaml_ng::from_str(raw).unwrap();
+        assert_eq!(c.audience, vec!["engineering", "leadership"]);
+    }
+
+    #[test]
+    fn audience_round_trips_as_list() {
+        let c = Classifications {
+            audience: vec!["engineering".into(), "founders".into()],
             ..Default::default()
         };
         let yaml = serde_yaml_ng::to_string(&c).unwrap();
@@ -255,6 +377,19 @@ mod tests {
         assert!(dims.contains(&"format"));
         assert!(dims.contains(&"tone"));
         assert!(dims.contains(&"theme"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_topic_and_audience_elements() {
+        let c = Classifications {
+            topic: vec!["leadership".into(), "made-up-topic".into()],
+            audience: vec!["engineering".into(), "made-up-audience".into()],
+            ..Default::default()
+        };
+        let v = c.violations(&Taxonomy::current_v1());
+        let dims: Vec<&str> = v.iter().map(|x| x.dimension.as_str()).collect();
+        assert!(dims.contains(&"topic"));
+        assert!(dims.contains(&"audience"));
     }
 
     #[test]

--- a/apps/blogctl/src/classifications.rs
+++ b/apps/blogctl/src/classifications.rs
@@ -1,7 +1,7 @@
 //! Structured tag dimensions for analytics. Sits alongside the
 //! free-form `tags: Vec<String>` on `PostMetadata`: each named field
 //! captures one dimension of the post's intent (format, hook, tone,
-//! audience, strategic role) plus a multi-valued `theme` list.
+//! audience) plus a multi-valued `theme` list.
 //!
 //! Values stay `Option<String>` / `Vec<String>` rather than enums so
 //! the taxonomy can evolve in `.blog-os.toml` without touching code.
@@ -38,11 +38,6 @@ pub struct Classifications {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audience: Option<String>,
 
-    /// `salal-positioning`, `career-brand`, `recruiting`,
-    /// `writing-practice`, `consulting-signal`. Single-valued.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub strategic_role: Option<String>,
-
     /// `ambiguity`, `delivery`, `interfaces`, `leadership`, `ai`,
     /// `engineering-culture`, `product`, `organizational-psychology`.
     /// Multi-valued — a post can sit in several themes.
@@ -59,7 +54,6 @@ impl Classifications {
             && self.hook.is_none()
             && self.tone.is_none()
             && self.audience.is_none()
-            && self.strategic_role.is_none()
             && self.theme.is_empty()
     }
 
@@ -113,13 +107,12 @@ impl Classifications {
         }
     }
 
-    fn single_valued_entries(&self) -> [(&'static str, Option<&str>); 5] {
+    fn single_valued_entries(&self) -> [(&'static str, Option<&str>); 4] {
         [
             ("format", self.format.as_deref()),
             ("hook", self.hook.as_deref()),
             ("tone", self.tone.as_deref()),
             ("audience", self.audience.as_deref()),
-            ("strategic_role", self.strategic_role.as_deref()),
         ]
     }
 
@@ -138,7 +131,6 @@ mod tests {
             hook: Some("contradiction".into()),
             tone: Some("sharp".into()),
             audience: Some("engineering".into()),
-            strategic_role: Some("career-brand".into()),
             theme: vec!["ambiguity".into(), "delivery".into()],
         }
     }

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -201,8 +201,12 @@ pub enum Command {
         no_sync: bool,
     },
     /// Set classification dimensions on a post (format, hook, tone,
-    /// audience, theme). Missing flags leave the existing value alone;
-    /// `--clear-<dim>` removes it.
+    /// audience, topic, narrative-structure, call-to-action,
+    /// visual-type, complexity, vulnerability, outcome-prediction,
+    /// theme). Missing flags leave the existing value alone;
+    /// `--clear-<dim>` removes it. Multi-valued dimensions
+    /// (audience, topic, narrative-structure, theme) take
+    /// comma-separated lists that replace the existing list.
     Classify {
         slug: String,
         /// Workdir path. Defaults to the current working directory.
@@ -214,10 +218,27 @@ pub enum Command {
         hook: Option<String>,
         #[arg(long)]
         tone: Option<String>,
+        /// Comma-separated list of audiences. Replaces the existing list.
+        #[arg(long, value_delimiter = ',')]
+        audience: Vec<String>,
+        /// Comma-separated list of topics. Replaces the existing list.
+        #[arg(long, value_delimiter = ',')]
+        topic: Vec<String>,
+        /// Comma-separated list of narrative-structure values.
+        /// Replaces the existing list.
+        #[arg(long, value_delimiter = ',')]
+        narrative_structure: Vec<String>,
         #[arg(long)]
-        audience: Option<String>,
-        /// Comma-separated list of themes. Replaces the existing
-        /// theme list entirely.
+        call_to_action: Option<String>,
+        #[arg(long)]
+        visual_type: Option<String>,
+        #[arg(long)]
+        complexity: Option<String>,
+        #[arg(long)]
+        vulnerability: Option<String>,
+        #[arg(long)]
+        outcome_prediction: Option<String>,
+        /// Comma-separated list of themes. Replaces the existing list.
         #[arg(long, value_delimiter = ',')]
         theme: Vec<String>,
         #[arg(long)]
@@ -228,6 +249,20 @@ pub enum Command {
         clear_tone: bool,
         #[arg(long)]
         clear_audience: bool,
+        #[arg(long)]
+        clear_topic: bool,
+        #[arg(long)]
+        clear_narrative_structure: bool,
+        #[arg(long)]
+        clear_call_to_action: bool,
+        #[arg(long)]
+        clear_visual_type: bool,
+        #[arg(long)]
+        clear_complexity: bool,
+        #[arg(long)]
+        clear_vulnerability: bool,
+        #[arg(long)]
+        clear_outcome_prediction: bool,
         #[arg(long)]
         clear_theme: bool,
         /// Skip the post-write `jj` commit + push for this invocation.
@@ -574,11 +609,25 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             hook,
             tone,
             audience,
+            topic,
+            narrative_structure,
+            call_to_action,
+            visual_type,
+            complexity,
+            vulnerability,
+            outcome_prediction,
             theme,
             clear_format,
             clear_hook,
             clear_tone,
             clear_audience,
+            clear_topic,
+            clear_narrative_structure,
+            clear_call_to_action,
+            clear_visual_type,
+            clear_complexity,
+            clear_vulnerability,
+            clear_outcome_prediction,
             clear_theme,
             no_sync,
         } => commands::classify::run(
@@ -590,11 +639,25 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 hook,
                 tone,
                 audience,
+                topic,
+                narrative_structure,
+                call_to_action,
+                visual_type,
+                complexity,
+                vulnerability,
+                outcome_prediction,
                 theme,
                 clear_format,
                 clear_hook,
                 clear_tone,
                 clear_audience,
+                clear_topic,
+                clear_narrative_structure,
+                clear_call_to_action,
+                clear_visual_type,
+                clear_complexity,
+                clear_vulnerability,
+                clear_outcome_prediction,
                 clear_theme,
                 no_sync,
             },
@@ -860,7 +923,21 @@ mod tests {
                 "--tone",
                 "sharp",
                 "--audience",
-                "engineering",
+                "engineering,leadership",
+                "--topic",
+                "leadership",
+                "--narrative-structure",
+                "analogy",
+                "--call-to-action",
+                "reflection",
+                "--visual-type",
+                "text-only",
+                "--complexity",
+                "moderate",
+                "--vulnerability",
+                "low",
+                "--outcome-prediction",
+                "medium",
                 "--theme",
                 "ambiguity,delivery",
             ],
@@ -874,6 +951,13 @@ mod tests {
                 "--clear-hook",
                 "--clear-tone",
                 "--clear-audience",
+                "--clear-topic",
+                "--clear-narrative-structure",
+                "--clear-call-to-action",
+                "--clear-visual-type",
+                "--clear-complexity",
+                "--clear-vulnerability",
+                "--clear-outcome-prediction",
                 "--clear-theme",
             ],
             vec![

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -201,8 +201,8 @@ pub enum Command {
         no_sync: bool,
     },
     /// Set classification dimensions on a post (format, hook, tone,
-    /// audience, strategic-role, theme). Missing flags leave the
-    /// existing value alone; `--clear-<dim>` removes it.
+    /// audience, theme). Missing flags leave the existing value alone;
+    /// `--clear-<dim>` removes it.
     Classify {
         slug: String,
         /// Workdir path. Defaults to the current working directory.
@@ -216,8 +216,6 @@ pub enum Command {
         tone: Option<String>,
         #[arg(long)]
         audience: Option<String>,
-        #[arg(long)]
-        strategic_role: Option<String>,
         /// Comma-separated list of themes. Replaces the existing
         /// theme list entirely.
         #[arg(long, value_delimiter = ',')]
@@ -230,8 +228,6 @@ pub enum Command {
         clear_tone: bool,
         #[arg(long)]
         clear_audience: bool,
-        #[arg(long)]
-        clear_strategic_role: bool,
         #[arg(long)]
         clear_theme: bool,
         /// Skip the post-write `jj` commit + push for this invocation.
@@ -578,13 +574,11 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             hook,
             tone,
             audience,
-            strategic_role,
             theme,
             clear_format,
             clear_hook,
             clear_tone,
             clear_audience,
-            clear_strategic_role,
             clear_theme,
             no_sync,
         } => commands::classify::run(
@@ -596,13 +590,11 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 hook,
                 tone,
                 audience,
-                strategic_role,
                 theme,
                 clear_format,
                 clear_hook,
                 clear_tone,
                 clear_audience,
-                clear_strategic_role,
                 clear_theme,
                 no_sync,
             },
@@ -869,8 +861,6 @@ mod tests {
                 "sharp",
                 "--audience",
                 "engineering",
-                "--strategic-role",
-                "career-brand",
                 "--theme",
                 "ambiguity,delivery",
             ],
@@ -884,7 +874,6 @@ mod tests {
                 "--clear-hook",
                 "--clear-tone",
                 "--clear-audience",
-                "--clear-strategic-role",
                 "--clear-theme",
             ],
             vec![

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -209,8 +209,40 @@ fn merge_classifications(target: &mut Classifications, source: &Classifications)
         target.tone = source.tone.clone();
         changed = true;
     }
-    if source.audience.is_some() && target.audience != source.audience {
+    if !source.audience.is_empty() && target.audience != source.audience {
         target.audience = source.audience.clone();
+        changed = true;
+    }
+    if !source.topic.is_empty() && target.topic != source.topic {
+        target.topic = source.topic.clone();
+        changed = true;
+    }
+    if !source.narrative_structure.is_empty()
+        && target.narrative_structure != source.narrative_structure
+    {
+        target.narrative_structure = source.narrative_structure.clone();
+        changed = true;
+    }
+    if source.call_to_action.is_some() && target.call_to_action != source.call_to_action {
+        target.call_to_action = source.call_to_action.clone();
+        changed = true;
+    }
+    if source.visual_type.is_some() && target.visual_type != source.visual_type {
+        target.visual_type = source.visual_type.clone();
+        changed = true;
+    }
+    if source.complexity.is_some() && target.complexity != source.complexity {
+        target.complexity = source.complexity.clone();
+        changed = true;
+    }
+    if source.vulnerability.is_some() && target.vulnerability != source.vulnerability {
+        target.vulnerability = source.vulnerability.clone();
+        changed = true;
+    }
+    if source.outcome_prediction.is_some()
+        && target.outcome_prediction != source.outcome_prediction
+    {
+        target.outcome_prediction = source.outcome_prediction.clone();
         changed = true;
     }
     if !source.theme.is_empty() && target.theme != source.theme {
@@ -423,6 +455,13 @@ fn process_one<R: BufRead, W: Write>(
 }
 
 fn single_dim_missing(c: &Classifications) -> Vec<&'static str> {
+    // Interactive backfill only prompts for the dims it can ask a
+    // single value for. `audience`, `topic`, `narrative_structure`,
+    // `theme` are multi-valued — set those via `blogctl classify
+    // --<dim> a,b`. The newer single-valued dims (call_to_action,
+    // visual_type, complexity, vulnerability, outcome_prediction)
+    // can stay out of the prompt menu until the interactive UX
+    // earns the screen real estate.
     let mut out = Vec::new();
     if c.format.is_none() {
         out.push("format");
@@ -433,9 +472,6 @@ fn single_dim_missing(c: &Classifications) -> Vec<&'static str> {
     if c.tone.is_none() {
         out.push("tone");
     }
-    if c.audience.is_none() {
-        out.push("audience");
-    }
     out
 }
 
@@ -444,7 +480,6 @@ fn set_classification(c: &mut Classifications, dim: &str, value: &str) {
         "format" => c.format = Some(value.to_string()),
         "hook" => c.hook = Some(value.to_string()),
         "tone" => c.tone = Some(value.to_string()),
-        "audience" => c.audience = Some(value.to_string()),
         _ => {} // unknown dim — never reached for the dims we prompt for
     }
 }

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -213,10 +213,6 @@ fn merge_classifications(target: &mut Classifications, source: &Classifications)
         target.audience = source.audience.clone();
         changed = true;
     }
-    if source.strategic_role.is_some() && target.strategic_role != source.strategic_role {
-        target.strategic_role = source.strategic_role.clone();
-        changed = true;
-    }
     if !source.theme.is_empty() && target.theme != source.theme {
         target.theme = source.theme.clone();
         changed = true;
@@ -440,9 +436,6 @@ fn single_dim_missing(c: &Classifications) -> Vec<&'static str> {
     if c.audience.is_none() {
         out.push("audience");
     }
-    if c.strategic_role.is_none() {
-        out.push("strategic_role");
-    }
     out
 }
 
@@ -452,7 +445,6 @@ fn set_classification(c: &mut Classifications, dim: &str, value: &str) {
         "hook" => c.hook = Some(value.to_string()),
         "tone" => c.tone = Some(value.to_string()),
         "audience" => c.audience = Some(value.to_string()),
-        "strategic_role" => c.strategic_role = Some(value.to_string()),
         _ => {} // unknown dim — never reached for the dims we prompt for
     }
 }

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -239,8 +239,7 @@ fn merge_classifications(target: &mut Classifications, source: &Classifications)
         target.vulnerability = source.vulnerability.clone();
         changed = true;
     }
-    if source.outcome_prediction.is_some()
-        && target.outcome_prediction != source.outcome_prediction
+    if source.outcome_prediction.is_some() && target.outcome_prediction != source.outcome_prediction
     {
         target.outcome_prediction = source.outcome_prediction.clone();
         changed = true;

--- a/apps/blogctl/src/commands/classify.rs
+++ b/apps/blogctl/src/commands/classify.rs
@@ -27,12 +27,26 @@ pub struct ClassifyArgs {
     pub format: Option<String>,
     pub hook: Option<String>,
     pub tone: Option<String>,
-    pub audience: Option<String>,
+    pub audience: Vec<String>,
+    pub topic: Vec<String>,
+    pub narrative_structure: Vec<String>,
+    pub call_to_action: Option<String>,
+    pub visual_type: Option<String>,
+    pub complexity: Option<String>,
+    pub vulnerability: Option<String>,
+    pub outcome_prediction: Option<String>,
     pub theme: Vec<String>,
     pub clear_format: bool,
     pub clear_hook: bool,
     pub clear_tone: bool,
     pub clear_audience: bool,
+    pub clear_topic: bool,
+    pub clear_narrative_structure: bool,
+    pub clear_call_to_action: bool,
+    pub clear_visual_type: bool,
+    pub clear_complexity: bool,
+    pub clear_vulnerability: bool,
+    pub clear_outcome_prediction: bool,
     pub clear_theme: bool,
     pub no_sync: bool,
 }
@@ -104,27 +118,69 @@ fn apply(c: &mut Classifications, args: &ClassifyArgs) -> Vec<String> {
         &mut changed,
     );
     apply_single(
+        &mut c.call_to_action,
+        &args.call_to_action,
+        args.clear_call_to_action,
+        "call_to_action",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.visual_type,
+        &args.visual_type,
+        args.clear_visual_type,
+        "visual_type",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.complexity,
+        &args.complexity,
+        args.clear_complexity,
+        "complexity",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.vulnerability,
+        &args.vulnerability,
+        args.clear_vulnerability,
+        "vulnerability",
+        &mut changed,
+    );
+    apply_single(
+        &mut c.outcome_prediction,
+        &args.outcome_prediction,
+        args.clear_outcome_prediction,
+        "outcome_prediction",
+        &mut changed,
+    );
+
+    apply_multi(
         &mut c.audience,
         &args.audience,
         args.clear_audience,
         "audience",
         &mut changed,
     );
-
-    // Theme is multi-valued. --theme a,b REPLACES the list; --clear-theme
-    // empties it. They're mutually exclusive in spirit; if both are set
-    // we honor --clear-theme last (matches the spirit of an explicit
-    // clear).
-    if !args.theme.is_empty() && c.theme != args.theme {
-        c.theme = args.theme.clone();
-        changed.push("theme".into());
-    }
-    if args.clear_theme && !c.theme.is_empty() {
-        c.theme.clear();
-        if !changed.contains(&"theme".to_string()) {
-            changed.push("theme".into());
-        }
-    }
+    apply_multi(
+        &mut c.topic,
+        &args.topic,
+        args.clear_topic,
+        "topic",
+        &mut changed,
+    );
+    apply_multi(
+        &mut c.narrative_structure,
+        &args.narrative_structure,
+        args.clear_narrative_structure,
+        "narrative_structure",
+        &mut changed,
+    );
+    apply_multi(
+        &mut c.theme,
+        &args.theme,
+        args.clear_theme,
+        "theme",
+        &mut changed,
+    );
 
     changed
 }
@@ -149,6 +205,29 @@ fn apply_single(
             *field = Some(v.clone());
             changed.push(name.into());
         }
+    }
+}
+
+/// Mirror of `apply_single` for multi-valued dimensions. `--<dim>
+/// a,b` REPLACES the existing list; `--clear-<dim>` empties it.
+/// Clear wins over set (matches the spirit of an explicit clear).
+fn apply_multi(
+    field: &mut Vec<String>,
+    new_value: &[String],
+    clear: bool,
+    name: &str,
+    changed: &mut Vec<String>,
+) {
+    if clear {
+        if !field.is_empty() {
+            field.clear();
+            changed.push(name.into());
+        }
+        return;
+    }
+    if !new_value.is_empty() && field != new_value {
+        *field = new_value.to_vec();
+        changed.push(name.into());
     }
 }
 

--- a/apps/blogctl/src/commands/classify.rs
+++ b/apps/blogctl/src/commands/classify.rs
@@ -28,13 +28,11 @@ pub struct ClassifyArgs {
     pub hook: Option<String>,
     pub tone: Option<String>,
     pub audience: Option<String>,
-    pub strategic_role: Option<String>,
     pub theme: Vec<String>,
     pub clear_format: bool,
     pub clear_hook: bool,
     pub clear_tone: bool,
     pub clear_audience: bool,
-    pub clear_strategic_role: bool,
     pub clear_theme: bool,
     pub no_sync: bool,
 }
@@ -110,13 +108,6 @@ fn apply(c: &mut Classifications, args: &ClassifyArgs) -> Vec<String> {
         &args.audience,
         args.clear_audience,
         "audience",
-        &mut changed,
-    );
-    apply_single(
-        &mut c.strategic_role,
-        &args.strategic_role,
-        args.clear_strategic_role,
-        "strategic_role",
         &mut changed,
     );
 

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -94,6 +94,14 @@ pub enum Finding {
         value: String,
         allowed: Vec<String>,
     },
+    /// The post's `tags` list overruns the workdir's declared cap
+    /// (`[tags] max = N`). Workdirs without a cap declared never
+    /// trip this.
+    TagsExceedMax {
+        path: PathBuf,
+        count: usize,
+        max: u32,
+    },
 }
 
 impl fmt::Display for Finding {
@@ -182,6 +190,11 @@ impl fmt::Display for Finding {
                 "invalid classification in {}: {dimension}={value:?} is not in the taxonomy (allowed: {})",
                 path.display(),
                 allowed.join(", "),
+            ),
+            Self::TagsExceedMax { path, count, max } => write!(
+                f,
+                "too many tags in {}: {count} tags exceeds max {max}",
+                path.display(),
             ),
         }
     }
@@ -274,6 +287,18 @@ pub fn audit(workdir: &Workdir) -> Result<Vec<Finding>> {
                             value: v.value,
                             allowed: v.allowed,
                         });
+                    }
+                    // Tag cap. Workdirs that haven't declared
+                    // `[tags] max = N` skip silently — the field
+                    // stays `None` and there's nothing to enforce.
+                    if let Some(max) = cfg.tags.max {
+                        if meta.tags.len() > max as usize {
+                            findings.push(Finding::TagsExceedMax {
+                                path: path.clone(),
+                                count: meta.tags.len(),
+                                max,
+                            });
+                        }
                     }
                 }
                 slug_index.entry(meta.slug).or_default().push(path);
@@ -667,6 +692,69 @@ mod tests {
             invalid.len(),
             3,
             "expected one finding per bad value: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn audit_flags_tags_exceeding_max() {
+        // Declare `[tags] max = 2` and write a post with 3 tags —
+        // doctor surfaces one TagsExceedMax finding for that post.
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            "version = 1\n[themes.standard]\n[tags]\nmax = 2\n",
+        )
+        .unwrap();
+
+        let mut post = fixture_post("over-tagged", Stage::Concept);
+        post.metadata.tags = vec!["a".into(), "b".into(), "c".into()];
+        fs::write(
+            tmp.path().join("concepts/over-tagged.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        let tags_findings: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| matches!(f, Finding::TagsExceedMax { .. }))
+            .collect();
+        assert_eq!(
+            tags_findings.len(),
+            1,
+            "expected one TagsExceedMax finding: {findings:?}",
+        );
+        if let Finding::TagsExceedMax { count, max, .. } = tags_findings[0] {
+            assert_eq!(*count, 3);
+            assert_eq!(*max, 2);
+        }
+    }
+
+    #[test]
+    fn audit_silent_on_tags_when_no_max_declared() {
+        // No `[tags]` block in config → doctor is permissive even on
+        // posts with arbitrarily many tags.
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            "version = 1\n[themes.standard]\n",
+        )
+        .unwrap();
+
+        let mut post = fixture_post("loose-tagged", Stage::Concept);
+        post.metadata.tags = (0..50).map(|i| format!("tag-{i}")).collect();
+        fs::write(
+            tmp.path().join("concepts/loose-tagged.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        assert!(
+            !findings
+                .iter()
+                .any(|f| matches!(f, Finding::TagsExceedMax { .. })),
+            "expected no TagsExceedMax findings without `[tags] max`: {findings:?}",
         );
     }
 

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -62,6 +62,7 @@ pub enum SkipReason {
     ConfigUnparsable,
     UnpushedCommits,
     InvalidClassification,
+    TagsExceedMax,
     JjUnavailable,
 }
 
@@ -79,6 +80,9 @@ impl fmt::Display for SkipReason {
             }
             Self::InvalidClassification => {
                 "manual: `blogctl classify` to a valid value, or add it to the taxonomy"
+            }
+            Self::TagsExceedMax => {
+                "manual: prune the post's `tags` list or raise `[tags] max` in .blog-os.toml"
             }
             Self::JjUnavailable => {
                 "manual: install jj and run `jj git init --colocate` in the workdir"
@@ -147,6 +151,10 @@ pub fn plan(findings: Vec<Finding>) -> Vec<Repair> {
             f @ Finding::InvalidClassification { .. } => skips.push(Repair::Skip {
                 finding: f,
                 reason: SkipReason::InvalidClassification,
+            }),
+            f @ Finding::TagsExceedMax { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::TagsExceedMax,
             }),
             f @ (Finding::JjNotInstalled | Finding::NotAJjRepo { .. }) => {
                 skips.push(Repair::Skip {

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -592,7 +592,6 @@ body
         // Dimensions not set in YAML stay at their defaults.
         assert!(post.metadata.classifications.tone.is_none());
         assert!(post.metadata.classifications.audience.is_none());
-        assert!(post.metadata.classifications.strategic_role.is_none());
     }
 
     #[test]
@@ -658,7 +657,6 @@ body
             hook: Some("contradiction".into()),
             tone: Some("sharp".into()),
             audience: Some("engineering".into()),
-            strategic_role: Some("career-brand".into()),
             theme: vec!["ambiguity".into(), "delivery".into()],
         };
         let original = Post::new(metadata, "Body.\n");

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -591,7 +591,7 @@ body
         assert_eq!(post.metadata.classifications.theme.len(), 2);
         // Dimensions not set in YAML stay at their defaults.
         assert!(post.metadata.classifications.tone.is_none());
-        assert!(post.metadata.classifications.audience.is_none());
+        assert!(post.metadata.classifications.audience.is_empty());
     }
 
     #[test]
@@ -656,8 +656,9 @@ body
             format: Some("thesis".into()),
             hook: Some("contradiction".into()),
             tone: Some("sharp".into()),
-            audience: Some("engineering".into()),
+            audience: vec!["engineering".into()],
             theme: vec!["ambiguity".into(), "delivery".into()],
+            ..Default::default()
         };
         let original = Post::new(metadata, "Body.\n");
         let rendered = original.render().unwrap();

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -53,6 +53,12 @@ pub struct Config {
     /// see `Config::stage_config`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub kinds: BTreeMap<String, KindConfig>,
+    /// Constraints on the free-form `tags: Vec<String>` field on each
+    /// post. Currently a single `max` cap, surfaced by doctor as a
+    /// `TagsExceedMax` finding when a post overruns it. Unset =
+    /// unlimited; workdirs opt in by declaring `[tags] max = N`.
+    #[serde(default, skip_serializing_if = "TagsConfig::is_default")]
+    pub tags: TagsConfig,
 }
 
 /// Workdir-wide defaults. The theme `blogctl new` selects when `--theme`
@@ -89,6 +95,25 @@ fn default_theme_name() -> String {
 pub struct ThemeConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub prompts: BTreeMap<String, String>,
+}
+
+/// Settings for the per-post `tags` field. Today: a single `max` cap
+/// (free-form tags only; classification dimensions are constrained by
+/// `[classifications.*]`). `max = None` means unlimited — workdirs
+/// opt in to the cap by writing `[tags] max = N` in `.blog-os.toml`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct TagsConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max: Option<u32>,
+}
+
+impl TagsConfig {
+    /// True when no fields are set — used by `skip_serializing_if`
+    /// to keep `[tags]` out of `.blog-os.toml` for workdirs that
+    /// haven't opted in.
+    fn is_default(&self) -> bool {
+        self.max.is_none()
+    }
 }
 
 /// Per-kind stage configuration. Keyed by `Stage::as_str()` so the TOML
@@ -167,6 +192,7 @@ impl Config {
             sync: SyncConfig::default(),
             classifications: Taxonomy::current_v1().to_btreemap(),
             kinds: BTreeMap::new(),
+            tags: TagsConfig::default(),
         }
     }
 

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -5,9 +5,9 @@
 //!
 //! The taxonomy is data, not code — adding a new format or theme
 //! is a config edit, not a Rust change. The struct's *dimension
-//! names* (`format`, `hook`, `tone`, `audience`, `strategic_role`,
-//! `theme`) come from `Classifications`'s field names and are
-//! fixed; the *values* inside each dimension are user-configurable.
+//! names* (`format`, `hook`, `tone`, `audience`, `theme`) come from
+//! `Classifications`'s field names and are fixed; the *values*
+//! inside each dimension are user-configurable.
 
 use std::collections::BTreeMap;
 
@@ -98,7 +98,7 @@ pub struct Violation {
 /// The dimension names `Classifications` knows about. Kept in code
 /// because the struct's field set is fixed; only the *values* inside
 /// each dimension are config-driven.
-pub const SINGLE_VALUED: &[&str] = &["format", "hook", "tone", "audience", "strategic_role"];
+pub const SINGLE_VALUED: &[&str] = &["format", "hook", "tone", "audience"];
 pub const MULTI_VALUED: &[&str] = &["theme"];
 
 fn starter_v1() -> BTreeMap<String, Dimension> {
@@ -148,19 +148,6 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
                 "leadership",
                 "founders",
                 "general",
-            ]),
-        },
-    );
-    m.insert(
-        "strategic_role".into(),
-        Dimension {
-            multi: false,
-            values: strs(&[
-                "salal-positioning",
-                "career-brand",
-                "recruiting",
-                "writing-practice",
-                "consulting-signal",
             ]),
         },
     );

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -98,8 +98,17 @@ pub struct Violation {
 /// The dimension names `Classifications` knows about. Kept in code
 /// because the struct's field set is fixed; only the *values* inside
 /// each dimension are config-driven.
-pub const SINGLE_VALUED: &[&str] = &["format", "hook", "tone", "audience"];
-pub const MULTI_VALUED: &[&str] = &["theme"];
+pub const SINGLE_VALUED: &[&str] = &[
+    "format",
+    "hook",
+    "tone",
+    "call_to_action",
+    "visual_type",
+    "complexity",
+    "vulnerability",
+    "outcome_prediction",
+];
+pub const MULTI_VALUED: &[&str] = &["audience", "topic", "narrative_structure", "theme"];
 
 fn starter_v1() -> BTreeMap<String, Dimension> {
     let mut m = BTreeMap::new();
@@ -141,7 +150,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
     m.insert(
         "audience".into(),
         Dimension {
-            multi: false,
+            multi: true,
             values: strs(&[
                 "engineering",
                 "product",
@@ -149,6 +158,67 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
                 "founders",
                 "general",
             ]),
+        },
+    );
+    m.insert(
+        "topic".into(),
+        Dimension {
+            multi: true,
+            values: strs(&[
+                "engineering",
+                "leadership",
+                "product",
+                "career",
+                "general",
+            ]),
+        },
+    );
+    m.insert(
+        "narrative_structure".into(),
+        Dimension {
+            multi: true,
+            values: strs(&[
+                "direct-statement",
+                "personal-anecdote",
+                "metaphor",
+                "analogy",
+                "contrast",
+            ]),
+        },
+    );
+    m.insert(
+        "call_to_action".into(),
+        Dimension {
+            multi: false,
+            values: strs(&["none", "reflection", "discussion"]),
+        },
+    );
+    m.insert(
+        "visual_type".into(),
+        Dimension {
+            multi: false,
+            values: strs(&["text-only", "diagram", "illustration", "screenshot"]),
+        },
+    );
+    m.insert(
+        "complexity".into(),
+        Dimension {
+            multi: false,
+            values: strs(&["simple", "moderate", "dense"]),
+        },
+    );
+    m.insert(
+        "vulnerability".into(),
+        Dimension {
+            multi: false,
+            values: strs(&["none", "low", "medium", "high"]),
+        },
+    );
+    m.insert(
+        "outcome_prediction".into(),
+        Dimension {
+            multi: false,
+            values: strs(&["low", "medium", "high"]),
         },
     );
     m.insert(
@@ -164,6 +234,13 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
                 "engineering-culture",
                 "product",
                 "organizational-psychology",
+                // Cross-disciplinary values that show up in the
+                // blogs-and-posts taxonomy too — kept short, full
+                // vocabulary lives in `.blog-os.toml`.
+                "adaptation",
+                "tradeoffs",
+                "learning",
+                "community",
             ]),
         },
     );

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -164,13 +164,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "topic".into(),
         Dimension {
             multi: true,
-            values: strs(&[
-                "engineering",
-                "leadership",
-                "product",
-                "career",
-                "general",
-            ]),
+            values: strs(&["engineering", "leadership", "product", "career", "general"]),
         },
     );
     m.insert(

--- a/apps/blogctl/tests/backfill.rs
+++ b/apps/blogctl/tests/backfill.rs
@@ -344,9 +344,8 @@ fn interactive_writes_classification_picked_by_number() {
     //   hook:   skip
     //   tone:   skip
     //   audience: skip
-    //   strategic_role: skip
     //   metrics for linkedin: skip-post (S)
-    let input_bytes = b"2\n\n\n\n\nS\n";
+    let input_bytes = b"2\n\n\n\nS\n";
     let mut input = std::io::Cursor::new(&input_bytes[..]);
     let mut output: Vec<u8> = Vec::new();
     commands::backfill::run_interactive(

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
@@ -11,7 +11,8 @@ classifications:
   format: thesis
   hook: contradiction
   tone: sharp
-  audience: engineering
+  audience:
+    - engineering
   theme:
     - ambiguity
     - delivery

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
@@ -12,7 +12,6 @@ classifications:
   hook: contradiction
   tone: sharp
   audience: engineering
-  strategic_role: career-brand
   theme:
     - ambiguity
     - delivery


### PR DESCRIPTION
Three commits:

1. **`refactor(blogctl): remove strategic_role classification dimension`** — drops the author-intent dimension that the 12-axis taxonomy designed for `kolohelios/blogs-and-posts#78` doesn't use. No migration needed; no post in any known workdir sets it.
2. **`feat(blogctl): expand classification schema for richer taxonomy`** — adds seven new dimensions (`topic`, `narrative_structure`, `call_to_action`, `visual_type`, `complexity`, `vulnerability`, `outcome_prediction`) plus promotes `audience` to multi-valued (`Vec<String>` with a string-or-list deserializer so single-string frontmatter still parses). CLI flags + `--clear-*` companions for every dimension. Doctor, analytics, backfill, and the starter taxonomy all extended; tests + README updated.
3. **`feat(blogctl): enforce tags max via doctor`** — adds `[tags] max = N` to workdir config and a `Finding::TagsExceedMax` doctor variant. `max` unset = unlimited (opt-in); fix surfaces as a manual-action skip.

Unblocks `kolohelios/blogs-and-posts#78` (12-dimension taxonomy declaration + Beaver/Fox backfill, with `[tags] max = 10`).

Pairs with `#627` (`theme` → `motifs` rename) and `#602` (per-stage `required_by` completeness) as separate follow-ups.

Closes #630