### PR TITLE
feat(apps/cascadiajs2026-notes): link speaker slide decks

### DIFF
--- a/apps/cascadiajs2026-notes/data/talks.cue
+++ b/apps/cascadiajs2026-notes/data/talks.cue
@@ -49,6 +49,7 @@ talks: [...#Talk] & [
 		title:   "AI Agent Swarms Are Amazing"
 		day:     1
 		order:   2
+		slides:  "https://cascadia.wzrrd.sh/"
 		projects: [
 			{name: "opencode", url: "https://github.com/sst/opencode"},
 			{name: "mattpocock/skills", url: "https://github.com/mattpocock/skills"},
@@ -178,7 +179,7 @@ talks: [...#Talk] & [
 		title:   "Choosing TypeScript Matters More Than Ever"
 		day:     2
 		order:   2
-		slides:  "https://forms.gle/j5KMBi1ASB5d1Lj76"
+		slides:  "https://sodic.dev/choosing-typescript-matters-cascadiajs-2026.pdf"
 		projects: [
 			{name: "Wasp", url: "https://wasp.sh"},
 		]
@@ -190,6 +191,7 @@ talks: [...#Talk] & [
 		title:   "Accelerating Musical Live Coding With On-Device AI"
 		day:     2
 		order:   3
+		slides:  "https://bit.ly/cascadia-ai-music"
 		projects: [
 			{name: "Strudel", url: "https://strudel.cc"},
 			{name: "transformers.js", url: "https://github.com/huggingface/transformers.js"},
@@ -213,6 +215,10 @@ talks: [...#Talk] & [
 		title:   "Beowulf Stroganoff: Building Economically Useless Chatbots"
 		day:     2
 		order:   5
+		slides:  "https://docs.google.com/presentation/d/1mxPhGJUA2f2FTfEm0B09IbVC5MwJ-f8oEgMhEBA1A64/edit?usp=sharing"
+		projects: [
+			{name: "Beowulf Stroganoff (Hugging Face Space)", url: "https://huggingface.co/spaces/MollyJeanB/beowulf-stroganoff"},
+		]
 	},
 	{
 		slug:    "design-tokens"
@@ -243,6 +249,7 @@ talks: [...#Talk] & [
 		title:   "Building Apps With ATProto"
 		day:     2
 		order:   8
+		slides:  "https://docs.google.com/presentation/d/1GCG0h4H5w-ZLJ0Gl9YkQXu1iHyivS-AhueAtUzqfqzw/edit?usp=drivesdk"
 		projects: [
 			{name: "ATStore", url: "https://atstore.fyi"},
 			{name: "Sifa.id", url: "https://sifa.id"},
@@ -258,6 +265,7 @@ talks: [...#Talk] & [
 		title:   "The Request Tax: Re-evaluating 20+ Years of Web Performance Dogma"
 		day:     2
 		order:   9
+		slides:  "https://github.com/moonmeister/request-tax/tree/cascadia-js"
 	},
 	{
 		slug:    "human-in-the-loop"

--- a/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
@@ -80,6 +80,9 @@ all threads through the context limit.</p>
 
 
 
+  <section class="mt-6">
+    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://cascadia.wzrrd.sh/">Slides</a>
+  </section>
 
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/atproto-apps/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/atproto-apps/index.html
@@ -53,6 +53,9 @@
 
 
 
+  <section class="mt-6">
+    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://docs.google.com/presentation/d/1GCG0h4H5w-ZLJ0Gl9YkQXu1iHyivS-AhueAtUzqfqzw/edit?usp=drivesdk">Slides</a>
+  </section>
 
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/beowulf-stroganoff/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/beowulf-stroganoff/index.html
@@ -31,8 +31,20 @@
   </div>
 
 
+  <section class="mt-10">
+    <h2 class="text-xs font-semibold uppercase tracking-wider text-[color:var(--fg-faint)]">Referenced</h2>
+    <ul class="mt-3 space-y-1">
+
+      <li><a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://huggingface.co/spaces/MollyJeanB/beowulf-stroganoff">Beowulf Stroganoff (Hugging Face Space)</a></li>
+
+    </ul>
+  </section>
 
 
+
+  <section class="mt-6">
+    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://docs.google.com/presentation/d/1mxPhGJUA2f2FTfEm0B09IbVC5MwJ-f8oEgMhEBA1A64/edit?usp=sharing">Slides</a>
+  </section>
 
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/choosing-typescript/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/choosing-typescript/index.html
@@ -48,7 +48,7 @@
 
 
   <section class="mt-6">
-    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://forms.gle/j5KMBi1ASB5d1Lj76">Slides</a>
+    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://sodic.dev/choosing-typescript-matters-cascadiajs-2026.pdf">Slides</a>
   </section>
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/on-device-ai-music/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/on-device-ai-music/index.html
@@ -50,6 +50,9 @@
 
 
 
+  <section class="mt-6">
+    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://bit.ly/cascadia-ai-music">Slides</a>
+  </section>
 
 
 

--- a/apps/cascadiajs2026-notes/dist/talks/request-tax/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/request-tax/index.html
@@ -40,6 +40,9 @@
 
 
 
+  <section class="mt-6">
+    <a class="text-[color:var(--link)] underline hover:text-[color:var(--link-hover)]" href="https://github.com/moonmeister/request-tax/tree/cascadia-js">Slides</a>
+  </section>
 
 
 


### PR DESCRIPTION
Several CascadiaJS 2026 speakers shared their decks and resource pages
after the talks; this links them from the relevant pages. Covers five
Day 2 talks and backfills Day 1's agent-swarms resource page, plus adds
the Beowulf Stroganoff chatbot Space as a referenced project. dist/ is
regenerated.

Follow-up to #724.