### PR TITLE
refactor(blogctl): migrate from thiserror to snafu

### DIFF
--- a/apps/blogctl/Cargo.lock
+++ b/apps/blogctl/Cargo.lock
@@ -112,8 +112,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "snafu",
  "tempfile",
- "thiserror",
  "time",
  "toml",
  "ureq",
@@ -1073,6 +1073,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,26 +1154,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/apps/blogctl/Cargo.toml
+++ b/apps/blogctl/Cargo.toml
@@ -20,7 +20,7 @@ humantime = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
-thiserror = "1"
+snafu = "0.9"
 time = { version = "0.3", features = [
   "formatting",
   "parsing",

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -17,7 +17,7 @@ use crate::target::Target;
 fn workdir_or_pwd(workdir: Option<PathBuf>) -> Result<PathBuf> {
     match workdir {
         Some(p) => Ok(p),
-        None => env::current_dir().map_err(Error::CurrentDirUnavailable),
+        None => env::current_dir().map_err(|source| Error::CurrentDirUnavailable { source }),
     }
 }
 

--- a/apps/blogctl/src/commands/analytics.rs
+++ b/apps/blogctl/src/commands/analytics.rs
@@ -70,7 +70,8 @@ pub fn summary(args: SummaryArgs) -> Result<()> {
         writeln!(
             out,
             "{}",
-            serde_json::to_string_pretty(&summary).map_err(Error::SummaryJson)?
+            serde_json::to_string_pretty(&summary)
+                .map_err(|source| Error::SummaryJson { source })?
         )
         .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     } else {
@@ -172,7 +173,8 @@ pub fn compare(args: CompareArgs) -> Result<()> {
         writeln!(
             out,
             "{}",
-            serde_json::to_string_pretty(&comparison).map_err(Error::SummaryJson)?
+            serde_json::to_string_pretty(&comparison)
+                .map_err(|source| Error::SummaryJson { source })?
         )
         .map_err(|e| Error::io(PathBuf::from("<stdout>"), e))?;
     } else {

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -68,7 +68,7 @@ pub fn run(jj: &dyn Jj, args: BackfillArgs) -> Result<()> {
 fn run_import(jj: &dyn Jj, args: &BackfillArgs, path: PathBuf) -> Result<()> {
     let raw = fs::read_to_string(&path).map_err(|e| Error::io(&path, e))?;
     let entries: Vec<BackfillEntry> =
-        serde_json::from_str(&raw).map_err(Error::BackfillImportParse)?;
+        serde_json::from_str(&raw).map_err(|source| Error::BackfillImportParse { source })?;
 
     let repo = Repository::open(Workdir::new(&args.workdir))?;
     let taxonomy = repo.read_taxonomy()?;
@@ -99,7 +99,9 @@ fn run_import(jj: &dyn Jj, args: &BackfillArgs, path: PathBuf) -> Result<()> {
         return if warnings.is_empty() {
             Ok(())
         } else {
-            Err(Error::BackfillPartialFailure(warnings.len()))
+            Err(Error::BackfillPartialFailure {
+                warnings: warnings.len(),
+            })
         };
     }
 
@@ -119,7 +121,9 @@ fn run_import(jj: &dyn Jj, args: &BackfillArgs, path: PathBuf) -> Result<()> {
     if warnings.is_empty() {
         Ok(())
     } else {
-        Err(Error::BackfillPartialFailure(warnings.len()))
+        Err(Error::BackfillPartialFailure {
+            warnings: warnings.len(),
+        })
     }
 }
 

--- a/apps/blogctl/src/commands/doctor.rs
+++ b/apps/blogctl/src/commands/doctor.rs
@@ -374,7 +374,9 @@ pub fn run(jj: &dyn Jj, workdir: PathBuf) -> Result<()> {
     for finding in &findings {
         println!("{finding}");
     }
-    Err(Error::WorkdirUnhealthy(findings.len()))
+    Err(Error::WorkdirUnhealthy {
+        findings: findings.len(),
+    })
 }
 
 fn theme_known(cfg: &Config, theme: &str) -> bool {
@@ -807,7 +809,7 @@ mod tests {
         // stray-entry finding actually surfaces.
         let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::Ok);
         let err = run(&jj, tmp.path().to_path_buf()).unwrap_err();
-        assert!(matches!(err, Error::WorkdirUnhealthy(n) if n >= 1));
+        assert!(matches!(err, Error::WorkdirUnhealthy { findings: n } if n >= 1));
     }
 
     #[test]
@@ -843,7 +845,7 @@ mod tests {
         let (tmp, _workdir) = fresh_workdir();
         let jj = crate::sync::FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
         let err = run(&jj, tmp.path().to_path_buf()).unwrap_err();
-        assert!(matches!(err, Error::WorkdirUnhealthy(1)));
+        assert!(matches!(err, Error::WorkdirUnhealthy { findings: 1 }));
     }
 
     #[test]

--- a/apps/blogctl/src/commands/fix.rs
+++ b/apps/blogctl/src/commands/fix.rs
@@ -354,7 +354,9 @@ pub fn run(jj: &dyn Jj, workdir: PathBuf, dry_run: bool, no_sync: bool) -> Resul
         for finding in &findings {
             println!("{finding}");
         }
-        return Err(Error::WorkdirUnhealthy(findings.len()));
+        return Err(Error::WorkdirUnhealthy {
+            findings: findings.len(),
+        });
     }
 
     let plan = plan(findings);
@@ -379,7 +381,9 @@ pub fn run(jj: &dyn Jj, workdir: PathBuf, dry_run: bool, no_sync: bool) -> Resul
         return if remaining == 0 {
             Ok(())
         } else {
-            Err(Error::WorkdirUnhealthy(remaining))
+            Err(Error::WorkdirUnhealthy {
+                findings: remaining,
+            })
         };
     }
 
@@ -401,7 +405,9 @@ pub fn run(jj: &dyn Jj, workdir: PathBuf, dry_run: bool, no_sync: bool) -> Resul
     if remaining == 0 {
         Ok(())
     } else {
-        Err(Error::WorkdirUnhealthy(remaining))
+        Err(Error::WorkdirUnhealthy {
+            findings: remaining,
+        })
     }
 }
 
@@ -772,7 +778,7 @@ mod tests {
         fs::write(tmp.path().join("concepts/.DS_Store"), "x").unwrap();
         let jj = FakeJj::new();
         let err = run(&jj, tmp.path().to_path_buf(), false, true).unwrap_err();
-        assert!(matches!(err, Error::WorkdirUnhealthy(_)));
+        assert!(matches!(err, Error::WorkdirUnhealthy { .. }));
     }
 
     #[test]
@@ -790,7 +796,7 @@ mod tests {
 
         let jj = FakeJj::new().with_status(crate::sync::Status::NotAJjRepo);
         let err = run(&jj, tmp.path().to_path_buf(), false, true).unwrap_err();
-        assert!(matches!(err, Error::WorkdirUnhealthy(1)));
+        assert!(matches!(err, Error::WorkdirUnhealthy { findings: 1 }));
 
         // File must be untouched.
         let raw_after = fs::read_to_string(&path).unwrap();

--- a/apps/blogctl/src/commands/import.rs
+++ b/apps/blogctl/src/commands/import.rs
@@ -46,7 +46,7 @@ pub struct ImportArgs {
 
 pub fn run(jj: &dyn Jj, args: ImportArgs) -> Result<()> {
     if args.title.trim().is_empty() {
-        return Err(Error::EmptyTitle(args.title));
+        return Err(Error::EmptyTitle { value: args.title });
     }
     let resolved_slug = match args.slug {
         Some(s) => slug::validate(&s)?.to_string(),

--- a/apps/blogctl/src/commands/init.rs
+++ b/apps/blogctl/src/commands/init.rs
@@ -10,7 +10,9 @@ pub fn run(jj: &dyn Jj, workdir: PathBuf, no_sync: bool) -> Result<()> {
     // happens to fail first (conflicted bookmark, missing remote, …).
     let wd = Workdir::new(&workdir);
     if wd.config_path().exists() {
-        return Err(Error::WorkdirAlreadyInitialized(wd.root().to_path_buf()));
+        return Err(Error::WorkdirAlreadyInitialized {
+            path: wd.root().to_path_buf(),
+        });
     }
 
     // `init` creates `.blog-os.toml`, so we have no config to read

--- a/apps/blogctl/src/commands/new.rs
+++ b/apps/blogctl/src/commands/new.rs
@@ -20,7 +20,7 @@ pub fn run(
     no_sync: bool,
 ) -> Result<()> {
     if title.trim().is_empty() {
-        return Err(Error::EmptyTitle(title));
+        return Err(Error::EmptyTitle { value: title });
     }
     let resolved_slug = match slug_override {
         Some(s) => slug::validate(&s)?.to_string(),

--- a/apps/blogctl/src/error.rs
+++ b/apps/blogctl/src/error.rs
@@ -1,38 +1,41 @@
 use std::path::PathBuf;
 
+use snafu::Snafu;
+
 use crate::stage::Stage;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
 pub enum Error {
-    #[error("workdir not initialized at {0} (run `blogctl init`)")]
-    WorkdirNotInitialized(PathBuf),
+    #[snafu(display("workdir not initialized at {} (run `blogctl init`)", path.display()))]
+    WorkdirNotInitialized { path: PathBuf },
 
-    #[error("workdir already initialized at {0}")]
-    WorkdirAlreadyInitialized(PathBuf),
+    #[snafu(display("workdir already initialized at {}", path.display()))]
+    WorkdirAlreadyInitialized { path: PathBuf },
 
-    #[error("post not found: {0}")]
-    PostNotFound(String),
+    #[snafu(display("post not found: {slug}"))]
+    PostNotFound { slug: String },
 
-    #[error(
+    #[snafu(display(
         "post {slug:?} disagrees with its location: directory says {dir_stage}, frontmatter says {fm_stage}"
-    )]
+    ))]
     StageMismatch {
         slug: String,
         dir_stage: Stage,
         fm_stage: Stage,
     },
 
-    #[error("multiple posts share slug {0:?}: {1}")]
-    DuplicateSlug(String, String),
+    #[snafu(display("multiple posts share slug {slug:?}: {paths}"))]
+    DuplicateSlug { slug: String, paths: String },
 
-    #[error("cannot promote from {0}: already at the final workflow stage")]
-    PromoteFromTerminal(Stage),
+    #[snafu(display("cannot promote from {stage}: already at the final workflow stage"))]
+    PromoteFromTerminal { stage: Stage },
 
-    #[error(
+    #[snafu(display(
         "cannot promote {slug:?} from {from} to {to}: exit predicate {predicate} not satisfied"
-    )]
+    ))]
     PromoteBlocked {
         slug: String,
         from: Stage,
@@ -40,187 +43,197 @@ pub enum Error {
         predicate: String,
     },
 
-    #[error(
+    #[snafu(display(
         "cannot draft post {slug:?} from stage {stage}: drafting requires the post to be in the `ideation` stage"
-    )]
+    ))]
     DraftWrongStage { slug: String, stage: Stage },
 
-    #[error(
+    #[snafu(display(
         "cannot refine post {slug:?} from stage {stage}: refining requires the post to be in the `editing` stage"
-    )]
+    ))]
     RefineWrongStage { slug: String, stage: Stage },
 
-    #[error(
+    #[snafu(display(
         "cannot final-edit post {slug:?} from stage {stage}: the polish pass requires the post to be in the `final-editing` stage"
-    )]
+    ))]
     FinalEditWrongStage { slug: String, stage: Stage },
 
-    #[error("cannot demote from {0}: already at the first workflow stage")]
-    DemoteFromInitial(Stage),
+    #[snafu(display("cannot demote from {stage}: already at the first workflow stage"))]
+    DemoteFromInitial { stage: Stage },
 
-    #[error("cannot demote a published post (use --force when implemented)")]
+    #[snafu(display("cannot demote a published post (use --force when implemented)"))]
     DemotePublished,
 
-    #[error("invalid stage {0:?}")]
-    InvalidStage(String),
+    #[snafu(display("invalid stage {value:?}"))]
+    InvalidStage { value: String },
 
-    #[error("invalid kind {0:?}: expected `post` or `article`")]
-    InvalidKind(String),
+    #[snafu(display("invalid kind {value:?}: expected `post` or `article`"))]
+    InvalidKind { value: String },
 
-    #[error("invalid target {0:?}: expected `linkedin` or `blog`")]
-    InvalidTarget(String),
+    #[snafu(display("invalid target {value:?}: expected `linkedin` or `blog`"))]
+    InvalidTarget { value: String },
 
-    #[error("invalid target status {0:?}: expected `planned`, `published`, or `retracted`")]
-    InvalidTargetStatus(String),
+    #[snafu(display(
+        "invalid target status {value:?}: expected `planned`, `published`, or `retracted`"
+    ))]
+    InvalidTargetStatus { value: String },
 
-    #[error("duplicate target {name} in {path} (each target may appear at most once)")]
+    #[snafu(display(
+        "duplicate target {name} in {} (each target may appear at most once)",
+        path.display()
+    ))]
     DuplicateTarget {
         path: PathBuf,
         name: crate::target::Target,
     },
 
-    #[error("target {name} in {path} has status `published` but `url` is not set")]
+    #[snafu(display(
+        "target {name} in {} has status `published` but `url` is not set",
+        path.display()
+    ))]
     PublishedTargetMissingUrl {
         path: PathBuf,
         name: crate::target::Target,
     },
 
-    #[error("target {name} in {path} has status `published` but `published_at` is not set")]
+    #[snafu(display(
+        "target {name} in {} has status `published` but `published_at` is not set",
+        path.display()
+    ))]
     PublishedTargetMissingPublishedAt {
         path: PathBuf,
         name: crate::target::Target,
     },
 
-    #[error("unknown theme {theme:?}: known themes are {}", known.join(", "))]
+    #[snafu(display("unknown theme {theme:?}: known themes are {}", known.join(", ")))]
     UnknownTheme { theme: String, known: Vec<String> },
 
-    #[error("invalid slug {0:?}: {1}")]
-    InvalidSlug(String, String),
+    #[snafu(display("invalid slug {value:?}: {reason}"))]
+    InvalidSlug { value: String, reason: String },
 
-    #[error("invalid title {0:?}: cannot derive slug")]
-    EmptyTitle(String),
+    #[snafu(display("invalid title {value:?}: cannot derive slug"))]
+    EmptyTitle { value: String },
 
-    #[error("missing frontmatter delimiter `---` at start of {0}")]
-    FrontmatterMissingOpen(PathBuf),
+    #[snafu(display("missing frontmatter delimiter `---` at start of {}", path.display()))]
+    FrontmatterMissingOpen { path: PathBuf },
 
-    #[error("missing closing frontmatter delimiter `---` in {0}")]
-    FrontmatterMissingClose(PathBuf),
+    #[snafu(display("missing closing frontmatter delimiter `---` in {}", path.display()))]
+    FrontmatterMissingClose { path: PathBuf },
 
-    #[error("could not parse frontmatter in {path}: {source}")]
+    #[snafu(display("could not parse frontmatter in {}: {source}", path.display()))]
     FrontmatterParse {
         path: PathBuf,
-        #[source]
         source: serde_yaml_ng::Error,
     },
 
-    #[error("could not serialize frontmatter: {0}")]
-    FrontmatterSerialize(#[source] serde_yaml_ng::Error),
+    #[snafu(display("could not serialize frontmatter: {source}"))]
+    FrontmatterSerialize { source: serde_yaml_ng::Error },
 
-    #[error("could not parse config {path}: {source}")]
+    #[snafu(display("could not parse config {}: {source}", path.display()))]
     ConfigParse {
         path: PathBuf,
-        #[source]
         source: toml::de::Error,
     },
 
-    #[error("could not serialize config: {0}")]
-    ConfigSerialize(#[source] toml::ser::Error),
+    #[snafu(display("could not serialize config: {source}"))]
+    ConfigSerialize { source: toml::ser::Error },
 
-    #[error("could not format timestamp: {0}")]
-    TimeFormat(#[source] time::error::Format),
+    #[snafu(display("could not format timestamp: {source}"))]
+    TimeFormat { source: time::error::Format },
 
-    #[error("io error at {path}: {source}")]
+    #[snafu(display("io error at {}: {source}", path.display()))]
     Io {
         path: PathBuf,
-        #[source]
         source: std::io::Error,
     },
 
-    #[error("could not resolve current working directory: {0}")]
-    CurrentDirUnavailable(#[source] std::io::Error),
+    #[snafu(display("could not resolve current working directory: {source}"))]
+    CurrentDirUnavailable { source: std::io::Error },
 
-    #[error(
-        "workdir unhealthy: {0} finding(s); run `blogctl fix` to repair the auto-correctable subset"
-    )]
-    WorkdirUnhealthy(usize),
+    #[snafu(display(
+        "workdir unhealthy: {findings} finding(s); run `blogctl fix` to repair the auto-correctable subset"
+    ))]
+    WorkdirUnhealthy { findings: usize },
 
-    #[error(
+    #[snafu(display(
         "OPENROUTER_API_KEY not set — invoke through `op run --env-file=.env -- ...` or set it in the environment"
-    )]
+    ))]
     OpenrouterApiKeyMissing,
 
-    #[error("OpenRouter request failed: {0}")]
-    OpenrouterRequest(String),
+    #[snafu(display("OpenRouter request failed: {message}"))]
+    OpenrouterRequest { message: String },
 
-    #[error("OpenRouter response contained no choices")]
+    #[snafu(display("OpenRouter response contained no choices"))]
     OpenrouterEmptyResponse,
 
-    #[error("could not parse predicate: {0}")]
-    PredicateParse(String),
+    #[snafu(display("could not parse predicate: {message}"))]
+    PredicateParse { message: String },
 
-    #[error("could not evaluate predicate {predicate:?}: {reason}")]
+    #[snafu(display("could not evaluate predicate {predicate:?}: {reason}"))]
     PredicateEval { predicate: String, reason: String },
 
-    #[error("could not invoke `{command}`: {source}")]
+    #[snafu(display("could not invoke `{command}`: {source}"))]
     JjInvoke {
         command: String,
-        #[source]
         source: std::io::Error,
     },
 
-    #[error("`{command}` failed (exit {status}): {stderr}")]
+    #[snafu(display("`{command}` failed (exit {status}): {stderr}"))]
     JjCommandFailed {
         command: String,
         status: i32,
         stderr: String,
     },
 
-    #[error(
+    #[snafu(display(
         "bookmark `{bookmark}` is in a conflicted state ({} candidate(s): {}); resolve via `jj bookmark set {bookmark} -r <REVISION>`",
         candidates.len(),
         candidates.join(", "),
-    )]
+    ))]
     JjBookmarkConflicted {
         bookmark: String,
         candidates: Vec<String>,
     },
 
-    #[error(
+    #[snafu(display(
         "rebase of @ onto {bookmark}@{remote} produced conflicts — resolve via `jj` before re-running blogctl"
-    )]
+    ))]
     SyncRebaseConflict { bookmark: String, remote: String },
 
-    #[error(
+    #[snafu(display(
         "@ has commits from side branch(es) {} below it; run `blogctl update` to bring @ on top of {bookmark}",
         side_bookmarks.join(", "),
-    )]
+    ))]
     WorkdirOnSideBranch {
         bookmark: String,
         side_bookmarks: Vec<String>,
     },
 
-    #[error(
+    #[snafu(display(
         "local {bookmark} has {count} unpushed commit(s); resolve via `jj git push --bookmark {bookmark}` before running `blogctl update`"
-    )]
+    ))]
     UpdateHasUnpushedCommits { bookmark: String, count: usize },
 
-    #[error("`blogctl update` requires sync to be enabled (config: `sync.enabled = true`, and don't pass `--no-sync`)")]
+    #[snafu(display(
+        "`blogctl update` requires sync to be enabled (config: `sync.enabled = true`, and don't pass `--no-sync`)"
+    ))]
     UpdateRequiresSyncEnabled,
 
-    #[error(
+    #[snafu(display(
         "`blogctl update` needs `jj`: install it (and run `jj git init --colocate` in the workdir)"
-    )]
+    ))]
     UpdateRequiresJj,
 
-    #[error(
-        "`blogctl {0}` is not yet implemented (CLI surface only; behavior lands in a follow-up)"
-    )]
-    Unimplemented(&'static str),
+    #[snafu(display(
+        "`blogctl {command}` is not yet implemented (CLI surface only; behavior lands in a follow-up)"
+    ))]
+    Unimplemented { command: &'static str },
 
-    #[error(
-        "invalid classification in {path}: {dimension}={value:?} is not in the taxonomy. allowed values: {}",
+    #[snafu(display(
+        "invalid classification in {}: {dimension}={value:?} is not in the taxonomy. allowed values: {}",
+        path.display(),
         allowed.join(", "),
-    )]
+    ))]
     InvalidClassification {
         path: PathBuf,
         dimension: String,
@@ -228,41 +241,40 @@ pub enum Error {
         allowed: Vec<String>,
     },
 
-    #[error("could not serialize analytics summary to JSON: {0}")]
-    SummaryJson(#[source] serde_json::Error),
+    #[snafu(display("could not serialize analytics summary to JSON: {source}"))]
+    SummaryJson { source: serde_json::Error },
 
-    #[error(
+    #[snafu(display(
         "target {target} is not on post {slug:?} — promote it via the targets editing flow before running `metrics update`"
-    )]
+    ))]
     TargetNotInPost {
         slug: String,
         target: crate::target::Target,
     },
 
-    #[error("invalid --sampled-at {value:?}: expected RFC 3339 timestamp ({source})")]
+    #[snafu(display("invalid --sampled-at {value:?}: expected RFC 3339 timestamp ({source})"))]
     InvalidSampledAt {
         value: String,
-        #[source]
         source: time::error::Parse,
     },
 
-    #[error("invalid --published-at {value:?}: expected RFC 3339 timestamp ({source})")]
+    #[snafu(display("invalid --published-at {value:?}: expected RFC 3339 timestamp ({source})"))]
     InvalidPublishedAt {
         value: String,
-        #[source]
         source: time::error::Parse,
     },
 
-    #[error("could not parse backfill import file: {0}")]
-    BackfillImportParse(#[source] serde_json::Error),
+    #[snafu(display("could not parse backfill import file: {source}"))]
+    BackfillImportParse { source: serde_json::Error },
 
-    #[error("backfill completed with {0} warning(s) — see stderr for details")]
-    BackfillPartialFailure(usize),
+    #[snafu(display("backfill completed with {warnings} warning(s) — see stderr for details"))]
+    BackfillPartialFailure { warnings: usize },
 
-    #[error("invalid --stale-after {value:?}: expected a humantime duration like `7d` or `24h` ({source})")]
+    #[snafu(display(
+        "invalid --stale-after {value:?}: expected a humantime duration like `7d` or `24h` ({source})"
+    ))]
     InvalidStaleAfter {
         value: String,
-        #[source]
         source: humantime::DurationError,
     },
 }

--- a/apps/blogctl/src/kind.rs
+++ b/apps/blogctl/src/kind.rs
@@ -41,7 +41,9 @@ impl FromStr for Kind {
         match s {
             "post" => Ok(Kind::Post),
             "article" => Ok(Kind::Article),
-            other => Err(Error::InvalidKind(other.to_string())),
+            other => Err(Error::InvalidKind {
+                value: other.to_string(),
+            }),
         }
     }
 }
@@ -60,7 +62,7 @@ mod tests {
     #[test]
     fn parse_rejects_unknown_kind() {
         let err = "essay".parse::<Kind>().unwrap_err();
-        assert!(matches!(err, Error::InvalidKind(_)));
+        assert!(matches!(err, Error::InvalidKind { .. }));
     }
 
     #[test]

--- a/apps/blogctl/src/openrouter.rs
+++ b/apps/blogctl/src/openrouter.rs
@@ -69,11 +69,13 @@ pub fn chat(prompt: &str, model: &str) -> Result<String> {
         .set("Authorization", &format!("Bearer {api_key}"))
         .set("Content-Type", "application/json")
         .send_json(body)
-        .map_err(|e| Error::OpenrouterRequest(e.to_string()))?;
+        .map_err(|e| Error::OpenrouterRequest {
+            message: e.to_string(),
+        })?;
 
-    let parsed: ChatResponse = response
-        .into_json()
-        .map_err(|e| Error::OpenrouterRequest(format!("could not parse response: {e}")))?;
+    let parsed: ChatResponse = response.into_json().map_err(|e| Error::OpenrouterRequest {
+        message: format!("could not parse response: {e}"),
+    })?;
 
     parsed
         .choices

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -136,7 +136,8 @@ impl Post {
 
     /// Render the post back to a frontmatter-prefixed Markdown string.
     pub fn render(&self) -> Result<String> {
-        let yaml = serde_yaml_ng::to_string(&self.metadata).map_err(Error::FrontmatterSerialize)?;
+        let yaml = serde_yaml_ng::to_string(&self.metadata)
+            .map_err(|source| Error::FrontmatterSerialize { source })?;
         let mut out = String::with_capacity(yaml.len() + self.body.len() + 16);
         out.push_str(DELIM);
         out.push('\n');
@@ -188,8 +189,10 @@ fn validate_targets(path: &Path, targets: &[TargetEntry]) -> Result<()> {
 }
 
 fn split_frontmatter<'a>(path: &Path, contents: &'a str) -> Result<(&'a str, &'a str)> {
-    let after_opening = strip_opening_delim(contents)
-        .ok_or_else(|| Error::FrontmatterMissingOpen(path.to_path_buf()))?;
+    let after_opening =
+        strip_opening_delim(contents).ok_or_else(|| Error::FrontmatterMissingOpen {
+            path: path.to_path_buf(),
+        })?;
 
     // Locate the closing `---` line. We look for `\n---` followed by either
     // end-of-input or another `\n` so a body line that happens to start with
@@ -219,7 +222,9 @@ fn split_frontmatter<'a>(path: &Path, contents: &'a str) -> Result<(&'a str, &'a
         search_from = abs + 1;
     }
 
-    Err(Error::FrontmatterMissingClose(path.to_path_buf()))
+    Err(Error::FrontmatterMissingClose {
+        path: path.to_path_buf(),
+    })
 }
 
 fn strip_opening_delim(contents: &str) -> Option<&str> {
@@ -345,13 +350,19 @@ Body.
     #[test]
     fn parse_rejects_missing_opening_delim() {
         let raw = "title: Example\n---\n\nbody\n";
-        assert!(matches!(parse(raw), Err(Error::FrontmatterMissingOpen(_))));
+        assert!(matches!(
+            parse(raw),
+            Err(Error::FrontmatterMissingOpen { .. })
+        ));
     }
 
     #[test]
     fn parse_rejects_missing_closing_delim() {
         let raw = "---\ntitle: Example\nslug: example\n";
-        assert!(matches!(parse(raw), Err(Error::FrontmatterMissingClose(_))));
+        assert!(matches!(
+            parse(raw),
+            Err(Error::FrontmatterMissingClose { .. })
+        ));
     }
 
     #[test]

--- a/apps/blogctl/src/predicate.rs
+++ b/apps/blogctl/src/predicate.rs
@@ -100,13 +100,17 @@ impl Predicate {
     /// the operator, trimmed" so quoted strings can contain spaces.
     pub fn parse(input: &str) -> Result<Self> {
         let trimmed = input.trim();
-        let (acc_tok, after_acc) = next_token(trimmed)
-            .ok_or_else(|| Error::PredicateParse(format!("empty predicate: {input:?}")))?;
-        let (op_tok, after_op) = next_token(after_acc)
-            .ok_or_else(|| Error::PredicateParse(format!("missing operator: {input:?}")))?;
+        let (acc_tok, after_acc) = next_token(trimmed).ok_or_else(|| Error::PredicateParse {
+            message: format!("empty predicate: {input:?}"),
+        })?;
+        let (op_tok, after_op) = next_token(after_acc).ok_or_else(|| Error::PredicateParse {
+            message: format!("missing operator: {input:?}"),
+        })?;
         let lit_tok = after_op.trim();
         if lit_tok.is_empty() {
-            return Err(Error::PredicateParse(format!("missing literal: {input:?}")));
+            return Err(Error::PredicateParse {
+                message: format!("missing literal: {input:?}"),
+            });
         }
 
         Ok(Self {
@@ -312,26 +316,28 @@ fn parse_accessor(tok: &str) -> Result<Accessor> {
         other => {
             if let Some(rest) = other.strip_prefix("frontmatter.") {
                 if rest.is_empty() {
-                    return Err(Error::PredicateParse(format!(
-                        "frontmatter accessor missing field name: {tok:?}"
-                    )));
+                    return Err(Error::PredicateParse {
+                        message: format!("frontmatter accessor missing field name: {tok:?}"),
+                    });
                 }
                 if let Some(field) = rest.strip_suffix(".len") {
                     if field.is_empty() || field.contains('.') {
-                        return Err(Error::PredicateParse(format!(
-                            "invalid frontmatter accessor: {tok:?}"
-                        )));
+                        return Err(Error::PredicateParse {
+                            message: format!("invalid frontmatter accessor: {tok:?}"),
+                        });
                     }
                     Ok(Accessor::FrontmatterLen(field.to_string()))
                 } else if rest.contains('.') {
-                    Err(Error::PredicateParse(format!(
-                        "nested frontmatter paths not supported: {tok:?}"
-                    )))
+                    Err(Error::PredicateParse {
+                        message: format!("nested frontmatter paths not supported: {tok:?}"),
+                    })
                 } else {
                     Ok(Accessor::Frontmatter(rest.to_string()))
                 }
             } else {
-                Err(Error::PredicateParse(format!("unknown accessor: {tok:?}")))
+                Err(Error::PredicateParse {
+                    message: format!("unknown accessor: {tok:?}"),
+                })
             }
         }
     }
@@ -345,9 +351,9 @@ fn parse_op(tok: &str) -> Result<Op> {
         "<=" => Ok(Op::Le),
         ">" => Ok(Op::Gt),
         "<" => Ok(Op::Lt),
-        other => Err(Error::PredicateParse(format!(
-            "unknown operator: {other:?}"
-        ))),
+        other => Err(Error::PredicateParse {
+            message: format!("unknown operator: {other:?}"),
+        }),
     }
 }
 
@@ -361,15 +367,17 @@ fn parse_literal(tok: &str) -> Result<Literal> {
     if let Some(inner) = tok.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
         // No escape syntax — embedded `"` is rejected to keep the grammar boring.
         if inner.contains('"') {
-            return Err(Error::PredicateParse(format!(
-                "string literal may not contain `\"`: {tok:?}"
-            )));
+            return Err(Error::PredicateParse {
+                message: format!("string literal may not contain `\"`: {tok:?}"),
+            });
         }
         return Ok(Literal::Str(inner.to_string()));
     }
     tok.parse::<i64>()
         .map(Literal::Int)
-        .map_err(|_| Error::PredicateParse(format!("not a valid literal: {tok:?}")))
+        .map_err(|_| Error::PredicateParse {
+            message: format!("not a valid literal: {tok:?}"),
+        })
 }
 
 #[cfg(test)]
@@ -437,11 +445,11 @@ mod tests {
     fn rejects_empty_input() {
         assert!(matches!(
             Predicate::parse(""),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
         assert!(matches!(
             Predicate::parse("   "),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -449,7 +457,7 @@ mod tests {
     fn rejects_missing_literal() {
         assert!(matches!(
             Predicate::parse("body.words >="),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -457,7 +465,7 @@ mod tests {
     fn rejects_unknown_accessor() {
         assert!(matches!(
             Predicate::parse("post.length > 0"),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -465,7 +473,7 @@ mod tests {
     fn rejects_unknown_operator() {
         assert!(matches!(
             Predicate::parse("body.words =~ 150"),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -475,7 +483,7 @@ mod tests {
         // with the only allowed suffix being `.len`.
         assert!(matches!(
             Predicate::parse("frontmatter.classifications.format == \"thesis\""),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -483,7 +491,7 @@ mod tests {
     fn rejects_bare_frontmatter() {
         assert!(matches!(
             Predicate::parse("frontmatter. == 1"),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -491,7 +499,7 @@ mod tests {
     fn rejects_invalid_literal() {
         assert!(matches!(
             Predicate::parse("body.words >= maybe"),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 
@@ -499,7 +507,7 @@ mod tests {
     fn rejects_string_literal_with_embedded_quote() {
         assert!(matches!(
             Predicate::parse(r#"frontmatter.title == "a"b""#),
-            Err(Error::PredicateParse(_))
+            Err(Error::PredicateParse { .. })
         ));
     }
 

--- a/apps/blogctl/src/slug.rs
+++ b/apps/blogctl/src/slug.rs
@@ -26,7 +26,9 @@ pub fn slugify(title: &str) -> Result<String> {
     }
 
     if out.is_empty() {
-        return Err(Error::EmptyTitle(title.to_string()));
+        return Err(Error::EmptyTitle {
+            value: title.to_string(),
+        });
     }
     Ok(out)
 }
@@ -35,33 +37,39 @@ pub fn slugify(title: &str) -> Result<String> {
 /// no trailing `-`. Returns the slug as-is if valid.
 pub fn validate(slug: &str) -> Result<&str> {
     if slug.is_empty() {
-        return Err(Error::InvalidSlug(slug.to_string(), "empty".into()));
+        return Err(Error::InvalidSlug {
+            value: slug.to_string(),
+            reason: "empty".into(),
+        });
     }
     let bytes = slug.as_bytes();
     let first = bytes[0];
     if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
-        return Err(Error::InvalidSlug(
-            slug.to_string(),
-            "must start with [a-z0-9]".into(),
-        ));
+        return Err(Error::InvalidSlug {
+            value: slug.to_string(),
+            reason: "must start with [a-z0-9]".into(),
+        });
     }
     if bytes[bytes.len() - 1] == b'-' {
-        return Err(Error::InvalidSlug(
-            slug.to_string(),
-            "cannot end with '-'".into(),
-        ));
+        return Err(Error::InvalidSlug {
+            value: slug.to_string(),
+            reason: "cannot end with '-'".into(),
+        });
     }
     let mut prev_dash = false;
     for &b in bytes {
         let ok = b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-';
         if !ok {
-            return Err(Error::InvalidSlug(
-                slug.to_string(),
-                format!("contains invalid byte {:?}", b as char),
-            ));
+            return Err(Error::InvalidSlug {
+                value: slug.to_string(),
+                reason: format!("contains invalid byte {:?}", b as char),
+            });
         }
         if b == b'-' && prev_dash {
-            return Err(Error::InvalidSlug(slug.to_string(), "contains '--'".into()));
+            return Err(Error::InvalidSlug {
+                value: slug.to_string(),
+                reason: "contains '--'".into(),
+            });
         }
         prev_dash = b == b'-';
     }
@@ -97,9 +105,15 @@ mod tests {
 
     #[test]
     fn slugify_rejects_empty_titles() {
-        assert!(matches!(slugify("").unwrap_err(), Error::EmptyTitle(_)));
-        assert!(matches!(slugify("   ").unwrap_err(), Error::EmptyTitle(_)));
-        assert!(matches!(slugify("???").unwrap_err(), Error::EmptyTitle(_)));
+        assert!(matches!(slugify("").unwrap_err(), Error::EmptyTitle { .. }));
+        assert!(matches!(
+            slugify("   ").unwrap_err(),
+            Error::EmptyTitle { .. }
+        ));
+        assert!(matches!(
+            slugify("???").unwrap_err(),
+            Error::EmptyTitle { .. }
+        ));
     }
 
     #[test]
@@ -129,7 +143,7 @@ mod tests {
     #[test]
     fn validate_rejects_malformed_slugs() {
         for s in ["", "-foo", "foo-", "foo--bar", "Foo", "foo_bar", "foo bar"] {
-            assert!(matches!(validate(s), Err(Error::InvalidSlug(_, _))), "{s}");
+            assert!(matches!(validate(s), Err(Error::InvalidSlug { .. })), "{s}");
         }
     }
 }

--- a/apps/blogctl/src/stage.rs
+++ b/apps/blogctl/src/stage.rs
@@ -60,7 +60,7 @@ impl Stage {
             Stage::Ideation => Ok(Stage::Editing),
             Stage::Editing => Ok(Stage::FinalEditing),
             Stage::FinalEditing => Ok(Stage::Published),
-            Stage::Published | Stage::Abandoned => Err(Error::PromoteFromTerminal(self)),
+            Stage::Published | Stage::Abandoned => Err(Error::PromoteFromTerminal { stage: self }),
         }
     }
 
@@ -68,12 +68,12 @@ impl Stage {
     /// without an explicit force (a future flag); Abandoned can't demote.
     pub fn demote(self) -> Result<Stage> {
         match self {
-            Stage::Concept => Err(Error::DemoteFromInitial(self)),
+            Stage::Concept => Err(Error::DemoteFromInitial { stage: self }),
             Stage::Ideation => Ok(Stage::Concept),
             Stage::Editing => Ok(Stage::Ideation),
             Stage::FinalEditing => Ok(Stage::Editing),
             Stage::Published => Err(Error::DemotePublished),
-            Stage::Abandoned => Err(Error::DemoteFromInitial(self)),
+            Stage::Abandoned => Err(Error::DemoteFromInitial { stage: self }),
         }
     }
 }
@@ -94,7 +94,9 @@ impl FromStr for Stage {
             "final-editing" => Ok(Stage::FinalEditing),
             "published" => Ok(Stage::Published),
             "abandoned" => Ok(Stage::Abandoned),
-            other => Err(Error::InvalidStage(other.to_string())),
+            other => Err(Error::InvalidStage {
+                value: other.to_string(),
+            }),
         }
     }
 }
@@ -114,13 +116,23 @@ mod tests {
     #[test]
     fn promote_from_published_is_terminal() {
         let err = Stage::Published.promote().unwrap_err();
-        assert!(matches!(err, Error::PromoteFromTerminal(Stage::Published)));
+        assert!(matches!(
+            err,
+            Error::PromoteFromTerminal {
+                stage: Stage::Published
+            }
+        ));
     }
 
     #[test]
     fn promote_from_abandoned_is_terminal() {
         let err = Stage::Abandoned.promote().unwrap_err();
-        assert!(matches!(err, Error::PromoteFromTerminal(Stage::Abandoned)));
+        assert!(matches!(
+            err,
+            Error::PromoteFromTerminal {
+                stage: Stage::Abandoned
+            }
+        ));
     }
 
     #[test]
@@ -133,7 +145,12 @@ mod tests {
     #[test]
     fn demote_from_concept_is_initial() {
         let err = Stage::Concept.demote().unwrap_err();
-        assert!(matches!(err, Error::DemoteFromInitial(Stage::Concept)));
+        assert!(matches!(
+            err,
+            Error::DemoteFromInitial {
+                stage: Stage::Concept
+            }
+        ));
     }
 
     #[test]

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -324,7 +324,9 @@ pub struct Repository {
 impl Repository {
     pub fn open(workdir: Workdir) -> Result<Self> {
         if !workdir.config_path().is_file() {
-            return Err(Error::WorkdirNotInitialized(workdir.root().to_path_buf()));
+            return Err(Error::WorkdirNotInitialized {
+                path: workdir.root().to_path_buf(),
+            });
         }
         Ok(Self { workdir })
     }
@@ -345,15 +347,16 @@ impl Repository {
     /// created with `create_dir_all`.
     pub fn init(&self) -> Result<()> {
         if self.workdir.config_path().exists() {
-            return Err(Error::WorkdirAlreadyInitialized(
-                self.workdir.root().to_path_buf(),
-            ));
+            return Err(Error::WorkdirAlreadyInitialized {
+                path: self.workdir.root().to_path_buf(),
+            });
         }
         for dir in self.workdir.directories() {
             fs::create_dir_all(&dir).map_err(|e| Error::io(&dir, e))?;
         }
         let config_path = self.workdir.config_path();
-        let serialized = toml::to_string(&Config::current()).map_err(Error::ConfigSerialize)?;
+        let serialized = toml::to_string(&Config::current())
+            .map_err(|source| Error::ConfigSerialize { source })?;
         fs::write(&config_path, serialized).map_err(|e| Error::io(&config_path, e))?;
         self.write_readme(false)?;
         Ok(())
@@ -390,10 +393,10 @@ impl Repository {
     /// a file with that slug already exists in any stage.
     pub fn create_post(&self, post: &Post) -> Result<PathBuf> {
         if let Some(existing) = self.find_path(&post.metadata.slug)? {
-            return Err(Error::DuplicateSlug(
-                post.metadata.slug.clone(),
-                existing.display().to_string(),
-            ));
+            return Err(Error::DuplicateSlug {
+                slug: post.metadata.slug.clone(),
+                paths: existing.display().to_string(),
+            });
         }
         let stage = post.metadata.status;
         let dir = self.workdir.stage_dir(stage);
@@ -427,9 +430,9 @@ impl Repository {
     /// can still be rewritten to a valid set — otherwise the very
     /// tool meant to fix the problem would be blocked by it.
     pub fn load_raw(&self, slug: &str) -> Result<(PostHandle, Post)> {
-        let (stage, path) = self
-            .locate(slug)?
-            .ok_or_else(|| Error::PostNotFound(slug.to_string()))?;
+        let (stage, path) = self.locate(slug)?.ok_or_else(|| Error::PostNotFound {
+            slug: slug.to_string(),
+        })?;
         let raw = fs::read_to_string(&path).map_err(|e| Error::io(&path, e))?;
         let post = Post::parse(&path, &raw)?;
         if post.metadata.status != stage {
@@ -641,10 +644,10 @@ impl Repository {
             let candidate = self.workdir.post_path(stage, slug);
             if candidate.is_file() {
                 if let Some((_, existing_path)) = &found {
-                    return Err(Error::DuplicateSlug(
-                        slug.to_string(),
-                        format!("{} and {}", existing_path.display(), candidate.display(),),
-                    ));
+                    return Err(Error::DuplicateSlug {
+                        slug: slug.to_string(),
+                        paths: format!("{} and {}", existing_path.display(), candidate.display()),
+                    });
                 }
                 found = Some((stage, candidate));
             }
@@ -858,14 +861,14 @@ mod tests {
     fn init_refuses_to_clobber_existing_config() {
         let (_tmp, repo) = fresh_repo();
         let err = repo.init().unwrap_err();
-        assert!(matches!(err, Error::WorkdirAlreadyInitialized(_)));
+        assert!(matches!(err, Error::WorkdirAlreadyInitialized { .. }));
     }
 
     #[test]
     fn open_requires_an_initialized_workdir() {
         let tmp = TempDir::new().unwrap();
         let err = Repository::open(Workdir::new(tmp.path())).unwrap_err();
-        assert!(matches!(err, Error::WorkdirNotInitialized(_)));
+        assert!(matches!(err, Error::WorkdirNotInitialized { .. }));
     }
 
     #[test]
@@ -885,7 +888,7 @@ mod tests {
         let err = repo
             .create_post(&fixture_post("dup", Stage::Concept))
             .unwrap_err();
-        assert!(matches!(err, Error::DuplicateSlug(_, _)));
+        assert!(matches!(err, Error::DuplicateSlug { .. }));
     }
 
     #[test]
@@ -933,7 +936,7 @@ mod tests {
     fn load_returns_post_not_found_for_missing_slug() {
         let (_tmp, repo) = fresh_repo();
         let err = repo.load("nope").unwrap_err();
-        assert!(matches!(err, Error::PostNotFound(_)));
+        assert!(matches!(err, Error::PostNotFound { .. }));
     }
 
     #[test]
@@ -945,7 +948,7 @@ mod tests {
         fs::write(tmp.path().join("editing/dup.md"), p2.render().unwrap()).unwrap();
 
         let err = repo.load("dup").unwrap_err();
-        assert!(matches!(err, Error::DuplicateSlug(_, _)));
+        assert!(matches!(err, Error::DuplicateSlug { .. }));
     }
 
     #[test]

--- a/apps/blogctl/src/target.rs
+++ b/apps/blogctl/src/target.rs
@@ -48,7 +48,9 @@ impl FromStr for Target {
         match s {
             "linkedin" => Ok(Target::Linkedin),
             "blog" => Ok(Target::Blog),
-            other => Err(Error::InvalidTarget(other.to_string())),
+            other => Err(Error::InvalidTarget {
+                value: other.to_string(),
+            }),
         }
     }
 }
@@ -92,7 +94,9 @@ impl FromStr for TargetStatus {
             "planned" => Ok(TargetStatus::Planned),
             "published" => Ok(TargetStatus::Published),
             "retracted" => Ok(TargetStatus::Retracted),
-            other => Err(Error::InvalidTargetStatus(other.to_string())),
+            other => Err(Error::InvalidTargetStatus {
+                value: other.to_string(),
+            }),
         }
     }
 }
@@ -150,7 +154,7 @@ mod tests {
     #[test]
     fn target_parse_rejects_unknown() {
         let err = "mastodon".parse::<Target>().unwrap_err();
-        assert!(matches!(err, Error::InvalidTarget(_)));
+        assert!(matches!(err, Error::InvalidTarget { .. }));
     }
 
     #[test]
@@ -163,7 +167,7 @@ mod tests {
     #[test]
     fn target_status_parse_rejects_unknown() {
         let err = "draft".parse::<TargetStatus>().unwrap_err();
-        assert!(matches!(err, Error::InvalidTargetStatus(_)));
+        assert!(matches!(err, Error::InvalidTargetStatus { .. }));
     }
 
     #[test]

--- a/apps/blogctl/tests/backfill.rs
+++ b/apps/blogctl/tests/backfill.rs
@@ -164,7 +164,7 @@ fn import_with_unknown_slug_warns_continues_and_returns_partial_failure() {
     );
     let err = result.expect_err("unknown slug should produce a partial-failure error");
     assert!(
-        matches!(err, blogctl::Error::BackfillPartialFailure(n) if n == 1),
+        matches!(err, blogctl::Error::BackfillPartialFailure { warnings: n } if n == 1),
         "got: {err:?}"
     );
     // Partial progress preserved: the known slug got its update.
@@ -203,7 +203,7 @@ fn import_with_metrics_for_missing_target_warns() {
     );
     let err = result.expect_err("missing target should produce a partial-failure error");
     assert!(
-        matches!(err, blogctl::Error::BackfillPartialFailure(n) if n == 1),
+        matches!(err, blogctl::Error::BackfillPartialFailure { warnings: n } if n == 1),
         "got: {err:?}"
     );
 }
@@ -227,7 +227,7 @@ fn import_with_invalid_classification_warns() {
     );
     let err = result.expect_err("invalid value should produce a partial-failure error");
     assert!(
-        matches!(err, blogctl::Error::BackfillPartialFailure(n) if n == 1),
+        matches!(err, blogctl::Error::BackfillPartialFailure { warnings: n } if n == 1),
         "got: {err:?}"
     );
     // File on disk must be untouched (the entry errored before write).

--- a/apps/blogctl/tests/import.rs
+++ b/apps/blogctl/tests/import.rs
@@ -105,7 +105,7 @@ fn import_refuses_when_slug_already_exists() {
     let second = commands::import::run(&FakeJj::new(), import_args(&workdir));
 
     match second {
-        Err(Error::DuplicateSlug(slug, _)) => {
+        Err(Error::DuplicateSlug { slug, .. }) => {
             assert_eq!(slug, "backfill-is-the-shape");
         }
         other => panic!("expected DuplicateSlug, got {other:?}"),

--- a/apps/blogctl/tests/sync.rs
+++ b/apps/blogctl/tests/sync.rs
@@ -437,8 +437,8 @@ fn doctor_surfaces_stale_unpushed_commits_finding() {
     }));
     let err = commands::doctor::run(&jj, path).unwrap_err();
     assert!(
-        matches!(err, blogctl::Error::WorkdirUnhealthy(n) if n == 1),
-        "expected WorkdirUnhealthy(1), got: {err:?}"
+        matches!(err, blogctl::Error::WorkdirUnhealthy { findings: n } if n == 1),
+        "expected WorkdirUnhealthy {{ findings: 1 }}, got: {err:?}"
     );
 }
 


### PR DESCRIPTION
Second of two migrations to consolidate rust error-handling on
`snafu` (todoist half landed via #640 / PR #665). `snafu` gives us
typed enums with `.context(...)` attach, which `thiserror` lacks on
its own.

Substantive changes:

- `src/error.rs` — `#[derive(thiserror::Error)]` → `#[derive(Snafu)]`;
  every `#[error("...")]` → `#[snafu(display("..."))]`. The display
  strings are byte-identical to the thiserror originals (existing
  tests assert on substrings, all 435 still pass).
- **Every tuple variant converted to a struct variant** — snafu's
  selector API (`XSnafu { ... }.fail()`, `.context(XSnafu)`) only
  works for named-field variants, and consistent shape across the
  whole enum makes the surface easier to reach for. Field names
  follow the most semantic option from each variant's message text
  (`path`, `value`, `source`, `message`, `slug`, etc.).
- 77 construction sites across 16 source files (plus 3 integration
  test files) updated from `Error::Foo(arg)` to
  `Error::Foo { field: arg }`. Pattern-match sites updated from
  `Error::Foo(_)` to `Error::Foo { .. }`. `map_err(Error::Foo)`
  function-pointer uses became closures (`|source|
  Error::Foo { source }`).
- `thiserror` dropped from `Cargo.toml`; `snafu = "0.9"` added.

No error-message regressions (every `.to_string()` and substring
assertion preserved). No behavior changes — pure refactor.

Closes #654