### PR TITLE
fix(apps/cascadiajs2026-notes): correct speakers and add slide links

### DIFF
--- a/apps/cascadiajs2026-notes/data/talks.cue
+++ b/apps/cascadiajs2026-notes/data/talks.cue
@@ -44,9 +44,9 @@ talks: [...#Talk] & [
 	},
 	{
 		slug:    "agent-swarms"
-		speaker: "Joel Duffy"
-		company: "Pulumi"
-		title:   "Agent Swarms & Harness Engineering"
+		speaker: "Joel Hooks"
+		company: "Badass Courses"
+		title:   "AI Agent Swarms Are Amazing"
 		day:     1
 		order:   2
 		projects: [
@@ -57,12 +57,12 @@ talks: [...#Talk] & [
 	},
 	{
 		slug:    "modern-css-colors"
-		speaker: "James Steinbeck"
+		speaker: "James Steinbach"
 		company: "Delinea"
 		title:   "Practical Refactors with Modern CSS Colors"
 		day:     1
 		order:   3
-		slides:  "https://jds.li/css-colors"
+		slides:  "https://jdsteinbach.com/practical-color-css/"
 	},
 	{
 		slug:    "web-workers"
@@ -79,18 +79,22 @@ talks: [...#Talk] & [
 		slug:    "ai-to-learn"
 		speaker: "Daniel Mendoza"
 		company: "Storyblok"
-		title:   "Using AI to Learn"
+		title:   "AI Helped Me Learn: Vue Through the Lens of a React Developer"
 		day:     1
 		order:   5
+		slides:  "https://new.express.adobe.com/publishedV2/urn:aaid:sc:US:5b2e8fce-4bc0-5bcc-bb70-62f7c36f80b2?promoid=Y69SGM5H&mv=other"
 	},
 	{
 		slug:    "linked-literate-programming"
 		speaker: "James Ide"
 		company: "Expo"
-		title:   "Linked Literate Programming"
+		title:   "Implementing the Web on Native with Linked Literate Programming"
 		day:     1
 		order:   6
+		slides:  "https://github.com/expo/web-standard-camera-demo/releases/download/v1.0.0/slides.pdf"
 		projects: [
+			{name: "ccheever/llp", url: "https://github.com/ccheever/llp"},
+			{name: "Web demo", url: "https://standard-camera-demo.expo.app/"},
 			{name: "Web Platform Tests", url: "https://github.com/web-platform-tests/wpt"},
 		]
 	},
@@ -104,6 +108,7 @@ talks: [...#Talk] & [
 		projects: [
 			{name: "decepulis/ax-bench", url: "https://github.com/decepulis/ax-bench"},
 			{name: "Observable Plot", url: "https://observablehq.com/plot/"},
+			{name: "Bret Victor — Ladder of Abstraction", url: "https://worrydream.com/LadderOfAbstraction/"},
 		]
 	},
 	{
@@ -113,6 +118,7 @@ talks: [...#Talk] & [
 		title:   "Shared Components Beyond the Design System"
 		day:     1
 		order:   8
+		slides:  "https://jonathankeslin.com/cascadiajs26"
 	},
 	{
 		slug:    "junior-dev-team"
@@ -121,6 +127,7 @@ talks: [...#Talk] & [
 		title:   "How to Successfully Build a Junior Dev Team"
 		day:     1
 		order:   9
+		slides:  "https://learningasleadership.my.canva.site/cascadiajs-presentation"
 	},
 	{
 		slug:    "skeptics-to-champions"
@@ -134,7 +141,7 @@ talks: [...#Talk] & [
 		slug:    "spec-driven-development"
 		speaker: "Erik Hanchett"
 		company: "AWS"
-		title:   "Spec-Driven Development"
+		title:   "How to Use Spec-Driven Development for Production Workflows"
 		day:     1
 		order:   11
 		projects: [

--- a/apps/cascadiajs2026-notes/dist/index.html
+++ b/apps/cascadiajs2026-notes/dist/index.html
@@ -30,15 +30,15 @@
 
     <li class="py-3">
       <a href="/talks/agent-swarms/" class="group block">
-        <span class="font-medium text-stone-900 group-hover:text-blue-700">Agent Swarms &amp; Harness Engineering</span>
-        <span class="block text-sm text-stone-500">Joel Duffy · Pulumi</span>
+        <span class="font-medium text-stone-900 group-hover:text-blue-700">AI Agent Swarms Are Amazing</span>
+        <span class="block text-sm text-stone-500">Joel Hooks · Badass Courses</span>
       </a>
     </li>
 
     <li class="py-3">
       <a href="/talks/modern-css-colors/" class="group block">
         <span class="font-medium text-stone-900 group-hover:text-blue-700">Practical Refactors with Modern CSS Colors</span>
-        <span class="block text-sm text-stone-500">James Steinbeck · Delinea</span>
+        <span class="block text-sm text-stone-500">James Steinbach · Delinea</span>
       </a>
     </li>
 
@@ -51,14 +51,14 @@
 
     <li class="py-3">
       <a href="/talks/ai-to-learn/" class="group block">
-        <span class="font-medium text-stone-900 group-hover:text-blue-700">Using AI to Learn</span>
+        <span class="font-medium text-stone-900 group-hover:text-blue-700">AI Helped Me Learn: Vue Through the Lens of a React Developer</span>
         <span class="block text-sm text-stone-500">Daniel Mendoza · Storyblok</span>
       </a>
     </li>
 
     <li class="py-3">
       <a href="/talks/linked-literate-programming/" class="group block">
-        <span class="font-medium text-stone-900 group-hover:text-blue-700">Linked Literate Programming</span>
+        <span class="font-medium text-stone-900 group-hover:text-blue-700">Implementing the Web on Native with Linked Literate Programming</span>
         <span class="block text-sm text-stone-500">James Ide · Expo</span>
       </a>
     </li>
@@ -93,7 +93,7 @@
 
     <li class="py-3">
       <a href="/talks/spec-driven-development/" class="group block">
-        <span class="font-medium text-stone-900 group-hover:text-blue-700">Spec-Driven Development</span>
+        <span class="font-medium text-stone-900 group-hover:text-blue-700">How to Use Spec-Driven Development for Production Workflows</span>
         <span class="block text-sm text-stone-500">Erik Hanchett · AWS</span>
       </a>
     </li>

--- a/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Agent Swarms &amp; Harness Engineering · CascadiaJS 2026 Notes</title>
+<title>AI Agent Swarms Are Amazing · CascadiaJS 2026 Notes</title>
 <link rel="stylesheet" href="/style.css">
 </head>
 <body class="bg-stone-50 text-stone-800 antialiased">
@@ -17,8 +17,8 @@
 <a href="/" class="text-sm text-stone-500 hover:text-stone-700">← All talks</a>
 <article class="mt-4">
   <header>
-    <h1 class="text-2xl font-bold tracking-tight text-stone-900">Agent Swarms &amp; Harness Engineering</h1>
-    <p class="mt-2 text-stone-600">Joel Duffy · Pulumi · Day 1</p>
+    <h1 class="text-2xl font-bold tracking-tight text-stone-900">AI Agent Swarms Are Amazing</h1>
+    <p class="mt-2 text-stone-600">Joel Hooks · Badass Courses · Day 1</p>
   </header>
   <div class="notes mt-8">
 <p>Capability is going exponential with Opus 4.5+, and the leverage point is no

--- a/apps/cascadiajs2026-notes/dist/talks/ai-to-learn/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/ai-to-learn/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Using AI to Learn · CascadiaJS 2026 Notes</title>
+<title>AI Helped Me Learn: Vue Through the Lens of a React Developer · CascadiaJS 2026 Notes</title>
 <link rel="stylesheet" href="/style.css">
 </head>
 <body class="bg-stone-50 text-stone-800 antialiased">
@@ -17,7 +17,7 @@
 <a href="/" class="text-sm text-stone-500 hover:text-stone-700">← All talks</a>
 <article class="mt-4">
   <header>
-    <h1 class="text-2xl font-bold tracking-tight text-stone-900">Using AI to Learn</h1>
+    <h1 class="text-2xl font-bold tracking-tight text-stone-900">AI Helped Me Learn: Vue Through the Lens of a React Developer</h1>
     <p class="mt-2 text-stone-600">Daniel Mendoza · Storyblok · Day 1</p>
   </header>
   <div class="notes mt-8">
@@ -55,6 +55,9 @@ skill you can apply on demand.</p>
 
 
 
+  <section class="mt-6">
+    <a class="text-blue-700 underline hover:text-blue-900" href="https://new.express.adobe.com/publishedV2/urn:aaid:sc:US:5b2e8fce-4bc0-5bcc-bb70-62f7c36f80b2?promoid=Y69SGM5H&amp;mv=other">Slides</a>
+  </section>
 
 
 
@@ -65,7 +68,7 @@ skill you can apply on demand.</p>
   <a class="text-stone-600 hover:text-blue-700" href="/talks/web-workers/">← Keep the Main Thread Free with Web Workers</a>
 
 
-  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/linked-literate-programming/">Linked Literate Programming →</a>
+  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/linked-literate-programming/">Implementing the Web on Native with Linked Literate Programming →</a>
 
 </nav>
 

--- a/apps/cascadiajs2026-notes/dist/talks/biilman-agent-experience/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/biilman-agent-experience/index.html
@@ -95,7 +95,7 @@ also gets more required.</p>
   <span></span>
 
 
-  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/agent-swarms/">Agent Swarms &amp; Harness Engineering →</a>
+  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/agent-swarms/">AI Agent Swarms Are Amazing →</a>
 
 </nav>
 

--- a/apps/cascadiajs2026-notes/dist/talks/junior-dev-team/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/junior-dev-team/index.html
@@ -53,6 +53,9 @@ people has not.</p>
 
 
 
+  <section class="mt-6">
+    <a class="text-blue-700 underline hover:text-blue-900" href="https://learningasleadership.my.canva.site/cascadiajs-presentation">Slides</a>
+  </section>
 
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/last-mile-is-code/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/last-mile-is-code/index.html
@@ -59,7 +59,7 @@ anymore.</strong></p>
 
 <nav class="mt-12 flex justify-between gap-4 border-t border-stone-200 pt-6 text-sm">
 
-  <a class="text-stone-600 hover:text-blue-700" href="/talks/spec-driven-development/">← Spec-Driven Development</a>
+  <a class="text-stone-600 hover:text-blue-700" href="/talks/spec-driven-development/">← How to Use Spec-Driven Development for Production Workflows</a>
 
 
   <span></span>

--- a/apps/cascadiajs2026-notes/dist/talks/linked-literate-programming/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/linked-literate-programming/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Linked Literate Programming · CascadiaJS 2026 Notes</title>
+<title>Implementing the Web on Native with Linked Literate Programming · CascadiaJS 2026 Notes</title>
 <link rel="stylesheet" href="/style.css">
 </head>
 <body class="bg-stone-50 text-stone-800 antialiased">
@@ -17,7 +17,7 @@
 <a href="/" class="text-sm text-stone-500 hover:text-stone-700">← All talks</a>
 <article class="mt-4">
   <header>
-    <h1 class="text-2xl font-bold tracking-tight text-stone-900">Linked Literate Programming</h1>
+    <h1 class="text-2xl font-bold tracking-tight text-stone-900">Implementing the Web on Native with Linked Literate Programming</h1>
     <p class="mt-2 text-stone-600">James Ide · Expo · Day 1</p>
   </header>
   <div class="notes mt-8">
@@ -55,6 +55,10 @@ programmatic.</p>
     <h2 class="text-xs font-semibold uppercase tracking-wider text-stone-400">Referenced</h2>
     <ul class="mt-3 space-y-1">
 
+      <li><a class="text-blue-700 underline hover:text-blue-900" href="https://github.com/ccheever/llp">ccheever/llp</a></li>
+
+      <li><a class="text-blue-700 underline hover:text-blue-900" href="https://standard-camera-demo.expo.app/">Web demo</a></li>
+
       <li><a class="text-blue-700 underline hover:text-blue-900" href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a></li>
 
     </ul>
@@ -62,6 +66,9 @@ programmatic.</p>
 
 
 
+  <section class="mt-6">
+    <a class="text-blue-700 underline hover:text-blue-900" href="https://github.com/expo/web-standard-camera-demo/releases/download/v1.0.0/slides.pdf">Slides</a>
+  </section>
 
 
 
@@ -69,7 +76,7 @@ programmatic.</p>
 
 <nav class="mt-12 flex justify-between gap-4 border-t border-stone-200 pt-6 text-sm">
 
-  <a class="text-stone-600 hover:text-blue-700" href="/talks/ai-to-learn/">← Using AI to Learn</a>
+  <a class="text-stone-600 hover:text-blue-700" href="/talks/ai-to-learn/">← AI Helped Me Learn: Vue Through the Lens of a React Developer</a>
 
 
   <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/wrong-abstraction/">Choosing the Wrong Abstraction (And What It Cost Us) →</a>

--- a/apps/cascadiajs2026-notes/dist/talks/modern-css-colors/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/modern-css-colors/index.html
@@ -18,7 +18,7 @@
 <article class="mt-4">
   <header>
     <h1 class="text-2xl font-bold tracking-tight text-stone-900">Practical Refactors with Modern CSS Colors</h1>
-    <p class="mt-2 text-stone-600">James Steinbeck · Delinea · Day 1</p>
+    <p class="mt-2 text-stone-600">James Steinbach · Delinea · Day 1</p>
   </header>
   <div class="notes mt-8">
 <p>Practical refactors you can do today with modern CSS color features. The
@@ -69,7 +69,7 @@ colors to mix a tint in and still get a legible foreground. Support is only
 
 
   <section class="mt-6">
-    <a class="text-blue-700 underline hover:text-blue-900" href="https://jds.li/css-colors">Slides</a>
+    <a class="text-blue-700 underline hover:text-blue-900" href="https://jdsteinbach.com/practical-color-css/">Slides</a>
   </section>
 
 
@@ -78,7 +78,7 @@ colors to mix a tint in and still get a legible foreground. Support is only
 
 <nav class="mt-12 flex justify-between gap-4 border-t border-stone-200 pt-6 text-sm">
 
-  <a class="text-stone-600 hover:text-blue-700" href="/talks/agent-swarms/">← Agent Swarms &amp; Harness Engineering</a>
+  <a class="text-stone-600 hover:text-blue-700" href="/talks/agent-swarms/">← AI Agent Swarms Are Amazing</a>
 
 
   <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/web-workers/">Keep the Main Thread Free with Web Workers →</a>

--- a/apps/cascadiajs2026-notes/dist/talks/shared-components/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/shared-components/index.html
@@ -61,6 +61,9 @@ gold is a nice model), and <strong>recognize authors</strong> for their contribu
 
 
 
+  <section class="mt-6">
+    <a class="text-blue-700 underline hover:text-blue-900" href="https://jonathankeslin.com/cascadiajs26">Slides</a>
+  </section>
 
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/skeptics-to-champions/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/skeptics-to-champions/index.html
@@ -55,7 +55,7 @@ already in the repo. So <strong>replay the agent</strong> against them.</li>
   <a class="text-stone-600 hover:text-blue-700" href="/talks/junior-dev-team/">← How to Successfully Build a Junior Dev Team</a>
 
 
-  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/spec-driven-development/">Spec-Driven Development →</a>
+  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/spec-driven-development/">How to Use Spec-Driven Development for Production Workflows →</a>
 
 </nav>
 

--- a/apps/cascadiajs2026-notes/dist/talks/spec-driven-development/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/spec-driven-development/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Spec-Driven Development · CascadiaJS 2026 Notes</title>
+<title>How to Use Spec-Driven Development for Production Workflows · CascadiaJS 2026 Notes</title>
 <link rel="stylesheet" href="/style.css">
 </head>
 <body class="bg-stone-50 text-stone-800 antialiased">
@@ -17,7 +17,7 @@
 <a href="/" class="text-sm text-stone-500 hover:text-stone-700">← All talks</a>
 <article class="mt-4">
   <header>
-    <h1 class="text-2xl font-bold tracking-tight text-stone-900">Spec-Driven Development</h1>
+    <h1 class="text-2xl font-bold tracking-tight text-stone-900">How to Use Spec-Driven Development for Production Workflows</h1>
     <p class="mt-2 text-stone-600">Erik Hanchett · AWS · Day 1</p>
   </header>
   <div class="notes mt-8">

--- a/apps/cascadiajs2026-notes/dist/talks/web-workers/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/web-workers/index.html
@@ -83,7 +83,7 @@ its keep.</p>
   <a class="text-stone-600 hover:text-blue-700" href="/talks/modern-css-colors/">← Practical Refactors with Modern CSS Colors</a>
 
 
-  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/ai-to-learn/">Using AI to Learn →</a>
+  <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/ai-to-learn/">AI Helped Me Learn: Vue Through the Lens of a React Developer →</a>
 
 </nav>
 

--- a/apps/cascadiajs2026-notes/dist/talks/wrong-abstraction/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/wrong-abstraction/index.html
@@ -82,6 +82,8 @@ tree-shaking, at least).</p>
 
       <li><a class="text-blue-700 underline hover:text-blue-900" href="https://observablehq.com/plot/">Observable Plot</a></li>
 
+      <li><a class="text-blue-700 underline hover:text-blue-900" href="https://worrydream.com/LadderOfAbstraction/">Bret Victor — Ladder of Abstraction</a></li>
+
     </ul>
   </section>
 
@@ -94,7 +96,7 @@ tree-shaking, at least).</p>
 
 <nav class="mt-12 flex justify-between gap-4 border-t border-stone-200 pt-6 text-sm">
 
-  <a class="text-stone-600 hover:text-blue-700" href="/talks/linked-literate-programming/">← Linked Literate Programming</a>
+  <a class="text-stone-600 hover:text-blue-700" href="/talks/linked-literate-programming/">← Implementing the Web on Native with Linked Literate Programming</a>
 
 
   <a class="text-right text-stone-600 hover:text-blue-700" href="/talks/shared-components/">Shared Components Beyond the Design System →</a>


### PR DESCRIPTION
Reconcile Day 1 talk metadata against the official schedule and the
speakers who shared slides in the conference Discord:

- agent-swarms was misattributed — it is Joel Hooks (Badass Courses),
  "AI Agent Swarms Are Amazing", not Joel/Joe Duffy at Pulumi.
- fix James Steinbach spelling; align the ai-to-learn, LLP, and
  spec-driven titles to the official schedule wording.
- add speaker-shared slide links for five talks, plus the LLP repo,
  web demo, and Bret Victor Ladder of Abstraction reference.