### PR TITLE
feat(shaka): repo send/pr queue auto-merge by default

### DIFF
--- a/tools/shaka/src/repo.rs
+++ b/tools/shaka/src/repo.rs
@@ -69,6 +69,12 @@ pub enum RepoCommand {
         #[arg(long)]
         no_pr: bool,
 
+        /// Skip queueing GitHub auto-merge after PR creation. The PR
+        /// will be opened (and any existing PR left in place) but the
+        /// merge has to be triggered manually.
+        #[arg(long)]
+        no_auto_merge: bool,
+
         /// Print the commands that would run without executing them
         #[arg(long)]
         dry_run: bool,
@@ -78,6 +84,12 @@ pub enum RepoCommand {
         /// Bookmark name (auto-detected from the current change if omitted)
         #[arg(long)]
         bookmark: Option<String>,
+
+        /// Skip queueing GitHub auto-merge after PR creation. The PR
+        /// will be opened (and any existing PR left in place) but the
+        /// merge has to be triggered manually.
+        #[arg(long)]
+        no_auto_merge: bool,
 
         /// Print the commands that would run without executing them
         #[arg(long)]
@@ -193,9 +205,14 @@ pub fn run(cmd: RepoCommand) {
         RepoCommand::Send {
             bookmark,
             no_pr,
+            no_auto_merge,
             dry_run,
-        } => send::run(bookmark, no_pr, dry_run),
-        RepoCommand::Pr { bookmark, dry_run } => pr::run(bookmark, dry_run),
+        } => send::run(bookmark, no_pr, no_auto_merge, dry_run),
+        RepoCommand::Pr {
+            bookmark,
+            no_auto_merge,
+            dry_run,
+        } => pr::run(bookmark, no_auto_merge, dry_run),
         RepoCommand::Ship {
             bookmark,
             skip_preflight,

--- a/tools/shaka/src/repo/pr.rs
+++ b/tools/shaka/src/repo/pr.rs
@@ -2,9 +2,9 @@ use crate::gh;
 use crate::jj;
 use crate::repo::describe;
 use crate::repo::send::resolve_bookmark;
-use crate::term::{BOLD, GREEN, RED, RESET};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
-pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
+pub fn run(bookmark_arg: Option<String>, no_auto_merge: bool, dry_run: bool) {
     let description = match jj::current_description() {
         Ok(d) => d,
         Err(e) => {
@@ -45,6 +45,9 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
         println!("would run: jj bookmark set {bookmark} -r @");
         println!("would run: jj git push --allow-new --bookmark {bookmark}");
         println!("would ensure PR exists for head {bookmark}");
+        if !no_auto_merge {
+            println!("would run: gh pr merge --auto --rebase <pr-url>");
+        }
         return;
     }
 
@@ -68,10 +71,16 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
         }
     };
 
-    match gh::pr_for_head(&repo, &bookmark) {
-        Ok(Some(pr)) => println!("{GREEN}{BOLD}pushed{RESET} (PR: {})", pr.url),
+    let pr_url = match gh::pr_for_head(&repo, &bookmark) {
+        Ok(Some(pr)) => {
+            println!("{GREEN}{BOLD}pushed{RESET} (PR: {})", pr.url);
+            pr.url
+        }
         Ok(None) => match gh::pr_create(&repo, title, body, &bookmark) {
-            Ok(url) => println!("{GREEN}{BOLD}created{RESET} ({url})"),
+            Ok(url) => {
+                println!("{GREEN}{BOLD}created{RESET} ({url})");
+                url
+            }
             Err(e) => {
                 eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");
                 std::process::exit(1);
@@ -80,6 +89,15 @@ pub fn run(bookmark_arg: Option<String>, dry_run: bool) {
         Err(e) => {
             eprintln!("{RED}{BOLD}error:{RESET} {e}");
             std::process::exit(1);
+        }
+    };
+
+    if !no_auto_merge {
+        match gh::pr_merge_auto_rebase(&pr_url) {
+            Ok(()) => println!("{DIM}auto-merge queued{RESET}"),
+            Err(e) => {
+                eprintln!("{YELLOW}{BOLD}warn:{RESET} could not queue auto-merge for {pr_url}: {e}")
+            }
         }
     }
 }

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -4,7 +4,7 @@ use crate::preflight;
 use crate::repo::describe;
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
-pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
+pub fn run(bookmark_arg: Option<String>, no_pr: bool, no_auto_merge: bool, dry_run: bool) {
     let description = match jj::current_description() {
         Ok(d) => d,
         Err(e) => {
@@ -52,6 +52,9 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         println!("would run: jj git push --allow-new --bookmark {bookmark}");
         if !no_pr {
             println!("would run: gh pr create --title {title:?} --head {bookmark}");
+            if !no_auto_merge {
+                println!("would run: gh pr merge --auto --rebase <pr-url>");
+            }
         }
         return;
     }
@@ -117,10 +120,16 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         }
     };
 
-    match gh::pr_for_head(&repo, &bookmark) {
-        Ok(Some(pr)) => println!("{GREEN}{BOLD}pushed{RESET} (PR exists: {})", pr.url),
+    let pr_url = match gh::pr_for_head(&repo, &bookmark) {
+        Ok(Some(pr)) => {
+            println!("{GREEN}{BOLD}pushed{RESET} (PR exists: {})", pr.url);
+            pr.url
+        }
         Ok(None) => match gh::pr_create(&repo, title, body, &bookmark) {
-            Ok(url) => println!("{GREEN}{BOLD}sent{RESET} ({url})"),
+            Ok(url) => {
+                println!("{GREEN}{BOLD}sent{RESET} ({url})");
+                url
+            }
             Err(e) => {
                 eprintln!("{RED}{BOLD}pr create failed:{RESET} {e}");
                 std::process::exit(1);
@@ -129,6 +138,22 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, dry_run: bool) {
         Err(e) => {
             eprintln!("{YELLOW}{BOLD}warn:{RESET} could not check existing PRs: {e}");
             std::process::exit(1);
+        }
+    };
+
+    if !no_auto_merge {
+        queue_auto_merge(&pr_url);
+    }
+}
+
+/// Queue GitHub auto-merge (rebase strategy) on the PR. Soft-fails:
+/// the PR is already open, so a missing repo policy (e.g.
+/// `allow_auto_merge: false`) should warn rather than error out.
+fn queue_auto_merge(pr_url: &str) {
+    match gh::pr_merge_auto_rebase(pr_url) {
+        Ok(()) => println!("{DIM}auto-merge queued{RESET}"),
+        Err(e) => {
+            eprintln!("{YELLOW}{BOLD}warn:{RESET} could not queue auto-merge for {pr_url}: {e}")
         }
     }
 }

--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -44,7 +44,7 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
         } else {
             println!("would run: shaka preflight");
         }
-        send::run(Some(bookmark), false, true);
+        send::run(Some(bookmark), false, false, true);
         return;
     }
 
@@ -94,5 +94,5 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
     }
 
     println!("{BOLD}step 6/6: handing off to repo send{RESET}");
-    send::run(Some(bookmark), false, false);
+    send::run(Some(bookmark), false, false, false);
 }


### PR DESCRIPTION
`shaka repo send` and `shaka repo pr` create a PR but leave
auto-merge off, so the PR waits for a manual merge after CI goes
green. As a solo dev with a single CI gate (`shaka preflight`),
the steady-state pattern is "open PR → wait for green → rebase
merge" — exactly what auto-merge automates.

After PR creation (or detecting an existing PR), call
`gh::pr_merge_auto_rebase` to queue `gh pr merge --auto --rebase`.
Add a `--no-auto-merge` opt-out flag on both subcommands for the
rare case where the PR should sit open.

Soft-fail on auto-merge errors: the PR is already opened
successfully, so a missing `allow_auto_merge: true` (or any other
auto-merge precondition not met) should warn rather than abort.
Repo policy is already audited by `shaka repo audit` (#396), so
the typical failure mode is loud at audit time, not here.

`repo ship` continues to call `send::run` with default auto-merge
on, matching the opinionated end-to-end workflow.

Dry-run output for both subcommands now includes the auto-merge
line so users can see what will run.

The `gh::pr_merge_auto_rebase` helper already exists (added in
#385 for `repo bump-locks`); this commit just extends its use to
the two main PR-creating code paths.

Closes #57