### PR TITLE
feat(blogctl): doctor enforces classification completeness

### DIFF
--- a/apps/blogctl/src/classifications.rs
+++ b/apps/blogctl/src/classifications.rs
@@ -159,6 +159,45 @@ impl Classifications {
         }
     }
 
+    /// Names of dimensions that are required at `stage` (per each
+    /// declared dimension's `required_by`) but unset on this post.
+    /// "Unset" means `None` for single-valued, empty for multi-valued.
+    ///
+    /// `Abandoned` posts always come back empty — they bypass the
+    /// completeness check entirely; see
+    /// `Stage::triggers_required_by`. Dimensions the taxonomy doesn't
+    /// declare are silent (consistent with `violations`).
+    pub fn missing_at_stage(
+        &self,
+        taxonomy: &Taxonomy,
+        stage: crate::stage::Stage,
+    ) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        for (name, opt) in self.single_valued_entries() {
+            let Some(dim) = taxonomy.dimension(name) else {
+                continue;
+            };
+            let Some(threshold) = dim.required_by else {
+                continue;
+            };
+            if stage.triggers_required_by(threshold) && opt.is_none() {
+                out.push(name);
+            }
+        }
+        for (name, values) in self.multi_valued_entries() {
+            let Some(dim) = taxonomy.dimension(name) else {
+                continue;
+            };
+            let Some(threshold) = dim.required_by else {
+                continue;
+            };
+            if stage.triggers_required_by(threshold) && values.is_empty() {
+                out.push(name);
+            }
+        }
+        out
+    }
+
     fn single_valued_entries(&self) -> [(&'static str, Option<&str>); 8] {
         [
             ("format", self.format.as_deref()),
@@ -410,5 +449,157 @@ mod tests {
         let c = Classifications::default();
         let t = Taxonomy::current_v1();
         assert!(c.validate(&t).is_ok());
+    }
+
+    use crate::stage::Stage;
+    use crate::taxonomy::Dimension;
+    use std::collections::BTreeMap;
+
+    fn taxonomy_with(name: &str, dim: Dimension) -> Taxonomy {
+        let mut m = BTreeMap::new();
+        m.insert(name.to_string(), dim);
+        Taxonomy::new(m)
+    }
+
+    #[test]
+    fn missing_at_stage_flags_unset_required_single_dim() {
+        let t = taxonomy_with(
+            "format",
+            Dimension {
+                values: vec!["essay".into(), "parable".into()],
+                required_by: Some(Stage::Published),
+                ..Default::default()
+            },
+        );
+        let c = Classifications::default();
+        assert_eq!(
+            c.missing_at_stage(&t, Stage::Published),
+            vec!["format"],
+            "published post with missing required format should be flagged",
+        );
+    }
+
+    #[test]
+    fn missing_at_stage_silent_when_post_has_not_reached_threshold() {
+        let t = taxonomy_with(
+            "format",
+            Dimension {
+                values: vec!["essay".into()],
+                required_by: Some(Stage::Published),
+                ..Default::default()
+            },
+        );
+        let c = Classifications::default();
+        // Earlier stages skip — required-ness only activates at the
+        // threshold.
+        for &stage in &[
+            Stage::Concept,
+            Stage::Ideation,
+            Stage::Editing,
+            Stage::FinalEditing,
+        ] {
+            assert!(
+                c.missing_at_stage(&t, stage).is_empty(),
+                "stage {stage} should bypass `required_by = published`",
+            );
+        }
+    }
+
+    #[test]
+    fn missing_at_stage_silent_when_dim_is_set() {
+        let t = taxonomy_with(
+            "format",
+            Dimension {
+                values: vec!["essay".into()],
+                required_by: Some(Stage::Published),
+                ..Default::default()
+            },
+        );
+        let c = Classifications {
+            format: Some("essay".into()),
+            ..Default::default()
+        };
+        assert!(c.missing_at_stage(&t, Stage::Published).is_empty());
+    }
+
+    #[test]
+    fn missing_at_stage_silent_for_abandoned_posts() {
+        // Abandoned posts always bypass — the check never fires
+        // regardless of `required_by`.
+        let t = taxonomy_with(
+            "format",
+            Dimension {
+                values: vec!["essay".into()],
+                required_by: Some(Stage::Published),
+                ..Default::default()
+            },
+        );
+        let c = Classifications::default();
+        assert!(c.missing_at_stage(&t, Stage::Abandoned).is_empty());
+    }
+
+    #[test]
+    fn missing_at_stage_flags_empty_required_multi_dim() {
+        let t = taxonomy_with(
+            "audience",
+            Dimension {
+                multi: true,
+                values: vec!["engineering".into(), "general".into()],
+                required_by: Some(Stage::Published),
+            },
+        );
+        let c = Classifications::default(); // audience: Vec is empty
+        assert_eq!(c.missing_at_stage(&t, Stage::Published), vec!["audience"],);
+    }
+
+    #[test]
+    fn missing_at_stage_silent_when_multi_dim_has_at_least_one_value() {
+        let t = taxonomy_with(
+            "audience",
+            Dimension {
+                multi: true,
+                values: vec!["engineering".into(), "general".into()],
+                required_by: Some(Stage::Published),
+            },
+        );
+        let c = Classifications {
+            audience: vec!["engineering".into()],
+            ..Default::default()
+        };
+        assert!(c.missing_at_stage(&t, Stage::Published).is_empty());
+    }
+
+    #[test]
+    fn missing_at_stage_silent_on_dimensions_without_required_by() {
+        // Without `required_by`, the dimension is always optional —
+        // even for published posts.
+        let t = taxonomy_with(
+            "format",
+            Dimension {
+                values: vec!["essay".into()],
+                required_by: None,
+                ..Default::default()
+            },
+        );
+        let c = Classifications::default();
+        assert!(c.missing_at_stage(&t, Stage::Published).is_empty());
+    }
+
+    #[test]
+    fn missing_at_stage_required_by_abandoned_is_no_op() {
+        // Declaring `required_by = "abandoned"` never triggers — no
+        // post ever needs to "reach abandoned" in pipeline order.
+        let t = taxonomy_with(
+            "format",
+            Dimension {
+                values: vec!["essay".into()],
+                required_by: Some(Stage::Abandoned),
+                ..Default::default()
+            },
+        );
+        let c = Classifications::default();
+        for &stage in Stage::ALL {
+            assert!(c.missing_at_stage(&t, stage).is_empty());
+        }
     }
 }

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -102,6 +102,16 @@ pub enum Finding {
         count: usize,
         max: u32,
     },
+    /// The post has reached or passed the declared `required_by`
+    /// stage for `dimension`, but the field is unset on the post.
+    /// Abandoned posts never trip this — they bypass the
+    /// completeness check entirely.
+    MissingClassification {
+        path: PathBuf,
+        dimension: String,
+        stage: Stage,
+        required_by: Stage,
+    },
 }
 
 impl fmt::Display for Finding {
@@ -196,6 +206,16 @@ impl fmt::Display for Finding {
                 "too many tags in {}: {count} tags exceeds max {max}",
                 path.display(),
             ),
+            Self::MissingClassification {
+                path,
+                dimension,
+                stage,
+                required_by,
+            } => write!(
+                f,
+                "missing classification in {}: {dimension} is required by {required_by} (post is at {stage})",
+                path.display(),
+            ),
         }
     }
 }
@@ -286,6 +306,25 @@ pub fn audit(workdir: &Workdir) -> Result<Vec<Finding>> {
                             dimension: v.dimension,
                             value: v.value,
                             allowed: v.allowed,
+                        });
+                    }
+                    // Completeness check: dimensions with
+                    // `required_by` set, where the post has reached
+                    // the threshold but the field is unset. Abandoned
+                    // posts always bypass.
+                    for dim_name in meta
+                        .classifications
+                        .missing_at_stage(&taxonomy, meta.status)
+                    {
+                        let threshold = taxonomy
+                            .dimension(dim_name)
+                            .and_then(|d| d.required_by)
+                            .expect("missing_at_stage only returns dims with required_by set");
+                        findings.push(Finding::MissingClassification {
+                            path: path.clone(),
+                            dimension: dim_name.to_string(),
+                            stage: meta.status,
+                            required_by: threshold,
                         });
                     }
                     // Tag cap. Workdirs that haven't declared
@@ -761,6 +800,186 @@ mod tests {
                 .any(|f| matches!(f, Finding::TagsExceedMax { .. })),
             "expected no TagsExceedMax findings without `[tags] max`: {findings:?}",
         );
+    }
+
+    #[test]
+    fn audit_flags_missing_required_classification_at_or_past_threshold() {
+        // Declare `format` required at `published`. Write a published
+        // post with no `format` → expect a MissingClassification
+        // finding.
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            concat!(
+                "version = 1\n",
+                "[themes.standard]\n",
+                "[classifications.format]\n",
+                "values = [\"essay\", \"parable\"]\n",
+                "required_by = \"published\"\n",
+            ),
+        )
+        .unwrap();
+
+        let post = fixture_post("incomplete-published", Stage::Published);
+        fs::write(
+            tmp.path().join("published/incomplete-published.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        let missing: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| matches!(f, Finding::MissingClassification { .. }))
+            .collect();
+        assert_eq!(
+            missing.len(),
+            1,
+            "expected one missing finding: {findings:?}"
+        );
+        if let Finding::MissingClassification {
+            dimension,
+            stage,
+            required_by,
+            ..
+        } = missing[0]
+        {
+            assert_eq!(dimension, "format");
+            assert_eq!(*stage, Stage::Published);
+            assert_eq!(*required_by, Stage::Published);
+        }
+    }
+
+    #[test]
+    fn audit_silent_when_post_set_required_dimension_at_published() {
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            concat!(
+                "version = 1\n",
+                "[themes.standard]\n",
+                "[classifications.format]\n",
+                "values = [\"essay\", \"parable\"]\n",
+                "required_by = \"published\"\n",
+            ),
+        )
+        .unwrap();
+
+        let mut post = fixture_post("complete-published", Stage::Published);
+        post.metadata.classifications.format = Some("parable".into());
+        fs::write(
+            tmp.path().join("published/complete-published.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        assert!(
+            !findings
+                .iter()
+                .any(|f| matches!(f, Finding::MissingClassification { .. })),
+            "expected no MissingClassification findings: {findings:?}",
+        );
+    }
+
+    #[test]
+    fn audit_silent_on_missing_classification_before_threshold() {
+        // Required at `published`, but post is at `concept` — bypass.
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            concat!(
+                "version = 1\n",
+                "[themes.standard]\n",
+                "[classifications.format]\n",
+                "values = [\"essay\", \"parable\"]\n",
+                "required_by = \"published\"\n",
+            ),
+        )
+        .unwrap();
+
+        let post = fixture_post("draft-with-no-format", Stage::Concept);
+        fs::write(
+            tmp.path().join("concepts/draft-with-no-format.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        assert!(
+            !findings
+                .iter()
+                .any(|f| matches!(f, Finding::MissingClassification { .. })),
+            "concept-stage post must bypass `required_by = published`: {findings:?}",
+        );
+    }
+
+    #[test]
+    fn audit_silent_on_missing_classification_for_abandoned_post() {
+        // Abandoned posts always bypass, regardless of threshold.
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            concat!(
+                "version = 1\n",
+                "[themes.standard]\n",
+                "[classifications.format]\n",
+                "values = [\"essay\", \"parable\"]\n",
+                "required_by = \"published\"\n",
+            ),
+        )
+        .unwrap();
+
+        let post = fixture_post("killed", Stage::Abandoned);
+        fs::write(
+            tmp.path().join("abandoned/killed.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        assert!(
+            !findings
+                .iter()
+                .any(|f| matches!(f, Finding::MissingClassification { .. })),
+            "abandoned posts must bypass completeness: {findings:?}",
+        );
+    }
+
+    #[test]
+    fn audit_flags_missing_multi_valued_required_dim_when_empty() {
+        // Multi-valued `audience` with `required_by = published`. An
+        // empty audience list on a published post should flag.
+        let (tmp, workdir) = fresh_workdir();
+        fs::write(
+            tmp.path().join(".blog-os.toml"),
+            concat!(
+                "version = 1\n",
+                "[themes.standard]\n",
+                "[classifications.audience]\n",
+                "multi = true\n",
+                "values = [\"engineering\", \"general\"]\n",
+                "required_by = \"published\"\n",
+            ),
+        )
+        .unwrap();
+
+        let post = fixture_post("audience-empty-published", Stage::Published);
+        fs::write(
+            tmp.path().join("published/audience-empty-published.md"),
+            post.render().unwrap(),
+        )
+        .unwrap();
+
+        let findings = audit(&workdir).unwrap();
+        let missing: Vec<&Finding> = findings
+            .iter()
+            .filter(|f| matches!(f, Finding::MissingClassification { .. }))
+            .collect();
+        assert_eq!(missing.len(), 1);
+        if let Finding::MissingClassification { dimension, .. } = missing[0] {
+            assert_eq!(dimension, "audience");
+        }
     }
 
     #[test]

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -63,6 +63,7 @@ pub enum SkipReason {
     UnpushedCommits,
     InvalidClassification,
     TagsExceedMax,
+    MissingClassification,
     JjUnavailable,
 }
 
@@ -83,6 +84,9 @@ impl fmt::Display for SkipReason {
             }
             Self::TagsExceedMax => {
                 "manual: prune the post's `tags` list or raise `[tags] max` in .blog-os.toml"
+            }
+            Self::MissingClassification => {
+                "manual: `blogctl classify` to set the value, or relax `required_by` in .blog-os.toml"
             }
             Self::JjUnavailable => {
                 "manual: install jj and run `jj git init --colocate` in the workdir"
@@ -155,6 +159,10 @@ pub fn plan(findings: Vec<Finding>) -> Vec<Repair> {
             f @ Finding::TagsExceedMax { .. } => skips.push(Repair::Skip {
                 finding: f,
                 reason: SkipReason::TagsExceedMax,
+            }),
+            f @ Finding::MissingClassification { .. } => skips.push(Repair::Skip {
+                finding: f,
+                reason: SkipReason::MissingClassification,
             }),
             f @ (Finding::JjNotInstalled | Finding::NotAJjRepo { .. }) => {
                 skips.push(Repair::Skip {

--- a/apps/blogctl/src/stage.rs
+++ b/apps/blogctl/src/stage.rs
@@ -52,6 +52,36 @@ impl Stage {
         Stage::ALL.iter().copied().find(|s| s.dirname() == dir)
     }
 
+    /// Linear position in the editorial pipeline: `Concept` is 0,
+    /// `Published` is 4. `Abandoned` sits off the pipeline and returns
+    /// `None` — callers that compare ranks (e.g. completeness checks)
+    /// must handle the bypass explicitly.
+    pub fn pipeline_rank(self) -> Option<u8> {
+        match self {
+            Stage::Concept => Some(0),
+            Stage::Ideation => Some(1),
+            Stage::Editing => Some(2),
+            Stage::FinalEditing => Some(3),
+            Stage::Published => Some(4),
+            Stage::Abandoned => None,
+        }
+    }
+
+    /// True when a `required_by = <threshold>` rule kicks in for a post
+    /// at `self`. `Abandoned` posts always bypass (they're being killed,
+    /// no need to enforce classification); otherwise the post has to
+    /// have reached `threshold` (in pipeline order).
+    pub fn triggers_required_by(self, threshold: Stage) -> bool {
+        match (self.pipeline_rank(), threshold.pipeline_rank()) {
+            (Some(here), Some(at)) => here >= at,
+            // self is abandoned → always bypass.
+            // threshold is abandoned → never triggers (declaring
+            // `required_by = "abandoned"` is meaningless config, not
+            // an error).
+            _ => false,
+        }
+    }
+
     /// Promote along the linear workflow: concept → ideation → editing →
     /// final-editing → published. Abandoned and Published are terminal.
     pub fn promote(self) -> Result<Stage> {
@@ -177,5 +207,49 @@ mod tests {
             assert_eq!(Stage::from_dirname(s.dirname()), Some(s));
         }
         assert_eq!(Stage::from_dirname("history"), None);
+    }
+
+    #[test]
+    fn pipeline_rank_orders_the_linear_stages() {
+        assert!(Stage::Concept.pipeline_rank() < Stage::Ideation.pipeline_rank());
+        assert!(Stage::Ideation.pipeline_rank() < Stage::Editing.pipeline_rank());
+        assert!(Stage::Editing.pipeline_rank() < Stage::FinalEditing.pipeline_rank());
+        assert!(Stage::FinalEditing.pipeline_rank() < Stage::Published.pipeline_rank());
+    }
+
+    #[test]
+    fn pipeline_rank_is_none_for_abandoned() {
+        assert!(Stage::Abandoned.pipeline_rank().is_none());
+    }
+
+    #[test]
+    fn triggers_required_by_when_post_has_reached_threshold() {
+        // required_by = "editing" → editing, final-editing, and
+        // published all trigger.
+        assert!(Stage::Editing.triggers_required_by(Stage::Editing));
+        assert!(Stage::FinalEditing.triggers_required_by(Stage::Editing));
+        assert!(Stage::Published.triggers_required_by(Stage::Editing));
+        // …but earlier stages don't.
+        assert!(!Stage::Concept.triggers_required_by(Stage::Editing));
+        assert!(!Stage::Ideation.triggers_required_by(Stage::Editing));
+    }
+
+    #[test]
+    fn abandoned_posts_bypass_required_by_completely() {
+        // Regardless of threshold, an abandoned post never triggers
+        // required-ness checks — the post is being killed.
+        for &threshold in Stage::ALL {
+            assert!(!Stage::Abandoned.triggers_required_by(threshold));
+        }
+    }
+
+    #[test]
+    fn required_by_abandoned_is_meaningless_config() {
+        // Declaring `required_by = "abandoned"` never triggers for
+        // any post (no post needs to "reach abandoned"). Doesn't
+        // error; just a no-op rule.
+        for &here in Stage::ALL {
+            assert!(!here.triggers_required_by(Stage::Abandoned));
+        }
     }
 }

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -334,7 +334,13 @@ mod tests {
 
     #[test]
     fn dimension_required_by_parses_each_stage() {
-        for stage_str in ["concept", "ideation", "editing", "final-editing", "published"] {
+        for stage_str in [
+            "concept",
+            "ideation",
+            "editing",
+            "final-editing",
+            "published",
+        ] {
             let raw = format!("values = [\"x\"]\nrequired_by = \"{stage_str}\"\n");
             let d: Dimension = toml::from_str(&raw).unwrap();
             assert!(

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -13,17 +13,32 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-/// One dimension of the taxonomy: a list of allowed values plus a
-/// `multi` flag that documents whether the dimension is single- or
-/// multi-valued semantically. The Rust type system carries the
+use crate::stage::Stage;
+
+/// One dimension of the taxonomy: a list of allowed values, a `multi`
+/// flag documenting the cardinality, and an optional `required_by`
+/// stage threshold for the completeness check.
+///
+/// `multi` is informational — the Rust type system carries the
 /// single/multi distinction (each `Classifications` field is either
-/// `Option<String>` or `Vec<String>`), so `multi` is informational
-/// only — kept for the taxonomy file's self-documentation.
+/// `Option<String>` or `Vec<String>`), so `multi = true` here is
+/// self-documentation for the taxonomy file.
+///
+/// `required_by` activates the completeness check (see
+/// `Classifications::missing_at_stage`): the dimension must be set on
+/// posts whose status has reached the named stage. Absence means
+/// "never required" — the previous behavior before #602.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Dimension {
     #[serde(default)]
     pub multi: bool,
     pub values: Vec<String>,
+    /// Stage at (and beyond) which the dimension is required. `None`
+    /// means the dimension is always optional. `Some(Stage::Abandoned)`
+    /// is a meaningless config — no post ever needs to "reach
+    /// abandoned" — but parses cleanly and is a no-op at check time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_by: Option<Stage>,
 }
 
 impl Dimension {
@@ -116,6 +131,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "format".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&[
                 "parable",
                 "thesis",
@@ -130,6 +146,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "hook".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&[
                 "proverb",
                 "contradiction",
@@ -144,6 +161,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "tone".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&["gentle", "sharp", "vulnerable", "reflective", "provocative"]),
         },
     );
@@ -151,6 +169,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "audience".into(),
         Dimension {
             multi: true,
+            required_by: None,
             values: strs(&[
                 "engineering",
                 "product",
@@ -164,6 +183,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "topic".into(),
         Dimension {
             multi: true,
+            required_by: None,
             values: strs(&["engineering", "leadership", "product", "career", "general"]),
         },
     );
@@ -171,6 +191,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "narrative_structure".into(),
         Dimension {
             multi: true,
+            required_by: None,
             values: strs(&[
                 "direct-statement",
                 "personal-anecdote",
@@ -184,6 +205,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "call_to_action".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&["none", "reflection", "discussion"]),
         },
     );
@@ -191,6 +213,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "visual_type".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&["text-only", "diagram", "illustration", "screenshot"]),
         },
     );
@@ -198,6 +221,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "complexity".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&["simple", "moderate", "dense"]),
         },
     );
@@ -205,6 +229,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "vulnerability".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&["none", "low", "medium", "high"]),
         },
     );
@@ -212,6 +237,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "outcome_prediction".into(),
         Dimension {
             multi: false,
+            required_by: None,
             values: strs(&["low", "medium", "high"]),
         },
     );
@@ -219,6 +245,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         "motifs".into(),
         Dimension {
             multi: true,
+            required_by: None,
             values: strs(&[
                 "ambiguity",
                 "delivery",
@@ -296,5 +323,42 @@ mod tests {
         let raw = "values = [\"x\", \"y\"]\n";
         let d: Dimension = toml::from_str(raw).unwrap();
         assert!(!d.multi);
+    }
+
+    #[test]
+    fn dimension_required_by_defaults_to_none() {
+        let raw = "values = [\"x\"]\n";
+        let d: Dimension = toml::from_str(raw).unwrap();
+        assert!(d.required_by.is_none());
+    }
+
+    #[test]
+    fn dimension_required_by_parses_each_stage() {
+        for stage_str in ["concept", "ideation", "editing", "final-editing", "published"] {
+            let raw = format!("values = [\"x\"]\nrequired_by = \"{stage_str}\"\n");
+            let d: Dimension = toml::from_str(&raw).unwrap();
+            assert!(
+                d.required_by.is_some(),
+                "expected required_by = {stage_str:?} to parse",
+            );
+        }
+    }
+
+    #[test]
+    fn dimension_required_by_rejects_unknown_stage() {
+        let raw = "values = [\"x\"]\nrequired_by = \"draft\"\n";
+        assert!(toml::from_str::<Dimension>(raw).is_err());
+    }
+
+    #[test]
+    fn dimension_required_by_round_trips_through_toml() {
+        let d = Dimension {
+            multi: false,
+            values: vec!["x".into()],
+            required_by: Some(Stage::Published),
+        };
+        let raw = toml::to_string(&d).unwrap();
+        let back: Dimension = toml::from_str(&raw).unwrap();
+        assert_eq!(back, d);
     }
 }


### PR DESCRIPTION
Two commits:

1. **`feat(blogctl): add required_by stage field to Dimension schema`** — extend `[classifications.<dim>]` with optional `required_by` stage. `Stage::pipeline_rank` + `triggers_required_by` capture the "post status has reached threshold" predicate. Abandoned posts always bypass.
2. **`feat(blogctl): doctor enforces classification completeness`** — add `Classifications::missing_at_stage`, `Finding::MissingClassification`, audit wire-up, fix skip case. Closes the "any post can have zero classifications and pass doctor" loophole flagged in #602.

Once a `required_by` is added to any dimension in `.blog-os.toml`, incomplete posts past the threshold fail Preflight. Pairs with the taxonomy declaration in `kolohelios/blogs-and-posts#78` and the `doctor` Preflight step there.

Closes #602