### PR TITLE
refactor(infra/home): drop nix-managed claude-code; carve out to brew

### DIFF
--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -17,8 +17,13 @@
     pkgs.bat
     pkgs.eza
     pkgs.zellij
-    pkgs.claude-code
-    # Portable Claude Code harness hooks. The duplicate-issue-create
+    # `claude-code` is intentionally NOT here. `nixpkgs/release-25.11`
+    # lags upstream by days to weeks for fast-moving tools like this.
+    # Install via `brew install --cask claude-code` on macOS; Linux
+    # install path tracked in #653. Don't reflexively add
+    # `pkgs.claude-code` back — see #652. `claude-hooks`, by contrast,
+    # IS nix-managed: we publish it ourselves to FlakeHub and it
+    # doesn't ship multiple versions per week. The duplicate-issue-create
     # gate (#515) calls `claude-hooks pre-issue-create` from
     # `~/.claude/settings.json` (wired in #534); having it on PATH
     # globally lets the hook fire in any working directory, not just


### PR DESCRIPTION
Claude Code ships frequent (often weekly) releases. nixpkgs/release-25.11
lags upstream by days to weeks, leaving the nix-installed claude on an
older version (2.1.81 / Opus 4.6 default while upstream was on 2.1.112 /
Opus 4.7 at carve-out time). On top of that, `claude update` can't
succeed on a nix install — it tries to self-modify via npm and prints
a misleading "Failed to fetch" error.

Carving claude-code out of the nix-managed tool set is the right shape.
The declarative-everywhere principle stays intact for foundational
tools (zsh, helix, jj, direnv, ripgrep, etc.) and for genuinely
nix-co-managed pieces like `claude-hooks` (small, we publish it
ourselves, doesn't ship weekly). Fast-moving upstream tools where
staying current matters more than the declarative purity get carved
out per-tool.

Repo change is one line: remove `pkgs.claude-code` from `common.nix`'s
`home.packages`. Inline comment at the site documents the rationale so
a future edit doesn't reflexively add it back. `claude-hooks` stays.

User-side install:

- macOS: `brew install --cask claude-code`; updates via `brew upgrade`.
- Linux devbox: TBD — tracked in #653.

Closes #652