### PR TITLE
fix(shaka): workspace status surfaces open PRs for the issue

### DIFF
--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -332,18 +332,36 @@ pub(crate) fn parse_pr_for_issue(body: &str) -> Result<Option<PrInfo>, GhError> 
     let Some(first) = value.as_array().and_then(|a| a.first()) else {
         return Ok(None);
     };
-    let number = first["number"].as_u64().context(SchemaSnafu {
+    parse_one_pr_list_entry(first).map(Some)
+}
+
+/// Parse a `gh pr list --json number,state,url` JSON array into a
+/// `Vec<PrInfo>`. Empty input yields an empty Vec; one malformed entry
+/// short-circuits with an error rather than silently dropping it.
+pub(crate) fn parse_all_prs(body: &str) -> Result<Vec<PrInfo>, GhError> {
+    let value: Value = serde_json::from_str(body).context(JsonParseSnafu {
+        context: "failed to parse gh pr list JSON".to_string(),
+    })?;
+    let Some(arr) = value.as_array() else {
+        return Ok(Vec::new());
+    };
+    arr.iter().map(parse_one_pr_list_entry).collect()
+}
+
+/// Lift one entry from a `gh pr list --json number,state,url` array
+/// into a `PrInfo`. State strings are upper-case here (unlike the REST
+/// API's lower-case `open`/`closed` + separate `merged_at`).
+fn parse_one_pr_list_entry(value: &Value) -> Result<PrInfo, GhError> {
+    let number = value["number"].as_u64().context(SchemaSnafu {
         message: "PR missing 'number' field",
     })?;
-    let url = first["url"]
+    let url = value["url"]
         .as_str()
         .with_context(|| SchemaSnafu {
             message: format!("PR #{number} missing 'url' field"),
         })?
         .to_string();
-    // gh pr list reports state as upper-case OPEN/CLOSED/MERGED (unlike the
-    // REST API which uses lower-case open/closed plus a separate merged_at).
-    let state = match first["state"].as_str() {
+    let state = match value["state"].as_str() {
         Some("OPEN") => PrState::Open,
         Some("MERGED") => PrState::Merged,
         Some("CLOSED") => PrState::Closed,
@@ -354,7 +372,44 @@ pub(crate) fn parse_pr_for_issue(body: &str) -> Result<Option<PrInfo>, GhError> 
             .fail();
         }
     };
-    Ok(Some(PrInfo { number, url, state }))
+    Ok(PrInfo { number, url, state })
+}
+
+/// All OPEN PRs whose body references `Closes #n`. Returns an empty
+/// Vec if none. See [`pr_for_issue`] for the single-PR (any-state)
+/// variant; this helper exists so `shaka workspace status` can surface
+/// live work even when the PR's bookmark isn't on the workspace's `@`.
+pub fn open_prs_for_issue(repo: &str, n: u64) -> Result<Vec<PrInfo>, GhError> {
+    let query = format!("in:body Closes #{n}");
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--search",
+            &query,
+            "--state",
+            "open",
+            "--limit",
+            "10",
+            "--json",
+            "number,state,url",
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: format!("gh pr list (open, search Closes #{n})"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    parse_all_prs(&body)
 }
 
 /// Run `gh pr create` and return the PR URL.
@@ -1135,6 +1190,32 @@ mod tests {
     fn parse_pr_for_issue_unknown_state_errors() {
         let body = r#"[{"number": 1, "state": "WAT", "url": "u"}]"#;
         assert!(parse_pr_for_issue(body).is_err());
+    }
+
+    #[test]
+    fn parse_all_prs_multiple() {
+        let body = r#"[
+            {"number": 1, "state": "OPEN", "url": "u1"},
+            {"number": 2, "state": "OPEN", "url": "u2"}
+        ]"#;
+        let prs = parse_all_prs(body).unwrap();
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].number, 1);
+        assert_eq!(prs[1].number, 2);
+    }
+
+    #[test]
+    fn parse_all_prs_empty() {
+        assert!(parse_all_prs("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_all_prs_short_circuits_on_bad_entry() {
+        let body = r#"[
+            {"number": 1, "state": "OPEN", "url": "u1"},
+            {"number": 2, "state": "WAT", "url": "u2"}
+        ]"#;
+        assert!(parse_all_prs(body).is_err());
     }
 
     #[test]

--- a/tools/shaka/src/workspace/status.rs
+++ b/tools/shaka/src/workspace/status.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use serde::Serialize;
 
+use super::issue_link;
 use super::staleness::{self, Staleness};
 use super::{die, workspace_path, BOLD, DIM, GREEN, RED, RESET, YELLOW};
 use crate::{gh, jj};
@@ -15,6 +18,17 @@ struct WorkspaceStatus {
     dirty: bool,
     dirty_counts: DirtyCounts,
     staleness: Staleness,
+    /// Open PRs that close the workspace's persisted issue. Catches
+    /// the "PR opened, then `jj new` moved `@` off the bookmark" case
+    /// where the on-`@` reads (`bookmarks_on_workspace`, `ahead_count`)
+    /// report nothing.
+    open_prs: Vec<OpenPrSummary>,
+}
+
+#[derive(Serialize)]
+struct OpenPrSummary {
+    number: u64,
+    url: String,
 }
 
 #[derive(Serialize)]
@@ -71,6 +85,14 @@ pub fn run(json: bool) {
             Staleness::Active
         };
 
+        let open_prs = if ws.name == "default" {
+            Vec::new()
+        } else if let Some(r) = &repo {
+            open_prs_for(&repo_root, r, &ws.name)
+        } else {
+            Vec::new()
+        };
+
         statuses.push(WorkspaceStatus {
             name: ws.name.clone(),
             path: path.display().to_string(),
@@ -86,6 +108,7 @@ pub fn run(json: bool) {
                 total: counts.total(),
             },
             staleness,
+            open_prs,
         });
     }
 
@@ -154,6 +177,17 @@ fn render_human(statuses: &[WorkspaceStatus]) {
             println!("  {BOLD}merged:{RESET}     {DIM}{pr_url}{RESET}");
         }
 
+        // Open PRs for the workspace's issue, regardless of where the
+        // bookmark sits relative to `@`. Surfacing these prevents a
+        // workspace from looking empty when its work has been pushed
+        // and `@` has moved off the bookmark.
+        for pr in &ws.open_prs {
+            println!(
+                "  {BOLD}open PR:{RESET}    {GREEN}#{}{RESET}  {DIM}{}{RESET}",
+                pr.number, pr.url
+            );
+        }
+
         println!();
     }
 
@@ -175,5 +209,31 @@ fn render_human(statuses: &[WorkspaceStatus]) {
             "{YELLOW}{stale} workspace{plural} stale ({merged} merged, {orphan} orphan); \
              run shaka workspace cleanup{RESET}"
         );
+    }
+}
+
+/// Look up open PRs whose body references `Closes #<issue>` for the
+/// workspace's persisted issue. Returns an empty Vec when there's no
+/// issue link or the `gh` call fails (warns to stderr in the failure
+/// case, matching `staleness::resolve_merged_pr`).
+fn open_prs_for(repo_root: &Path, repo: &str, name: &str) -> Vec<OpenPrSummary> {
+    let Ok(Some(link)) = issue_link::read(repo_root, name) else {
+        return Vec::new();
+    };
+    match gh::open_prs_for_issue(repo, link.issue) {
+        Ok(prs) => prs
+            .into_iter()
+            .map(|p| OpenPrSummary {
+                number: p.number,
+                url: p.url,
+            })
+            .collect(),
+        Err(e) => {
+            eprintln!(
+                "{DIM}warn:{RESET} could not query open PRs for issue #{}: {e}",
+                link.issue
+            );
+            Vec::new()
+        }
     }
 }


### PR DESCRIPTION
`shaka workspace status` reports state of the workspace's `@` only.
If the user has done work in a workspace, pushed it (creating a
bookmark and opening a PR), then run `jj new` to start something
fresh, `@` becomes an empty change — and status now reports the
workspace as `clean / 0 commits ahead / no bookmarks`, hiding the
open PR's existence. This nearly cost a live workspace (`i637` with
open PR #643) during a cleanup pass.

Add an `open_prs` field to `WorkspaceStatus`, populated by reading
the workspace's persisted issue link and querying
`gh::open_prs_for_issue` (a new helper that mirrors the existing
`pr_for_issue` but returns all open matches via `--state open`,
unbounded by the previous helper's `--limit 1`). Render the list
in both JSON and human output, after the existing `merged:` line.

The open-PR list is orthogonal to `Staleness`: a workspace can be
Active and have open PRs (the i637 case), or Merged and have
follow-up open PRs (rare but possible). Keeping them as separate
fields avoids re-shaping the Staleness enum.

Workspaces with no persisted issue link (ad-hoc names) skip the
lookup — they can't be attributed without the metadata. Capturing
those would need either a schema extension (persist the bookmark
on `repo send`) or a bookmark-graph attribution heuristic; both
are out of scope for this fix.

Closes #655