### PR TITLE
docs: document snafu as the rust error-handling convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,11 @@ A few tasks pay off when run on a cadence rather than per-PR:
   allowlist.
 - **Don't add CI jobs to `.github/workflows/main.yaml`** for new validation
   steps — extend `shaka preflight` so CI and local stay in lockstep.
+- **Don't reach for `anyhow` or `thiserror` in new rust code.** The repo
+  standardized on `snafu` (typed per-module error `enum`s with named-field
+  variants, `.context(XSnafu)` attach, `#[snafu(display("..."))]` for
+  user-facing messages) via #640 / #654. See `tools/shaka/src/gh.rs` or
+  `tools/todoist/src/api.rs` for the canonical shape.
 - **Don't add Claude Code attribution** to commits, code, or docs.
 - **Don't run mutating `git` commands.** The repo is `jj`-colocated;
   `git stash`, `git stash pop`, `git checkout`, `git reset`,


### PR DESCRIPTION
Captures the convention that #640 (todoist, merged via #665) and
#654 (blogctl, queued in #694) consolidated on: `snafu` for all
rust error handling, named-field variants, `.context(XSnafu)` for
attach, `#[snafu(display("..."))]` for user-facing messages.

Adds a single bullet to `CLAUDE.md`'s "Things to avoid" list rather
than spinning up a new section — the convention is one rule, the
"avoid anyhow/thiserror" framing matches the surrounding bullets,
and the pointers to `shaka/gh.rs` and `todoist/api.rs` send future
code at a working example faster than prose would.

Closes #695