### PR TITLE
feat(infra/home): write nix.custom.conf for Determinate GC tuning

### DIFF
--- a/infra/home/README.md
+++ b/infra/home/README.md
@@ -37,6 +37,24 @@ otherwise clobber is renamed to `<path>.backup`
 Review and delete the `.backup` files once you've confirmed the
 nix-managed version has everything you care about.
 
+## Nix configuration on macOS
+
+Determinate Nix manages the daemon and writes `/etc/nix/nix.conf`
+itself (the file header literally says "do not modify"). The
+user-editable overlay is `/etc/nix/nix.custom.conf`, which `nix.conf`
+pulls in via `!include`.
+
+Because nix-darwin's `nix.*` options are unreachable here (gated by
+Determinate per #631), settings that would normally live there are
+written via `environment.etc."nix/nix.custom.conf"` in
+`modules/darwin.nix`. Today that's just GC tuning (`min-free` /
+`max-free` / `auto-optimise-store` from #632); same pattern applies for
+any future daemon setting.
+
+If GC behavior needs another knob, edit `darwin.nix` and re-run the
+`darwin-rebuild switch` from below. Don't hand-edit `nix.custom.conf` —
+the next switch overwrites it.
+
 ## Local zsh extensions
 
 The generated `~/.zshrc` is a symlink into the Nix store. Tool-specific

--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -59,4 +59,19 @@
       "claude-code"
     ];
   };
+
+  # Determinate writes `/etc/nix/nix.conf` itself (header says "do not
+  # modify"), but the user-editable overlay it `!include`s,
+  # `/etc/nix/nix.custom.conf`, is fair game. `nix.*` options are
+  # unreachable via the gate (#631), but `environment.etc` is a
+  # different module entirely and works fine — gives us a declarative
+  # home for what would otherwise have been `nix.settings.*`. The
+  # daemon auto-GCs mid-build when free space drops below `min-free`
+  # and reclaims up to `max-free`, which is the load-bearing fix for
+  # the 30–60 GB/hour accumulation symptom from #573. Tracked in #632.
+  environment.etc."nix/nix.custom.conf".text = ''
+    min-free = ${toString (10 * 1024 * 1024 * 1024)}
+    max-free = ${toString (50 * 1024 * 1024 * 1024)}
+    auto-optimise-store = true
+  '';
 }


### PR DESCRIPTION
Closes the loop on the original 30–60 GB/hour accumulation symptom from
#573. Investigation: `/etc/nix/nix.custom.conf` was empty, so neither
`min-free` nor `max-free` was ever set, and the daemon never auto-GCs
on disk pressure. With the daily `kolohelios-nix` bump churning
dev-shell generations, paths just piled up until a manual
`nix-store --gc` ran — exactly the reported symptom.

Determinate writes `/etc/nix/nix.conf` itself (header says "do not
modify") but `!include`s `nix.custom.conf` as a user-editable overlay.
`nix.*` options are unreachable under the Determinate gate (#631), but
`environment.etc` is a different module and works fine. So nix-darwin
can manage `nix.custom.conf` declaratively without conflicting with
Determinate's `nix.conf` regeneration.

Settings: `min-free = 10 GiB`, `max-free = 50 GiB`,
`auto-optimise-store = true`. The first two are the safety net (auto-GC
mid-build when disk hits the threshold); `auto-optimise-store` is the
inline deduplication version of `nix-store --optimise` (no `launchd`
side-channel needed, which we couldn't reach anyway with
`nix.enable = false`).

README gets a new "Nix configuration on macOS" section documenting the
Determinate `nix.conf` / `nix.custom.conf` split and the
`environment.etc` pattern for future daemon settings.

Local action after merge: `sudo nix run nix-darwin -- switch ...` writes
the new `nix.custom.conf` and the daemon picks up the settings.

Out of scope (filed separately):
- `sudo determinate-nixd upgrade` to 3.21.0.
- A proactive (timer-driven) GC if `min-free`/`max-free` alone leaves
  too-large gaps between reactive GCs.

Closes #632