### PR TITLE
feat(infra/home): declare brew casks via nix-darwin homebrew module

### DIFF
--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -19,9 +19,10 @@
     pkgs.zellij
     # `claude-code` is intentionally NOT here. `nixpkgs/release-25.11`
     # lags upstream by days to weeks for fast-moving tools like this.
-    # Install via `brew install --cask claude-code` on macOS; Linux
-    # install path tracked in #653. Don't reflexively add
-    # `pkgs.claude-code` back — see #652. `claude-hooks`, by contrast,
+    # On macOS it's declared via nix-darwin's `homebrew.casks` in
+    # `modules/darwin.nix` (#657) and installed by brew. Linux install
+    # path is tracked in #653. Don't reflexively add `pkgs.claude-code`
+    # back — see #652. `claude-hooks`, by contrast,
     # IS nix-managed: we publish it ourselves to FlakeHub and it
     # doesn't ship multiple versions per week. The duplicate-issue-create
     # gate (#515) calls `claude-hooks pre-issue-create` from

--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -3,6 +3,11 @@
 {
   system.stateVersion = 5;
 
+  # Required by nix-darwin's `homebrew` module (below) and any other
+  # user-scoped option in the modern multi-user model — activation runs
+  # as root but these options apply to this user.
+  system.primaryUser = "jedwards";
+
   nixpkgs.hostPlatform = "aarch64-darwin";
   nixpkgs.config.allowUnfree = true;
 
@@ -34,4 +39,24 @@
   # future drift the same way. Review and delete `.backup` files after
   # activation. Tracked in #633.
   home-manager.backupFileExtension = "backup";
+
+  # Declarative brew-cask install via nix-darwin's Brewfile emission.
+  # Reachable even with `nix.enable = false` because `homebrew.*` lives
+  # outside the `nix.*` namespace Determinate gates. Casks that get
+  # carved out of `pkgs.*` for the "fast-moving upstream, nixpkgs lags"
+  # reason (per #652) come here so they're still declared in version
+  # control. Conservative `onActivation` defaults: ensure listed casks
+  # are installed; don't touch anything else. Bump to
+  # `cleanup = "uninstall"` later if full declarative parity is wanted.
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = false;
+      upgrade = false;
+      cleanup = "none";
+    };
+    casks = [
+      "claude-code"
+    ];
+  };
 }


### PR DESCRIPTION
Follow-up to #652: claude-code is the first cask in the "fast-moving
upstream, nixpkgs lags" carve-out. #652 dropped `pkgs.claude-code` and
pointed install at a manual `brew install --cask claude-code`. This
lands the declarative version: nix-darwin's `homebrew` module emits a
Brewfile and runs `brew bundle` at activation, so the cask is declared
in version control even though brew handles the install and version
selection.

The `homebrew.*` option namespace lives outside `nix.*`, so it's
reachable under `nix.enable = false` from #631 — Determinate's gate
doesn't touch it.

Conservative `onActivation` defaults: `autoUpdate = false`,
`upgrade = false`, `cleanup = "none"`. The module ensures listed casks
are installed; doesn't touch anything else. Bumping `cleanup` to
`"uninstall"` later (after an audit of what's in brew today vs. what we
want declared) gets us full declarative parity.

Required side effect: `system.primaryUser = "jedwards"`. nix-darwin's
modern multi-user model runs activation as root but applies user-scoped
options (homebrew included) to the named primary user. The flake check
errors clearly when it's missing.

Comment in `common.nix` updated to point at `homebrew.casks` in
`darwin.nix` instead of the manual brew step.

Closes #657