### PR TITLE
feat(shaka): enable shellCompletions for aof, claude-hooks, todoist

### DIFF
--- a/tools/aof/Cargo.lock
+++ b/tools/aof/Cargo.lock
@@ -64,6 +64,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "clap",
+ "clap_complete",
  "image",
  "resvg",
  "serde",
@@ -145,6 +146,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/tools/aof/Cargo.toml
+++ b/tools/aof/Cargo.toml
@@ -14,13 +14,14 @@ name = "aof"
 path = "src/main.rs"
 
 [dependencies]
-base64     = "0.22"
-clap       = { version = "4", features = ["derive"] }
-image      = { version = "0.25", default-features = false, features = ["png"] }
-resvg      = "0.45"
-serde      = { version = "1", features = ["derive"] }
-serde_json = "1"
-snafu      = "0.9"
+base64        = "0.22"
+clap          = { version = "4", features = ["derive"] }
+clap_complete = "4"
+image         = { version = "0.25", default-features = false, features = ["png"] }
+resvg         = "0.45"
+serde         = { version = "1", features = ["derive"] }
+serde_json    = "1"
+snafu         = "0.9"
 
 [lints.clippy]
 mod_module_files = "deny"

--- a/tools/aof/flake.nix
+++ b/tools/aof/flake.nix
@@ -56,6 +56,13 @@
             version = "0.1.0";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+            postInstall = ''
+              installShellCompletion --cmd aof \
+                --bash <($out/bin/aof completions bash) \
+                --fish <($out/bin/aof completions fish) \
+                --zsh  <($out/bin/aof completions zsh)
+            '';
           };
         }
       );

--- a/tools/aof/project.cue
+++ b/tools/aof/project.cue
@@ -4,8 +4,9 @@ package project
 	name: "aof"
 	kind: "rust-cli"
 	cli: {
-		binaryName: "aof"
-		package:    true
+		binaryName:       "aof"
+		package:          true
+		shellCompletions: true
 	}
 	coverage: {
 		line: {

--- a/tools/aof/src/main.rs
+++ b/tools/aof/src/main.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use aof::{render, todoist};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 
 #[derive(Parser)]
 #[command(
@@ -32,6 +33,8 @@ enum Command {
         #[arg(long)]
         from: PathBuf,
     },
+    #[command(hide = true)]
+    Completions { shell: Shell },
 }
 
 fn main() -> ExitCode {
@@ -55,6 +58,12 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
+        Command::Completions { shell } => {
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+            ExitCode::SUCCESS
+        }
     }
 }
 
@@ -82,7 +91,6 @@ fn unimplemented(name: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::CommandFactory;
 
     #[test]
     fn cli_definition_is_valid() {

--- a/tools/claude-hooks/Cargo.lock
+++ b/tools/claude-hooks/Cargo.lock
@@ -75,6 +75,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +106,7 @@ name = "claude-hooks"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "serde",
  "serde_json",
  "shlex",

--- a/tools/claude-hooks/Cargo.toml
+++ b/tools/claude-hooks/Cargo.toml
@@ -10,7 +10,8 @@ name = "claude-hooks"
 path = "src/main.rs"
 
 [dependencies]
-clap       = { version = "4", features = ["derive"] }
+clap          = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
 shlex      = "1"

--- a/tools/claude-hooks/flake.nix
+++ b/tools/claude-hooks/flake.nix
@@ -56,6 +56,13 @@
             version = "0.1.0";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+            postInstall = ''
+              installShellCompletion --cmd claude-hooks \
+                --bash <($out/bin/claude-hooks completions bash) \
+                --fish <($out/bin/claude-hooks completions fish) \
+                --zsh  <($out/bin/claude-hooks completions zsh)
+            '';
           };
         }
       );

--- a/tools/claude-hooks/project.cue
+++ b/tools/claude-hooks/project.cue
@@ -4,7 +4,8 @@ package project
 	name: "claude-hooks"
 	kind: "rust-cli"
 	cli: {
-		binaryName: "claude-hooks"
+		binaryName:       "claude-hooks"
+		shellCompletions: true
 		// Consumed by `infra/home/modules/common.nix` so the binary
 		// is on PATH for every claude session, not just inside the
 		// kolohelios checkout. Build deps stay minimal — no

--- a/tools/claude-hooks/src/main.rs
+++ b/tools/claude-hooks/src/main.rs
@@ -18,7 +18,8 @@
 use std::io::Read;
 use std::process::Command;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use serde::Deserialize;
 
 /// Env-var prefix that lets the user opt out of the duplicate-check
@@ -57,12 +58,19 @@ enum Hook {
     /// invocations and runs a duplicate-search; blocks with a list of
     /// candidate matches if any open issue's title overlaps.
     PreIssueCreate,
+    #[command(hide = true)]
+    Completions { shell: Shell },
 }
 
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Hook::PreIssueCreate => pre_issue_create(),
+        Hook::Completions { shell } => {
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+        }
     }
 }
 

--- a/tools/todoist/Cargo.lock
+++ b/tools/todoist/Cargo.lock
@@ -115,6 +115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +732,7 @@ name = "todoist"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "serde",
  "serde_json",
  "snafu",

--- a/tools/todoist/Cargo.toml
+++ b/tools/todoist/Cargo.toml
@@ -10,7 +10,8 @@ name = "todoist"
 path = "src/main.rs"
 
 [dependencies]
-clap       = { version = "4", features = ["derive"] }
+clap          = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu      = "0.9"

--- a/tools/todoist/project.cue
+++ b/tools/todoist/project.cue
@@ -4,7 +4,8 @@ package project
 	name: "todoist"
 	kind: "rust-cli"
 	cli: {
-		binaryName: "todoist"
+		binaryName:       "todoist"
+		shellCompletions: true
 		// No `nix build ./tools/todoist` consumer today; only the
 		// devShell is needed. Skipping the package keeps the
 		// generated flake minimal.

--- a/tools/todoist/src/main.rs
+++ b/tools/todoist/src/main.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use snafu::{ResultExt, Snafu};
 
 mod api;
@@ -49,6 +50,8 @@ enum Command {
     Projects(ProjectsCmd),
     /// Manage tasks
     Tasks(TasksCmd),
+    #[command(hide = true)]
+    Completions { shell: Shell },
 }
 
 #[derive(Args)]
@@ -155,6 +158,12 @@ fn dispatch(command: Command) -> Result<(), CliError> {
         Command::Auth(AuthCmd { command }) => handle_auth(command),
         Command::Projects(ProjectsCmd { command }) => handle_projects(command),
         Command::Tasks(TasksCmd { command }) => handle_tasks(command),
+        Command::Completions { shell } => {
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
+            Ok(())
+        }
     }
 }
 
@@ -298,7 +307,6 @@ fn render_status(state: auth::AuthState) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::CommandFactory;
 
     #[test]
     fn cli_definition_is_valid() {


### PR DESCRIPTION
Each CLI now exposes a hidden `completions <shell>` subcommand via
clap_complete, matching the pattern already in shaka and blogctl.
This is the Rust-side prerequisite for the flake template to emit
installShellCompletion in postInstall.

Set shellCompletions: true in each project.cue and regenerate flakes.
aof and claude-hooks gain installShellCompletion in postInstall;
todoist records intent but has no package block (package: false).

Closes #614