### PR TITLE
feat(shaka): emit completion-activating shellHook in rust-cli devshell

### DIFF
--- a/apps/blogctl/flake.nix
+++ b/apps/blogctl/flake.nix
@@ -94,6 +94,15 @@
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
+            shellHook = ''
+              if command -v blogctl &>/dev/null; then
+                _completions_dir="''${XDG_CACHE_HOME:-$HOME/.cache}/kolohelios-completions/blogctl"
+                mkdir -p "$_completions_dir"
+                blogctl completions zsh > "$_completions_dir/_blogctl" 2>/dev/null
+                FPATH="$_completions_dir:$FPATH"
+                unset _completions_dir
+              fi
+            '';
           };
         }
       );

--- a/tools/aof/flake.nix
+++ b/tools/aof/flake.nix
@@ -93,6 +93,15 @@
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
+            shellHook = ''
+              if command -v aof &>/dev/null; then
+                _completions_dir="''${XDG_CACHE_HOME:-$HOME/.cache}/kolohelios-completions/aof"
+                mkdir -p "$_completions_dir"
+                aof completions zsh > "$_completions_dir/_aof" 2>/dev/null
+                FPATH="$_completions_dir:$FPATH"
+                unset _completions_dir
+              fi
+            '';
           };
         }
       );

--- a/tools/claude-hooks/flake.nix
+++ b/tools/claude-hooks/flake.nix
@@ -93,6 +93,15 @@
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
+            shellHook = ''
+              if command -v claude-hooks &>/dev/null; then
+                _completions_dir="''${XDG_CACHE_HOME:-$HOME/.cache}/kolohelios-completions/claude-hooks"
+                mkdir -p "$_completions_dir"
+                claude-hooks completions zsh > "$_completions_dir/_claude-hooks" 2>/dev/null
+                FPATH="$_completions_dir:$FPATH"
+                unset _completions_dir
+              fi
+            '';
           };
         }
       );

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -123,6 +123,15 @@
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
+            shellHook = ''
+              if command -v shaka &>/dev/null; then
+                _completions_dir="''${XDG_CACHE_HOME:-$HOME/.cache}/kolohelios-completions/shaka"
+                mkdir -p "$_completions_dir"
+                shaka completions zsh > "$_completions_dir/_shaka" 2>/dev/null
+                FPATH="$_completions_dir:$FPATH"
+                unset _completions_dir
+              fi
+            '';
           };
         }
       );

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -334,6 +334,14 @@ fn render_devshell(cli: &CliMeta) -> String {
     out.push_str(
         "            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;\n",
     );
+
+    if cli.shell_completions {
+        let bin = &cli.binary_name;
+        out.push_str(&format!(
+            "            shellHook = ''\n              if command -v {bin} &>/dev/null; then\n                _completions_dir=\"''${{XDG_CACHE_HOME:-$HOME/.cache}}/kolohelios-completions/{bin}\"\n                mkdir -p \"$_completions_dir\"\n                {bin} completions zsh > \"$_completions_dir/_{bin}\" 2>/dev/null\n                FPATH=\"$_completions_dir:$FPATH\"\n                unset _completions_dir\n              fi\n            '';\n"
+        ));
+    }
+
     out.push_str("          };\n        }\n      );\n");
     out
 }
@@ -878,5 +886,26 @@ mod tests {
         let outputs_pos = out.find("outputs =").expect("outputs");
         let extra_pos = out.find("supportedSystems = []").expect("extra");
         assert!(outputs_pos < extra_pos);
+    }
+
+    #[test]
+    fn shell_completions_emit_devshell_shell_hook() {
+        let cli = CliMeta {
+            shell_completions: true,
+            ..minimal_cli()
+        };
+        let out = render_flake("demo", &cli);
+        assert!(out.contains("shellHook"));
+        assert!(out.contains("demo completions zsh"));
+        assert!(out.contains("kolohelios-completions/demo"));
+        assert!(out.contains("FPATH="));
+        // Verify nix escaping: ''${ produces a literal ${ in the shell
+        assert!(out.contains("''${XDG_CACHE_HOME:-"));
+    }
+
+    #[test]
+    fn no_shell_hook_without_shell_completions() {
+        let out = render_flake("demo", &minimal_cli());
+        assert!(!out.contains("shellHook"));
     }
 }

--- a/tools/todoist/flake.nix
+++ b/tools/todoist/flake.nix
@@ -64,6 +64,15 @@
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
+            shellHook = ''
+              if command -v todoist &>/dev/null; then
+                _completions_dir="''${XDG_CACHE_HOME:-$HOME/.cache}/kolohelios-completions/todoist"
+                mkdir -p "$_completions_dir"
+                todoist completions zsh > "$_completions_dir/_todoist" 2>/dev/null
+                FPATH="$_completions_dir:$FPATH"
+                unset _completions_dir
+              fi
+            '';
           };
         }
       );


### PR DESCRIPTION
When shellCompletions is true, the generated devShell gains a
shellHook that runs `<binary> completions zsh` on entry (if the
binary exists on PATH) and prepends the output directory to FPATH.
Completions are cached in $XDG_CACHE_HOME/kolohelios-completions/
so repeated shell entries are fast.

Closes #615