### PR TITLE
fix(infra/home): drop devenv direnvrc that breaks use_flake

### DIFF
--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -65,12 +65,6 @@
   programs.direnv = {
     enable = true;
     nix-direnv.enable = true;
-    # Devenv integration — keeps `use devenv` working in project envrcs
-    # that opt into it (none in this repo today, but preserved for
-    # parity with the user's existing direnvrc).
-    stdlib = ''
-      source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
-    '';
   };
 
   programs.pay-respects = {


### PR DESCRIPTION
The devenv direnvrc sourced via programs.direnv.stdlib redefines
_nix_direnv_preflight without setting _nix_direnv_nix. Since direnvrc
loads after lib/hm-nix-direnv.sh, devenv's version wins and leaves
the variable empty. When use_flake calls _nix(), the shell tries to
execute --no-warn-dirty as a command, failing every `use flake` repo.

No projects in active development use devenv; remove the stdlib
entirely rather than conditionalizing it.