### PR TITLE
feat(infra/home): weekly proactive nix-store --gc via launchd

### DIFF
--- a/infra/home/README.md
+++ b/infra/home/README.md
@@ -55,6 +55,14 @@ If GC behavior needs another knob, edit `darwin.nix` and re-run the
 `darwin-rebuild switch` from below. Don't hand-edit `nix.custom.conf` —
 the next switch overwrites it.
 
+GC has two layers on this host: the reactive `min-free`/`max-free`
+above (catches catastrophic disk-full mid-build), and a proactive
+weekly `launchd.daemons.nix-gc` (also in `modules/darwin.nix`, per
+#664) that runs `nix-store --gc --delete-older-than 7d` Sundays at
+03:00, logging to `/var/log/nix-gc.log`. macOS `launchd` doesn't make
+up missed runs on wake, so a sleeping Mac skips that week's GC —
+`min-free` remains the safety net in that case.
+
 ## Local zsh extensions
 
 The generated `~/.zshrc` is a symlink into the Nix store. Tool-specific

--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -74,4 +74,30 @@
     max-free = ${toString (50 * 1024 * 1024 * 1024)}
     auto-optimise-store = true
   '';
+
+  # Proactive companion to the reactive `min-free`/`max-free` settings
+  # above. `min-free` only fires when disk pressure hits, so dead
+  # dev-shell generations from the daily `kolohelios-nix` bump can sit
+  # rooted-then-unrooted indefinitely if free space stays above the
+  # threshold. This `launchd` job runs `nix-store --gc` weekly
+  # (Sundays 03:00) with a 7-day retention bound. launchd lives outside
+  # nix-darwin's `nix.*` namespace so the Determinate gate (#631)
+  # doesn't reach it. macOS doesn't make up missed runs on wake — if
+  # the Mac's asleep at 03:00 the week's GC just skips, and
+  # `min-free` remains the safety net. Tracked in #664.
+  launchd.daemons.nix-gc = {
+    command = "/nix/var/nix/profiles/default/bin/nix-store --gc --delete-older-than 7d";
+    serviceConfig = {
+      StartCalendarInterval = [
+        {
+          Weekday = 0;
+          Hour = 3;
+          Minute = 0;
+        }
+      ];
+      StandardOutPath = "/var/log/nix-gc.log";
+      StandardErrorPath = "/var/log/nix-gc.log";
+      RunAtLoad = false;
+    };
+  };
 }


### PR DESCRIPTION
Complements the reactive `min-free`/`max-free` from #632. The reactive
trigger only fires when disk pressure hits, so dead dev-shell
generations from the daily `kolohelios-nix` bump can sit indefinitely
between bumps if free space stays above `min-free`. This launchd job
runs `nix-store --gc --delete-older-than 7d` Sundays at 03:00 to clean
up steady-state accumulation, logging to `/var/log/nix-gc.log`.

`launchd.daemons.*` lives outside the `nix.*` namespace Determinate
gates (#631) so it's reachable here. The job calls
`/nix/var/nix/profiles/default/bin/nix-store` (Determinate's profile
path) directly, talking to the same daemon socket nix-darwin would.

macOS launchd does NOT make up missed runs on wake — if the Mac is
asleep Sundays at 03:00, that week's gc just skips. `min-free`
remains the safety net for catastrophic accumulation when the Mac is
predominantly asleep at the scheduled time.

README's "Nix configuration on macOS" section gets a paragraph
documenting the two-layer GC story (reactive #632, proactive #664) so
the next reader doesn't have to spelunk two separate PRs.

Closes #664