### PR TITLE
feat(aof): SVG → terminal renderer via Kitty graphics protocol

### DIFF
--- a/tools/aof/Cargo.lock
+++ b/tools/aof/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,8 +62,66 @@ dependencies = [
 name = "aof"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "clap",
+ "image",
+ "resvg",
+ "snafu",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -100,10 +164,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
 
 [[package]]
 name = "heck"
@@ -112,16 +273,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "log"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -133,6 +422,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,10 +443,136 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -159,16 +586,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "windows-link"
@@ -183,4 +735,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core",
 ]

--- a/tools/aof/Cargo.toml
+++ b/tools/aof/Cargo.toml
@@ -5,12 +5,20 @@ name    = "aof"
 publish = false
 version = "0.1.0"
 
+[lib]
+name = "aof"
+path = "src/lib.rs"
+
 [[bin]]
 name = "aof"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+base64 = "0.22"
+clap   = { version = "4", features = ["derive"] }
+image  = { version = "0.25", default-features = false, features = ["png"] }
+resvg  = "0.45"
+snafu  = "0.9"
 
 [lints.clippy]
 mod_module_files = "deny"

--- a/tools/aof/README.md
+++ b/tools/aof/README.md
@@ -5,8 +5,9 @@ Areas of focus — a typed tree of life domains, reconciled against
 
 The tree is defined in CUE under `data/`, so a malformed structure
 fails locally and in CI. `aof render` produces an SVG via the `d2`
-binary, converts it to a bitmap in-process with `resvg`, and displays
-it using the terminal's inline image protocol (Kitty / iTerm2).
+binary, converts it to a bitmap in-process with `resvg`, and emits
+it using the Kitty graphics protocol (`Ghostty` / `Kitty` /
+`WezTerm`).
 
 `Todoist` reconciliation reports drift in both directions: projects
 with no matching area, and areas with no `Todoist` project. The match
@@ -16,7 +17,9 @@ is read-only — `aof` never mutates `Todoist` state.
 
 - `aof validate` — vet the areas tree against the schema.
 - `aof sync` — reconcile against `Todoist` and print a drift report.
-- `aof render` — emit an inline diagram of the tree.
+- `aof render --from <path>` — display an SVG inline via the Kitty
+  graphics protocol. Tree-to-SVG generation lands in #608; today this
+  takes a pre-rendered SVG path.
 
-This crate is currently a skeleton — each subcommand is stubbed.
-Real behavior lands across follow-up issues (#605–#610).
+`validate` and `sync` are still stubbed; real behavior lands across
+the remaining `aof` issues.

--- a/tools/aof/deny.toml
+++ b/tools/aof/deny.toml
@@ -6,11 +6,13 @@ version      = 2
 allow = [
   "MIT",
   "Apache-2.0",
+  "BSD-2-Clause",
   "BSD-3-Clause",
   "CDLA-Permissive-2.0",
   "ISC",
   "Unicode-3.0",
   "Unicode-DFS-2016",
+  "Zlib",
 ]
 private = { ignore = true }
 version = 2

--- a/tools/aof/src/lib.rs
+++ b/tools/aof/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod render;

--- a/tools/aof/src/main.rs
+++ b/tools/aof/src/main.rs
@@ -1,3 +1,7 @@
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use aof::render;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -17,22 +21,43 @@ enum Command {
     Validate,
     /// Reconcile areas against Todoist projects and report drift
     Sync,
-    /// Render the areas tree as an inline terminal diagram
-    Render,
+    /// Render an SVG diagram inline in the current terminal
+    Render {
+        /// Path to the SVG file to render
+        #[arg(long)]
+        from: PathBuf,
+    },
 }
 
-fn main() {
+fn main() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
-        Command::Validate => unimplemented("validate"),
-        Command::Sync => unimplemented("sync"),
-        Command::Render => unimplemented("render"),
+        Command::Validate => {
+            unimplemented("validate");
+            ExitCode::FAILURE
+        }
+        Command::Sync => {
+            unimplemented("sync");
+            ExitCode::FAILURE
+        }
+        Command::Render { from } => match run_render(&from) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("aof render: {e}");
+                ExitCode::FAILURE
+            }
+        },
     }
+}
+
+fn run_render(from: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let svg = std::fs::read(from)?;
+    render::render_svg(&svg)?;
+    Ok(())
 }
 
 fn unimplemented(name: &str) {
     eprintln!("aof {name}: not yet implemented");
-    std::process::exit(1);
 }
 
 #[cfg(test)]

--- a/tools/aof/src/render.rs
+++ b/tools/aof/src/render.rs
@@ -1,0 +1,122 @@
+use std::io::{self, Write};
+
+use base64::Engine;
+use image::ImageFormat;
+use resvg::tiny_skia;
+use resvg::usvg;
+use snafu::{ResultExt, Snafu};
+
+/// Maximum payload bytes per Kitty graphics protocol chunk. The protocol
+/// specifies that escape sequences carrying image data may not exceed
+/// 4096 bytes of base64 payload per chunk; longer images are split into
+/// multiple chunks with `m=1` on all but the last.
+const KITTY_CHUNK_BYTES: usize = 4096;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum RenderError {
+    #[snafu(display("failed to parse SVG: {source}"))]
+    SvgParse { source: usvg::Error },
+
+    #[snafu(display("pixmap allocation failed for {width}x{height}"))]
+    PixmapAlloc { width: u32, height: u32 },
+
+    #[snafu(display("failed to encode rasterized image as PNG: {source}"))]
+    PngEncode { source: image::ImageError },
+
+    #[snafu(display("failed to write Kitty graphics protocol to stdout: {source}"))]
+    Display { source: io::Error },
+}
+
+/// Rasterize an SVG byte slice to an in-memory `DynamicImage` at the
+/// SVG's natural pixel size. Split from `render_svg` so tests can
+/// verify the rasterization pipeline without needing a real TTY.
+pub fn rasterize(svg: &[u8]) -> Result<image::DynamicImage, RenderError> {
+    let tree = usvg::Tree::from_data(svg, &usvg::Options::default()).context(SvgParseSnafu)?;
+    let size = tree.size().to_int_size();
+    let (width, height) = (size.width(), size.height());
+
+    let mut pixmap = tiny_skia::Pixmap::new(width, height)
+        .ok_or_else(|| PixmapAllocSnafu { width, height }.build())?;
+    resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
+
+    let rgba = image::RgbaImage::from_raw(width, height, pixmap.data().to_vec())
+        .expect("pixmap buffer always matches width*height*4");
+    Ok(image::DynamicImage::ImageRgba8(rgba))
+}
+
+/// Rasterize and display the SVG inline in the current terminal using
+/// the Kitty graphics protocol (supported natively by Ghostty, Kitty,
+/// and WezTerm).
+pub fn render_svg(svg: &[u8]) -> Result<(), RenderError> {
+    let img = rasterize(svg)?;
+    let png = encode_png(&img)?;
+    write_kitty_image(&mut io::stdout(), &png).context(DisplaySnafu)
+}
+
+fn encode_png(img: &image::DynamicImage) -> Result<Vec<u8>, RenderError> {
+    let mut buf = Vec::new();
+    img.write_to(&mut io::Cursor::new(&mut buf), ImageFormat::Png)
+        .context(PngEncodeSnafu)?;
+    Ok(buf)
+}
+
+/// Emit a complete Kitty graphics protocol "transmit and display" command
+/// for `png_bytes`. The first chunk carries the format / action keys; all
+/// subsequent chunks carry only `m=` (1 for more, 0 for final).
+fn write_kitty_image(out: &mut impl Write, png_bytes: &[u8]) -> io::Result<()> {
+    let payload = base64::engine::general_purpose::STANDARD.encode(png_bytes);
+    let chunks: Vec<&str> = payload
+        .as_bytes()
+        .chunks(KITTY_CHUNK_BYTES)
+        .map(|c| std::str::from_utf8(c).expect("base64 output is ascii"))
+        .collect();
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let is_first = i == 0;
+        let is_last = i == chunks.len() - 1;
+        out.write_all(b"\x1b_G")?;
+        if is_first {
+            // f=100: payload is PNG. a=T: transmit and display.
+            out.write_all(b"f=100,a=T,")?;
+        }
+        write!(out, "m={}", if is_last { 0 } else { 1 })?;
+        out.write_all(b";")?;
+        out.write_all(chunk.as_bytes())?;
+        out.write_all(b"\x1b\\")?;
+    }
+    // Trailing newline so the cursor lands below the image rather than
+    // overwriting its bottom row with the next prompt.
+    out.write_all(b"\n")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_kitty_image_emits_a_single_chunk_for_small_payloads() {
+        let mut out = Vec::new();
+        write_kitty_image(&mut out, b"tiny").unwrap();
+        let s = std::str::from_utf8(&out).unwrap();
+        // Exactly one ESC_G ... ESC\ envelope.
+        assert_eq!(s.matches("\x1b_G").count(), 1);
+        assert_eq!(s.matches("\x1b\\").count(), 1);
+        // First (and only) chunk carries the f= and a= keys and m=0.
+        assert!(s.contains("f=100,a=T,m=0;"));
+    }
+
+    #[test]
+    fn write_kitty_image_chunks_large_payloads() {
+        // A payload that base64-encodes to slightly more than one chunk.
+        let raw = vec![0u8; (KITTY_CHUNK_BYTES * 3 / 4) + 1];
+        let mut out = Vec::new();
+        write_kitty_image(&mut out, &raw).unwrap();
+        let s = std::str::from_utf8(&out).unwrap();
+        // Two chunks: header chunk has m=1, final chunk has m=0.
+        assert_eq!(s.matches("\x1b_G").count(), 2);
+        assert!(s.contains("f=100,a=T,m=1;"));
+        assert!(s.contains("\x1b_Gm=0;"));
+    }
+}

--- a/tools/aof/tests/fixtures/render/sample.svg
+++ b/tools/aof/tests/fixtures/render/sample.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60">
+  <rect x="0" y="0" width="120" height="60" fill="#f0f0f0"/>
+  <circle cx="30" cy="30" r="20" fill="#3399ff"/>
+  <text x="60" y="35" font-family="sans-serif" font-size="16" fill="#222">aof</text>
+</svg>

--- a/tools/aof/tests/render.rs
+++ b/tools/aof/tests/render.rs
@@ -1,0 +1,26 @@
+use aof::render;
+
+const SAMPLE_SVG: &str = "tests/fixtures/render/sample.svg";
+
+#[test]
+fn rasterize_sample_produces_non_empty_image() {
+    let bytes = std::fs::read(SAMPLE_SVG).expect("fixture must exist");
+    let img = render::rasterize(&bytes).expect("rasterize must succeed");
+
+    let (w, h) = (img.width(), img.height());
+    assert_eq!(w, 120, "fixture width comes from the SVG viewBox");
+    assert_eq!(h, 60, "fixture height comes from the SVG viewBox");
+
+    // Verify the rasterizer actually drew something: the blue circle in
+    // the fixture should contribute at least one fully-opaque pixel.
+    let rgba = img.to_rgba8();
+    let has_opaque = rgba.pixels().any(|p| p.0[3] == 255);
+    assert!(has_opaque, "rasterized image should have opaque pixels");
+}
+
+#[test]
+fn rasterize_invalid_svg_returns_error() {
+    let bytes = b"not an svg";
+    let result = render::rasterize(bytes);
+    assert!(result.is_err(), "garbage input must fail SVG parse");
+}


### PR DESCRIPTION
Adds the SVG-to-inline-terminal-image pipeline:

- `aof::render::rasterize(svg) -> DynamicImage` — resvg/usvg → tiny_skia
  Pixmap → image::DynamicImage at the SVG's natural pixel size.
- `aof::render::render_svg(svg) -> Result<(), RenderError>` — encodes
  the rasterized image as PNG and emits it via a hand-rolled Kitty
  graphics protocol writer (chunked, ≤4096 bytes of base64 per
  `_G…\x1b\\` envelope).
- `aof render --from <path>` subcommand exercises the full pipeline.

Implemented the Kitty protocol writer directly rather than pulling
`viuer` or `kitty_image`. `viuer` is multi-protocol (Kitty / iTerm2
/ Sixel / ANSI) but transitively pulls `ansi_colours`, which is
LGPL-3.0; `kitty_image` is itself LGPL-3.0. The protocol is ~30
lines, the project is single-protocol by design (Kitty only —
Ghostty on macOS / Linux is the target), and rolling our own
removes the LGPL allow-list question entirely.

Test split: `tests/render.rs` integration-tests the rasterizer
end-to-end against a fixture SVG (no TTY needed); two unit tests in
`render.rs` cover single-chunk and multi-chunk Kitty payload framing.
The actual stdout emission to a real terminal is verified manually —
not worth a fake-TTY harness for one library call.

Also adds `BSD-2-Clause` and `Zlib` to aof's `deny.toml` allow-list.
Both are standard permissive licenses pulled by `arrayref` and
`slotmap` respectively (transitive through `resvg`/`image`); the
scaffold baseline omitted them.

Closes #607