### PR TITLE
feat(apps/cascadiajs2026-notes): link source folder in footer

### DIFF
--- a/apps/cascadiajs2026-notes/dist/index.html
+++ b/apps/cascadiajs2026-notes/dist/index.html
@@ -114,6 +114,7 @@
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
@@ -99,6 +99,7 @@ all threads through the context limit.</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/ai-to-learn/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/ai-to-learn/index.html
@@ -77,6 +77,7 @@ skill you can apply on demand.</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/biilman-agent-experience/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/biilman-agent-experience/index.html
@@ -104,6 +104,7 @@ also gets more required.</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/junior-dev-team/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/junior-dev-team/index.html
@@ -75,6 +75,7 @@ people has not.</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/last-mile-is-code/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/last-mile-is-code/index.html
@@ -71,6 +71,7 @@ anymore.</strong></p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/linked-literate-programming/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/linked-literate-programming/index.html
@@ -88,6 +88,7 @@ programmatic.</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/modern-css-colors/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/modern-css-colors/index.html
@@ -90,6 +90,7 @@ colors to mix a tint in and still get a legible foreground. Support is only
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/shared-components/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/shared-components/index.html
@@ -83,6 +83,7 @@ gold is a nice model), and <strong>recognize authors</strong> for their contribu
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/skeptics-to-champions/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/skeptics-to-champions/index.html
@@ -64,6 +64,7 @@ already in the repo. So <strong>replay the agent</strong> against them.</li>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/spec-driven-development/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/spec-driven-development/index.html
@@ -97,6 +97,7 @@ use to prove this works." Conceptually — does it work the way I expect?</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/web-workers/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/web-workers/index.html
@@ -92,6 +92,7 @@ its keep.</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/dist/talks/wrong-abstraction/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/wrong-abstraction/index.html
@@ -108,6 +108,7 @@ tree-shaking, at least).</p>
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>

--- a/apps/cascadiajs2026-notes/templates/layout.html
+++ b/apps/cascadiajs2026-notes/templates/layout.html
@@ -19,6 +19,7 @@
   <div class="mx-auto max-w-3xl space-y-1 px-6 py-8 text-xs text-[color:var(--fg-faint)]">
     <p>Personal notes from <a class="underline hover:text-[color:var(--fg-muted)]" href="https://www.cascadiajs.com/">CascadiaJS 2026</a>.</p>
     <p>Cross-referenced against the community notes at <a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/hurrendor/cascadiajs26">hurrendor/cascadiajs26</a> (GPL-3.0); no prose copied.</p>
+    <p><a class="underline hover:text-[color:var(--fg-muted)]" href="https://github.com/kolohelios/kolohelios/tree/main/apps/cascadiajs2026-notes">Source</a></p>
   </div>
 </footer>
 </body>


### PR DESCRIPTION
Add a "Source" link in the footer pointing at the project folder in the
monorepo, so readers can jump to the code/content. Styled like the other
footer links, so it themes in both light and dark. The URL hardcodes the
repo path; if the project ever moves slot/name the link needs updating —
an accepted low-odds cost.

Closes #720