### PR TITLE
feat(todoist): projects list [--json] subcommand

### DIFF
--- a/tools/todoist/README.md
+++ b/tools/todoist/README.md
@@ -52,6 +52,17 @@ through `4` (highest) — out-of-range values are rejected before the
 request reaches the server. Repeating `--label` attaches multiple
 labels at once.
 
+## Listing projects
+
+```
+todoist projects list [--json]
+```
+
+Prints the project list as a column table (`name`, `id`, `parent_id`,
+where `parent_id` is blank for top-level projects). `--json` emits one
+project object per line — the shape `aof reconcile` consumes to detect
+drift against the areas-of-focus tree.
+
 ## Completing tasks
 
 ```

--- a/tools/todoist/src/api.rs
+++ b/tools/todoist/src/api.rs
@@ -29,6 +29,8 @@ impl std::error::Error for ApiError {}
 pub struct Project {
     pub id: String,
     pub name: String,
+    #[serde(default)]
+    pub parent_id: Option<String>,
 }
 
 // Todoist v1 list endpoints wrap results in a paginated envelope.
@@ -218,6 +220,21 @@ mod tests {
         let page: Paginated<Project> = serde_json::from_str(raw).unwrap();
         assert_eq!(page.results.len(), 1);
         assert_eq!(page.results[0].name, "Inbox");
+        assert_eq!(page.results[0].parent_id, None);
+    }
+
+    #[test]
+    fn project_round_trips_parent_id() {
+        // `projects list` and `aof reconcile` rely on parent_id to render and
+        // walk the hierarchy. Missing parent_id (top-level project) must
+        // deserialize as None, present parent_id must round-trip its value.
+        let raw = r#"{"results":[
+            {"id":"1","name":"Top","parent_id":null},
+            {"id":"2","name":"Child","parent_id":"1"}
+        ],"next_cursor":null}"#;
+        let page: Paginated<Project> = serde_json::from_str(raw).unwrap();
+        assert_eq!(page.results[0].parent_id, None);
+        assert_eq!(page.results[1].parent_id.as_deref(), Some("1"));
     }
 
     #[test]

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Args, Parser, Subcommand};
 
 mod api;
 mod auth;
+mod projects;
 mod tasks;
 
 use auth::OpRunner;
@@ -18,6 +19,8 @@ struct Cli {
 enum Command {
     /// Manage Todoist API credentials
     Auth(AuthCmd),
+    /// Inspect Todoist projects
+    Projects(ProjectsCmd),
     /// Manage tasks
     Tasks(TasksCmd),
 }
@@ -40,6 +43,22 @@ enum AuthSubcommand {
     Status,
     /// Forget the stored token reference
     Logout,
+}
+
+#[derive(Args)]
+struct ProjectsCmd {
+    #[command(subcommand)]
+    command: ProjectsSubcommand,
+}
+
+#[derive(Subcommand)]
+enum ProjectsSubcommand {
+    /// List all projects
+    List {
+        /// Emit raw project objects as ndjson
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Args)]
@@ -100,7 +119,24 @@ fn main() -> Result<()> {
 fn dispatch(command: Command) -> Result<()> {
     match command {
         Command::Auth(AuthCmd { command }) => handle_auth(command),
+        Command::Projects(ProjectsCmd { command }) => handle_projects(command),
         Command::Tasks(TasksCmd { command }) => handle_tasks(command),
+    }
+}
+
+fn handle_projects(cmd: ProjectsSubcommand) -> Result<()> {
+    match cmd {
+        ProjectsSubcommand::List { json } => {
+            let token = resolve_token()?;
+            let client = api::RealClient::default();
+            let projects = projects::run_list(&client, &token)?;
+            if json {
+                println!("{}", projects::render_ndjson(&projects));
+            } else {
+                println!("{}", projects::render_table(&projects));
+            }
+            Ok(())
+        }
     }
 }
 
@@ -332,6 +368,29 @@ mod tests {
         });
         assert!(out.contains("op://x"));
         assert!(out.contains("vault locked"));
+    }
+
+    #[test]
+    fn parses_projects_list_default() {
+        let cli = Cli::try_parse_from(["todoist", "projects", "list"]).expect("should parse");
+        match cli.command {
+            Command::Projects(ProjectsCmd {
+                command: ProjectsSubcommand::List { json },
+            }) => assert!(!json),
+            _ => panic!("expected Projects::List"),
+        }
+    }
+
+    #[test]
+    fn parses_projects_list_with_json_flag() {
+        let cli =
+            Cli::try_parse_from(["todoist", "projects", "list", "--json"]).expect("should parse");
+        match cli.command {
+            Command::Projects(ProjectsCmd {
+                command: ProjectsSubcommand::List { json },
+            }) => assert!(json),
+            _ => panic!("expected Projects::List"),
+        }
     }
 
     #[test]

--- a/tools/todoist/src/projects.rs
+++ b/tools/todoist/src/projects.rs
@@ -1,0 +1,182 @@
+use anyhow::{anyhow, Result};
+
+use crate::api::{Project, TodoistClient};
+
+pub fn run_list(client: &impl TodoistClient, token: &str) -> Result<Vec<Project>> {
+    client.list_projects(token).map_err(|e| anyhow!(e))
+}
+
+pub fn render_ndjson(projects: &[Project]) -> String {
+    projects
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "id": p.id,
+                "name": p.name,
+                "parent_id": p.parent_id,
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn render_table(projects: &[Project]) -> String {
+    if projects.is_empty() {
+        return "no projects".to_string();
+    }
+    let rows: Vec<[String; 3]> = projects
+        .iter()
+        .map(|p| {
+            [
+                p.name.clone(),
+                p.id.clone(),
+                p.parent_id.clone().unwrap_or_default(),
+            ]
+        })
+        .collect();
+
+    let headers = ["name", "id", "parent_id"];
+    let mut widths = headers.map(str::len);
+    for row in &rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.chars().count());
+        }
+    }
+
+    let format_row = |cells: &[String; 3]| -> String {
+        cells
+            .iter()
+            .enumerate()
+            .map(|(i, c)| format!("{:width$}", c, width = widths[i]))
+            .collect::<Vec<_>>()
+            .join("  ")
+    };
+
+    let header_row = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| format!("{:width$}", h, width = widths[i]))
+        .collect::<Vec<_>>()
+        .join("  ");
+
+    let mut lines = vec![header_row];
+    lines.extend(rows.iter().map(format_row));
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{ApiError, CreateTaskBody, Project, TaskListQuery, TodoistClient};
+
+    struct FakeClient {
+        projects: Vec<Project>,
+    }
+
+    impl TodoistClient for FakeClient {
+        fn list_tasks(
+            &self,
+            _token: &str,
+            _query: &TaskListQuery,
+        ) -> Result<Vec<serde_json::Value>, ApiError> {
+            Ok(vec![])
+        }
+
+        fn list_projects(&self, _token: &str) -> Result<Vec<Project>, ApiError> {
+            Ok(self.projects.clone())
+        }
+
+        fn create_task(
+            &self,
+            _token: &str,
+            _body: &CreateTaskBody,
+        ) -> Result<serde_json::Value, ApiError> {
+            unimplemented!()
+        }
+
+        fn close_task(&self, _token: &str, _id: &str) -> Result<(), ApiError> {
+            unimplemented!()
+        }
+    }
+
+    fn project(id: &str, name: &str, parent_id: Option<&str>) -> Project {
+        Project {
+            id: id.to_string(),
+            name: name.to_string(),
+            parent_id: parent_id.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn run_list_returns_projects_from_client() {
+        let client = FakeClient {
+            projects: vec![
+                project("1", "Inbox", None),
+                project("2", "Errands", Some("1")),
+            ],
+        };
+        let out = run_list(&client, "tok").unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1].parent_id.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn render_table_reports_empty_set() {
+        assert_eq!(render_table(&[]), "no projects");
+    }
+
+    #[test]
+    fn render_table_shows_name_id_and_parent_id() {
+        let projects = vec![
+            project("1", "Inbox", None),
+            project("22", "Errands", Some("1")),
+        ];
+        let out = render_table(&projects);
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(lines[0].contains("name"));
+        assert!(lines[0].contains("id"));
+        assert!(lines[0].contains("parent_id"));
+        assert!(out.contains("Inbox"));
+        assert!(out.contains("Errands"));
+        assert!(out.contains("22"));
+    }
+
+    #[test]
+    fn render_table_leaves_parent_id_blank_for_top_level() {
+        let projects = vec![project("1", "Top", None)];
+        let out = render_table(&projects);
+        let data_row = out.lines().nth(1).unwrap();
+        // No trailing token after the id column means parent_id rendered empty.
+        assert!(data_row.trim_end().ends_with('1'));
+    }
+
+    #[test]
+    fn render_ndjson_emits_one_object_per_line() {
+        let projects = vec![
+            project("1", "Inbox", None),
+            project("2", "Errands", Some("1")),
+        ];
+        let out = render_ndjson(&projects);
+        assert_eq!(out.lines().count(), 2);
+        assert!(out.contains("\"name\":\"Inbox\""));
+        assert!(out.contains("\"name\":\"Errands\""));
+        assert!(out.contains("\"parent_id\":\"1\""));
+        assert!(out.contains("\"parent_id\":null"));
+    }
+
+    #[test]
+    fn render_ndjson_each_line_parses_as_json() {
+        let projects = vec![
+            project("1", "Inbox", None),
+            project("2", "Errands", Some("1")),
+        ];
+        let out = render_ndjson(&projects);
+        for line in out.lines() {
+            let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert!(v.get("id").is_some());
+            assert!(v.get("name").is_some());
+            assert!(v.get("parent_id").is_some());
+        }
+    }
+}

--- a/tools/todoist/src/tasks.rs
+++ b/tools/todoist/src/tasks.rs
@@ -362,6 +362,7 @@ mod tests {
         Project {
             id: id.to_string(),
             name: name.to_string(),
+            parent_id: None,
         }
     }
 


### PR DESCRIPTION
aof reconcile (#610) needs the current Todoist project list to detect
drift against the areas-of-focus tree. Until now projects were only
fetched as a side effect of tasks list, so any consumer had to embed
todoist internals to get at them.

Add todoist projects list as a standalone read-only command. The default
table renders name, id, and parent_id (blank for top-level projects);
--json emits one project object per line so jq and aof can consume the
output directly. Project gains a parent_id: Option<String> on the
deserialize side, with #[serde(default)] so a missing field stays None.

Closes #637