### PR TITLE
feat(infra/home): bell on Claude Code stop for Ghostty tab blink

### DIFF
--- a/infra/home/dotfiles/claude/settings.json
+++ b/infra/home/dotfiles/claude/settings.json
@@ -18,6 +18,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '\\a'"
+          }
+        ]
+      }
     ]
   }
 }

--- a/infra/home/dotfiles/ghostty/config
+++ b/infra/home/dotfiles/ghostty/config
@@ -1,0 +1,4 @@
+keybind = shift+enter=text:\x1b\r
+
+# Silent bell — blink the tab instead of playing a sound
+window-urgency = true

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -91,6 +91,7 @@
   # Zellij's keybind tree is too elaborate to express idiomatically in
   # nix. Ship the kdl file as-is and let home-manager symlink it.
   xdg.configFile."zellij/config.kdl".source = ../dotfiles/zellij/config.kdl;
+  xdg.configFile."ghostty/config".source = ../dotfiles/ghostty/config;
 
   # Claude Code skills that aren't tied to a specific project. Lifted
   # from `kolohelios/.claude/commands/` so they apply to claude


### PR DESCRIPTION
Add a Stop hook to the Claude Code settings that emits BEL (\a) when
Claude finishes and needs attention. Add Ghostty config to home-manager
(via xdg.configFile) with window-urgency = true so the BEL triggers a
silent tab blink instead of an audible bell.