### PR TITLE
chore(infra/home): swap claude-code cask to claude-code@latest

### DIFF
--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -56,7 +56,7 @@
       cleanup = "none";
     };
     casks = [
-      "claude-code"
+      "claude-code@latest"
     ];
   };
 


### PR DESCRIPTION
The default `claude-code` cask lags upstream releases. The
`claude-code@latest` variant tracks the latest claude-code release
more aggressively, recommended by the `claude update` output itself
for users wanting more frequent updates.

`homebrew.onActivation.cleanup = "none"` means the old cask isn't
auto-removed; a one-time `brew uninstall --cask claude-code` on each
host completes the swap.

Closes #709