### PR TITLE
refactor(todoist): migrate from anyhow to snafu

### DIFF
--- a/tools/todoist/Cargo.lock
+++ b/tools/todoist/Cargo.lock
@@ -635,6 +635,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,10 +722,10 @@ dependencies = [
 name = "todoist"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "serde",
  "serde_json",
+ "snafu",
  "tempfile",
  "toml",
  "ureq",

--- a/tools/todoist/Cargo.toml
+++ b/tools/todoist/Cargo.toml
@@ -10,10 +10,10 @@ name = "todoist"
 path = "src/main.rs"
 
 [dependencies]
-anyhow     = "1"
 clap       = { version = "4", features = ["derive"] }
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
+snafu      = "0.9"
 toml       = "0.8"
 ureq       = { version = "2", features = ["json"] }
 

--- a/tools/todoist/src/api.rs
+++ b/tools/todoist/src/api.rs
@@ -1,29 +1,18 @@
 use serde::{Deserialize, Serialize};
+use snafu::Snafu;
 
 pub const API_BASE: &str = "https://api.todoist.com/api/v1";
 
-#[derive(Debug)]
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 pub enum ApiError {
+    #[snafu(display("token invalid; run `todoist auth login` to refresh"))]
     Unauthorized,
-    Network(String),
+    #[snafu(display("network error: {message}"))]
+    Network { message: String },
+    #[snafu(display("Todoist API returned {status}: {body}"))]
     Other { status: u16, body: String },
 }
-
-impl std::fmt::Display for ApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Unauthorized => {
-                write!(f, "token invalid; run `todoist auth login` to refresh")
-            }
-            Self::Network(msg) => write!(f, "network error: {msg}"),
-            Self::Other { status, body } => {
-                write!(f, "Todoist API returned {status}: {body}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for ApiError {}
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 pub struct Project {
@@ -125,8 +114,9 @@ impl TodoistClient for RealClient {
         let req = ureq::post(&format!("{}/tasks", self.base))
             .set("Authorization", &format!("Bearer {token}"))
             .set("Content-Type", "application/json");
-        let payload =
-            serde_json::to_value(body).map_err(|e| ApiError::Network(format!("encode: {e}")))?;
+        let payload = serde_json::to_value(body).map_err(|e| ApiError::Network {
+            message: format!("encode: {e}"),
+        })?;
         send_json(req.send_json(payload))
     }
 
@@ -147,7 +137,9 @@ fn send_no_content(result: Result<ureq::Response, ureq::Error>) -> Result<(), Ap
                 .unwrap_or_else(|_| "<unreadable>".into());
             Err(ApiError::Other { status, body })
         }
-        Err(ureq::Error::Transport(t)) => Err(ApiError::Network(t.to_string())),
+        Err(ureq::Error::Transport(t)) => Err(ApiError::Network {
+            message: t.to_string(),
+        }),
     }
 }
 
@@ -155,9 +147,9 @@ fn send_json<T: for<'de> Deserialize<'de>>(
     result: Result<ureq::Response, ureq::Error>,
 ) -> Result<T, ApiError> {
     match result {
-        Ok(response) => response
-            .into_json::<T>()
-            .map_err(|e| ApiError::Network(format!("could not parse response: {e}"))),
+        Ok(response) => response.into_json::<T>().map_err(|e| ApiError::Network {
+            message: format!("could not parse response: {e}"),
+        }),
         Err(ureq::Error::Status(401, _)) => Err(ApiError::Unauthorized),
         Err(ureq::Error::Status(status, response)) => {
             let body = response
@@ -165,7 +157,9 @@ fn send_json<T: for<'de> Deserialize<'de>>(
                 .unwrap_or_else(|_| "<unreadable>".into());
             Err(ApiError::Other { status, body })
         }
-        Err(ureq::Error::Transport(t)) => Err(ApiError::Network(t.to_string())),
+        Err(ureq::Error::Transport(t)) => Err(ApiError::Network {
+            message: t.to_string(),
+        }),
     }
 }
 
@@ -181,7 +175,10 @@ mod tests {
 
     #[test]
     fn network_message_includes_detail() {
-        let msg = ApiError::Network("dns failed".into()).to_string();
+        let msg = ApiError::Network {
+            message: "dns failed".into(),
+        }
+        .to_string();
         assert!(msg.contains("dns failed"));
     }
 

--- a/tools/todoist/src/auth.rs
+++ b/tools/todoist/src/auth.rs
@@ -1,26 +1,59 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
     pub token_op_ref: String,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Snafu)]
+#[snafu(display("{message}"))]
 pub struct OpError {
     pub message: String,
 }
 
-impl std::fmt::Display for OpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum AuthError {
+    #[snafu(display("HOME is not set"))]
+    HomeNotSet { source: std::env::VarError },
 
-impl std::error::Error for OpError {}
+    #[snafu(display("could not resolve {op_ref}: {source}"))]
+    OpResolve { op_ref: String, source: OpError },
+
+    #[snafu(display("serializing config"))]
+    TomlSerialize { source: toml::ser::Error },
+
+    #[snafu(display("parsing config"))]
+    TomlParse { source: toml::de::Error },
+
+    #[snafu(display("creating {}", path.display()))]
+    CreateDir {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("writing {}", path.display()))]
+    Write {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("reading {}", path.display()))]
+    Read {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("removing {}", path.display()))]
+    Remove {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
 
 pub trait OpRunner {
     fn read(&self, op_ref: &str) -> Result<String, OpError>;
@@ -55,29 +88,32 @@ impl OpRunner for RealOp {
     }
 }
 
-pub fn default_config_path() -> Result<PathBuf> {
+pub fn default_config_path() -> Result<PathBuf, AuthError> {
     let base = if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
         PathBuf::from(xdg)
     } else {
-        let home = std::env::var("HOME").context("HOME is not set")?;
+        let home = std::env::var("HOME").context(HomeNotSetSnafu)?;
         PathBuf::from(home).join(".config")
     };
     Ok(base.join("todoist").join("config.toml"))
 }
 
-pub fn login(op: &impl OpRunner, config_path: &Path, op_ref: &str) -> Result<()> {
-    op.read(op_ref)
-        .map_err(|e| anyhow!("could not resolve {op_ref}: {e}"))?;
+pub fn login(op: &impl OpRunner, config_path: &Path, op_ref: &str) -> Result<(), AuthError> {
+    op.read(op_ref).context(OpResolveSnafu {
+        op_ref: op_ref.to_string(),
+    })?;
     let config = Config {
         token_op_ref: op_ref.to_string(),
     };
-    let serialized = toml::to_string(&config).context("serializing config")?;
+    let serialized = toml::to_string(&config).context(TomlSerializeSnafu)?;
     if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating {}", parent.display()))?;
+        std::fs::create_dir_all(parent).context(CreateDirSnafu {
+            path: parent.to_path_buf(),
+        })?;
     }
-    std::fs::write(config_path, serialized)
-        .with_context(|| format!("writing {}", config_path.display()))?;
+    std::fs::write(config_path, serialized).context(WriteSnafu {
+        path: config_path.to_path_buf(),
+    })?;
     Ok(())
 }
 
@@ -89,13 +125,14 @@ pub enum AuthState {
     },
 }
 
-pub fn status(op: &impl OpRunner, config_path: &Path) -> Result<AuthState> {
+pub fn status(op: &impl OpRunner, config_path: &Path) -> Result<AuthState, AuthError> {
     if !config_path.exists() {
         return Ok(AuthState::NotLoggedIn);
     }
-    let raw = std::fs::read_to_string(config_path)
-        .with_context(|| format!("reading {}", config_path.display()))?;
-    let config: Config = toml::from_str(&raw).context("parsing config")?;
+    let raw = std::fs::read_to_string(config_path).context(ReadSnafu {
+        path: config_path.to_path_buf(),
+    })?;
+    let config: Config = toml::from_str(&raw).context(TomlParseSnafu)?;
     let resolve_err = op.read(&config.token_op_ref).err().map(|e| e.message);
     Ok(AuthState::Configured {
         op_ref: config.token_op_ref,
@@ -103,11 +140,13 @@ pub fn status(op: &impl OpRunner, config_path: &Path) -> Result<AuthState> {
     })
 }
 
-pub fn logout(config_path: &Path) -> Result<()> {
+pub fn logout(config_path: &Path) -> Result<(), AuthError> {
     match std::fs::remove_file(config_path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(anyhow::Error::new(e).context(format!("removing {}", config_path.display()))),
+        Err(e) => Err(e).context(RemoveSnafu {
+            path: config_path.to_path_buf(),
+        }),
     }
 }
 

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -1,5 +1,7 @@
-use anyhow::{anyhow, Context, Result};
+use std::error::Error;
+
 use clap::{Args, Parser, Subcommand};
+use snafu::{ResultExt, Snafu};
 
 mod api;
 mod auth;
@@ -7,6 +9,30 @@ mod projects;
 mod tasks;
 
 use auth::OpRunner;
+
+#[derive(Debug, Snafu)]
+enum CliError {
+    #[snafu(display("{source}"))]
+    Auth { source: auth::AuthError },
+
+    #[snafu(display("{source}"))]
+    Projects { source: projects::ProjectsError },
+
+    #[snafu(display("{source}"))]
+    Tasks { source: tasks::TasksError },
+
+    #[snafu(display("could not read {} — run `todoist auth login` first", path.display()))]
+    ReadConfig {
+        path: std::path::PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("could not parse stored auth config"))]
+    ParseConfig { source: toml::de::Error },
+
+    #[snafu(display("could not resolve token from 1Password: {source}"))]
+    ResolveToken { source: auth::OpError },
+}
 
 #[derive(Parser)]
 #[command(name = "todoist", version, about = "Command-line client for Todoist")]
@@ -112,11 +138,19 @@ enum TasksSubcommand {
     },
 }
 
-fn main() -> Result<()> {
-    dispatch(Cli::parse().command)
+fn main() {
+    if let Err(e) = dispatch(Cli::parse().command) {
+        eprintln!("{e}");
+        let mut source = e.source();
+        while let Some(s) = source {
+            eprintln!("  caused by: {s}");
+            source = s.source();
+        }
+        std::process::exit(1);
+    }
 }
 
-fn dispatch(command: Command) -> Result<()> {
+fn dispatch(command: Command) -> Result<(), CliError> {
     match command {
         Command::Auth(AuthCmd { command }) => handle_auth(command),
         Command::Projects(ProjectsCmd { command }) => handle_projects(command),
@@ -124,12 +158,12 @@ fn dispatch(command: Command) -> Result<()> {
     }
 }
 
-fn handle_projects(cmd: ProjectsSubcommand) -> Result<()> {
+fn handle_projects(cmd: ProjectsSubcommand) -> Result<(), CliError> {
     match cmd {
         ProjectsSubcommand::List { json } => {
             let token = resolve_token()?;
             let client = api::RealClient::default();
-            let projects = projects::run_list(&client, &token)?;
+            let projects = projects::run_list(&client, &token).context(ProjectsSnafu)?;
             if json {
                 println!("{}", projects::render_ndjson(&projects));
             } else {
@@ -140,7 +174,7 @@ fn handle_projects(cmd: ProjectsSubcommand) -> Result<()> {
     }
 }
 
-fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
+fn handle_tasks(cmd: TasksSubcommand) -> Result<(), CliError> {
     match cmd {
         TasksSubcommand::List {
             project,
@@ -158,7 +192,8 @@ fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
                     filter,
                     limit,
                 },
-            )?;
+            )
+            .context(TasksSnafu)?;
             if json {
                 println!("{}", tasks::render_ndjson(&outcome.tasks));
             } else {
@@ -190,14 +225,15 @@ fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
                     labels,
                     description,
                 },
-            )?;
+            )
+            .context(TasksSnafu)?;
             println!("{}", tasks::render_added(&created));
             Ok(())
         }
         TasksSubcommand::Complete { ids } => {
             let token = resolve_token()?;
             let client = api::RealClient::default();
-            let results = tasks::run_complete(&client, &token, &ids)?;
+            let results = tasks::run_complete(&client, &token, &ids).context(TasksSnafu)?;
             let use_unicode = std::io::IsTerminal::is_terminal(&std::io::stdout())
                 && std::env::var_os("NO_COLOR").is_none();
             let (out, any_failure) = tasks::render_complete_results(&results, use_unicode);
@@ -210,36 +246,32 @@ fn handle_tasks(cmd: TasksSubcommand) -> Result<()> {
     }
 }
 
-fn resolve_token() -> Result<String> {
-    let path = auth::default_config_path()?;
+fn resolve_token() -> Result<String, CliError> {
+    let path = auth::default_config_path().context(AuthSnafu)?;
     let op = auth::RealOp;
-    let raw = std::fs::read_to_string(&path).with_context(|| {
-        format!(
-            "could not read {} — run `todoist auth login` first",
-            path.display()
-        )
-    })?;
-    let config: auth::Config =
-        toml::from_str(&raw).context("could not parse stored auth config")?;
-    op.read(&config.token_op_ref)
-        .map_err(|e| anyhow!("could not resolve token from 1Password: {e}"))
+    let raw = std::fs::read_to_string(&path).context(ReadConfigSnafu { path: path.clone() })?;
+    let config: auth::Config = toml::from_str(&raw).context(ParseConfigSnafu)?;
+    op.read(&config.token_op_ref).context(ResolveTokenSnafu)
 }
 
-fn handle_auth(cmd: AuthSubcommand) -> Result<()> {
-    let path = auth::default_config_path()?;
+fn handle_auth(cmd: AuthSubcommand) -> Result<(), CliError> {
+    let path = auth::default_config_path().context(AuthSnafu)?;
     let op = auth::RealOp;
     match cmd {
         AuthSubcommand::Login { op_ref } => {
-            auth::login(&op, &path, &op_ref)?;
+            auth::login(&op, &path, &op_ref).context(AuthSnafu)?;
             println!("saved token reference to {}", path.display());
             Ok(())
         }
         AuthSubcommand::Status => {
-            println!("{}", render_status(auth::status(&op, &path)?));
+            println!(
+                "{}",
+                render_status(auth::status(&op, &path).context(AuthSnafu)?)
+            );
             Ok(())
         }
         AuthSubcommand::Logout => {
-            auth::logout(&path)?;
+            auth::logout(&path).context(AuthSnafu)?;
             println!("removed token reference (if any)");
             Ok(())
         }

--- a/tools/todoist/src/projects.rs
+++ b/tools/todoist/src/projects.rs
@@ -1,9 +1,16 @@
-use anyhow::{anyhow, Result};
+use snafu::{ResultExt, Snafu};
 
-use crate::api::{Project, TodoistClient};
+use crate::api::{ApiError, Project, TodoistClient};
 
-pub fn run_list(client: &impl TodoistClient, token: &str) -> Result<Vec<Project>> {
-    client.list_projects(token).map_err(|e| anyhow!(e))
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum ProjectsError {
+    #[snafu(display("{source}"))]
+    Api { source: ApiError },
+}
+
+pub fn run_list(client: &impl TodoistClient, token: &str) -> Result<Vec<Project>, ProjectsError> {
+    client.list_projects(token).context(ApiSnafu)
 }
 
 pub fn render_ndjson(projects: &[Project]) -> String {

--- a/tools/todoist/src/tasks.rs
+++ b/tools/todoist/src/tasks.rs
@@ -1,7 +1,21 @@
-use anyhow::{anyhow, Result};
 use std::collections::HashMap;
 
-use crate::api::{CreateTaskBody, Project, TaskListQuery, TodoistClient};
+use snafu::{ResultExt, Snafu};
+
+use crate::api::{ApiError, CreateTaskBody, Project, TaskListQuery, TodoistClient};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum TasksError {
+    #[snafu(display("{source}"))]
+    Api { source: ApiError },
+
+    #[snafu(display("no project named {arg:?} (known: {known})"))]
+    ProjectNotFound { arg: String, known: String },
+
+    #[snafu(display("{count} projects named {arg:?} — disambiguate by id"))]
+    ProjectAmbiguous { arg: String, count: usize },
+}
 
 pub const ID_PREFIX_LEN: usize = 6;
 
@@ -17,8 +31,12 @@ pub struct ListOutcome {
     pub projects_by_id: HashMap<String, String>,
 }
 
-pub fn run_list(client: &impl TodoistClient, token: &str, opts: &ListOpts) -> Result<ListOutcome> {
-    let projects = client.list_projects(token).map_err(|e| anyhow!(e))?;
+pub fn run_list(
+    client: &impl TodoistClient,
+    token: &str,
+    opts: &ListOpts,
+) -> Result<ListOutcome, TasksError> {
+    let projects = client.list_projects(token).context(ApiSnafu)?;
     let project_id = match &opts.project {
         Some(arg) => Some(resolve_project_id(&projects, arg)?),
         None => None,
@@ -27,7 +45,7 @@ pub fn run_list(client: &impl TodoistClient, token: &str, opts: &ListOpts) -> Re
         project_id,
         filter: opts.filter.clone(),
     };
-    let mut tasks = client.list_tasks(token, &query).map_err(|e| anyhow!(e))?;
+    let mut tasks = client.list_tasks(token, &query).context(ApiSnafu)?;
     if let Some(n) = opts.limit {
         tasks.truncate(n);
     }
@@ -38,7 +56,7 @@ pub fn run_list(client: &impl TodoistClient, token: &str, opts: &ListOpts) -> Re
     })
 }
 
-pub fn resolve_project_id(projects: &[Project], arg: &str) -> Result<String> {
+pub fn resolve_project_id(projects: &[Project], arg: &str) -> Result<String, TasksError> {
     if arg.chars().all(|c| c.is_ascii_digit()) {
         return Ok(arg.to_string());
     }
@@ -46,16 +64,18 @@ pub fn resolve_project_id(projects: &[Project], arg: &str) -> Result<String> {
     match matches.as_slice() {
         [] => {
             let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
-            Err(anyhow!(
-                "no project named {arg:?} (known: {})",
-                names.join(", ")
-            ))
+            ProjectNotFoundSnafu {
+                arg: arg.to_string(),
+                known: names.join(", "),
+            }
+            .fail()
         }
         [hit] => Ok(hit.id.clone()),
-        many => Err(anyhow!(
-            "{} projects named {arg:?} — disambiguate by id",
-            many.len()
-        )),
+        many => ProjectAmbiguousSnafu {
+            arg: arg.to_string(),
+            count: many.len(),
+        }
+        .fail(),
     }
 }
 
@@ -73,10 +93,10 @@ pub fn run_add(
     client: &impl TodoistClient,
     token: &str,
     opts: &AddOpts,
-) -> Result<serde_json::Value> {
+) -> Result<serde_json::Value, TasksError> {
     let project_id = match &opts.project {
         Some(arg) => {
-            let projects = client.list_projects(token).map_err(|e| anyhow!(e))?;
+            let projects = client.list_projects(token).context(ApiSnafu)?;
             Some(resolve_project_id(&projects, arg)?)
         }
         None => None,
@@ -89,7 +109,7 @@ pub fn run_add(
         labels: opts.labels.clone(),
         description: opts.description.clone(),
     };
-    client.create_task(token, &body).map_err(|e| anyhow!(e))
+    client.create_task(token, &body).context(ApiSnafu)
 }
 
 pub fn render_added(task: &serde_json::Value) -> String {
@@ -187,10 +207,10 @@ pub fn run_complete(
     client: &impl TodoistClient,
     token: &str,
     args: &[String],
-) -> Result<Vec<CompleteResult>> {
+) -> Result<Vec<CompleteResult>, TasksError> {
     let tasks = client
         .list_tasks(token, &TaskListQuery::default())
-        .map_err(|e| anyhow!(e))?;
+        .context(ApiSnafu)?;
     let mut results = Vec::with_capacity(args.len());
     for arg in args {
         match resolve_target(&tasks, arg) {


### PR DESCRIPTION
Brings `tools/todoist` in line with the in-house error style used by
`shaka`. `snafu` gives us typed enums with `.context(...)` attach,
which `anyhow` (dynamic) and `thiserror` (typed but no attach
pattern) each lack on their own.

Per-module error enums:

- `api::ApiError` — replaces the hand-rolled enum + manual `Display`
  / `Error` impls. Tuple variant `Network(String)` becomes
  `Network { message }` (snafu requires named fields); construction
  sites updated.
- `auth::OpError` — hand-rolled struct → snafu newtype; same
  `{message}` Display.
- `auth::AuthError` — new; covers config IO (`Read` / `Write` /
  `CreateDir` / `Remove`), TOML serde, op-resolve wrapping `OpError`,
  and the `HOME is not set` env-var path.
- `tasks::TasksError` — new; wraps `ApiError` for the three call
  sites that fan out from list / add / complete, plus typed variants
  for project-name resolution (`ProjectNotFound`, `ProjectAmbiguous`).
- `projects::ProjectsError` — new; wraps `ApiError` for the lone
  `run_list` call site. Added here because PR #643 landed `projects`
  on `anyhow` while this refactor was in flight; covering it in the
  same PR avoids landing a half-migrated `todoist`.
- `CliError` in `main.rs` — top-level enum wrapping the per-module
  errors and the token-resolution path that doesn't belong in
  `auth.rs`.

`fn main()` now prints the error and walks the source chain to
stderr before exiting non-zero — preserves the "caused by:" cascade
anyhow gave us on `Err` propagation from `main`, without anyhow's
`Debug`-based termination.

All 58 existing tests pass; every `.to_string().contains(...)`
assertion survives because each snafu `#[snafu(display(...))]` is
byte-identical to the message the hand-rolled / `anyhow!()` path
produced.

`anyhow` dropped from `Cargo.toml`.

The `apps/blogctl` half (thiserror → snafu) is tracked in #654.

Closes #640