### PR TITLE
refactor(blogctl): rename classification dimension theme to motifs

### DIFF
--- a/apps/blogctl/README.md
+++ b/apps/blogctl/README.md
@@ -58,7 +58,7 @@ blogctl classify <slug> --workdir <path> \
   [--call-to-action X] [--visual-type X] \
   [--complexity X] [--vulnerability X] \
   [--outcome-prediction X] \
-  [--theme A,B,...] [--clear-<dim>]
+  [--motifs A,B,...] [--clear-<dim>]
 blogctl metrics update <slug> --workdir <path> \
   --target <linkedin|blog> \
   --impressions N --reactions N --comments N --reposts N \
@@ -116,7 +116,7 @@ classifications:
   complexity: moderate
   vulnerability: low
   outcome_prediction: medium
-  theme:
+  motifs:
     - ambiguity
     - delivery
 targets:
@@ -199,7 +199,7 @@ values = ["none", "low", "medium", "high"]
 [classifications.outcome_prediction]
 values = ["low", "medium", "high"]
 
-[classifications.theme]
+[classifications.motifs]
 multi = true
 values = ["ambiguity", "delivery", "interfaces", "leadership", "ai",
           "engineering-culture", "product", "organizational-psychology",
@@ -255,7 +255,7 @@ blogctl classify the-only-way-out-is-through \
   --tone sharp \
   --audience engineering,leadership \
   --topic leadership \
-  --theme ambiguity,delivery \
+  --motifs ambiguity,delivery \
   --workdir ~/blog-os
 
 # 5. Refresh metrics weekly. `metrics show` prints the current

--- a/apps/blogctl/src/analytics/compare.rs
+++ b/apps/blogctl/src/analytics/compare.rs
@@ -70,7 +70,7 @@ struct Sample {
 /// `(value_a, value_b)` cross-product of its values on `dim_a` and
 /// `dim_b`, filtered to targets that match `target_filter` (or all
 /// targets, if `None`) and have metrics. Multi-valued dimensions
-/// (e.g. `theme: [a, b]`) explode into multiple cells.
+/// (e.g. `motifs: [a, b]`) explode into multiple cells.
 pub fn compute(
     posts: &[Post],
     dim_a: &str,
@@ -213,7 +213,7 @@ fn dimension_values(c: &Classifications, dim: &str) -> Vec<String> {
         "audience" => c.audience.clone(),
         "topic" => c.topic.clone(),
         "narrative_structure" => c.narrative_structure.clone(),
-        "theme" => c.theme.clone(),
+        "motifs" => c.motifs.clone(),
         _ => vec![], // unknown dimension — no samples contribute
     }
 }
@@ -236,7 +236,7 @@ mod tests {
         slug: &str,
         format: Option<&str>,
         hook: Option<&str>,
-        themes: &[&str],
+        motifs: &[&str],
         impressions: u64,
         reactions: u64,
     ) -> Post {
@@ -268,7 +268,7 @@ mod tests {
                 classifications: Classifications {
                     format: format.map(|s| s.to_string()),
                     hook: hook.map(|s| s.to_string()),
-                    theme: themes.iter().map(|s| (*s).to_string()).collect(),
+                    motifs: motifs.iter().map(|s| (*s).to_string()).collect(),
                     ..Default::default()
                 },
                 ai: None,
@@ -315,8 +315,8 @@ mod tests {
     }
 
     #[test]
-    fn multi_valued_theme_explodes_into_multiple_cells() {
-        // One post with theme=[a, b] and format=thesis → contributes
+    fn multi_valued_motifs_explode_into_multiple_cells() {
+        // One post with motifs=[a, b] and format=thesis → contributes
         // to (thesis, a) AND (thesis, b).
         let p = fixture_post(
             "x",
@@ -326,7 +326,7 @@ mod tests {
             1000,
             50,
         );
-        let c = compute(&[p], "format", "theme", None, 3, now());
+        let c = compute(&[p], "format", "motifs", None, 3, now());
         assert_eq!(c.cells.len(), 2);
         for cell in &c.cells {
             assert_eq!(cell.value_a, "thesis");

--- a/apps/blogctl/src/analytics/summary.rs
+++ b/apps/blogctl/src/analytics/summary.rs
@@ -158,9 +158,10 @@ fn value_summary(value: String, samples: &[Sample]) -> ValueSummary {
 
 /// Yield every `(dimension_name, value)` pair set on a
 /// `Classifications`. Single-valued fields yield 0 or 1 entries;
-/// the multi-valued `theme` yields 0 or N. Field names match the
-/// `Classifications` struct's field names (which match the
-/// `[classifications.<name>]` table in `.blog-os.toml`).
+/// multi-valued fields (audience, topic, narrative_structure,
+/// motifs) yield 0 or N. Field names match the `Classifications`
+/// struct's field names (which match the `[classifications.<name>]`
+/// table in `.blog-os.toml`).
 fn classification_entries(c: &Classifications) -> Vec<(&'static str, String)> {
     let mut out = Vec::new();
     if let Some(v) = &c.format {
@@ -196,8 +197,8 @@ fn classification_entries(c: &Classifications) -> Vec<(&'static str, String)> {
     for v in &c.narrative_structure {
         out.push(("narrative_structure", v.clone()));
     }
-    for v in &c.theme {
-        out.push(("theme", v.clone()));
+    for v in &c.motifs {
+        out.push(("motifs", v.clone()));
     }
     out
 }
@@ -219,7 +220,7 @@ mod tests {
     fn fixture_post(
         slug: &str,
         format: &str,
-        themes: &[&str],
+        motifs: &[&str],
         target: Target,
         impressions: u64,
         reactions: u64,
@@ -251,7 +252,7 @@ mod tests {
                 }],
                 classifications: Classifications {
                     format: Some(format.into()),
-                    theme: themes.iter().map(|s| (*s).to_string()).collect(),
+                    motifs: motifs.iter().map(|s| (*s).to_string()).collect(),
                     ..Default::default()
                 },
                 ai: None,
@@ -391,8 +392,8 @@ mod tests {
     }
 
     #[test]
-    fn multi_valued_theme_contributes_to_every_listed_theme() {
-        // One post with theme=[a, b] contributes to both a and b.
+    fn multi_valued_motifs_contribute_to_every_listed_value() {
+        // One post with motifs=[a, b] contributes to both a and b.
         let p = fixture_post(
             "x",
             "thesis",
@@ -401,10 +402,10 @@ mod tests {
             1000,
             50,
         );
-        let s = compute(&[p], None, Some("theme"), now());
-        let theme = &s.dimensions[0];
-        assert_eq!(theme.values.len(), 2);
-        for v in &theme.values {
+        let s = compute(&[p], None, Some("motifs"), now());
+        let motifs = &s.dimensions[0];
+        assert_eq!(motifs.values.len(), 2);
+        for v in &motifs.values {
             assert_eq!(v.n, 1, "value {} should have n=1", v.value);
         }
     }

--- a/apps/blogctl/src/classifications.rs
+++ b/apps/blogctl/src/classifications.rs
@@ -3,7 +3,7 @@
 //! captures one dimension of the post's intent (format, hook, tone,
 //! audience, topic, narrative-structure, call-to-action, visual-type,
 //! complexity, vulnerability, outcome-prediction) plus a multi-valued
-//! `theme` list.
+//! `motifs` list.
 //!
 //! Values stay `Option<String>` / `Vec<String>` rather than enums so
 //! the taxonomy can evolve in `.blog-os.toml` without touching code.
@@ -83,9 +83,11 @@ pub struct Classifications {
     pub outcome_prediction: Option<String>,
 
     /// Recurring conceptual threads — e.g. `adaptation`, `tradeoffs`,
-    /// `community`. Multi-valued.
+    /// `community`. Multi-valued. Previously named `theme`; renamed to
+    /// disambiguate from the singular narrative `theme` field on
+    /// `PostMetadata` (which picks a `[themes.*]` registry entry).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub theme: Vec<String>,
+    pub motifs: Vec<String>,
 }
 
 impl Classifications {
@@ -104,7 +106,7 @@ impl Classifications {
             && self.complexity.is_none()
             && self.vulnerability.is_none()
             && self.outcome_prediction.is_none()
-            && self.theme.is_empty()
+            && self.motifs.is_empty()
     }
 
     /// Enumerate every value not allowed by `taxonomy`. Dimensions
@@ -175,7 +177,7 @@ impl Classifications {
             ("audience", &self.audience),
             ("topic", &self.topic),
             ("narrative_structure", &self.narrative_structure),
-            ("theme", &self.theme),
+            ("motifs", &self.motifs),
         ]
     }
 }
@@ -218,7 +220,7 @@ mod tests {
             complexity: Some("moderate".into()),
             vulnerability: Some("low".into()),
             outcome_prediction: Some("medium".into()),
-            theme: vec!["ambiguity".into(), "delivery".into()],
+            motifs: vec!["ambiguity".into(), "delivery".into()],
         }
     }
 
@@ -247,7 +249,7 @@ mod tests {
         assert!(yaml.contains("format: thesis"), "got: {yaml}");
         assert!(!yaml.contains("hook"), "hook must be skipped: {yaml}");
         assert!(!yaml.contains("tone"), "tone must be skipped: {yaml}");
-        assert!(!yaml.contains("theme"), "theme must be skipped: {yaml}");
+        assert!(!yaml.contains("motifs"), "motifs must be skipped: {yaml}");
         assert!(!yaml.contains("topic"), "topic must be skipped: {yaml}");
         assert!(
             !yaml.contains("visual_type"),
@@ -262,7 +264,7 @@ mod tests {
         let c: Classifications = serde_yaml_ng::from_str(raw).unwrap();
         assert_eq!(c.format.as_deref(), Some("thesis"));
         assert!(c.hook.is_none());
-        assert!(c.theme.is_empty());
+        assert!(c.motifs.is_empty());
         assert!(c.topic.is_empty());
         assert!(c.call_to_action.is_none());
     }
@@ -277,22 +279,22 @@ mod tests {
     }
 
     #[test]
-    fn theme_round_trips_multi_value() {
+    fn motifs_round_trips_multi_value() {
         let c = Classifications {
-            theme: vec!["ambiguity".into(), "delivery".into(), "interfaces".into()],
+            motifs: vec!["ambiguity".into(), "delivery".into(), "interfaces".into()],
             ..Default::default()
         };
         let yaml = serde_yaml_ng::to_string(&c).unwrap();
         let back: Classifications = serde_yaml_ng::from_str(&yaml).unwrap();
         assert_eq!(back, c);
-        assert_eq!(back.theme.len(), 3);
+        assert_eq!(back.motifs.len(), 3);
     }
 
     #[test]
-    fn theme_single_element_round_trips() {
-        // The common case: one theme, written as a single-element list.
+    fn motifs_single_element_round_trips() {
+        // The common case: one motif, written as a single-element list.
         let c = Classifications {
-            theme: vec!["ambiguity".into()],
+            motifs: vec!["ambiguity".into()],
             ..Default::default()
         };
         let yaml = serde_yaml_ng::to_string(&c).unwrap();
@@ -351,15 +353,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_unknown_theme_element() {
+    fn validate_rejects_unknown_motif_element() {
         // Only the bad element shows up — the good one is silent.
         let c = Classifications {
-            theme: vec!["ambiguity".into(), "made-up".into()],
+            motifs: vec!["ambiguity".into(), "made-up".into()],
             ..Default::default()
         };
         let v = c.violations(&Taxonomy::current_v1());
         assert_eq!(v.len(), 1);
-        assert_eq!(v[0].dimension, "theme");
+        assert_eq!(v[0].dimension, "motifs");
         assert_eq!(v[0].value, "made-up");
     }
 
@@ -368,7 +370,7 @@ mod tests {
         let c = Classifications {
             format: Some("madeup-format".into()),
             tone: Some("madeup-tone".into()),
-            theme: vec!["madeup-theme".into()],
+            motifs: vec!["madeup-motif".into()],
             ..Default::default()
         };
         let v = c.violations(&Taxonomy::current_v1());
@@ -376,7 +378,7 @@ mod tests {
         let dims: Vec<&str> = v.iter().map(|x| x.dimension.as_str()).collect();
         assert!(dims.contains(&"format"));
         assert!(dims.contains(&"tone"));
-        assert!(dims.contains(&"theme"));
+        assert!(dims.contains(&"motifs"));
     }
 
     #[test]

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -203,9 +203,9 @@ pub enum Command {
     /// Set classification dimensions on a post (format, hook, tone,
     /// audience, topic, narrative-structure, call-to-action,
     /// visual-type, complexity, vulnerability, outcome-prediction,
-    /// theme). Missing flags leave the existing value alone;
+    /// motifs). Missing flags leave the existing value alone;
     /// `--clear-<dim>` removes it. Multi-valued dimensions
-    /// (audience, topic, narrative-structure, theme) take
+    /// (audience, topic, narrative-structure, motifs) take
     /// comma-separated lists that replace the existing list.
     Classify {
         slug: String,
@@ -238,9 +238,9 @@ pub enum Command {
         vulnerability: Option<String>,
         #[arg(long)]
         outcome_prediction: Option<String>,
-        /// Comma-separated list of themes. Replaces the existing list.
+        /// Comma-separated list of motifs. Replaces the existing list.
         #[arg(long, value_delimiter = ',')]
-        theme: Vec<String>,
+        motifs: Vec<String>,
         #[arg(long)]
         clear_format: bool,
         #[arg(long)]
@@ -264,7 +264,7 @@ pub enum Command {
         #[arg(long)]
         clear_outcome_prediction: bool,
         #[arg(long)]
-        clear_theme: bool,
+        clear_motifs: bool,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -616,7 +616,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             complexity,
             vulnerability,
             outcome_prediction,
-            theme,
+            motifs,
             clear_format,
             clear_hook,
             clear_tone,
@@ -628,7 +628,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             clear_complexity,
             clear_vulnerability,
             clear_outcome_prediction,
-            clear_theme,
+            clear_motifs,
             no_sync,
         } => commands::classify::run(
             jj,
@@ -646,7 +646,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 complexity,
                 vulnerability,
                 outcome_prediction,
-                theme,
+                motifs,
                 clear_format,
                 clear_hook,
                 clear_tone,
@@ -658,7 +658,7 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                 clear_complexity,
                 clear_vulnerability,
                 clear_outcome_prediction,
-                clear_theme,
+                clear_motifs,
                 no_sync,
             },
         ),
@@ -938,7 +938,7 @@ mod tests {
                 "low",
                 "--outcome-prediction",
                 "medium",
-                "--theme",
+                "--motifs",
                 "ambiguity,delivery",
             ],
             vec![
@@ -958,7 +958,7 @@ mod tests {
                 "--clear-complexity",
                 "--clear-vulnerability",
                 "--clear-outcome-prediction",
-                "--clear-theme",
+                "--clear-motifs",
             ],
             vec![
                 "blogctl",

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -197,8 +197,9 @@ fn apply_entry(
 }
 
 /// Merge `source` into `target`. Single-valued dims are overwritten
-/// when set in `source`; `theme` is replaced when non-empty.
-/// Returns `true` when anything actually changed.
+/// when set in `source`; multi-valued ones (including `motifs`) are
+/// replaced when non-empty. Returns `true` when anything actually
+/// changed.
 fn merge_classifications(target: &mut Classifications, source: &Classifications) -> bool {
     let mut changed = false;
     if source.format.is_some() && target.format != source.format {
@@ -248,8 +249,8 @@ fn merge_classifications(target: &mut Classifications, source: &Classifications)
         target.outcome_prediction = source.outcome_prediction.clone();
         changed = true;
     }
-    if !source.theme.is_empty() && target.theme != source.theme {
-        target.theme = source.theme.clone();
+    if !source.motifs.is_empty() && target.motifs != source.motifs {
+        target.motifs = source.motifs.clone();
         changed = true;
     }
     changed
@@ -349,8 +350,8 @@ fn process_one<R: BufRead, W: Write>(
 
     // Determine what's missing. A post is "complete" when every
     // single-valued classification is set and every published
-    // target has metrics. theme is intentionally not required
-    // (multi-valued; empty is meaningful).
+    // target has metrics. Multi-valued dims (motifs, topic, etc.)
+    // are intentionally not required (empty is meaningful).
     let cls_missing = single_dim_missing(&post.metadata.classifications);
     let needs_metrics: Vec<Target> = post
         .metadata
@@ -460,7 +461,7 @@ fn process_one<R: BufRead, W: Write>(
 fn single_dim_missing(c: &Classifications) -> Vec<&'static str> {
     // Interactive backfill only prompts for the dims it can ask a
     // single value for. `audience`, `topic`, `narrative_structure`,
-    // `theme` are multi-valued — set those via `blogctl classify
+    // `motifs` are multi-valued — set those via `blogctl classify
     // --<dim> a,b`. The newer single-valued dims (call_to_action,
     // visual_type, complexity, vulnerability, outcome_prediction)
     // can stay out of the prompt menu until the interactive UX
@@ -698,17 +699,17 @@ mod tests {
     }
 
     #[test]
-    fn merge_classifications_replaces_theme_list() {
+    fn merge_classifications_replaces_motifs_list() {
         let mut t = Classifications {
-            theme: vec!["ambiguity".into()],
+            motifs: vec!["ambiguity".into()],
             ..Default::default()
         };
         let s = Classifications {
-            theme: vec!["delivery".into(), "interfaces".into()],
+            motifs: vec!["delivery".into(), "interfaces".into()],
             ..Default::default()
         };
         assert!(merge_classifications(&mut t, &s));
-        assert_eq!(t.theme, vec!["delivery", "interfaces"]);
+        assert_eq!(t.motifs, vec!["delivery", "interfaces"]);
     }
 
     #[test]
@@ -753,7 +754,7 @@ mod tests {
                 "classifications": {
                     "format": "thesis",
                     "hook": "contradiction",
-                    "theme": ["ambiguity"]
+                    "motifs": ["ambiguity"]
                 },
                 "metrics": {
                     "linkedin": {
@@ -772,7 +773,7 @@ mod tests {
         assert_eq!(e.slug, "the-only-way-out-is-through");
         let cls = e.classifications.as_ref().unwrap();
         assert_eq!(cls.format.as_deref(), Some("thesis"));
-        assert_eq!(cls.theme, vec!["ambiguity"]);
+        assert_eq!(cls.motifs, vec!["ambiguity"]);
         let m = e.metrics.as_ref().unwrap();
         assert_eq!(m.get("linkedin").unwrap().impressions, 1234);
     }

--- a/apps/blogctl/src/commands/classify.rs
+++ b/apps/blogctl/src/commands/classify.rs
@@ -3,8 +3,8 @@
 //!
 //! Each `--<dim> value` overwrites the corresponding dimension;
 //! `--clear-<dim>` removes it. Unspecified dimensions are left
-//! untouched. `--theme a,b` replaces the entire theme list (the only
-//! multi-valued dimension in v1).
+//! untouched. `--motifs a,b` replaces the entire motifs list — same
+//! shape as the other multi-valued dimensions.
 //!
 //! Validates the resulting `Classifications` against the workdir's
 //! taxonomy *before* the file write — an invalid value fails fast
@@ -35,7 +35,7 @@ pub struct ClassifyArgs {
     pub complexity: Option<String>,
     pub vulnerability: Option<String>,
     pub outcome_prediction: Option<String>,
-    pub theme: Vec<String>,
+    pub motifs: Vec<String>,
     pub clear_format: bool,
     pub clear_hook: bool,
     pub clear_tone: bool,
@@ -47,7 +47,7 @@ pub struct ClassifyArgs {
     pub clear_complexity: bool,
     pub clear_vulnerability: bool,
     pub clear_outcome_prediction: bool,
-    pub clear_theme: bool,
+    pub clear_motifs: bool,
     pub no_sync: bool,
 }
 
@@ -175,10 +175,10 @@ fn apply(c: &mut Classifications, args: &ClassifyArgs) -> Vec<String> {
         &mut changed,
     );
     apply_multi(
-        &mut c.theme,
-        &args.theme,
-        args.clear_theme,
-        "theme",
+        &mut c.motifs,
+        &args.motifs,
+        args.clear_motifs,
+        "motifs",
         &mut changed,
     );
 
@@ -279,29 +279,29 @@ mod tests {
     }
 
     #[test]
-    fn apply_theme_replaces_list() {
+    fn apply_motifs_replaces_list() {
         let mut c = Classifications {
-            theme: vec!["ambiguity".into()],
+            motifs: vec!["ambiguity".into()],
             ..Default::default()
         };
         let mut a = empty_args();
-        a.theme = vec!["delivery".into(), "interfaces".into()];
+        a.motifs = vec!["delivery".into(), "interfaces".into()];
         let changed = apply(&mut c, &a);
-        assert_eq!(c.theme, vec!["delivery", "interfaces"]);
-        assert_eq!(changed, vec!["theme"]);
+        assert_eq!(c.motifs, vec!["delivery", "interfaces"]);
+        assert_eq!(changed, vec!["motifs"]);
     }
 
     #[test]
-    fn apply_clear_theme_empties_the_list() {
+    fn apply_clear_motifs_empties_the_list() {
         let mut c = Classifications {
-            theme: vec!["ambiguity".into()],
+            motifs: vec!["ambiguity".into()],
             ..Default::default()
         };
         let mut a = empty_args();
-        a.clear_theme = true;
+        a.clear_motifs = true;
         let changed = apply(&mut c, &a);
-        assert!(c.theme.is_empty());
-        assert_eq!(changed, vec!["theme"]);
+        assert!(c.motifs.is_empty());
+        assert_eq!(changed, vec!["motifs"]);
     }
 
     #[test]
@@ -322,10 +322,10 @@ mod tests {
         let mut a = empty_args();
         a.format = Some("thesis".into());
         a.hook = Some("contradiction".into());
-        a.theme = vec!["ambiguity".into()];
+        a.motifs = vec!["ambiguity".into()];
         let changed = apply(&mut c, &a);
         // Order matters for the commit message; should be the order
         // dimensions are applied.
-        assert_eq!(changed, vec!["format", "hook", "theme"]);
+        assert_eq!(changed, vec!["format", "hook", "motifs"]);
     }
 }

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -671,14 +671,17 @@ mod tests {
     fn audit_flags_invalid_classifications_per_dimension() {
         let (tmp, workdir) = fresh_workdir();
         let mut post = fixture_post("multi-bad", Stage::Concept);
-        // Two bad single-valued dims + one bad theme element.
+        // Two bad single-valued dims + one bad motifs element.
         post.metadata.classifications.format = Some("not-a-format".into());
         post.metadata.classifications.tone = Some("brisk".into());
-        post.metadata.classifications.theme.push("ambiguity".into()); // good
         post.metadata
             .classifications
-            .theme
-            .push("made-up-theme".into()); // bad
+            .motifs
+            .push("ambiguity".into()); // good
+        post.metadata
+            .classifications
+            .motifs
+            .push("made-up-motif".into()); // bad
         fs::write(
             tmp.path().join("concepts/multi-bad.md"),
             post.render().unwrap(),

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -41,8 +41,8 @@ pub struct PostMetadata {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub targets: Vec<TargetEntry>,
     /// Structured tag dimensions (format, hook, tone, audience,
-    /// strategic role, theme). Sits alongside the free-form `tags`
-    /// list. Defaults to empty; skipped from serialization when no
+    /// motifs, ...). Sits alongside the free-form `tags` list.
+    /// Defaults to empty; skipped from serialization when no
     /// dimension has a value so posts predating the field stay
     /// quiet in their frontmatter.
     #[serde(default, skip_serializing_if = "Classifications::is_empty")]
@@ -583,7 +583,7 @@ tags: []
 classifications:
   format: thesis
   hook: contradiction
-  theme:
+  motifs:
     - ambiguity
     - delivery
 ---
@@ -599,7 +599,7 @@ body
             post.metadata.classifications.hook.as_deref(),
             Some("contradiction")
         );
-        assert_eq!(post.metadata.classifications.theme.len(), 2);
+        assert_eq!(post.metadata.classifications.motifs.len(), 2);
         // Dimensions not set in YAML stay at their defaults.
         assert!(post.metadata.classifications.tone.is_none());
         assert!(post.metadata.classifications.audience.is_empty());
@@ -668,7 +668,7 @@ body
             hook: Some("contradiction".into()),
             tone: Some("sharp".into()),
             audience: vec!["engineering".into()],
-            theme: vec!["ambiguity".into(), "delivery".into()],
+            motifs: vec!["ambiguity".into(), "delivery".into()],
             ..Default::default()
         };
         let original = Post::new(metadata, "Body.\n");

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -1113,7 +1113,7 @@ mod tests {
         let (_tmp, repo) = fresh_repo();
         let cfg = repo.read_config().unwrap();
         assert!(cfg.classifications.contains_key("format"));
-        assert!(cfg.classifications.contains_key("theme"));
+        assert!(cfg.classifications.contains_key("motifs"));
         // The seeded v1 set matches Taxonomy::current_v1().
         assert_eq!(cfg.classifications, Taxonomy::current_v1().to_btreemap());
     }

--- a/apps/blogctl/src/taxonomy.rs
+++ b/apps/blogctl/src/taxonomy.rs
@@ -3,9 +3,9 @@
 //! this module loads it into a `Taxonomy` and runs the validation
 //! pass against `Classifications` instances.
 //!
-//! The taxonomy is data, not code — adding a new format or theme
+//! The taxonomy is data, not code — adding a new format or motif
 //! is a config edit, not a Rust change. The struct's *dimension
-//! names* (`format`, `hook`, `tone`, `audience`, `theme`) come from
+//! names* (`format`, `hook`, `tone`, `audience`, `motifs`) come from
 //! `Classifications`'s field names and are fixed; the *values*
 //! inside each dimension are user-configurable.
 
@@ -108,7 +108,7 @@ pub const SINGLE_VALUED: &[&str] = &[
     "vulnerability",
     "outcome_prediction",
 ];
-pub const MULTI_VALUED: &[&str] = &["audience", "topic", "narrative_structure", "theme"];
+pub const MULTI_VALUED: &[&str] = &["audience", "topic", "narrative_structure", "motifs"];
 
 fn starter_v1() -> BTreeMap<String, Dimension> {
     let mut m = BTreeMap::new();
@@ -216,7 +216,7 @@ fn starter_v1() -> BTreeMap<String, Dimension> {
         },
     );
     m.insert(
-        "theme".into(),
+        "motifs".into(),
         Dimension {
             multi: true,
             values: strs(&[
@@ -261,10 +261,10 @@ mod tests {
     }
 
     #[test]
-    fn current_v1_theme_is_multi_valued() {
+    fn current_v1_motifs_is_multi_valued() {
         let t = Taxonomy::current_v1();
-        let theme = t.dimension("theme").unwrap();
-        assert!(theme.multi);
+        let motifs = t.dimension("motifs").unwrap();
+        assert!(motifs.multi);
     }
 
     #[test]

--- a/apps/blogctl/tests/backfill.rs
+++ b/apps/blogctl/tests/backfill.rs
@@ -63,7 +63,7 @@ fn import_fills_classifications_and_metrics_for_bare_post() {
                 "classifications": {
                     "format": "thesis",
                     "hook": "contradiction",
-                    "theme": ["ambiguity"]
+                    "motifs": ["ambiguity"]
                 },
                 "metrics": {
                     "linkedin": {

--- a/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
+++ b/apps/blogctl/tests/fixtures/frontmatter/valid/with-classifications.md
@@ -13,7 +13,7 @@ classifications:
   tone: sharp
   audience:
     - engineering
-  theme:
+  motifs:
     - ambiguity
     - delivery
 ---

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -475,12 +475,12 @@ fn classify_drives_full_sync_with_changed_dimensions_in_message() {
             workdir: path.clone(),
             format: Some("thesis".into()),
             hook: Some("contradiction".into()),
-            theme: vec!["ambiguity".into(), "delivery".into()],
+            motifs: vec!["ambiguity".into(), "delivery".into()],
             ..Default::default()
         },
     )
     .unwrap();
-    assert_full_sync_flow(&jj.calls(), "post(hello): classify (format,hook,theme)");
+    assert_full_sync_flow(&jj.calls(), "post(hello): classify (format,hook,motifs)");
 
     // And the post on disk now carries the new classifications.
     let raw = fs::read_to_string(path.join("concepts/hello.md")).unwrap();


### PR DESCRIPTION
`blogctl` had two unrelated concepts both spelled "theme": the
singular narrative theme picked at post creation (`theme: standard`
in frontmatter, `[themes.*]` registry, `blogctl new --theme`) and the
multi-valued classification dimension set after the fact
(`classifications.theme: [a, b]`, `[classifications.theme]`,
`blogctl classify --theme a,b`). Same word, different field, different
multiplicity, different stage — a real cognitive trap.

Rename the classification dimension to `motifs`, leaving the
narrative theme alone:

- The narrative theme is the older field, lives in every post's
  frontmatter, and anchors the `[themes.*]` registry — renaming it
  would touch every post and every config block in every workdir.
- The classification dimension is currently set on zero posts in the
  known world (per kolohelios/blogs-and-posts state), so the
  consumer-side migration is just the `[classifications.theme]` →
  `[classifications.motifs]` line in `.blog-os.toml`.

`motifs` (plural) reflects the multi-valued shape and captures the
"recurring thread in my writing" semantic the post-hoc, multi-element
dimension implies. No serde alias for the old name — zero existing
usage, cleaner diff.

Touches the schema, CLI flags (`--motifs` / `--clear-motifs` replace
`--theme` / `--clear-theme` on `classify`), the merge logic in
`backfill`, the analytics dimension switch, doctor's classification
audit, README, and one frontmatter fixture.

Closes #627