### PR TITLE
feat(shaka): systematize Cloudflare preview Worker cleanup

### DIFF
--- a/.github/workflows/cascadiajs2026-notes-cleanup.yml
+++ b/.github/workflows/cascadiajs2026-notes-cleanup.yml
@@ -3,7 +3,7 @@
 #
 # Source of truth: <slot>/<project>/project.cue.
 
-name: kolohelios-portfolio cleanup
+name: cascadiajs2026-notes cleanup
 on:
   pull_request:
     types:
@@ -31,10 +31,10 @@ jobs:
     - uses: DeterminateSystems/flakehub-cache-action@v3
     - name: wrangler delete preview Worker
       run: |
-        cd apps/kolohelios-portfolio
+        cd apps/cascadiajs2026-notes
         cp .env.example .env
         nix develop . --command op run --env-file=.env -- \
           wrangler delete \
-          --name kolohelios-portfolio-pr-${{ github.event.pull_request.number }} \
+          --name cascadiajs2026-notes-pr-${{ github.event.pull_request.number }} \
           --force \
           || true

--- a/.github/workflows/sweep-preview-workers.yaml
+++ b/.github/workflows/sweep-preview-workers.yaml
@@ -1,0 +1,69 @@
+# Hand-authored (allowlisted in tools/shaka/src/ci/audit_workflows.rs).
+#
+# Repo-wide backstop for the per-PR `<name>-cleanup.yml` jobs: deletes
+# any Cloudflare preview Worker `<previewScriptPrefix>-pr-<N>` whose PR
+# has closed or merged. Runs `shaka deploy sweep-previews`, which
+# discovers every Worker app from its `project.cue` and cross-checks
+# each preview's PR state via `gh`. #719.
+#
+# Project-agnostic, so it can't live in any single project's `ci:`
+# block — hence hand-authored rather than generated.
+#
+# Triggers: every `push: main` (reap a just-merged PR's preview
+# promptly), a daily cron (catch abandoned PRs and any per-PR cleanup
+# that errored), and manual dispatch.
+#
+# `id-token: write` lets nix-installer authenticate with FlakeHub for
+# the private `kolohelios-nix` input. CF creds resolve through `op run`
+# from the shared `.env.example` (account-scoped deploy token); `gh`
+# reads PR state via `GITHUB_TOKEN`.
+name: sweep preview workers
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+
+# One sweep at a time so a cron tick and a push:main don't race on the
+# same delete.
+concurrency:
+  group: sweep-preview-workers
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: verify OP_SERVICE_ACCOUNT_TOKEN
+        run: |
+          if [[ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]]; then
+            echo "::error::OP_SERVICE_ACCOUNT_TOKEN is empty; check repo/org secret"
+            exit 1
+          fi
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: sweep orphaned preview Workers
+        # The CF deploy token + account id are identical across every
+        # Worker app's `.env.example`; copy any one to the repo root so
+        # `op run` resolves the `op://` refs `sweep-previews` reads from
+        # the env. `shaka` runs from the repo root so its project walk
+        # sees every `project.cue`.
+        run: |
+          cp apps/kolohelios-portfolio/.env.example .env
+          nix develop ./tools/shaka --command \
+            op run --env-file=.env -- \
+            shaka deploy sweep-previews

--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -7,6 +7,7 @@ mod gate;
 mod generate;
 mod main_workflow;
 mod mask_and_run;
+mod worker_cleanup_workflow;
 mod worker_deploy_workflow;
 mod workflow;
 

--- a/tools/shaka/src/ci/audit_workflows.rs
+++ b/tools/shaka/src/ci/audit_workflows.rs
@@ -24,16 +24,16 @@ const HAND_AUTHORED: &[&str] = &[
     // Reusable workflow_call templates
     "tf-apply.yml",
     "cf-deploy.yml",
-    // Hand-authored sibling of the generated
-    // `kolohelios-portfolio-deploy.yml`: runs on `pull_request: closed`
-    // to delete the ephemeral preview Worker. Different trigger and
-    // project-specific wrangler invocation; not derivable from
-    // `ci.deploy` metadata.
-    "kolohelios-portfolio-cleanup.yml",
     // Repo-event-driven
     "auto-rebase-prs.yaml",
     "bump-kolohelios-nix.yaml",
     "codeql.yml",
+    // Repo-wide backstop: deletes any preview Worker whose PR has
+    // closed. Runs on `push: main` + a daily cron + manual dispatch
+    // (#719). Project-agnostic — not derivable from any single
+    // project's `ci:` block, unlike the per-PR `<name>-cleanup.yml`
+    // siblings, which `shaka ci generate-workflows` now owns.
+    "sweep-preview-workers.yaml",
     // Hand-authored darwin build of infra/home — runs on macos-latest
     // to populate the FlakeHub Cache so cold-bootstrap on a fresh
     // aarch64-darwin host pulls cached artifacts instead of compiling
@@ -150,7 +150,10 @@ fn generated_filenames() -> Vec<String> {
                     any_build = true;
                 }
                 if ci.deploy.is_some() {
+                    // A `ci.deploy` block emits two siblings: the
+                    // deploy workflow and the preview-Worker cleanup.
                     out.push(format!("{}-deploy.yml", meta.name));
+                    out.push(format!("{}-cleanup.yml", meta.name));
                 }
             }
         }

--- a/tools/shaka/src/ci/generate.rs
+++ b/tools/shaka/src/ci/generate.rs
@@ -81,10 +81,21 @@ pub fn run(check: bool) {
                     project_name: meta.name.clone(),
                     deploy,
                 };
-                let workflow = super::worker_deploy_workflow::build(&spec);
-                let target =
-                    PathBuf::from(".github/workflows").join(format!("{}-deploy.yml", meta.name));
-                items.push((target, workflow::emit(&workflow)));
+                // A `ci.deploy` block emits two siblings from the same
+                // spec: `<name>-deploy.yml` (verify/preview/deploy) and
+                // `<name>-cleanup.yml` (delete the preview Worker on PR
+                // close). Generating cleanup alongside deploy means a
+                // new Worker app can't silently leak previews (#719).
+                let deploy_workflow = super::worker_deploy_workflow::build(&spec);
+                items.push((
+                    PathBuf::from(".github/workflows").join(format!("{}-deploy.yml", meta.name)),
+                    workflow::emit(&deploy_workflow),
+                ));
+                let cleanup_workflow = super::worker_cleanup_workflow::build(&spec);
+                items.push((
+                    PathBuf::from(".github/workflows").join(format!("{}-cleanup.yml", meta.name)),
+                    workflow::emit(&cleanup_workflow),
+                ));
             }
         }
     }

--- a/tools/shaka/src/ci/main_workflow.rs
+++ b/tools/shaka/src/ci/main_workflow.rs
@@ -22,7 +22,7 @@ use serde_yaml_ng::Value;
 
 use super::workflow::{
     ActionStep, CancelInProgress, Concurrency, Empty, InlineJob, Job, Needs, On, PermissionLevel,
-    Permissions, PushTrigger, RunStep, Step, Workflow,
+    Permissions, PullRequestTrigger, PushTrigger, RunStep, Step, Workflow,
 };
 
 /// One project's contribution to `main.yaml`: its filesystem location,
@@ -100,7 +100,7 @@ pub fn build(specs: &[MainBuildSpec]) -> Workflow {
     Workflow {
         name: "CI".to_string(),
         on: On {
-            pull_request: Some(Empty),
+            pull_request: Some(PullRequestTrigger::All(Empty)),
             push: Some(PushTrigger {
                 branches: vec!["main".to_string()],
                 paths: vec![],

--- a/tools/shaka/src/ci/worker_cleanup_workflow.rs
+++ b/tools/shaka/src/ci/worker_cleanup_workflow.rs
@@ -1,0 +1,184 @@
+//! Builder for `<name>-cleanup.yml` — deletes a Worker app's
+//! ephemeral preview Worker when its PR closes (merged or abandoned).
+//!
+//! Generated as a sibling of `<name>-deploy.yml` (see
+//! `worker_deploy_workflow.rs`) so every project with a `ci.deploy`
+//! block automatically gets cleanup — there is no "remember to
+//! hand-author the cleanup file" step to forget (#719). Both files
+//! derive from the same `previewScriptPrefix`, so the deleted name
+//! always matches the name the deploy workflow's `preview` job
+//! created.
+//!
+//! Trigger: `pull_request: [closed]` — fires for both merge and
+//! abandon. `wrangler delete --force || true` is idempotent: a PR
+//! that closed before its first preview ever deployed just no-ops.
+//! A repo-wide `shaka deploy sweep-previews` sweep (run on `push:
+//! main` and a daily cron) backstops anything this per-PR job misses.
+
+use std::collections::BTreeMap;
+
+use indexmap::IndexMap;
+use serde_yaml_ng::Value;
+
+use super::worker_deploy_workflow::WorkerDeploySpec;
+use super::workflow::{
+    ActionStep, InlineJob, Job, Needs, On, PermissionLevel, Permissions, PullRequestTrigger,
+    RunStep, Step, Workflow,
+};
+
+pub fn build(spec: &WorkerDeploySpec) -> Workflow {
+    let mut jobs: IndexMap<String, Job> = IndexMap::new();
+    jobs.insert("cleanup".to_string(), Job::Inline(cleanup_job(spec)));
+
+    Workflow {
+        name: format!("{} cleanup", spec.project_name),
+        on: On {
+            pull_request: Some(PullRequestTrigger::Types {
+                types: vec!["closed".to_string()],
+            }),
+            push: None,
+            workflow_dispatch: None,
+        },
+        // `id-token: write` lets nix-installer authenticate with
+        // FlakeHub for the `kolohelios-nix` private input; the SA
+        // token (job env) resolves the `op://` refs `wrangler` needs.
+        permissions: Some(Permissions {
+            id_token: Some(PermissionLevel::Write),
+            contents: Some(PermissionLevel::Read),
+            pull_requests: None,
+        }),
+        concurrency: None,
+        jobs,
+    }
+}
+
+fn cleanup_job(spec: &WorkerDeploySpec) -> InlineJob {
+    let mut env: BTreeMap<String, String> = BTreeMap::new();
+    env.insert(
+        "OP_SERVICE_ACCOUNT_TOKEN".to_string(),
+        "${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}".to_string(),
+    );
+
+    InlineJob {
+        name: None,
+        needs: Needs::Multiple(vec![]),
+        if_: None,
+        runs_on: "ubuntu-latest".to_string(),
+        permissions: None,
+        env,
+        outputs: BTreeMap::new(),
+        steps: vec![
+            // `required: true` on the consuming workflow catches a
+            // missing secret; this catches an empty value (org secret
+            // unset) before the downstream `op run` surfaces a cryptic
+            // error.
+            Step::Run(RunStep {
+                id: None,
+                name: Some("verify OP_SERVICE_ACCOUNT_TOKEN".to_string()),
+                if_: None,
+                run: r#"if [[ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]]; then
+  echo "::error::OP_SERVICE_ACCOUNT_TOKEN is empty; check repo/org secret"
+  exit 1
+fi
+"#
+                .to_string(),
+                env: BTreeMap::new(),
+            }),
+            Step::Action(ActionStep {
+                uses: "actions/checkout@v6".to_string(),
+                id: None,
+                name: None,
+                if_: None,
+                with: BTreeMap::new(),
+                env: BTreeMap::new(),
+            }),
+            Step::Action(ActionStep {
+                uses: "DeterminateSystems/nix-installer-action@main".to_string(),
+                id: None,
+                name: None,
+                if_: None,
+                with: {
+                    let mut w = BTreeMap::new();
+                    w.insert("determinate".to_string(), Value::Bool(true));
+                    w.insert("flakehub".to_string(), Value::Bool(true));
+                    w
+                },
+                env: BTreeMap::new(),
+            }),
+            Step::Action(ActionStep {
+                uses: "DeterminateSystems/flakehub-cache-action@v3".to_string(),
+                id: None,
+                name: None,
+                if_: None,
+                with: BTreeMap::new(),
+                env: BTreeMap::new(),
+            }),
+            // `--force` skips interactive confirmation; safe because
+            // the script name is deterministically derived from the PR
+            // number. `|| true` tolerates "not found" so a PR that
+            // never produced a preview (closed before first deploy)
+            // doesn't fail the workflow. `.env` is gitignored — copy
+            // the in-repo example so `op run` finds the `op://` refs.
+            Step::Run(RunStep {
+                id: None,
+                name: Some("wrangler delete preview Worker".to_string()),
+                if_: None,
+                run: format!(
+                    r#"cd {dir}
+cp .env.example .env
+nix develop . --command op run --env-file=.env -- \
+  wrangler delete \
+  --name {prefix}-pr-${{{{ github.event.pull_request.number }}}} \
+  --force \
+  || true
+"#,
+                    dir = spec.project_dir.to_string_lossy(),
+                    prefix = spec.deploy.preview_script_prefix,
+                ),
+                env: BTreeMap::new(),
+            }),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::super::worker_deploy_workflow::{CiDeploy, WorkerDeploySpec};
+    use super::*;
+
+    fn fixture_spec() -> WorkerDeploySpec {
+        WorkerDeploySpec {
+            project_dir: PathBuf::from("apps/example-notes"),
+            project_name: "example-notes".to_string(),
+            deploy: CiDeploy {
+                reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
+                preview_script_prefix: "example-notes".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn triggers_only_on_pull_request_closed() {
+        let yaml = super::super::workflow::emit(&build(&fixture_spec()));
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid YAML");
+        let types = &parsed["on"]["pull_request"]["types"];
+        assert_eq!(types[0].as_str(), Some("closed"));
+        assert!(types[1].is_null(), "only `closed`, no other activity types");
+        // Cleanup must not fire on push:main or dispatch — that's the
+        // deploy workflow's and the sweep's job.
+        assert!(parsed["on"]["push"].is_null());
+        assert!(parsed["on"]["workflow_dispatch"].is_null());
+    }
+
+    #[test]
+    fn deletes_the_prefix_pr_number_worker() {
+        let yaml = super::super::workflow::emit(&build(&fixture_spec()));
+        // The deleted name must match what the deploy workflow's
+        // `preview` job creates: `<previewScriptPrefix>-pr-<N>`.
+        assert!(yaml.contains("--name example-notes-pr-${{ github.event.pull_request.number }}"));
+        assert!(yaml.contains("cd apps/example-notes"));
+        assert!(yaml.contains("|| true"), "delete is idempotent");
+    }
+}

--- a/tools/shaka/src/ci/worker_deploy_workflow.rs
+++ b/tools/shaka/src/ci/worker_deploy_workflow.rs
@@ -16,10 +16,10 @@
 //!    `push: main` or `workflow_dispatch`.
 //!
 //! The `cleanup` job that runs on `pull_request: closed` lives in a
-//! hand-authored sibling file `<name>-cleanup.yml`: its trigger and
-//! concern (Worker deletion) are orthogonal to the deploy lifecycle,
-//! and the wrangler invocation is project-specific in ways the
-//! schema would only awkwardly express.
+//! generated sibling file `<name>-cleanup.yml` (see
+//! `worker_cleanup_workflow.rs`): its trigger and concern (Worker
+//! deletion) are orthogonal to the deploy lifecycle, so it gets its
+//! own file, but both derive from the same `ci.deploy` block.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -30,7 +30,7 @@ use serde_yaml_ng::Value;
 
 use super::workflow::{
     ActionStep, CancelInProgress, Concurrency, Empty, InlineJob, Job, Needs, On, PermissionLevel,
-    Permissions, PushTrigger, ReusableCall, RunStep, Step, Workflow,
+    Permissions, PullRequestTrigger, PushTrigger, ReusableCall, RunStep, Step, Workflow,
 };
 
 /// One Worker project's deploy workflow inputs.
@@ -59,10 +59,10 @@ pub fn build(spec: &WorkerDeploySpec) -> Workflow {
         name: format!("{} deploy", spec.project_name),
         on: On {
             // Default PR types (opened/synchronize/reopened); the
-            // `closed` event goes to the hand-authored cleanup
-            // sibling so generated jobs don't carry redundant
-            // `action != 'closed'` guards.
-            pull_request: Some(Empty),
+            // `closed` event goes to the generated cleanup sibling
+            // (`<name>-cleanup.yml`) so deploy jobs don't carry
+            // redundant `action != 'closed'` guards.
+            pull_request: Some(PullRequestTrigger::All(Empty)),
             push: Some(PushTrigger {
                 branches: vec!["main".to_string()],
                 paths: vec![],

--- a/tools/shaka/src/ci/workflow.rs
+++ b/tools/shaka/src/ci/workflow.rs
@@ -22,11 +22,24 @@ pub struct Workflow {
 #[derive(Serialize, Debug, Default)]
 pub struct On {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pull_request: Option<Empty>,
+    pub pull_request: Option<PullRequestTrigger>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub push: Option<PushTrigger>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workflow_dispatch: Option<Empty>,
+}
+
+/// The `pull_request:` trigger, in either of the two shapes the
+/// generated workflows need. `All` emits a bare `pull_request:` (null)
+/// — every default activity type, used by the deploy workflow. `Types`
+/// restricts to specific activity types (e.g. `[closed]`), used by the
+/// cleanup workflow. Untagged so each serializes to its native YAML
+/// shape; `actionlint` rejects a quoted scalar here.
+#[derive(Serialize, Debug)]
+#[serde(untagged)]
+pub enum PullRequestTrigger {
+    All(Empty),
+    Types { types: Vec<String> },
 }
 
 #[derive(Serialize, Debug)]

--- a/tools/shaka/src/deploy.rs
+++ b/tools/shaka/src/deploy.rs
@@ -1,11 +1,16 @@
-//! `shaka deploy` — turn `deploy:` blocks in `project.cue` into
-//! committed Terraform under `infra/cloudflare-deploy/terraform/generated/`.
+//! `shaka deploy` — Cloudflare Worker deploy plumbing:
 //!
-//! Today only the `cloudflare-worker` target is implemented; future
-//! targets (`fly`, `hetzner`, ...) extend the schema disjunction and
-//! the emitter in `generate_tf.rs`.
+//! - `generate-tf` turns `deploy:` blocks in `project.cue` into
+//!   committed Terraform under
+//!   `infra/cloudflare-deploy/terraform/generated/`. Today only the
+//!   `cloudflare-worker` target is implemented; future targets (`fly`,
+//!   `hetzner`, ...) extend the schema disjunction and the emitter in
+//!   `generate_tf.rs`.
+//! - `sweep-previews` reaps orphaned per-PR preview Workers (see
+//!   `sweep_previews.rs`).
 
 pub mod generate_tf;
+pub mod sweep_previews;
 
 use clap::Subcommand;
 
@@ -21,10 +26,21 @@ pub enum DeployCommand {
         #[arg(long)]
         check: bool,
     },
+    /// Delete orphaned Cloudflare preview Workers — those named
+    /// `<previewScriptPrefix>-pr-<N>` whose PR has closed or merged.
+    /// Backstops the per-PR `<name>-cleanup.yml` job. Reads
+    /// `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` from the env, so
+    /// wrap it in `op run --env-file=.env -- ...`.
+    SweepPreviews {
+        /// Report what would be deleted without deleting anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 pub fn run(cmd: DeployCommand) {
     match cmd {
         DeployCommand::GenerateTf { check } => generate_tf::run(check),
+        DeployCommand::SweepPreviews { dry_run } => sweep_previews::run(dry_run),
     }
 }

--- a/tools/shaka/src/deploy/sweep_previews.rs
+++ b/tools/shaka/src/deploy/sweep_previews.rs
@@ -1,0 +1,338 @@
+//! `shaka deploy sweep-previews` — reap orphaned Cloudflare preview
+//! Workers.
+//!
+//! Each Worker app with a `ci.deploy` block deploys a per-PR preview
+//! Worker named `<previewScriptPrefix>-pr-<N>` (see
+//! `ci/worker_deploy_workflow.rs`). The generated `<name>-cleanup.yml`
+//! deletes each one on its PR's `closed` event. This command is the
+//! project-agnostic backstop for anything that path misses (a cleanup
+//! run that errored, a Worker created before cleanup was generated,
+//! #719): it lists every preview Worker, asks GitHub whether its PR is
+//! still open, and deletes the ones whose PR has closed or merged.
+//!
+//! Discovery is metadata-driven — it reads each `project.cue`'s
+//! `ci.deploy.previewScriptPrefix` — so a new Worker app is covered
+//! the moment it lands, with no edit here. It runs on `push: main` and
+//! a daily cron via `.github/workflows/sweep-preview-workers.yaml`.
+//!
+//! Credentials come from the environment (`CLOUDFLARE_API_TOKEN`,
+//! `CLOUDFLARE_ACCOUNT_ID`) exactly as `wrangler` consumes them, so the
+//! caller wraps this in `op run --env-file=.env -- shaka deploy
+//! sweep-previews`. PR state comes from `gh`.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_json::Value;
+use snafu::{OptionExt, ResultExt, Snafu};
+
+use crate::project::schema_check::{discover, write_schema as project_schema_path};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+
+#[derive(Debug, Snafu)]
+enum SweepError {
+    #[snafu(display(
+        "{name} is not set; run via `op run --env-file=.env -- shaka deploy sweep-previews`"
+    ))]
+    MissingEnv { name: String },
+
+    #[snafu(display("could not resolve project schema: {message}"))]
+    Schema { message: String },
+
+    #[snafu(display("cue export failed for {path}: {stderr}"))]
+    CueExport { path: String, stderr: String },
+
+    #[snafu(display("failed to spawn {cmd}: {source}"))]
+    Spawn { cmd: String, source: std::io::Error },
+
+    // Deliberately omits the Cloudflare bearer token that lives in the
+    // curl argv — only the label and stderr surface.
+    #[snafu(display("{label} failed: {stderr}"))]
+    Curl { label: String, stderr: String },
+
+    #[snafu(display("Cloudflare API error ({label}): {message}"))]
+    CloudflareApi { label: String, message: String },
+
+    #[snafu(display("{context}: {source}"))]
+    JsonParse {
+        context: String,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("gh: {source}"))]
+    Gh { source: crate::gh::GhError },
+}
+
+/// Subset of a project's CUE export: just the preview-Worker prefix.
+#[derive(Deserialize)]
+struct ProjectExport {
+    #[serde(default)]
+    ci: Option<Ci>,
+}
+
+#[derive(Deserialize)]
+struct Ci {
+    #[serde(default)]
+    deploy: Option<CiDeploy>,
+}
+
+#[derive(Deserialize)]
+struct CiDeploy {
+    #[serde(rename = "previewScriptPrefix")]
+    preview_script_prefix: String,
+}
+
+pub fn run(dry_run: bool) {
+    match sweep(Path::new("."), dry_run) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("{RED}{BOLD}deploy sweep-previews failed{RESET}: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn sweep(root: &Path, dry_run: bool) -> Result<(), SweepError> {
+    let token = env_var("CLOUDFLARE_API_TOKEN")?;
+    let account = env_var("CLOUDFLARE_ACCOUNT_ID")?;
+
+    let prefixes = collect_prefixes(root)?;
+    if prefixes.is_empty() {
+        println!("{GREEN}{BOLD}sweep-previews{RESET}: no Worker projects with a deploy block");
+        return Ok(());
+    }
+
+    let scripts = cf_list_script_ids(&account, &token)?;
+
+    // Every (script, prefix, pr) where the script is a preview Worker.
+    let mut previews: Vec<(String, u64)> = Vec::new();
+    for script in &scripts {
+        for prefix in &prefixes {
+            if let Some(pr) = preview_pr_number(script, prefix) {
+                previews.push((script.clone(), pr));
+                break;
+            }
+        }
+    }
+
+    if previews.is_empty() {
+        println!(
+            "{GREEN}{BOLD}sweep-previews{RESET}: no preview Workers found ({} script(s) scanned)",
+            scripts.len()
+        );
+        return Ok(());
+    }
+
+    let mut deleted = 0usize;
+    let mut kept = 0usize;
+    for (script, pr) in &previews {
+        if pr_is_open(*pr)? {
+            println!("  {DIM}keep{RESET}   {script} (PR #{pr} open)");
+            kept += 1;
+            continue;
+        }
+        if dry_run {
+            println!("  {YELLOW}orphan{RESET} {script} (PR #{pr} closed) — would delete");
+        } else {
+            cf_delete_script(&account, &token, script)?;
+            println!("  {YELLOW}delete{RESET} {script} (PR #{pr} closed)");
+        }
+        deleted += 1;
+    }
+
+    let verb = if dry_run { "would delete" } else { "deleted" };
+    println!(
+        "{GREEN}{BOLD}sweep-previews{RESET}: {verb} {deleted}, kept {kept} ({} preview Worker(s))",
+        previews.len()
+    );
+    Ok(())
+}
+
+fn env_var(name: &str) -> Result<String, SweepError> {
+    std::env::var(name)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .context(MissingEnvSnafu { name })
+}
+
+/// Walk every project and collect the `ci.deploy.previewScriptPrefix`
+/// of each Worker app, sorted and deduplicated.
+fn collect_prefixes(root: &Path) -> Result<Vec<String>, SweepError> {
+    let schema_path = project_schema_path().map_err(|e| {
+        SchemaSnafu {
+            message: e.to_string(),
+        }
+        .build()
+    })?;
+    let mut out = Vec::new();
+    for project_dir in discover(root) {
+        let project_file = project_dir.join("project.cue");
+        if !project_file.exists() {
+            continue;
+        }
+        let output = Command::new("cue")
+            .arg("export")
+            .arg(&schema_path)
+            .arg(&project_file)
+            .output()
+            .context(SpawnSnafu { cmd: "cue export" })?;
+        if !output.status.success() {
+            return CueExportSnafu {
+                path: project_file.display().to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            }
+            .fail();
+        }
+        let export: ProjectExport =
+            serde_json::from_slice(&output.stdout).context(JsonParseSnafu {
+                context: format!("cue export of {}", project_file.display()),
+            })?;
+        if let Some(prefix) = export
+            .ci
+            .and_then(|c| c.deploy)
+            .map(|d| d.preview_script_prefix)
+        {
+            out.push(prefix);
+        }
+    }
+    out.sort();
+    out.dedup();
+    Ok(out)
+}
+
+/// `<prefix>-pr-<N>` → `Some(N)`, else `None`. Anchored on both ends:
+/// the production Worker `<prefix>` (no `-pr-<N>` suffix) and unrelated
+/// Workers never match, so they're never deletion candidates.
+fn preview_pr_number(script: &str, prefix: &str) -> Option<u64> {
+    let suffix = script.strip_prefix(prefix)?.strip_prefix("-pr-")?;
+    if suffix.is_empty() || !suffix.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    suffix.parse().ok()
+}
+
+/// `.result[].id` from a Cloudflare `workers/scripts` list response.
+fn extract_script_ids(body: &Value) -> Vec<String> {
+    body.get("result")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|i| i.get("id").and_then(Value::as_str).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn cf_list_script_ids(account: &str, token: &str) -> Result<Vec<String>, SweepError> {
+    let url = format!("https://api.cloudflare.com/client/v4/accounts/{account}/workers/scripts");
+    let body = cf_curl("GET", token, &url, "cloudflare list scripts")?;
+    Ok(extract_script_ids(&body))
+}
+
+fn cf_delete_script(account: &str, token: &str, name: &str) -> Result<(), SweepError> {
+    let url =
+        format!("https://api.cloudflare.com/client/v4/accounts/{account}/workers/scripts/{name}");
+    cf_curl("DELETE", token, &url, "cloudflare delete script")?;
+    Ok(())
+}
+
+/// Run an authenticated CF API call via `curl` and return the parsed
+/// body, failing if the API's `success` flag is false. The bearer
+/// token rides in the argv; `label` (not the full command) is what
+/// reaches error messages so the token never lands in a log.
+fn cf_curl(method: &str, token: &str, url: &str, label: &str) -> Result<Value, SweepError> {
+    let output = Command::new("curl")
+        .args(["-sS", "-X", method, "-H"])
+        .arg(format!("Authorization: Bearer {token}"))
+        .arg(url)
+        .output()
+        .context(SpawnSnafu { cmd: "curl" })?;
+    if !output.status.success() {
+        return CurlSnafu {
+            label: label.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        }
+        .fail();
+    }
+    let body: Value = serde_json::from_slice(&output.stdout).context(JsonParseSnafu {
+        context: format!("{label} response"),
+    })?;
+    if body.get("success").and_then(Value::as_bool) != Some(true) {
+        let message = body
+            .get("errors")
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string());
+        return CloudflareApiSnafu {
+            label: label.to_string(),
+            message,
+        }
+        .fail();
+    }
+    Ok(body)
+}
+
+/// Is PR `number` still open? Closed and merged PRs both count as "not
+/// open" — either way the preview is reapable. Resolves the repo from
+/// `GITHUB_REPOSITORY` when set (CI), otherwise relies on `gh`'s
+/// ambient repo context (a checkout's git remote).
+fn pr_is_open(number: u64) -> Result<bool, SweepError> {
+    let endpoint = match std::env::var("GITHUB_REPOSITORY") {
+        Ok(repo) if !repo.is_empty() => format!("repos/{repo}/pulls/{number}"),
+        _ => format!("repos/{{owner}}/{{repo}}/pulls/{number}"),
+    };
+    let body = crate::gh::api_get(&endpoint).context(GhSnafu)?;
+    Ok(body.get("state").and_then(Value::as_str) == Some("open"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_pr_number_matches_prefix_pr_n() {
+        assert_eq!(
+            preview_pr_number("cascadiajs2026-notes-pr-713", "cascadiajs2026-notes"),
+            Some(713)
+        );
+        assert_eq!(preview_pr_number("portfolio-pr-1", "portfolio"), Some(1));
+    }
+
+    #[test]
+    fn preview_pr_number_rejects_production_and_unrelated() {
+        // Production Worker — no `-pr-<N>` suffix.
+        assert_eq!(
+            preview_pr_number("cascadiajs2026-notes", "cascadiajs2026-notes"),
+            None
+        );
+        // A Worker for a different app entirely.
+        assert_eq!(preview_pr_number("buzzingo", "cascadiajs2026-notes"), None);
+        // Non-numeric / empty suffix.
+        assert_eq!(preview_pr_number("portfolio-pr-", "portfolio"), None);
+        assert_eq!(preview_pr_number("portfolio-pr-abc", "portfolio"), None);
+        // Prefix is a substring but not a `-pr-` boundary.
+        assert_eq!(preview_pr_number("portfolio-staging", "portfolio"), None);
+    }
+
+    #[test]
+    fn extract_script_ids_reads_cloudflare_list_response() {
+        // Real `GET /accounts/{id}/workers/scripts` response shape.
+        let raw = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/sweep-previews/workers-scripts.json"
+        ))
+        .expect("fixture readable");
+        let body: Value = serde_json::from_str(&raw).expect("valid JSON");
+        let ids = extract_script_ids(&body);
+        assert_eq!(
+            ids,
+            vec![
+                "buzzingo",
+                "cascadiajs2026-notes",
+                "cascadiajs2026-notes-pr-713",
+                "kolohelios-portfolio",
+            ]
+        );
+    }
+}

--- a/tools/shaka/tests/fixtures/sweep-previews/workers-scripts.json
+++ b/tools/shaka/tests/fixtures/sweep-previews/workers-scripts.json
@@ -1,0 +1,27 @@
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "buzzingo",
+      "created_on": "2026-04-01T00:00:00.000000Z",
+      "modified_on": "2026-04-01T00:00:00.000000Z"
+    },
+    {
+      "id": "cascadiajs2026-notes",
+      "created_on": "2026-06-02T05:23:22.000000Z",
+      "modified_on": "2026-06-02T05:49:14.000000Z"
+    },
+    {
+      "id": "cascadiajs2026-notes-pr-713",
+      "created_on": "2026-06-02T05:40:00.000000Z",
+      "modified_on": "2026-06-02T05:40:00.000000Z"
+    },
+    {
+      "id": "kolohelios-portfolio",
+      "created_on": "2026-05-14T18:13:23.000000Z",
+      "modified_on": "2026-05-14T18:13:23.000000Z"
+    }
+  ]
+}


### PR DESCRIPTION
Preview Workers (`<previewScriptPrefix>-pr-<N>`) are created by each
Worker app's generated deploy workflow, but the cleanup that deletes
them on PR close was hand-authored and existed only for
kolohelios-portfolio. cascadiajs2026-notes landed with a deploy block
and no cleanup sibling, so its merged PR #713 leaked a preview Worker —
a silent gap every future Worker app would hit.

Close the gap structurally and add a backstop:

- Generate `<name>-cleanup.yml` alongside `<name>-deploy.yml` from the
  same `ci.deploy` block, so a new Worker app can't forget cleanup. The
  hand-authored kolohelios-portfolio cleanup leaves the audit allowlist.
- Add `shaka deploy sweep-previews`: a project-agnostic reaper that
  lists CF Worker scripts, cross-references each preview's PR state via
  gh, and deletes orphans (`--dry-run` to audit). A hand-authored
  sweep-preview-workers.yaml runs it on push:main + a daily cron.

Closes #719