### PR TITLE
feat(claude): /audit-workflow drops read-before-edit pattern

### DIFF
--- a/.claude/commands/audit-workflow.md
+++ b/.claude/commands/audit-workflow.md
@@ -73,6 +73,16 @@ taxonomy and evidence rules are load-bearing):
 >   `"is_error":true`, error keywords, and the user's correction
 >   phrases above, then read the surrounding turns.
 >
+> **Proven-unfixable patterns to skip** (don't surface as findings,
+> even when the evidence triples exist):
+>
+> - `"File has not been read yet"` errors before `Edit`/`Write`. The
+>   harness's read-check runs upstream of `PreToolUse` hooks, so no
+>   hook-shaped fix is possible; `additionalContext` doesn't
+>   substitute for an actual `Read` invocation either. Ref #626 for
+>   the full spike. Revisit if the hook API gains a
+>   `pre-tool-validate` event or hook ordering changes.
+>
 > **Output format** — one row per pattern with these fields:
 >
 > - Pattern: one-sentence description


### PR DESCRIPTION
Adds an explicit "proven-unfixable patterns to skip" block to the
agent prompt in .claude/commands/audit-workflow.md, with the
`"File has not been read yet"` error class as its first entry.

The first real /audit-workflow run (after #618 shipped) flagged
Edit-without-Read churn as a high-priority finding — 60+ wasted-turn
cycles across 10 sessions. We filed it as #626, spiked a PreToolUse
hook in tools/claude-hooks, and a two-session diagnostic proved the
fix shape is structurally impossible:

- The harness's "must Read first" check runs upstream of PreToolUse,
  so the hook never sees the failure case it was designed to catch.
- Even when the hook does fire (on a previously-Read file), the
  additionalContext field doesn't substitute for an actual Read
  tool invocation — Claude retries verbatim and loops.

Without this exclusion, every future /audit-workflow run would
re-surface the same finding and the user would have to re-decide it
each time. The exclusion is phrased so a future hook-API change
(new pre-tool-validate event, ordering change) would naturally
invite revisiting.

Closes #636