### PR TITLE
fix(ci): CI pipeline quick wins from audit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -323,14 +323,12 @@ jobs:
     - build-shaka
     if: always()
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
-    - uses: actions/checkout@v6
-    - uses: DeterminateSystems/nix-installer-action@main
-      with:
-        determinate: true
-        flakehub: true
-    - uses: DeterminateSystems/flakehub-cache-action@v3
-    - run: nix run ./tools/shaka -- ci gate --needs '${{ toJson(needs) }}'
+    - run: |-
+        echo '${{ toJson(needs) }}' | jq -e '
+          to_entries
+          | map(select(.value.result != "success" and .value.result != "skipped"))
+          | if length == 0 then "Gate passed"
+            else error("Gate failed: \(map(.key) | join(", "))")
+            end
+        '

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,7 +103,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.blogctl == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.blogctl == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -146,7 +146,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.image == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.image == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -171,7 +171,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.home == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.home == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -196,7 +196,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.nix-lib == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.nix-lib == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -221,7 +221,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.aof == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.aof == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -264,7 +264,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.claude-hooks == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.claude-hooks == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -289,7 +289,7 @@ jobs:
     needs:
     - preflight
     - changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.shaka == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.shaka == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/apps/blogctl/justfile
+++ b/apps/blogctl/justfile
@@ -53,4 +53,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/apps/kolohelios-portfolio/justfile
+++ b/apps/kolohelios-portfolio/justfile
@@ -69,4 +69,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: build-check fmt-check lint doc-check deny machete test coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check
+validate: build-check fmt-check lint doc-check deny machete coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check

--- a/apps/pollen-alert/justfile
+++ b/apps/pollen-alert/justfile
@@ -61,4 +61,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check

--- a/tools/aof/justfile
+++ b/tools/aof/justfile
@@ -53,4 +53,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/tools/claude-hooks/justfile
+++ b/tools/claude-hooks/justfile
@@ -53,4 +53,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/justfile
+++ b/tools/shaka/justfile
@@ -53,4 +53,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/src/ci/main_workflow.rs
+++ b/tools/shaka/src/ci/main_workflow.rs
@@ -554,55 +554,27 @@ fn gate_job(specs: &[MainBuildSpec]) -> InlineJob {
         needs_list.push(format!("build-{}", spec.build.job_id));
     }
 
-    let mut nix_install_with: BTreeMap<String, Value> = BTreeMap::new();
-    nix_install_with.insert("determinate".to_string(), Value::Bool(true));
-    nix_install_with.insert("flakehub".to_string(), Value::Bool(true));
-
     InlineJob {
         name: Some("Gate".to_string()),
         needs: Needs::Multiple(needs_list),
         if_: Some("always()".to_string()),
         runs_on: "ubuntu-latest".to_string(),
-        permissions: Some(Permissions {
-            id_token: Some(PermissionLevel::Write),
-            contents: Some(PermissionLevel::Read),
-            pull_requests: None,
-        }),
+        permissions: None,
         env: BTreeMap::new(),
         outputs: BTreeMap::new(),
-        steps: vec![
-            Step::Action(ActionStep {
-                uses: "actions/checkout@v6".to_string(),
-                id: None,
-                name: None,
-                if_: None,
-                with: BTreeMap::new(),
-                env: BTreeMap::new(),
-            }),
-            Step::Action(ActionStep {
-                uses: "DeterminateSystems/nix-installer-action@main".to_string(),
-                id: None,
-                name: None,
-                if_: None,
-                with: nix_install_with,
-                env: BTreeMap::new(),
-            }),
-            Step::Action(ActionStep {
-                uses: "DeterminateSystems/flakehub-cache-action@v3".to_string(),
-                id: None,
-                name: None,
-                if_: None,
-                with: BTreeMap::new(),
-                env: BTreeMap::new(),
-            }),
-            Step::Run(RunStep {
-                id: None,
-                name: None,
-                if_: None,
-                run: r#"nix run ./tools/shaka -- ci gate --needs '${{ toJson(needs) }}'"#
-                    .to_string(),
-                env: BTreeMap::new(),
-            }),
-        ],
+        steps: vec![Step::Run(RunStep {
+            id: None,
+            name: None,
+            if_: None,
+            run: r#"echo '${{ toJson(needs) }}' | jq -e '
+  to_entries
+  | map(select(.value.result != "success" and .value.result != "skipped"))
+  | if length == 0 then "Gate passed"
+    else error("Gate failed: \(map(.key) | join(", "))")
+    end
+'"#
+            .to_string(),
+            env: BTreeMap::new(),
+        })],
     }
 }

--- a/tools/shaka/src/ci/main_workflow.rs
+++ b/tools/shaka/src/ci/main_workflow.rs
@@ -344,7 +344,7 @@ fn preflight_job() -> InlineJob {
 fn build_job(spec: &MainBuildSpec) -> InlineJob {
     let project_dir_str = spec.project_dir.to_string_lossy().to_string();
     let if_cond = format!(
-        "github.event_name != 'pull_request' || needs.changes.outputs.{} == 'true'",
+        "github.event_name == 'workflow_dispatch' || needs.changes.outputs.{} == 'true'",
         spec.build.filter_key,
     );
     let publish_if = "github.event_name == 'push' || github.event_name == 'workflow_dispatch'";

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -63,7 +63,7 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check
 "#;
 
 const NIX_LIB_TEMPLATE: &str = r#"fmt-toml:
@@ -160,7 +160,7 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage wasm-check worker-build-check nix-fmt-check flake-check whitespace-check
 "#;
 
 // Infra projects intentionally do NOT run `nix flake check` in `validate`.
@@ -768,7 +768,7 @@ mod tests {
         assert!(RUST_TEMPLATE.contains("fmt-check"));
         assert!(RUST_TEMPLATE.contains("clippy"));
         assert!(RUST_TEMPLATE.contains(
-            "validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check"
+            "validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check"
         ));
     }
 

--- a/tools/todoist/justfile
+++ b/tools/todoist/justfile
@@ -53,4 +53,4 @@ flake-check:
 whitespace-check:
     ../../tools/shaka/bin/shaka whitespace check
 
-validate: fmt-check lint doc-check deny machete test coverage nix-fmt-check flake-check whitespace-check
+validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check


### PR DESCRIPTION
Three quick wins from the CI audit (#74): gate job jq replacement,
redundant test removal, and path-filtered builds on main.

Closes #702
Closes #703
Closes #704