### PR TITLE
feat(aof): consume Todoist projects via tools/todoist subprocess

### DIFF
--- a/tools/aof/Cargo.lock
+++ b/tools/aof/Cargo.lock
@@ -66,6 +66,8 @@ dependencies = [
  "clap",
  "image",
  "resvg",
+ "serde",
+ "serde_json",
  "snafu",
 ]
 
@@ -308,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +343,12 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmap2"
@@ -490,6 +504,49 @@ dependencies = [
  "unicode-ccc",
  "unicode-properties",
  "unicode-script",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -742,6 +799,12 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"

--- a/tools/aof/Cargo.toml
+++ b/tools/aof/Cargo.toml
@@ -14,11 +14,13 @@ name = "aof"
 path = "src/main.rs"
 
 [dependencies]
-base64 = "0.22"
-clap   = { version = "4", features = ["derive"] }
-image  = { version = "0.25", default-features = false, features = ["png"] }
-resvg  = "0.45"
-snafu  = "0.9"
+base64     = "0.22"
+clap       = { version = "4", features = ["derive"] }
+image      = { version = "0.25", default-features = false, features = ["png"] }
+resvg      = "0.45"
+serde      = { version = "1", features = ["derive"] }
+serde_json = "1"
+snafu      = "0.9"
 
 [lints.clippy]
 mod_module_files = "deny"

--- a/tools/aof/src/lib.rs
+++ b/tools/aof/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod render;
+pub mod todoist;

--- a/tools/aof/src/main.rs
+++ b/tools/aof/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use aof::render;
+use aof::{render, todoist};
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -19,8 +19,13 @@ struct Cli {
 enum Command {
     /// Validate the areas-of-focus tree against its CUE schema
     Validate,
-    /// Reconcile areas against Todoist projects and report drift
-    Sync,
+    /// Fetch and print the current Todoist project list (sanity check
+    /// for reconciliation; reconciliation itself lands in #610).
+    Sync {
+        /// Emit ndjson instead of the default human-readable table
+        #[arg(long)]
+        json: bool,
+    },
     /// Render an SVG diagram inline in the current terminal
     Render {
         /// Path to the SVG file to render
@@ -36,10 +41,13 @@ fn main() -> ExitCode {
             unimplemented("validate");
             ExitCode::FAILURE
         }
-        Command::Sync => {
-            unimplemented("sync");
-            ExitCode::FAILURE
-        }
+        Command::Sync { json } => match run_sync(json) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("aof sync: {e}");
+                ExitCode::FAILURE
+            }
+        },
         Command::Render { from } => match run_render(&from) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
@@ -53,6 +61,17 @@ fn main() -> ExitCode {
 fn run_render(from: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let svg = std::fs::read(from)?;
     render::render_svg(&svg)?;
+    Ok(())
+}
+
+fn run_sync(json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let projects = todoist::list_projects()?;
+    let out = if json {
+        todoist::render_ndjson(&projects)
+    } else {
+        todoist::render_table(&projects)
+    };
+    println!("{out}");
     Ok(())
 }
 

--- a/tools/aof/src/todoist.rs
+++ b/tools/aof/src/todoist.rs
@@ -1,0 +1,180 @@
+use std::io;
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum TodoistError {
+    #[snafu(display("could not spawn `todoist`: {source} (is `todoist` on PATH?)"))]
+    Spawn { source: io::Error },
+
+    #[snafu(display("`todoist projects list --json` exited {status}: {stderr}"))]
+    NonZeroExit { status: i32, stderr: String },
+
+    #[snafu(display(
+        "failed to parse line {line_no} from `todoist projects list --json`: {source}"
+    ))]
+    ParseJson {
+        line_no: usize,
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct Project {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+}
+
+/// Invoke `todoist projects list --json` and parse the ndjson output.
+/// `todoist` is expected to be on `PATH` at runtime — it's the sibling
+/// crate `tools/todoist`; `aof` deliberately doesn't carry its own
+/// Todoist API client.
+pub fn list_projects() -> Result<Vec<Project>, TodoistError> {
+    let output = Command::new("todoist")
+        .args(["projects", "list", "--json"])
+        .output()
+        .context(SpawnSnafu)?;
+    if !output.status.success() {
+        return NonZeroExitSnafu {
+            status: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        }
+        .fail();
+    }
+    parse_ndjson(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_ndjson(s: &str) -> Result<Vec<Project>, TodoistError> {
+    s.lines()
+        .enumerate()
+        .filter(|(_, l)| !l.trim().is_empty())
+        .map(|(i, l)| serde_json::from_str(l).context(ParseJsonSnafu { line_no: i + 1 }))
+        .collect()
+}
+
+pub fn render_table(projects: &[Project]) -> String {
+    if projects.is_empty() {
+        return "no projects".to_string();
+    }
+    projects
+        .iter()
+        .map(|p| match &p.parent_id {
+            Some(parent) => format!("{}  {}  [parent={parent}]", p.id, p.name),
+            None => format!("{}  {}", p.id, p.name),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn render_ndjson(projects: &[Project]) -> String {
+    projects
+        .iter()
+        .map(|p| serde_json::to_string(p).expect("Project always serializes"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ndjson_handles_valid_lines() {
+        let raw = r#"{"id":"1","name":"Inbox","parent_id":null}
+{"id":"2","name":"Errands","parent_id":"1"}"#;
+        let projects = parse_ndjson(raw).expect("parse should succeed");
+        assert_eq!(projects.len(), 2);
+        assert_eq!(projects[0].name, "Inbox");
+        assert_eq!(projects[0].parent_id, None);
+        assert_eq!(projects[1].name, "Errands");
+        assert_eq!(projects[1].parent_id.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn parse_ndjson_handles_empty_input() {
+        let projects = parse_ndjson("").expect("empty input is valid");
+        assert!(projects.is_empty());
+    }
+
+    #[test]
+    fn parse_ndjson_skips_blank_lines() {
+        // Trailing newline is common from line-oriented output; blank
+        // separator lines shouldn't be treated as parse failures either.
+        let raw = "\n{\"id\":\"1\",\"name\":\"Inbox\",\"parent_id\":null}\n\n";
+        let projects = parse_ndjson(raw).expect("blanks should be skipped");
+        assert_eq!(projects.len(), 1);
+    }
+
+    #[test]
+    fn parse_ndjson_reports_line_number_on_bad_input() {
+        // Line 2 is malformed; the error should point at line 2 so a
+        // user piping through tools can find the bad row.
+        let raw = "{\"id\":\"1\",\"name\":\"a\",\"parent_id\":null}\nnot json";
+        let err = parse_ndjson(raw).expect_err("garbage line must error");
+        let msg = err.to_string();
+        assert!(msg.contains("line 2"), "got: {msg}");
+    }
+
+    #[test]
+    fn project_treats_missing_parent_id_as_none() {
+        // todoist's render_ndjson always emits `parent_id` (null or
+        // string); but tolerating a missing key keeps us robust if the
+        // upstream shape ever drifts.
+        let raw = r#"{"id":"1","name":"Inbox"}"#;
+        let parsed: Project = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.parent_id, None);
+    }
+
+    #[test]
+    fn render_table_shows_one_project_per_line() {
+        let projects = vec![
+            Project {
+                id: "1".into(),
+                name: "Inbox".into(),
+                parent_id: None,
+            },
+            Project {
+                id: "2".into(),
+                name: "Errands".into(),
+                parent_id: Some("1".into()),
+            },
+        ];
+        let out = render_table(&projects);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("Inbox"));
+        assert!(!lines[0].contains("parent="));
+        assert!(lines[1].contains("Errands"));
+        assert!(lines[1].contains("parent=1"));
+    }
+
+    #[test]
+    fn render_table_reports_empty_set() {
+        assert_eq!(render_table(&[]), "no projects");
+    }
+
+    #[test]
+    fn render_ndjson_each_line_parses_back() {
+        let projects = vec![
+            Project {
+                id: "1".into(),
+                name: "Inbox".into(),
+                parent_id: None,
+            },
+            Project {
+                id: "2".into(),
+                name: "Errands".into(),
+                parent_id: Some("1".into()),
+            },
+        ];
+        let out = render_ndjson(&projects);
+        // Round-trip: parse our own output back into Vec<Project>.
+        let round_trip = parse_ndjson(&out).expect("our ndjson should re-parse");
+        assert_eq!(round_trip, projects);
+    }
+}


### PR DESCRIPTION
New `aof::todoist` module: subprocess wrapper around
`todoist projects list --json` plus parser for its ndjson output.
Replaces the original #609 plan (build a fresh HTTP client in `aof`)
— `tools/todoist` already has the API auth (1Password `op://` refs)
and HTTP wiring, so duplicating it in `aof` would split the surface
that needs to be reasoned about when the Todoist API changes.

Shape:

- `Project { id, name, parent_id: Option<String> }` — `Deserialize`
  for parsing and `Serialize` for re-emitting in `--json` mode.
- `list_projects()` invokes `todoist projects list --json` and parses
  the result. Distinct error variants for spawn failure, non-zero
  exit, and per-line JSON parse failure (the last carries the line
  number so a user piping through other tools can pinpoint the bad
  row).
- `render_table` / `render_ndjson` for the `aof sync` subcommand's
  two output modes.

`aof sync [--json]` wired up — fetch and print the current project
list as a sanity check. Reconciliation against the areas tree lands
in #610.

`todoist` is a runtime PATH dependency, not a build-time one (it's a
sibling local crate, not a nixpkgs entry). The `Spawn` error variant
points the user at PATH explicitly if invocation fails.

Closes #609