### PR TITLE
style(apps/cascadiajs2026-notes): reformat talk notes to airy layout

### DIFF
--- a/apps/cascadiajs2026-notes/content/talks/agent-swarms.md
+++ b/apps/cascadiajs2026-notes/content/talks/agent-swarms.md
@@ -1,49 +1,91 @@
-Capability is going exponential with Opus 4.5+, and the leverage point is no
-longer the model — it's the **harness**.
+**Agent swarms.**
+
+Going exponentially with Opus 4.5+.
+
+**Harness engineering is the state of the art.**
 
 ```
 model | harness | context
 ```
 
-**Harness engineering is the state of the art.** The Claude Code architecture
-diagram is wild once you see everything it bundles: prompts, skills,
-directives, subagents, tools, bundled infra, orchestration logic, hooks,
-middleware, and observability (logs!).
+The Claude Code arch diagram is wild.
 
-The takeaway in three words: **own the tools.** `opencode` gave us the
-opportunity to build our own.
+Harness includes:
 
-## Swarms
+- prompts, skills, directives, subagent
+- tools, bundled infra, orchestration logic
+- hooks, middleware, observability — logs!
 
-A swarm is **multi-agent coordination to survive context death** — when one
-agent's context fills up, the work survives across the swarm. Useful pattern:
-use the Socratic method to align intent and outcomes, plan, then fan out
-parallel agents.
+**Own the tools.**
 
-## Build a harness that makes you smile
+`opencode` — gave us the opportunity to build.
 
-- `SOUL.md` — give the agent a personality and an icon. Your harness should
-  make you smile.
-- There's another harness called **Pi** whose workflow implementation is much
-  better than the default. Pi **updates itself** — it reads its own source code
-  to add capabilities. Out of the box it's intentionally not featureful.
-- Pi subagents run in parallel and chains — a great extension for swarm-style
-  work.
-- `pi-cmux` — a terminal replacement built on Ghostty, managed by a Pi
-  extension.
-- `pi-notes` — HTML is *not* better than markdown; notes should be human
-  readable but also agent readable. (`mdsvex` is the Svelte take on MDX.)
-- `pi-feedback` — a support inbox: the last turn of a session sends a diff to
-  process feedback. With a lot of users you get a lot of support tickets, so a
-  feedback tool that improves the automated support over many turns pays off.
+**Swarm** — multi-agent coordination to survive context death.
 
-A recurring theme: **slow down.** Don't do everything, and don't do it quickly
-(cf. *Slow Productivity*).
+- Socratic method to align intent/outcomes
+- plan
+- parallel agent
 
-## Worth following
+Anthropic nerfed `opencode`.
 
-Cloudflare Durable Objects for state. Sunil Pai (something called "Think").
-Dillon Mulroy on artifacts, memory, and primitives. Addy Osmani's **"The
-Orchestration Tax"** — cognitive bandwidth is *not* parallelizable. Agent swarms
-are genuinely hard; the real skill is building systems that can pull any and
-all threads through the context limit.
+AI Skills — Matt Pocock — `mattpocock/skills`
+
+**OpenClaw!**
+
+`SOUL.md` — give the agent personality, an icon.
+
+Your harness should make you smile.
+
+## Pi
+
+Other thing: agent harness called `Pi`.
+
+Workflow in `Pi` is better than Claude Code's garbage implementation.
+
+Follow Mario on X.
+
+**Slow the F*** Down** — don't do everything, and don't do it quickly. (*Slow Productivity*)
+
+`Pi` will update itself; it will read its own source code to add stuff. Out of the box is not featureful.
+
+Nico Bailon — `Pi` stuff — `Pi` subagents.
+
+- run parallel and chains — great extension to get swarm
+
+`pi-cmux` — replacement for Terminal/Ghostty, but built on Ghostty. `Pi` extension to manage it.
+
+`Pi` — modify yourself to be better.
+
+`pi-notes` — Thariq — HTML is not better than markdown.
+
+`mdsvx` — Svelte version of MDX (which is what?).
+
+Human readable, but the agent can read it as well.
+
+`wzzrd.sh` — notes to share with the team.
+
+**Second brain** — better notes.
+
+`pi-feedback` — support inbox, last turn of the session, sends diff to process the feedback for the session.
+
+**Key metrics** — having a lot of users will lead to a lot of support tickets.
+
+Feedback tool to improve the automated support, lots of turns.
+
+## Swarms in the wild
+
+`agentdungeon.ai` — agents playing DnD, one is the DM, and the other agents work and collaborate.
+
+Cloudflare — Durable Objects — state.
+
+Sunil Pai — follow recommendation. Something called Think.
+
+Dillon Mulroy — artifacts — memory, primitives.
+
+**Agent swarms are hard, it's true.**
+
+Addy Osmani — The Orchestration Tax.
+
+**Cognitive bandwidth is not parallelizable.**
+
+The real skill is building the systems that can pull any and all of the threads of the system and context limit.

--- a/apps/cascadiajs2026-notes/content/talks/ai-to-learn.md
+++ b/apps/cascadiajs2026-notes/content/talks/ai-to-learn.md
@@ -1,34 +1,31 @@
-A talk about using AI to *learn*, with an honest framing about mental health and
-expectations.
+mental health
 
-## The expectation gap
+**How to use AI to learn.**
 
-We expect ~20% faster. In real tasks, one study found developers were **19%
-slower**. The boost is unevenly distributed: **less experienced devs got the
-boost; more experienced devs got the fuzzy end of the lollipop.** AI is a skill
-to be learned — treat it as risk management, and as the ultimate rubber duck.
+Expectation — productivity 20% faster; **19% slower** though in real tasks.
 
-## A learning loop
+Less experienced devs got the boost, more experienced devs got the fuzzy end of the lollipop.
 
-Apply it deliberately:
+Risk management — AI is a skill to be learned, the ultimate rubber ducky.
 
-- **Translate** from something you know to the new subject. Provide context,
-  then ask for the *differences* so you learn the delta.
-- Always ask **why** and **how** — not just what.
-- Ask Claude to create an **easily digestible diagram**.
-- Ask for an **example based on an example** you already understand.
-- **Acknowledge when AI is moving too fast** and ask clarifying questions.
-- Have it **generate quiz questions** to test your knowledge, then get help
-  filling the gaps.
-- Have a **Socratic conversation**.
-- **Simulate debugging** to practice.
-- Use the **Feynman Technique**: explain what you've learned and check whether
-  the explanation matches reality.
+## How do we apply it with the learning loop?
 
-**Develop skills as you go** — do it once, then turn it into a reusable "tutor"
-skill you can apply on demand.
+- Translate from something you know to the new subject.
+- Provide context! Get back the differences to learn.
 
-## Pair programming with AI
+**Why and how?**
 
-Ask: what can we **translate**, and what do we need to **rethink and rewrite**?
-**Refactor together**, then apply what you learned on your own.
+- Ask `Claude` to create an easily digestible diagram.
+- Ask `Claude` to provide an example based on an example.
+- Make sure you acknowledge when AI is moving too fast, ask clarifying questions.
+- Ask `Claude` to generate quiz questions to test our knowledge, and then get help to fill the gaps.
+- Have a socratic conversation.
+- Simulate debugging.
+
+**Feynman Technique** — explain what you've learned, and see if that matches reality.
+
+Develop skills as you go — do it once, and then reuse the tutor skill to apply it randomly and as required.
+
+Peer programming — what can we translate, and what do we need to rethink and rewrite?
+
+**Refactor together** — and then apply what you learn.

--- a/apps/cascadiajs2026-notes/content/talks/atproto-apps.md
+++ b/apps/cascadiajs2026-notes/content/talks/atproto-apps.md
@@ -1,17 +1,60 @@
-Brittany hosts the Overcommitted podcast (`brittanyellich.com`). Her pitch: open social isn't a dream — `ATProto` is what it looks like when it actually works, and the whole thing turns on owning your own data.
+Podcast host of *Overcommitted*.
 
-## How did we get here?
+`brittanyellich.com`
 
-The typical platform timeline — **launch, growth, monetize, maximize** (see the book *Enshittification*). Big app platforms weaponize design to trap you: A/B testing, infinite scroll, pull-to-refresh. People stay despite all of it because the apps are hard to leave — they own your data, and they can leave *without* you (RIP Google+). They exist to maximize revenue, not to connect people.
+## How We Got Here
 
-## What is ATProto?
+The early internet —
 
-The "Atmosphere" does for data what open source did for code. **If an app does something you don't like, you can just leave** — your content and your people come with you. Which forces apps to actually be *good* to keep you.
+Typical timeline for platforms: **launch, growth, monetize, maximize.**
 
-## How does it work?
+*Enshittification* book reference.
 
-Each user gets their own **repo** where their data lives. Sign in and you get a repo plus a `DID` — a Decentralized ID — and a handle, where handles are DNS records. The repo holds **records** (a piece of JSON, a bit of data) and **blobs** (binaries). Anyone can build their own thing to render content; it doesn't live in `Bluesky`, the user is in charge. `Blacksky` is an alternative to Bluesky; `Witchsky` adds badges and pronouns with a different representation; `Anisota` is a simplified view.
+Large app platforms use design to trap users — A/B testing, infinite scroll, pull to refresh.
+
+Many large app platforms continue to exist despite this — **they're hard to leave!** They exist to maximize revenue, not connect people.
+
+It's hard to leave a platform when they own your data; it may leave without you as well (like Google+).
+
+## What Is ATproto
+
+The Atmosphere — **does for data what open source did for code.**
+
+Apps have to be good to keep people using them!
+
+If an app is doing something you don't like, you can just leave without losing anything — data, content, and people are yours to take with you.
+
+## How Does It Work
+
+Each user gets their own repo where their data is stored; when they sign in, they get a repo, and a `DID`.
+
+- **`DID`** — Decentralized ID
+- User gets a handle
+- Handles are DNS records
+
+What lives in repo?
+
+- **record** — a piece of JSON, a bit of data
+- **blob** — binaries
+
+People can make their own thing to render content — it doesn't live in Bluesky. **The user is in charge.**
+
+- `blacksky` — an alternative to Bluesky
+- `witchsky` — another; adds badges/pronouns, different representation
+- `anisota` — simplified view
 
 ## Exploring the Atmosphere
 
-And you don't have to worry about auth anymore. `ATStore` (`atstore.fyi`) is a compendium of registered ATProto apps: `Sifa.id` (professional identity network), `Streamplace` (open-source livestreaming for video), `rpg.actor` (make an RPG character), `atmo.quest` (connect with folks at events). Get your stuff out easily, to multiple destinations. This is what open social looks like when it actually works.
+**Don't have to worry about auth anymore!?**
+
+`ATStore` — compendium of registered ATproto apps — `atstore.fyi`
+
+- `Sifa.id` — professional identity network
+- `Streamplace` — open source livestreaming app for video and live-streaming
+
+Get things out easily to multiple destinations.
+
+- `rpg.actor` — create an RPG character
+- `atmo.quest` — connect with folks at events
+
+**This is what open social looks like when it actually works.**

--- a/apps/cascadiajs2026-notes/content/talks/beowulf-stroganoff.md
+++ b/apps/cascadiajs2026-notes/content/talks/beowulf-stroganoff.md
@@ -1,11 +1,25 @@
-Ancient times — 2022 — `DALL-E mini`. "AGI" was never a useful term anyway. The phrase that actually sticks is from the OpenAI charter: **"economically valuable work."** And the flip side of optimizing for it is the flattening of culture that follows.
+Ancient times: 2022.
 
-So the mischievous question: what would happen if we made language models **bad**?
+**Dall-E mini!**
 
-## Training something useless on purpose
+**AGI** not a useful term.
 
-**`LoRA`** — Low-Rank Adaptation — lets you keep the base model frozen and train a little something on top. The v2 recipe: feed in a big text file of inspirational quotes and slogans.
+"economically valuable work" — from the OpenAI charter.
 
-Is the result better than a programmatic randomizer? **Yes.** Is it useful for creative purposes? **No.**
+Flattening culture.
 
-The point lands anyway: **protect your joy.** Make bad things!
+What would happen if we made language models **BAD**?
+
+`LoRA` — Low-Rank Adaptation — keep the base frozen and train on top of it.
+
+v2 — add a big text file of inspirational quotes and slogans.
+
+Better than a programmatic randomizer?
+
+- yes
+
+Useful for creative purposes?
+
+- no
+
+**Protect your joy. Make bad things!**

--- a/apps/cascadiajs2026-notes/content/talks/biilman-agent-experience.md
+++ b/apps/cascadiajs2026-notes/content/talks/biilman-agent-experience.md
@@ -1,54 +1,88 @@
-The progression is real: co-pilot → AI agent → AI assistance. We're moving
-from autocomplete toward genuine autonomy, and it changes the economics of
-building software.
+**AI autonomy:**
 
-**Build vs. buy has flipped.** Things that weren't viable to build before are
-now in reach — even whole HR systems. The SaaS budget is being replaced with a
-dev budget. Autonomous coding agents (e.g. **openclaw.ai**) are still early;
-one fun pattern is repurposing an old laptop as the host for one.
+```
+co-pilot -> AI agent -> AI assistance ->
+```
 
-The analogy that stuck: autonomous cars made us rethink cities; autonomous
-agents make us rethink programming and systems. **Software is now read/write
-for everyone.**
+**Build vs. buy has changed** — things that weren't viable before now are. Even whole HR systems.
+
+The SaaS budget is replaced with a dev budget.
+
+- `openclaw.ai` — autonomous coding agents, still early.
+- Repurpose an old laptop as the host for it.
+
+Autonomous cars make us rethink cities; autonomous agents make us rethink programming and systems.
+
+**Software is now read/write for everyone.**
 
 ## Chapter II: AX (Agent Experience)
 
-Build tools for the people that build tools.
+Build tools for people that build tools.
 
-- **UX** differentiates products from competitors.
-- **DX** differentiates platforms.
-- **AX** differentiates platforms *and* products.
+- **UX** — differentiates products from competitors
+- **DX** — differentiates platforms
+- **AX** — differentiates platforms *and* products
 
-The question: what experience do agents have with your tools and products? AX
-is **not** a single feature or protocol — and it's definitely not "just MCP."
+What experience do agents have with tools and products?
 
-## The four pillars
+So… how do we do it?
 
-**Access** — can agents reach the product at all? `netlify.ai` is built for
-humans *and* agents; the database is "batteries included" and available to
-agents directly. Emerging standards matter here too — e.g. WorkOS exploring
-self-authenticating identity for AI agents.
+Not a feature or a protocol, and definitely not just `MCP`.
 
-**Context** — does the agent understand the product? Optimize for agent
-consumption: prefer plain text / markdown, negotiate content types. **MCP is UI
-for LLMs** — context is the most important piece. Expose what the agent can act
-on, and steer it.
+**AX in practice:**
 
-**Tools** — agents will use your product *even if you provide no tools*. Every
-product **already has an agent experience** — the only question is whether it's
-good or bad. A CLI is often great DX but bad AX (interactive prompts are
-terrible for agents). API vs. MCP is the same product, different surfaces —
-naively shifting an entire API to MCP overwhelms the context window, so limit
-to a handful of tools. Provide **prompt escape hatches**.
+- **Access** — can they access the product?
+- **Context** — does it know about it and understand?
+- **Tools** — work with it?
+- **Orchestration** — can agents do work with the product?
 
-**Orchestration** — can agents do real work? Linear and Notion let you kick off
-longer-running tasks. Nobody wants another chat bot; orchestration lets people
-use tools they're *already* comfortable with. Agent runners execute in a
-sandbox so they can **actually do the thing** — async agents. The goal: make the
-whole team **builders**.
+## Pillar: Access
 
-## Measuring it
+`netlify.ai` — for humans and agents.
 
-**Evals** are how you measure agent experience — `axis.run` actually tries to
-onboard against your product and measure the AX. As this gets more abstract, it
-also gets more required.
+- Launch partners — payments, things to do with the thing.
+- Netlify database — available to agents as batteries included.
+
+Emerging standards — `workos` — self-authenticating UUID for AI agents.
+
+## Pillar: Context
+
+Optimize for agent optimization.
+
+Prefer plain text? Markdown? Negotiations about the content type.
+
+`MCP` is UI for LLMs — context is the most important piece; expose what the agent can do now. Steering context.
+
+**API vs. MCP** — same product, different surfaces.
+
+Just shifting from API to MCP will overwhelm context — limit to a handful of tools.
+
+## Pillar: Tools
+
+Agents will still use your product even if you don't provide tools.
+
+**Every product ALREADY has an agent experience** — is it GOOD or BAD?
+
+A CLI is often a great DX, but a bad AX — like, interactive stuff sucks for AX.
+
+**Churn churn churn.**
+
+Provide prompt escape hatches for AX.
+
+## Pillar: Orchestration
+
+`Linear`, `Notion` — kick off longer-running tasks.
+
+Chat bot — no one wants to use it; but orchestration lets people use the tools they are already familiar and comfortable with.
+
+Agent runners — run in sandbox.
+
+**Actually do the thing — async agents!!**
+
+**Make the whole team BUILDERS** — our teammates across the business need to be able to build.
+
+More abstract, and more required.
+
+## Evals — measuring agent experience
+
+`axis.run` — actually measure the AX — try to onboard.

--- a/apps/cascadiajs2026-notes/content/talks/choosing-typescript.md
+++ b/apps/cascadiajs2026-notes/content/talks/choosing-typescript.md
@@ -1,21 +1,96 @@
-Keep choosing TypeScript — it matters more than ever. LLM output is **not** "the new machine code"; you should still learn a language well, and `TypeScript` is the perfect choice.
+**Keep choosing TypeScript** — it matters more than ever.
 
-## Why the language layer still matters
+**LLM output is not "new machine code."**
+You should learn a language well, and TS is the perfect choice.
 
-Look at the world we built for agents: a tower of abstractions. `0/1` at the bottom, then `ASM`, then compilers down to `C`, then `TS`/`Go`/`Python`, then frameworks, then applications. We've spent most of our time in the language layer. People who dabble in predictions imagine squashing the lower languages — even the high-level ones. The truth sits in the middle, between "languages become irrelevant" and "English is a programming language." **English is not a good programming language** (per Paul Graham). If the prediction held, we'd be committing prompts instead of code — and we're not, yet.
+## Why should we care about the language?
 
-## Why TypeScript specifically
+Consider the world we have built for the agents: a tower of abstractions, `0`/`1` at the bottom, climb the tower —
 
-Software engineering is **compression** — the time spent compressing personal context. Picture nested, overlapping concepts where `MEMORY` is the outsized layer:
+```
+ASM, compilers -> C, TS/Go/Python -> frameworks -> applications
+```
+
+We spent most of our time in the language layer in years past.
+
+People who dabble in predictions — where will they land? Squash lower lower languages, including high-level languages.
+
+The truth is in the middle: between irrelevancy and English being a programming language.
+
+**English is not a good programming language.**
+
+Paul Graham — "… writing in a language…"
+
+We wouldn't be committing code, we would be committing prompts (and we're not, yet).
+
+- `WASP` — framework
+
+## Why TypeScript?
+
+**Software engineering is compression** — time to compress personal context.
 
 ```
 types -> code -> docs -> memory
 ```
 
-Shoot first, ask questions later — code is cheap, right? Imagine there's no TypeScript. **Plan A: documentation.** But docs aren't the harness — non-deterministic, no guarantee they match reality; you've just moved memory into docs. **Plan B: tests.** You move some memory into code via coverage and case exhaustion plus the happy path — but you reduce entropy by adding *more* code, and tests still expect you and the agent to generalize. Pile on tests if you want to throw off 100k lines a day.
+(overlapping nested concepts)
 
-## Start with the types
+**MEMORY is outsized in space.**
 
-**Then: types.** Move context out of memory and code and into types — if *you* know something, the types should know it too. A prompt is just a specification written in English; step back and define the type **manually**. That's more precise. Fred Brooks: *"Show me your flowcharts and conceal your tables…"* Reach for the right type and you compress memory *and* preserve context — discover the domain *while* you build the model. (`GrillMe` is a skill for refining domain modeling.)
+Shoot first, ask questions later?
+Code is cheap? Right?
 
-He considered branded types, result types, exhaustiveness, smart constructors, edge type safety — and kept it simpler. `Rust` can do all this and more — maybe more than we need. Meanwhile `TS` keeps evolving: rewritten in `Go`, better errors, legacy baggage shed, still the most popular language.
+Imagine there is no TypeScript; what's reasonable as far as compressing complexity?
+
+Did we answer our domain questions? **NO!** Where are the limits, and so on.
+So we didn't compress memory into types.
+
+So, hey! Let's add documentation!
+We just moved some of our memory to docs.
+
+**Docs are not the harness.**
+Docs are not deterministic, and there is no guarantee that docs match reality.
+
+## Plan B: Tests
+
+We can move some memory into code with test coverage and case exhaustion, and add happy path.
+
+Just use JS, not TS, and add a bunch of tests if you want to throw off 100k lines of code a day 🤑
+
+- Reduce entropy by adding extra code.
+- Tests expect us *and* the agent to generalize.
+
+## Types
+
+**Move context from memory and code to Types.**
+Encode information into the type.
+
+In the naive case, we still don't answer constraint-related questions.
+
+**If you know something, the types should know it as well!**
+
+## What if we start with the questions? With the Types?
+
+Fred Brooks: "Show me your flowcharts and conceal your tables, and I shall continue to be mystified. Show me your tables, and I won't usually need your flowcharts; they'll be obvious."
+
+We could define what we want in a prompt, which is basically a specification.
+
+We should instead take a step back and define our type **MANUALLY**. That's better than using English; it's more precise.
+
+- We can compress our memory AND preserve context by reaching for the right type.
+- Think about the questions related to our domain, and then define the appropriate types.
+- Discover the domain WHILE building the model.
+
+- `GrillMe` — skill to help refine domain modeling.
+
+He thought about talking about "branded types", result types, ensuring exhaustiveness, smart constructors, edge type safety — decided to make it simpler.
+
+`Rust` can do all of this, and other stuff; it may do stuff we don't need.
+
+## TypeScript continues to evolve
+
+- modern and safer
+- rewritten in Go
+- better errors
+- most popular language
+- removed legacy baggage

--- a/apps/cascadiajs2026-notes/content/talks/design-tokens.md
+++ b/apps/cascadiajs2026-notes/content/talks/design-tokens.md
@@ -1,19 +1,47 @@
-Design is not what ends up getting built. You've got `default`, `primary`, `special` — add `primary`/`muted` — and then you tell the agent "use the design system, don't make mistakes." Easier said than done.
+**Design.. not what ends up getting built!**
 
-## Not everything belongs in a design system
+- `default`, `primary`, `special`
+- add `primary` / `muted`
 
-Bind some complicated one-off edge case to every implementation and you've made a mess — too many decisions packed into each component. And every target needs a different language to consume the design system. So: **give the decisions names, give the names values, and give them instructions.** That's a single source of truth for branded targets — design tokens.
+> Hey agent! Use the design system, don't make mistakes
 
-The **Design Tokens Format Module** captures each design decision as a token in JSON, then defines relationships so you can swap values when you want. Lots of tooling already supports the spec — `Figma`, `Sketch`, `Penpot`, and more — coordinated by the **Design Tokens Community Group**.
+Not everything needs to be in a design system though — some complicated thing that's a one-off, we've just bound an extreme edge case to every implementation.
 
-## Teaching agents to follow them
+**Too many decisions in each component!**
 
-But how do we teach *agents* to follow them? Create skills, MCPs, hooks, plugins, CLIs; train a model on your design system and tokens. The loop:
+All of the different targets need a different language to use the design system.
+
+- give them names
+- then give them values
+- and give them instructions
+
+**Single source-of-truth** for getting branded targets.
+
+## Design Tokens
+
+- Design Tokens Form Module — capture design decision in the design token, in JSON files
+- then define relationships, swap them when we want
+
+Lots of tooling that supports the spec, including `Figma`, `Sketch`, `penpot`, and so on.
+
+Design Tokens Community Group
+
+## Teaching Agents
+
+How do we teach agents to follow these though?
+
+Create skills! `MCP`s! hooks! plugins! `CLI`s! train a model on your design system and tokens.
 
 ```
-find tokens (PLAN) --> code (VERIFY, e.g. lint) --> validate the suggestion
+find tokens - PLAN
+code       - VERIFY (lint)
+validate suggestion
 ```
 
-A lot of teams are investing in getting agents to follow design tokens — and there's little-to-no design-token tooling aimed at AIs yet.
+A lot of teams are investing time in getting agents to follow design tokens.
 
-Join the fight against UI slop. `designtokens.org`.
+No to little design-token tooling for AIs.
+
+**Join the fight against UI slop!!**
+
+`designtokens.org`

--- a/apps/cascadiajs2026-notes/content/talks/hidden-connections-graphs.md
+++ b/apps/cascadiajs2026-notes/content/talks/hidden-connections-graphs.md
@@ -1,15 +1,71 @@
-You fetch from two API endpoints, loop and merge by `id` — and it breaks because the `id`s don't match. A connection you wired by hand, mismatched. Now agents are making decisions about **people**, and if the guess is wrong we find out later, in a war room or a post-mortem.
+Fetching from two API endpoints, loop and merge by id — but it breaks because the ids don't match.
 
-## The implicit connection
+The connection we wired by hand — and mismatched.
 
-The worked example: Jessica works at Apex Global, which sits on the sanctions watchlist. She requests a $25k credit-line increase, and the agent **approves** it. Every fact was present — but the answer is still wrong, because the connection was *implicit*, not explicit. MIT reports **95% of organizations** see no measurable return from AI: there's no place to keep the context, no proof of work, the connection piece is missed.
+Now agents are making decisions about people. If the guess is wrong, we find out later in a warroom / post-mortem.
 
-## Knowledge graphs
+Jessica works at Apex Global — on the sanctions watchlist.
 
-To beat AI's black-box problem, knowledge has to be transparent. Picture three views of an apple — visual, vector, and knowledge-graph. Only the knowledge-graph view is legible to **both** humans and AI: you see the connections and can ask *one hop, or more than one?*
+- Jessica requests a $25k credit line increase.
+- The agent **APPROVES!**
 
-A **knowledge graph** is an organized, visual representation of relationships between entities — a property graph of nodes, relationships, and properties. Compare a 4-hop compliance check in `Cypher` to the `SQL` equivalent and the difference is stark. Text similarity finds documents with similar *meaning*; **structural** similarity finds entities with similar *connections* — and almost nobody is building the second one.
+Every fact was there, but the answer is still wrong. The connection was **IMPLICIT, not EXPLICIT.**
 
-## Context graphs record *why*
+**MIT** — 95% of organizations report no measurable return.
 
-The newer idea (Dec 2025): the **context graph**, or `graph RAG` — it traces the decision that was made. Both surface the decision **path**; the context graph supplies the missing "why" plain memory lacks. An audit log records *what*; a context graph records *why*. The pitch: cut down hallucinations and force agents to show their work by walking a causal chain — from "I have no idea" to full visibility. Learn more at Neo4j GraphAcademy.
+- No place to keep the context.
+- No proof of work.
+- Miss the connection piece.
+
+To overcome AI's black box problem, we need knowledge to be transparent.
+
+Visual view of apple, vector view of apple, knowledge graph of an apple.
+
+Knowledge graph view can be understood by human and AI.
+
+- Find the connections.
+- One hop? Or more than one hop?
+
+## Knowledge Graphs
+
+Organized / visual representation of relationships between entities.
+
+**Property graph** — nodes, relationships, properties.
+
+Example `Cypher` query for a 4-hop compliance check vs. the `SQL` example.
+
+## Similarity
+
+- **Text similarity** — documents with similar meaning.
+- **Structural similarity** — finds entities with similar connections.
+
+Almost nobody is building the second one.
+
+## Context Graph
+
+**Context graph** — graph RAG.
+
+Relatively new (Dec 2025).
+
+Contextual difference — tracing the decision that was made.
+
+Both context graph and knowledge graph find the decision path.
+
+The missing "why" — no memory.
+
+Traditional audit log vs. context graph.
+
+- Records vs. why.
+
+## Where to Learn More?
+
+- 1 — Build a system that cuts down on hallucinations.
+- 2 — Force the agents to show their work — force them to walk a causal chain.
+
+`neo4j` Graph Academy
+
+`graphacademy.neo4j.com`
+
+```
+You: "I have no idea" -> full visibility
+```

--- a/apps/cascadiajs2026-notes/content/talks/human-in-the-loop.md
+++ b/apps/cascadiajs2026-notes/content/talks/human-in-the-loop.md
@@ -1,17 +1,23 @@
-How do we get safety from agents? Put a human in the loop — because agents aren't just answering questions anymore, they're taking actions. Three patterns, ordered by stakes.
+How do we get safety from agents? **Put a human in the loop.**
+
+Agents aren't just answering questions anymore.
 
 ## Pattern 1: Interrupt
 
-A mid-task pause — the agent asks, the human answers, the agent continues. Low stakes, synchronous, **one function call**.
+- Mid-task pause — agent asks, human answers, agent continues.
+- Low stakes, sync, one function call.
 
 ## Pattern 2: Token Vault
 
-The agent hits a wall, you authorize it, and it succeeds on retry. The demo runs both patterns in one flow: hand out a **short-lived token scoped ONLY to what's needed**.
+- Agent hits a wall, you auth it, agent succeeds on retry.
+
+**DEMO:** both patterns in one flow.
+
+Give out a short-lived token that is scoped only to what is needed.
 
 ## Pattern 3: CIBA
 
-`CIBA` — Client-Initiated Backchannel Authentication. The industry is **already doing this**.
+- Client Initiated Backchannel Auth.
+- Industry is already doing this.
 
-## Match the pattern to the stakes
-
-That's the rule of thumb. **The higher the stakes, the more security you want.**
+**Match the pattern to the stakes** — the higher the stakes, the more security we need.

--- a/apps/cascadiajs2026-notes/content/talks/junior-dev-team.md
+++ b/apps/cascadiajs2026-notes/content/talks/junior-dev-team.md
@@ -1,30 +1,37 @@
-How to successfully build a junior dev team — built on ~300 hours of
-mentorship per junior: technical and consulting, book reading groups, feedback
-practice, demos, and tech talks. What's different here is **the investment.**
+**How to Successfully Build a Junior Dev Team**
 
-## The image we have of juniors is wrong
+300 hours of mentorship — technical and consulting.
 
-The usual framing:
+Book reading groups, feedback practice, demos, tech talks.
 
-- **Cheap** — there to free up seniors.
-- **Replaceable** — no institutional knowledge.
-- **Rentals** — can't build new technical capacity.
+**What's different? The investment!**
 
-## The AI death spiral
+## What is the image of juniors?
 
-With AI we're pushing human effort into more complex and chaotic modes of
-working. The trap: AI writes more code → the dev looks more "productive" → free
-them up for higher-level work → more output → **loop**. That's a death spiral if
-you stop investing in people.
+- **Cheap** — free up seniors
+- **Replaceable** — no institutional knowledge
+- **Rentals** — can't build new technical capacity
 
-## Reframe
+What does this mean for the senior devs?
 
-- Juniors are not cheap — they're an **investment**.
-- They are **not replaceable** — they're unique and far more diverse, which
-  matters more as the work shifts.
-- They're **invaluable, not rentals** — think two years of training, five years
-  of retention.
+With AI, we're moving human effort into more complex and chaotic modes of working.
 
-So: **heavily invest in early-career mentorship, hire for fit and the future,
-and do more interesting work.** The skills have changed — but the need for
-people has not.
+## The death spiral
+
+AI writes more code, the dev is more "productive", free them up for high-level work, which leads to more productive work, and LOOP — **a death spiral.**
+
+```
+more code -> more "productive" -> freed for high-level work -> more productive -> LOOP
+```
+
+## Reframe the juniors
+
+- Think of juniors as **not cheap** — an investment.
+- **NOT replaceable** — they are very unique and much more diverse (more important as work shifts).
+- **Invaluable**, not rentals.
+
+Two years of training, 5 year retention.
+
+Heavily invest in early career mentorship, hire for fit and the future, and do more interesting work.
+
+**The skills have changed! But the need for people has not!**

--- a/apps/cascadiajs2026-notes/content/talks/karaoke-stems.md
+++ b/apps/cascadiajs2026-notes/content/talks/karaoke-stems.md
@@ -1,17 +1,87 @@
-Karaoke in 2026 deserves a better file format than the 1980s gave it — and the pieces to build one are now lying around in open source. The argument: `.stem.mp4` is a worthy successor to `CD+G`.
+First song played — 1877.
 
-## The CD+G inheritance
+Karaoke — 1980s.
 
-The first song ever played dates to 1877, karaoke to the 1980s, and then `CD+G` — CD plus graphics — arrived backward-compatible. The split is comically lopsided: 2.27% graphics to 97.73% audio, with video squeezed into 26.5 kbit/s. The result is rough — 288x192, 16 of 4096 colors, 6x12 tiles. KJs (karaoke jockeys) still guard deep `CD+G` catalogs. We can probably do better — and we can render `CD+G` on a canvas with `WebGL`.
+## CD+G (CD + Graphics)
 
-## Stems are the DJ's dream
+Backward compatible.
 
-The DJ's dream is **stems** — separating a song into its parts so you can beat-match on drums or build mashups and remixes from isolated vocals. Stems were historically expensive, until AI source separation changed the math; by 2024, DJ software shipped it. `Demucs` (MIT-licensed, `PyTorch`) is good quality and breaks audio into separate files. Maybe MP4 stems are the new standard? **MP4 isn't a movie file** — it's just a container. And this is *real original audio*, not a MIDI recreation, so you can ride the vocal volume or mute it entirely.
+- 2.27% graphics, 97.73% audio
+- 26.5 kbit/s for video
 
-## Lyrics, with timing
+**It's rough!**
 
-`Whisper` (OpenAI) gives transcription plus timing — feed it the isolated vocals from `Demucs` and stash the result in the MP4. `Whisper` isn't perfect: timing drifts and it mangles some lyrics (hence "Hold me closer, Tony Danza"). **LLMs fix the transcription** while preserving the timing, and you can hand them open-source lyrics too.
+- 288 x 192 — 16 of 4096 colors
+- 6x12 tiles
 
-## Assembling the file
+KJs have a deep catalog of CD+G.
 
-The MP4 spec uses **atoms** — standard atoms, a stem atom, and a `kara` atom for synced lyrics. Wire it into a pipeline and add an open-source player. (`CREPE` handles musical key detection; `Butterchurn` revives the old WinAMP visualizers in `WebGL`.) See also `youmaynotneedelectron.com`.
+We could probably do better…
+
+We can render CD+G in canvas, with `WebGL`!
+
+## And now the AI stuff
+
+**The DJ's Dream (Stems)**
+
+- mix two songs together
+- have music separated out — drums for beat matching, vocals for mashups and remixes
+
+It's been expensive to get stems before.
+
+## AI Source Separation
+
+2024 — DJ software includes it.
+
+- `Demucs` — MIT license
+- good quality, `PyTorch`
+- breaks out files
+
+**MP4 Stems? The new standard?**
+
+`MP4` isn't a movie file, it's just a container.
+
+Real original audio, **NOT** MIDI recreation!
+
+Control vocal volume (or mute entirely).
+
+## Lyrics
+
+Okay, so we separated the tracks. What about the lyrics?
+
+`Whisper` from OpenAI —
+
+- we get transcription and timing
+- feed it isolated vocals from `Demucs`
+- put it in an `MP4` file
+
+`Whisper` isn't perfect; timing can be slightly off. Struggles with some lyrics.
+
+**LLMs for lyrics** — fix the transcription errors but keep the timing right.
+
+Can also pass along open source lyrics to it.
+
+"Hold me closer, Tony Danza" 🤣
+
+## Putting it together
+
+Corrected lyrics — we still want a file.
+
+`MP4` spec — atoms:
+
+- standard atoms
+- stem atom
+- kara atom — synced lyrics for karaoke
+
+Putting it all together — a pipeline.
+
+Also need an open source player.
+
+- `CREPE` can be used for musical key detection.
+- `Butterchurn` library — took WinAMP stuff encoded in `WebGL`.
+
+## Karaoke in 2026!
+
+**`.stem.mp4` is a worthy successor to CD+G!**
+
+`youmaynotneedelectron.com` mentioned.

--- a/apps/cascadiajs2026-notes/content/talks/last-mile-is-code.md
+++ b/apps/cascadiajs2026-notes/content/talks/last-mile-is-code.md
@@ -1,34 +1,47 @@
-Agents got really good at code, really fast — and you can represent almost any
-problem as code (one demo: `gc.cpp`, a million lines transpiled from LISP).
+`gc.cpp` — 1 million lines of code transpiled from LISP.
 
-On SWE-bench, the contamination-resistant **Pro** variant has moved fast:
-quality from ~33 (Aug '24) to 94, with Pro at 78 — and roughly 40 → 70 over the
-year.
+Agents got really good at code, really fast.
 
-## The stack shifted
+Represent any sort of problem as code.
+
+**`SWE Bench`** — Pro agent is contamination-resistant; quality has moved from 33 in Aug '24 to 94; Pro is 78.
+
+40 → 70 this year.
+
+## The Stack Has Changed
+
+The old stack:
 
 ```
-old: programming language --compiler--> machine code
-new: natural language --LLM--> programming language --compiler--> machine code
+programming language --compiler--> machine code
 ```
 
-The hard part **isn't the code anymore** — it's everything underneath it:
-ClickOps, infra, API keys, secrets. As Karpathy put it, *"Building a modern app
-is a bit like assembling IKEA furniture."*
+The new stack:
 
-## The last mile
+```
+natural language --LLM--> programming language --compiler--> machine code
+```
 
-For most of this, the last mile has always been **someone else's job** — a
-platform team, an SRE rotation, the person on call. And it's wildly lopsided:
-the agent only has what it was trained on, or what's in context.
+**The hard part isn't the code anymore** — it's everything underneath it: ClickOps, infra, API keys/secrets.
 
-So **put the last mile in code, too.** Take action in code space; a runtime
-(IaC) reflects it back into the cloud. **IaC is like `git diff` for your infra**
-— you see what it's going to do before it does it. Vibe infra like apps: ask for
-code you can review, approve, and merge.
+Andrej Karpathy — *"Building a modern app is a bit like assembling IKEA furniture."*
 
-This isn't just ergonomics. Per *CodeAct (Executable Code Actions Elicit Better
-LLM Agents)*, agents do **~20% better** when they act by **writing code** rather
-than emitting config. The shift is already underway: agents now drive **28% of
-deployments**, up from 4% late last year. **Shipping isn't a separate team's job
-anymore.**
+## The Last Mile
+
+For most of this, this part has always been someone else's job (a platform team, an SRE rotation, the person on call).
+
+It's wildly lopsided: agents have either what it was trained on, or it's in context.
+
+**Put the last mile in code, too.**
+
+Take action in code space; a runtime (IaC) reflects it back into the cloud.
+
+`IaC` is like `git diff`, but for your infra — see what it's going to do before it does it.
+
+Vibe infra like apps, by asking — code we can review, approve, and merge in code.
+
+**+20%** — agents do better when they act by writing code, not by emitting config (from *CodeAct — Executable Code Actions Elicit Better LLM Agents*).
+
+Agents now drive **28% of deployments**, up from 4% late last year.
+
+**Shipping isn't a separate team's job anymore.**

--- a/apps/cascadiajs2026-notes/content/talks/linked-literate-programming.md
+++ b/apps/cascadiajs2026-notes/content/talks/linked-literate-programming.md
@@ -1,36 +1,48 @@
-When agents write the code, **where does the intent live?** We still need
-durable intent.
+When agents write code, where does the intent live?
 
-## The problem with harness memory
+**We still need durable intent.**
 
-Agent harnesses have memory, but it's **tightly coupled** to the harness and
-brings lock-in. Markdown files, by contrast, are **portable**. So use markdown
-to hold the "memory."
+Agent harnesses have memory, but it's tightly coupled — and we have lock-in.
 
-## Linked Literate Programming (LLP)
+Markdown files, on the other hand, are portable.
 
-LLP = **markdown specs + references from code**. Code links back to the spec
-with a comment:
+Use markdown to create "memory."
+
+**LLP** — markdown specs + references from code.
 
 ```
 // @ref LLP 0000mediastream-constructor
 ```
 
-```markdown
+```
 # Constructors [mediastream-constructor]
 ```
 
-The links matter for three things:
+## Why links matter
 
-- **Coverage** — you can see whether each part of the spec was implemented.
+Links matter for coverage, accuracy, and intent.
+
+- **Coverage** — we can see if we implemented each part of the spec.
 - **Accuracy** — does the spec actually match the code?
 - **Intent** — are decisions visible *above* the code level?
 
-## Web specs are great LLP inputs
+## Web specs as inputs
 
-Web specs already have the edge cases considered and the APIs designed. Agents
-import the spec, then leave linking comments back to it. The same spec can drive
-**both web and native** implementations. Pair it with **WPT** (Web Platform
-Tests) to close the loop: set up LLP, pull in the relevant parts of a spec, and
-test coverage against it. LLP + web specs makes the whole thing more
-programmatic.
+Web specs are good inputs for LLP:
+
+- edge cases already considered
+- designed APIs
+
+Agents import the spec, then use linking comments back to the spec.
+
+**LLP pattern** — implementation for web and native apps using the same spec??
+
+## Workflow
+
+Set up LLP, get the relevant parts of a spec, test coverage.
+
+`WPT` — Web Platform Tests.
+
+Make a feedback loop with LLP.
+
+**LLP + web specs** — more programmatic.

--- a/apps/cascadiajs2026-notes/content/talks/modern-css-colors.md
+++ b/apps/cascadiajs2026-notes/content/talks/modern-css-colors.md
@@ -1,14 +1,20 @@
-Practical refactors you can do today with modern CSS color features. The
-through-line: a lot of what we reached for a preprocessor to do, CSS now does
-natively, **in context**.
+## Theming
 
-## Theming with `light-dark()`
+Practical refactors with modern CSS colors
 
-`light-dark()` takes two values — a light-mode color and a dark-mode color (both
-must be colors) — and does the media query's job for you.
+`jds.li/css-colors`
 
-Overrides stay tiny. A six-line override (one block each for dark and light) is
-enough:
+CSS abstraction — how do we DRY our CSS?
+
+Use a pre-processor?
+
+`light-dark()` — two values: light mode color, dark mode color. Must be a color.
+
+Already doing the media-query's job.
+
+What about overrides?
+
+6-line override (one each for dark and light):
 
 ```css
 [data-theme="dark"] {
@@ -16,44 +22,83 @@ enough:
 }
 ```
 
-Global support is ~87% (check caniuse for the current number); Electron already
-supports it. Tailwind's `@theme` can lean on `light-dark()` too.
+**87% global support** — get more accurate on `caniuse`.
 
-## Color manipulation with relative colors
+`Electron` already has support.
 
-Relative color syntax pulls the raw channels out of an existing color:
+`tailwindcss` — `@theme` — `light-dark`?
+
+## Color Manipulation
+
+CSS relative colors:
 
 ```css
-rgb(from var(--red) r g b / 1);
+rgb(from var(--red), r, g, b, alpha);
 ```
 
-`from` extracts the source color's values. Modern color functions drop the
-commas — but alpha still needs a slash: `hsl(120 50% 20% / 0.2)`. Alpha is
-implicit regardless of whether you write `rgb` or `rgba`.
+`from` pulls out the raw color value from the variable.
 
-This unlocks, all without a preprocessor:
+Don't need commas anymore in color functions — but alpha needs a slash:
 
-- **Tints** — `rgb(from var(--surface-primary) r g 255)`. No clamping needed.
-- **Adjust alpha** — `rgb(from var(--surface-primary) r g b / 0.2)`.
-- **Normalized lightness** — same idea as alpha, but in `hsl`.
-- **Color math** — start from a named color and rotate hue: secondary at 120°,
-  tertiary at 240°.
+```css
+hsl(120 50 20 / 0.2)
+```
 
-These are the **mixins** we used SASS color functions for — now native (~89%
-support). Change one line to derive a variable and operate on it right there.
+Alpha is an implicit value — regardless of whether you use `rgba` or just `rgb`.
 
-## `color-mix()` and `contrast-color()`
+## Tints
 
-`color-mix()` blends colors in real time, in a chosen color space:
+```css
+from var(--surface-primary) r g 255
+```
+
+Do we need to clamp this? No, we don't.
+
+## Adjust Alpha
+
+```css
+from var(--surface-primary) r g b / 0.2
+```
+
+## Normalized Lightness
+
+Like alpha, but with `hsl`.
+
+## Color Math
+
+Start from a named color.
+
+- rotate secondary 120°, 67 33
+- rotate tertiary 240°, 67 33
+
+## Mixins
+
+`SASS` color functions — requires pre-processor.
+
+Now we can do this in CSS — set the var and do stuff with it.
+
+Change one line to get the var — happens in context.
+
+**89% support globally.**
+
+CSS `color-mix()` — new function to manipulate colors in real time. Color space, use `hsl`.
 
 ```css
 color-mix(in hsl, var(--button-color), var(--button-active-color))
 ```
 
-(~91% support.)
+**91%**
 
-For accessibility, `contrast-color()` returns black or white — whichever
-contrasts better against a given color, regardless of color scheme. It's
-**stackable**: use `color-mix()` *inside* `contrast-color()` with relative
-colors to mix a tint in and still get a legible foreground. Support is only
-~67% today, so progressively enhance.
+## Automatic Contrast
+
+Accessibility.
+
+`contrast-color()` — returns white or black, regardless of color scheme, whichever is better for contrast.
+
+Use `color-mix()` inside `contrast-color()` — `from` — with relative colors.
+
+Mix the tint in.
+
+**All stackable.**
+
+Only **67%** right now.

--- a/apps/cascadiajs2026-notes/content/talks/on-device-ai-music.md
+++ b/apps/cascadiajs2026-notes/content/talks/on-device-ai-music.md
@@ -1,23 +1,95 @@
-AI plus `Strudel` — a web-based, code-driven music tool where you make music with code. The goal is to **extend creativity, not replace it**: use AI for the technical bits, not to hand the whole thing over. A small model under the hood adds structural awareness.
+**AI and Strudel** — web-based music production tool.
 
-The kicker: it all runs in your browser tab. **No API, no cloud — all local.** Why local? Keep cost down (free), reduce latency (no round-trip), and preserve privacy (input never leaves the browser).
+**Make music with code!**
 
-## Picking the model
+Extend creativity, not replace it — using AI to get help, not handing something to AI to do.
 
-How do you make a small model good at a niche domain? First pick the *type*. Is the problem translation? Audio classification? Text generation? Each lives in a different model family — text generation made the most sense. `transformers.js` runs Hugging Face models in the browser.
+**Structural awareness** — a small model under the hood helping with the technical bits.
 
-## Shaping the I/O
+**In your browser tab!** No API, no cloud — all local.
 
-AI is good at ambiguity, inference, unstructured input; code is good at precision, rules, structured output. The right answer sits on a continuum between them, with tradeoffs. Off-the-shelf "just ask for code" looks plausible but won't run. "Intent JSON → deterministic engine" turns intent into pseudo-code, but bigger schemas and prompts add latency and stop feeling fluid. A **fine-tuned model** gives structural context: small input, sanitized and parsed output. Optimize further and you drop the deterministic guarantee for a tighter surface — just the right number of tokens.
+## Why local
 
-## Training data, validated
+Alex wants to:
 
-The model didn't know `Strudel`, and there wasn't much training data. So Alex used LLMs to generate examples — some of it confident nonsense referencing things that don't exist. The fix: **validate, then scale.** Run each example through `Strudel`; if it doesn't parse, throw it out. Don't scale the hallucinations. Add grounding so the model doesn't freestyle, and reward cross-domain reasoning.
+- **keep cost down** — free!
+- **reduce latency** — beats having a round-trip
+- **privacy** — input never leaves the browser
 
-The ongoing loop:
+So that's why local.
+
+## Getting a small model good at a niche domain
+
+How do you get a small model to be good at a niche domain?
+
+Pick a model — but first pick *which type* of model?
+
+- `transformers.js` — HuggingFace models to run in the browser.
+
+Is this problem translation? Is it audio classification? Each one is in a different model family.
+
+Text generation made the most sense; what does the interface look like?
+
+Shaping the model's I/O —
+
+- **AI** good at ambiguity, inference, unstructured input
+- **Code** good at precision, rules, and structured output
+
+The right answer depends on the need.
+
+## Finding the AI/code boundary
+
+- **Off-the-shelf model: ask for code** — NOT right! Looks plausible, but won't run.
+- **Try intent JSON** — deterministic engine; take intent and make pseudo code.
+
+A continuum of AI `<——>` code boundary, with tradeoffs between them.
+
+Latency to get a structured output; bigger schema, bigger prompt — doesn't feel fluid anymore.
+
+- **Try fine-tuned** -> structural context. Keep input context small; model output is sanitized and parsed.
+- **Optimized** — remove the deterministic guarantee for tighter and smaller surface area, just the right amount of tokens.
+
+But the model didn't know Strudel! Training took a lot more time.
+
+## Training data
+
+There wasn't a lot of training data available — didn't have time to create a lot of examples.
+
+Alex used LLMs to generate examples; ask for Strudel, see what it does.
+
+Some things didn't actually exist — **confident nonsense.**
+
+- Added validation step — run it through Strudel, throw it out if it doesn't parse.
+- Then scale — **DON'T scale the hallucinations.**
+
+Added grounding to what the LLM is being asked to do; don't freestyle, be concise — what is Strudel.
+
+Cross-domain reasoning.
+
+## The ongoing loop
+
+The work gets focused but doesn't stop; identify gap -> generate -> validate -> retrain.
 
 ```
-identify gap --> generate --> validate --> retrain
+identify gap -> generate -> validate -> retrain
 ```
 
-The work gets focused but never stops; each loop makes the tool more like something Alex actually wants to play with. Finally, fit it into a browser tab via **quantization** — shrink by reducing precision. Runtime is a few lines: import, await the pipeline, initialize. The questions to keep asking: what's the model task? where's the AI/code boundary? where does the training data come from? does it need to be local?
+Each loop makes the tool better — to become something Alex wants to work with.
+
+## Shrink it to fit
+
+Make something small enough to fit in a browser tab — **shrink it small, ship it small.**
+
+**Quantization!**
+
+- Shrink down by reducing precision.
+- Runtime in a few lines — import, await pipeline, initialize.
+
+**Ideas are endless.**
+
+## Questions to ask
+
+- Model task?
+- AI/code boundary?
+- Training data?
+- Does it need to be local?

--- a/apps/cascadiajs2026-notes/content/talks/request-tax.md
+++ b/apps/cascadiajs2026-notes/content/talks/request-tax.md
@@ -1,18 +1,48 @@
-An intervention: `React` just turned 13, and how we work has changed. To bundle, or not to bundle?
+An intervention.
 
-## Why we bundle
+React turned 13 years old — and how we've worked has changed.
 
-We bundle with `webpack` and `rollup` — but also with inlining, data URLs, and sprites. The *why* is historical: `TCP` was slow, and `HTTP/1.1` told us we had to. Caching hated bundling, so **code splitting** was invented to balance bundling against caching.
+## To Bundle or Not to Bundle?
 
-## The protocols moved on
+**How** we bundle:
 
-Then `HTTP/2` (`SPDY`) fixed the `HTTP/1.1` problem — but `TCP` is still the problem. `HTTP/3` over `QUIC` fixed a lot of hard problems. But did we actually *fix* this?
+- `webpack`, `rollup`
+- BUT ALSO: inlining, data URLs, sprites
 
-Look at request granularity. Under `HTTP/1.1`, bundling is genuinely faster — the more you split into smaller pieces, the worse it looks, because the overhead of splitting goes up. `HTTP/3` is the opposite: the more you split, the **better** it looks, and delivery stays consistent. **`HTTP/3` plus caching is a love story.**
+**Why** do we bundle?
 
-## Takeaways, by audience
+TCP was slow; HTTP/1.1 told us we had to bundle.
 
-- **Average developers** — optimize for *caching* and stop stressing about the network.
-- **Framework and bundler maintainers** — is the default still the right answer?
-- **Cloudflare** — can you get us more data? Follow up on the 2020 article on `HTTP/3` performance.
-- **Everyone else** — anyone have cool data?
+Caching hated it.
+
+Code splitting invented to find a balance between bundling and caching.
+
+## HTTP Evolution
+
+`HTTP/2` — `SPDY` fixed the HTTP/1.1 problem.
+
+But TCP is still the problem.
+
+`HTTP/3` over `QUIC` — fixed a lot of hard problems.
+
+But did we actually **FIX** this?
+
+## Request Granularity
+
+HTTP/1.1 is actually faster when bundling.
+
+The more we split and make smaller, the better HTTP/3 looks.
+
+- **HTTP/1.1** — overhead of splitting goes up
+- **HTTP/3** — more consistent at delivery
+
+```
+HTTP/3 + caching = ❤️
+```
+
+## Prompts
+
+- **Average developers:** OPTIMIZE for CACHING, stop stressing about the network.
+- **Framework / bundler maintainers:** is the default still the answer?
+- **Cloudflare:** can you get us more data? Can you follow up on the 2020 article on HTTP/3 performance?
+- Anyone else have cool data?

--- a/apps/cascadiajs2026-notes/content/talks/rethink-everything.md
+++ b/apps/cascadiajs2026-notes/content/talks/rethink-everything.md
@@ -1,17 +1,131 @@
-Building software is wildly different now because of AI — the same way the cloud changed everything before it. The same movie, playing again.
+Building software is **WAYYYY different** because…
 
-## The cloud already ran this play
+**AI is the cloud!**
 
-**Before the cloud**, building was capital-intensive: you had to predict the future, and experimentation was expensive. **After**, you start small and scale up, experimentation is cheap, and you don't need God-tier infra devs — Amazon-tier hardware without an Amazon-tier budget. AI is that movie again: **Amazon-scale software without Amazon-scale SWE teams.** The expertise required drops; the things that were rigid aren't anymore.
+## Life before the cloud
 
-## Rethink the assumptions we stopped questioning
+1. Building was more capital-intense
+2. You had to predict the future
+3. Experimentation was expensive
 
-Why can't we commit `.env` files? Why can't a public repo have private parts? Why can't a file be in two folders at once? Why do we need a file system to compile my app? Why do we assume our codebases still matter — our packages? Why can't we rebuild everything? **Why can't we boil the ocean?**
+## Life after the cloud
 
-`Salesforce` is the opposite of all this — a giant pile of features. Everyone needs a few, the Fortune 500 needs more, and there's a long tail that 1% of users touch. You have to build for every snowflake. Or do you? **Breadth is now trivial to cover; depth isn't the problem** — build a platform and let the client's agents handle the depth. Too broad is hard; too deep isn't good.
+1. You can start small and scale up
+2. Experimentation is cheap
+3. You don't need to hire God-tier infra devs anymore
 
-## Boil the ocean
+Easy scaling made a lot of things possible.
 
-**Before**: 40 hours to build, 3 hours to deploy. **After**: 30 minutes to build, 3 hours to deploy — now the deploy is the obnoxious part. `shoo.dev` does auth in two lines (easy, not necessarily secure or good); it didn't ship because it was built too deep in the vertical. So make all the problems go away. Theo went too far and built `Lakebed` [alpha] — `npx lakebed new sup-seattle`, then `npx lakebed deploy`, deployed in seconds; change something, redeploy in seconds. He built the language, compiler, CLI, *and* deployer. We kid ourselves that we need all the perfect things — just prompt something into existence. `lakebed.dev`.
+**Amazon-tier hardware without Amazon-tier budget.**
 
-**Why haven't we been thinking right?** We are not building big enough. Find the place where going so big makes you feel STUPID. The last 5, 10, 50 years don't matter — where will things be in five? You aren't building big enough.
+And AI… we've been through this before…
+
+## Life before the Claude
+
+1. Building was capital-intense
+2. You had to predict the future
+3. Experimentation was expensive
+
+Amazon-scale software, with Amazon-scale SWE teams.
+
+**Everything we believe is no longer true.**
+
+Expertise required is a lot less now; things that were rigid aren't true anymore.
+
+## Things we should rethink
+
+We may be past where this stuff makes sense:
+
+- Why can't we commit `.env` files?
+- Why can't a public repo have private parts?
+- Why can't a file be in two folders at once?
+- Why do we need a file system to compile my app?
+- Why do we assume our codebases still matter?
+- Why do we assume our packages still matter?
+- Why can't we rebuild everything?
+- Why can't we boil the ocean?
+
+## Salesforce
+
+`Salesforce` is the opposite of everything mentioned…
+
+Salesforce has a lot of features.
+
+Everyone needs a small number, Fortune 500 needs some, and then there's the long tail of things 1% of users use.
+
+Features `[company]` needs.
+
+You have to build for every snowflake.
+
+Or do you?????
+
+What if you could cover what a company needs trivially?
+
+- **breadth of features** — range
+- **depth of features** — # of features in a given area
+
+Too broad? Hard. Too deep? Not good.
+
+But a broad range of things you cover — **it's viable now.**
+
+The depth isn't a problem; build a platform and let the client deal with that with their agents.
+
+## What does this look like?
+
+**Before**
+
+- build — 40 hours
+- deploy — 3 hours
+
+**After**
+
+- build — 30 minutes
+- deploy — 3 hours
+
+So obnoxious! Why!! The 3 hours sucks worse now.
+
+## shoo.dev
+
+- `shoo.dev`
+- auth in 2 lines of code
+- easy way to add auth, not secure or good necessarily
+- didn't ship? built too deep in the vertical
+
+**BOIL THE OCEAN!!!** Make all the problems go away.
+
+Theo went too far.
+
+## Lakebed [alpha]
+
+**LIVE DEMO!!**
+
+```
+npx lakebed new sup-seattle
+```
+
+- nothing special on his machine
+
+```
+npx lakebed deploy
+```
+
+- deployed just like that, super quick
+- changed something, deployed in seconds
+
+Built language, compiler, CLI, deployer.
+
+Holy crap — so simple.
+
+We kid ourselves that we need all the perfect things, just prompt something into existence.
+
+`lakebed.dev`
+
+## Why haven't we been thinking right
+
+**WE ARE NOT BUILDING BIG ENOUGH.**
+
+Find the place where we feel **STUPID** for going so big.
+
+Where will things be in 5 years? The last 5, 10, 50 years don't matter.
+
+**YOU AREN'T BUILDING BIG ENOUGH.**

--- a/apps/cascadiajs2026-notes/content/talks/rust-critical-path.md
+++ b/apps/cascadiajs2026-notes/content/talks/rust-critical-path.md
@@ -1,23 +1,118 @@
-JavaScript winning the web isn't controversial — default for front-ends, huge ecosystem, fast iteration, the thing most web teams already know. The interesting frontier is the **critical path**: product work where performance, latency, memory pressure, and runtime predictability dominate.
+**JavaScript winning the web is not controversial** — it's the default choice for front-ends, has a huge ecosystem, fast iteration, and most web teams already know it.
 
-## "Is Rust ready for web development?" is a useless, dumb question
+Web only as product work, performance, latency, memory pressure, runtime predictability => **this is the critical path.**
 
-Ready for *what*? "Web development" could mean landing pages, proxies, or `WASM` — each optimizing for something different. For product-heavy UI work, no. When the constraints change, yes. The web stack is far more than the browser — frontend, edge, and a lot of layers underneath.
+## Is Rust Ready for Web Development?
 
-Rust wins when the web becomes **systems programming**: predictable, low-latency, memory-efficient, safe concurrency, fewer runtime surprises. It's not *just* fast — explicit errors, strong types, `WASM`-ready, ownership and allocation control, memory safety without a garbage collector. From the outside it looks like web dev; from the inside it behaves like a systems language. Not for everything.
+This question is useless; it's a dumb question.
 
-## One pattern, real examples
+**What does web development even mean?**
 
-Rust entering the parts that need stronger guarantees:
+- Landing pages, proxies, `WASM`, and so on.
 
-- **Cloudflare** built `Pingora`, an HTTP proxy — 1T+ requests/day on a third of the CPU and memory.
-- **Discord** rewrote Read States in Rust: GC caused latency spikes, and P99 mattered more than simplicity. A targeted hot-path swap, not an ideological rewrite.
-- **Shopify Functions** compile to `WASM` — Rust for portable business logic, fast.
+**Ready for what?**
 
-## The stack, and where to reach for it
+- Product-heavy UI work.
+- When constraints change? Yes.
 
-Frameworks `Axum` + `Actix`; foundations `Hyper` + `Tower`; data `SQLx`, `Diesel`, `SeaORM`; runtime `Tokio`; observability `OpenTelemetry`.
+The web stack is much more than the browser — frontend, edge, lots of other stuff.
 
-The `Tokio` mental model is close to Node: an `async fn` creates a lazy future, and the runtime — executor, scheduler, reactor, timers, async I/O, task spawning — runs it when ready. It's **not a thread**; it's machinery to let many futures make progress. Production engineering starts when many handlers share one runtime. `SQLx` keeps SQL explicit and moves failures earlier — verifying Rust types against the schema at compile time. Not an ORM, but with compile-time guarantees.
+Different layers optimize for different things.
 
-Rust wins at backend, auth, billing, realtime, proxies, `WASM`/tooling, queues — **realtime is the biggest win**. It loses when speed of change matters most: landing pages, blogs, classic CMS, three-day MVPs, frontend-heavy apps. It has a cost — learning curve, compile time, async complexity — so pay it when the leverage is worth it. Go is simpler but not the correctness win; Java/Kotlin for tooling and big teams; JS/TS for speed. Keep TypeScript for the frontend, reach for Rust at the constraints. **Hybrid wins.** Rust doesn't need to win the web — it should be on the critical path.
+## Where Rust Wins
+
+**Rust wins when the web becomes system programming** -> operating critical systems.
+
+- Predictable, low latency, memory efficiency, safe concurrency, fewer runtime surprises.
+
+**Rust is not JUST fast** — explicit errors, strong types, safe concurrency, `WASM`-ready, ownership and allocation control, memory safety without garbage collection.
+
+**Rust is NOT for everything.**
+
+- From the outside, looks like web development.
+- From the inside, behaves as a system language.
+
+## Real-World Patterns
+
+`Cloudflare` built `Pingora` — HTTP proxy.
+
+- 1T+ requests/day with 1/3 CPU and memory.
+- When the web becomes infrastructure, the choice becomes easy.
+
+`Discord` — Read states rewritten in Rust.
+
+- **GARBAGE COLLECTION** caused latency spikes; P99 latency mattered more than simplicity.
+- Critical path, GC spikes, hot path, targeted replacement.
+- Not an ideological rewrite, a very practical choice.
+
+`Shopify` Functions -> `WASM`.
+
+- Rust for portable business logic, fast.
+
+All three examples — recognizable pattern.
+
+**Rust is entering the parts that need stronger guarantees.**
+
+## Rust Web Stack
+
+- Web frameworks: `Axum` + `Actix`
+- Foundations: `Hyper` + `Tower`
+- Database layer: `SQLx`, `Diesel`, `SeaORM`
+- Async runtime: `Tokio`
+- Observability: `OpenTelemetry`
+
+## Tokio and Futures — Mental Model
+
+SIMILAR to `NodeJS` — `async fn` creates a future — lazy work.
+
+`Tokio` runtime — executor / scheduler / reactor / timers / async I/O / task spawning.
+
+- When ready, it runs.
+- Machinery that lets many futures make progress efficiently.
+- It is **NOT a thread.**
+
+`Axum` flow: production engineering starts when many handlers share the same runtime.
+
+## Database Access
+
+`SQLx` keeps SQL **EXPLICIT** and moves more failures earlier.
+
+- Compile time — verifies the Rust types against the schema.
+- NOT an ORM, but has compile-time guarantees.
+
+## Where Does Rust Win?
+
+- Backend, auth, billing, realtime, proxies, `WASM`/tooling, queues.
+- **Realtime is the biggest win.**
+
+## Where Does Rust NOT Win?
+
+- If speed of change is most important.
+- Landing pages, blogs, classic CMS websites.
+- Three-day MVPs, frontend-heavy apps.
+
+## Rust Has a Cost!
+
+Adoption costs:
+
+- Learning curve
+- Compile time
+- Async complexity
+
+**Pay the Rust cost when the leverage is worth it.**
+
+## Different Tools, Different Wins
+
+**Rust wins WHEN correctness, latency, safety, and predictability matter most.**
+
+- `Go` is a more simple choice, but not the correctness win.
+- `Java`/`Kotlin` for tooling / maturity / big teams.
+- `JS`/`TS` for the fastest speed of development.
+
+Keep `TypeScript` for the frontend — UI, fast iteration; use Rust for constraints.
+
+**Hybrid wins.**
+
+Reusable business logic — `WASM`, back-end, CLI.
+
+**Rust does not need to win the web, but it should be in the critical path.**

--- a/apps/cascadiajs2026-notes/content/talks/shared-components.md
+++ b/apps/cascadiajs2026-notes/content/talks/shared-components.md
@@ -1,36 +1,52 @@
-Shared components that live *beyond* the design system. The design system is
-UX foundations and atomicity; above it sits navigation, higher-level UX,
-team-specific components, and design-system candidates.
+**Shared Components Beyond the Design System**
 
-## Before you build
+`DS` == UX foundations, atomicity.
 
-- **Who are you building for?** Anchor on one consumer, then add a *second*
-  consumer early so the implementation doesn't get coupled to the anchor's use
-  case.
-- **Where are you building it?** Keep it separate from the app so it can evolve
-  independently, and publish artifacts to avoid copy-paste habits.
-- **Build it thoughtfully** — hold it to a higher standard than app code, and
-  keep the API consistent. The common case should take little to no effort; the
-  most custom case will take the most effort. Layer the complexity (1 → 2 → 3),
-  prioritize common use cases, and don't forget the complex-but-frequent ones.
-  Hard mode is allowed to be hard.
+nav / higher-level UX, team-specific, or design system candidates.
 
-## Six principles
+## Who are you building for?
 
-1. **Build up** from the design system.
-2. **Design with layered extensibility** — make the right way the easy way (e.g.
-   a button with an icon).
-3. **Don't build a Homer car** — don't cram in every feature.
-4. **It's okay to be opinionated.**
-5. **Consider including batteries** — reduce boilerplate, handle data fetching
-   where you can (like Relay's fragments), but keep an escape hatch so consumers
-   can do it themselves when needed.
-6. **Make it maintainable** — thorough tests, liberal docs, and a changelog
-   that says what changed and whether consumers need to act.
+Anchor consumer, then add a second consumer to keep implementation from getting coupled to the anchor consumer's use case.
 
-## Ecosystem and governance
+## Where are you building it?
 
-Shared components are valuable, so invest in **discoverability** — a docs site
-or marketplace; good docs matter more than ever. Provide **governance**: define
-patterns and practices, use a quality scale (Home Assistant's bronze / silver /
-gold is a nice model), and **recognize authors** for their contributions.
+Keep it separate from the app so it can evolve independently.
+
+Publish artifacts to avoid bad habits (copy-pasta).
+
+## Build it thoughtfully
+
+Use a higher standard than app code.
+
+Make API consistent.
+
+**Common case** — little to no effort; the most custom case will require the most effort (layer 1, 2, 3 with progressive complexity).
+
+Prioritize common use-cases, and don't forget complex but frequent things.
+
+Hard mode can be hard — that's okay.
+
+## Principles
+
+- **Principle 1:** build UP from the design system
+- **Principle 2:** design with layered extensibility — **make the right way the easy way** (example: button with icon)
+- **Principle 3:** don't build a Homer car
+- **Principle 4:** it's okay to be opinionated
+- **Principle 5:** consider including batteries — reduce boilerplate, handle data fetching if you can (like `Relay`'s fragments), keep an escape hatch — don't do everything for consumers in case they need to do something themselves
+- **Principle 6:** make it maintainable — write thorough tests, document liberally, keep a changelog — what changed and do they need to do anything about it
+
+## Foster an ecosystem
+
+Shared components are super valuable.
+
+Discoverability — doc site / marketplace.
+
+**Good docs matter more than ever.**
+
+## Provide governance
+
+Define patterns and practices.
+
+`Home Assistant` — Quality Scale — bronze / silver / gold.
+
+Recognize authors for their contributions.

--- a/apps/cascadiajs2026-notes/content/talks/skeptics-to-champions.md
+++ b/apps/cascadiajs2026-notes/content/talks/skeptics-to-champions.md
@@ -1,22 +1,37 @@
-How to make AI *real* inside an org and turn skeptics into champions — a
-"startup inside a startup," built on a decade of infra.
+**Make AI real.**
 
-## The first attempt missed
+Stripe Minion? A decade of infra.
 
-We built the impressive-sounding stuff — a skills/repo marketplace, sandboxes,
-guardrails, an AI bug diagnoser — but **didn't ask whether anyone actually
-needed it.** Nobody has time to do the AI's homework. The result: a **16% merge
-rate**, with no comments and no feedback.
+A startup in a startup.
 
-## What actually worked
+- Skills repo marketplace
+- Sandboxes
+- Guardrails
 
-- **Undeniable beats impressive.** Target tiny, annoying fixes. A sandbox makes
-  sense when it *eases the pain*; curate skills, on by default.
-- Don't ask people to build a knowledge graph or chase metrics before there's
-  value. **Create a feedback loop.**
-- The homework was **already done** — 1,000 fixes from the last year were
-  already in the repo. So **replay the agent** against them.
+Didn't ask if anyone actually needed any of this.
 
-That replay pushed clean fixes from 16% to **36%**.
+## AI Bug Diagnoser
 
-The mantra: **try it, measure it, delete what doesn't work.**
+Nobody has time to do the AI's homework.
+
+- Tiny, annoying fixes
+- Sandbox makes sense when it eases the pain
+- Curated skills, by default
+
+Build a knowledge graph? Show metrics before we take this on?
+
+**Undeniable beats impressive!**
+
+Create a feedback loop.
+
+16% merge rate — no comments or feedback.
+
+## The Homework Was Already Done
+
+1000 fixes from the last year — already in the repo.
+
+Replay the agent.
+
+**Improved to 36% clean fixes!**
+
+**Try it, measure it, delete what doesn't work.**

--- a/apps/cascadiajs2026-notes/content/talks/spec-driven-development.md
+++ b/apps/cascadiajs2026-notes/content/talks/spec-driven-development.md
@@ -1,46 +1,67 @@
-Specs are the **primary contract** for code generation. (Context: AWS's Kiro,
-which started life as a VS Code fork — Alexa lineage at AWS.)
+Specs are the primary contract for generation of code.
 
-## Why specs?
+Why?
 
-Treat the AI like an intern: one small deviation can produce wildly different
-results. So get planning and product involved, and write the contract down.
+**AI as intern** — one small deviation can result in very different results. Get planning and product involved.
 
-Can't the latest frontier models just do everything? A few things to keep in
-mind:
+Can't the latest frontier models do everything??
 
-- **Too much context** confuses models. Keep `AGENTS.md` / steering files
-  targeted. Use skills to create specs and implement them; agents can help with
-  the implementation plan.
-- **Too much trust** is a trap. Are we code reviewing? We're the human in the
-  loop — that matters. Set up AI code reviews as a second pass too.
-- Watch for **outcome divergence** (drifting off the intended target) and
-  **speed over maintainability** (what patterns are we creating?).
+Let's keep a few things in mind:
 
-## Doing it without Kiro
+- **Too much context!!** Models get confused.
+- `AGENTS.md` / steering — keep it targeted.
+- Use skills — create specs and implement, and agents can help with the implementation plan.
+- **Too much trust!!** Are we code reviewing? We are the human in the loop, it's important.
+- Set up AI code reviews as well / task rabbit etc.
 
-Tell the AI IDE what to produce, in order:
+Don't get off the intended target — **outcome divergence**.
 
-1. **User requirements**
-2. A **design document** derived from them
-3. **Implementation details** derived from both
+Speed over maintainability — what patterns are being created?
 
-Tools in this space: Spec-Kit, OpenSpec, BMad. Kiro's spec mode also works in a
-**brownfield** app. Use **EARS** (Easy Approach to Requirements Syntax) to go
-from requirements → design phase. Review the markdown, approve, then move to
-implementation — which can happen out of order. Create an MVP from the steps by
-taking a **vertical slice**, pedantically; keep it short and tight, and keep
-reviewing.
+History lesson — Alexa at AWS, Kiro, first as VS Code fork.
 
-## MCP and spec-driven development
+## Iterating on spec-driven development
 
-Isn't MCP dead? It's less hyped now — switching to CLIs is common — but it may
-still be valuable *for spec-driven development*:
+How do you do this stuff WITHOUT Kiro?
 
-- Specs can be **pulled from a project-management service**.
-- You can take an existing app/PoC and **reverse-engineer** a spec from it.
-- It will follow the rules set in your steering files.
+Tell the AI IDE what it should do:
 
-Close the loop with **property-based tests** that run as regression tests
-against the requirements: "take all these steps and create the few checks I can
-use to prove this works." Conceptually — does it work the way I expect?
+- include the following
+    - user requirements
+    - design document from that
+    - take both of those and create implementation details
+    - `Spec-kit` / `Open Spec` / `BMad`
+
+Can use Kiro spec mode in a brownfield application.
+
+**EARS** — Easy Approach to Requirements Syntax.
+
+```
+requirements -> design phase
+```
+
+Review the markdown, approve, move to implementation. Implementation phase can be out of order.
+
+Create an MVP from the steps — take a vertical slice, pedantically.
+
+- Keep it short and tight, continue to review.
+
+## MCP
+
+Isn't `MCP` dead? It's not as popular now… maybe still valuable for spec-driven development?
+
+Switching to CLIs is pretty common.
+
+```
+MCP <-> Spec Driven Development
+```
+
+- specs can be pulled from project management service
+- pulled from PM — take app/PoC and reverse-engineer it
+- will follow rules set forth in your steering files
+
+**Property-based tests** — testing to run regression tests against the requirements.
+
+"Take all these steps and create the four that I can use to prove that this works."
+
+Conceptually, does it work as I expect?

--- a/apps/cascadiajs2026-notes/content/talks/teaching-llms-new-tricks.md
+++ b/apps/cascadiajs2026-notes/content/talks/teaching-llms-new-tricks.md
@@ -1,17 +1,73 @@
-`Azoth` is an open-source library Marty built in winter 2023-24, shelved when AI hit, then revived in Nov 2025 — the AI era changed the math and brought it back. The lesson it taught him: you don't onboard an LLM to a new framework, you **subtract abstractions** until the model already knows the problem.
+`Azoth` — open source library.
 
-## The setup
+- Winter 2023–24: built it.
+- When AI hit: shelved it.
+- Nov 2025: AI changed the math, and brought back `Azoth`!
 
-Building a dashboard for a real estate brokerage on `Google Looker`, Marty needed a visually intensive component that wasn't in the "vending machine." Why not just write HTML and CSS? Because `JSX` is everywhere and the AI defaults to `React` — **same syntax, wrong semantics**. `Azoth` has no virtual DOM and controls rendering: `<p>Hello</p>` just returns a real `p` element.
+Creating a dashboard for a real estate brokerage — Google Looker — couldn't find the right thing in the "vending machine."
 
-## The wrong move
+Visually intensive components — just write HTML and CSS?
 
-The first instinct was to treat the new framework like a new framework — borrow an adjacent concept, "just use it a bit." It backfired: leaning on the incumbent's language confuses the LLM. So Marty wrote a "Don't say… / Say instead" map. But **describing your thing in the negative space of someone else's thing is still the wrong move** — *don't think about a pink elephant.*
+Combining a brokerage with a property developer.
 
-## The unlock: subtract
+Added integration analysis — high user touch.
 
-The real unlock is a shared mental model — a system metaphor you both hold, so you can talk about the thing AS IT IS. Don't onboard the LLM; **hire it as the new senior maintainer**, and they're curious about your tech. `Azoth`'s `JSX` is real DOM: it compiles HTML to a template, the JS creates no DOM, no factory function builds it — you add small, deduplicated binding helpers. What you opt INTO with `React`, you opt OUT of with `Azoth`. It accepts everything `JSX` already has — no proprietary primitives, just JS.
+`JSX` everywhere; the AI defaults to `React` — **same syntax, wrong semantics.**
 
-Notice the shape: **remove the abstraction.** Don't replace the vDOM; subtract it. Reduce everything to a DOM problem — a component is, literally, a constructor — and the LLM reaches for a tool that fits.
+`Azoth` — without vDOM, controlling renderer, no JS creating the DOM — `<p>Hello</p>` just returns a `p` tag!
 
-So prompts aren't engineering instructions; they're navigation. Push AWAY from what you're subtracting, pull TOWARD what you've unlocked. Two budgets matter now: **Context** (what you carry in) and **Corpus** (what's already in the model — spend it wisely). Subtract your abstractions, unlock the corpus.
+First instinct: treat the new framework like a new framework (take an adjacent concept); just use it a bit.
+
+**This backfired!** Use the language, then it confuses the LLM.
+
+## "Don't Say…, Say Instead" Map
+
+Don't confuse our innovation with the incumbent's.
+
+**Don't onboard the LLM: hire it as the new senior maintainer.**
+
+AND… they're curious about your tech!
+
+Shared mental model: a system metaphor that is shared; start a conversation.
+
+Don't describe in negative space against something else — talk about the thing as it is.
+
+## Azoth JSX is real DOM
+
+- What does it compile to? Doesn't interfere with JavaScript.
+- Takes the HTML and makes a template (the JS creates no DOM).
+- Doesn't use a factory function to make the DOM.
+- Add how to bind, small helper functions — deduplicated.
+
+Like the opposite of `React` — what you opt *into* with `React` you opt *out of* with `Azoth`.
+
+## Subtraction, not replacement
+
+Don't replace the vDOM, **subtract it.**
+
+The leap: closures and DOM — reduce to a DOM problem.
+
+`component = constructor`, literally.
+
+LLM, hey, **THIS IS DOM!** Reach for a tool that makes sense for the problem.
+
+`Azoth` basically accepts everything that `JSX` already has. No proprietary primitives, just JS.
+
+**Notice the shape** — this was the unlock. **REMOVE the abstraction.**
+
+New mapping is **SUBTRACT and unlock**, not "don't say, say this instead."
+
+## Prompts as Navigation
+
+Prompts aren't engineering instructions. **They're navigation.**
+
+Push away from what is being subtracted, and pull towards what's unlocked.
+
+Avoid NEGATION, like "Don't think about a pink elephant."
+
+## Law of AI Era Innovation
+
+- **Context** — what you carry into the conversation.
+- **Corpus** — what's already in the model — your budget! Be smart about this!
+
+**Subtract your abstractions, unlock the corpus.**

--- a/apps/cascadiajs2026-notes/content/talks/web-workers.md
+++ b/apps/cascadiajs2026-notes/content/talks/web-workers.md
@@ -1,45 +1,71 @@
-UX responsiveness is a workload problem. **Jank is a workload problem.** When
-the main thread is busy, the UI freezes — so move the heavy work off it.
+Keep the Main Thread Free with Web Workers
 
-## The mental model
+UX responsiveness
 
-The main thread is the **front desk**: clicks, paints, UI updates — and any
-heavy JS blocks the line. A worker is **not** a second UI; the main thread
-still owns the user experience. A worker thread is for plain data calculation:
-the main thread requests work, the worker returns a result.
+- `github.com/cyatteau`
+- `cascadiajs-2026-web-workers`
 
-## THREAD — the method
+**Feel the freeze, prove the blocker, move the work, add guardrails, use the pattern.**
 
-1. **Trigger** the stutter — reproduce the freeze.
-2. **Hunt** for the blocker — dev tools, code review, performance recording.
-3. **Relocate** the blocker — move it out of the UI thread.
-4. **Establish** the protocol for handing work to/from the worker.
-5. **Add** guardrails — progress, debounce, cancellation.
-6. **Decide** where the work belongs.
+**Jank is a workload problem.**
 
-## Trigger / hunt
+## Thread
 
-The demo: a heartbeat UI that freezes when a click kicks off an expensive task
-(sin/cos math over state data). Do a performance recording and you can see the
-JS work blocking the main thread.
+- Trigger the stutter
+- Hunt for the blocker (dev tools, code review)
+- Relocate the blocker to move it out of the UI
+- Establish the protocol for handling the blocker
+- Add progress / debounce / cancellation
+- Decide where the process belongs
+
+## Trigger / Hunt
+
+Heartbeat freezes — click causes expensive task (sin/cos maths on state data).
+
+CPU-heavy process in any case.
+
+Synthetic UI.
+
+Do a performance recording — see what's going on.
+
+JS work blocking main thread.
+
+**Mental model: the main thread is the front desk experience** — clicks, paints, UI updates, and **HEAVY JS** blocks the line at the front desk.
+
+A worker is **NOT a second UI** — main thread still owns the user experience.
+
+Worker thread is for plain data calculation.
+
+```
+main thread -> requests -> worker -> returns result
+```
 
 ## Relocate
 
-Offload the CPU-heavy work to a worker and the main thread is no longer
-UI-blocked.
+Move the work to a different thread.
 
-## Establish / guardrails
+Main thread blocked — offload to worker, and **no longer UI-blocked!**
 
-- **Make worker messages boring.** Boring is good when two threads talk — e.g.
-  `{ type, requestId, payload }`.
-- **Make requests cancellable.** A request can become stale; preempt when a new
-  message arrives by treating the latest message's `requestId` as the live one.
-- Add the usual usability guardrails: **debounce** (wait), **progress**
-  (inform), **cancel** (stop). For fast filters, ask whether the worker *can*
-  do the work — and whether it can do *only enough* of it.
+## Establish / Add Guardrails
+
+Make worker messages boring — **boring is good when two threads talk.**
+
+- e.g. `type`, `requestId`, `payload`
+
+Make cancellable — request becomes stale.
+
+Preemptive if there's a new message — take the latest message as the `requestId`.
+
+**Guardrails** — make this even more usable:
+
+- debouncing — wait
+- progress — inform
+- cancel — stop state
+
+Fast filters — worker filter flow. Can the worker do the work? Yes — and can it only do *enough* work.
 
 ## Decide
 
-Workers add complexity, so they're worth it for genuinely heavy computation —
-but **too heavy-handed for ordinary UI work.** Use the pattern where it earns
-its keep.
+Workers are more expensive in complexity.
+
+Too heavy for UI work.

--- a/apps/cascadiajs2026-notes/content/talks/wrong-abstraction.md
+++ b/apps/cascadiajs2026-notes/content/talks/wrong-abstraction.md
@@ -1,59 +1,110 @@
-A war story: a component starts simple and gets out of control. What went
-wrong, and what else could we have done?
+**Choosing the Wrong Abstraction (And What It Cost Us)**
 
-Material UI is fantastic *when you start*. Then you outgrow it — the migration
-path was Material UI → Base UI (components you can compose).
+A component that starts simple — and it gets out of control!
 
-## Programming interfaces are user interfaces
+What went wrong? What else could have been done?
 
-From Mike Bostock's 2016 essay *What Makes Software Good?*:
+`Material UI` — when you start, it's fantastic!
 
-> Programming interfaces are user interfaces. Programmers are people, too.
-
-- **Form must communicate function.**
-- Functions that take many arguments are not good functions.
-- `chart.js` vs. D3 is a **vending machine vs. a kitchen**.
-
-## Configuration vs. composition
-
-The "right" abstraction question is really config-type APIs vs. composable
-APIs. **Composable APIs are independent and stackable:**
-
-- **Independent** — each part does one thing well (select, find, extend; read,
-  filter, count). Lego blocks.
-- **Stackable** — the type of the input equals the type of the output, so they
-  stack. (cf. Fernando Rojo's *Composition Is All You Need*, React Universe
-  Conf 2025.)
-
-But composable APIs **aren't free.** Configuration cost is linear; composition
-is log(n) — and someone asks "isn't this a bit complex?" So **lower the cost of
-composition**: good docs, good idioms, sensible defaults, errors that teach,
-types, consistency, discoverability, examples.
-
-## The abstraction ladder
-
-Don't make developers spend all their time learning the Lego blocks. Provide a
-ladder:
-
-- **Lowest rung** — low-level code for constructing views.
-- **Higher rung** — a visual editor.
-
-You should be able to ascend or descend **without starting over**:
-
-```js
-const chart = Plot.plot()
-d3(chart) // descend the ladder to the lower-level primitive
+```
+Material UI -> Base UI
 ```
 
-Examples: D3 ↔ Plot, chart.js ↔ Observable Plot, shadcn → Base UI → HTML/CSS,
-Video.js (eject the skin to get the primitives). **Escape hatches are a config
-trap** — design the ladder instead.
+Components that can be composed.
 
-## "Can't we just vibe-code this?"
+2016 essay — Mike Bostock — *What Makes Software Good?*
 
-Per *Coding After Coders* (NYT Magazine): the Google CEO said devs are only ~10%
-faster, while a startup claimed 20×. The difference is **brownfield vs.
-greenfield.** Make code **AI-ready** — open for LLMs to read, understand, and
-improve. `decepulis/ax-bench` did better with a composable API. **Good DX is
-usually good AX.** And the right abstraction leads to smaller bundles (with
-tree-shaking, at least).
+**Programming interfaces are user interfaces. Programmers are people, too.**
+
+Form must communicate function.
+
+Functions that take many arguments are not good functions.
+
+`chart.js` vs `D3`
+
+```
+vending machine vs kitchen
+```
+
+## What IS the "right" abstraction?
+
+Configuration-type APIs vs composable APIs.
+
+**Composable APIs are INDEPENDENT and STACKABLE.**
+
+- **Independent** — each part does one thing well; `select`, `find`, `extend`; `read`, `filter`, `count`. Lego blocks.
+- **Stackable** — the type of the input == the type of the output — stackkkkkkk!!!
+
+*Composition is All You Need* — Fernando Rojo — 2025 React Universe Conf.
+
+"isn't this a bit complex?"
+
+**Composable APIs AREN'T FREE.**
+
+Configuration is linear, but composition is log(n).
+
+**Lower the cost of composition!**
+
+Why do we have the developers spend all their time learning the lego blocks?
+
+Lower the cost:
+
+- good docs
+- good idioms
+- defaults
+- errors that teach
+- types
+- consistency
+- discoverability
+- examples
+
+## Provide an abstraction ladder
+
+- lowest rung — low-level code for constructing views
+- higher rung — visual editor
+
+Gives a tradeoff of getting started quickly and getting more power.
+
+`D3` vs `Plot`
+
+`chart.js` vs `Observable Plot`
+
+You should be able to descend or ascend the ladder without having to start all over.
+
+```
+const chart = Plot.plot()
+d3(chart)   // now descending the ladder
+```
+
+```
+shadcn -> BaseUI -> HTML/CSS
+```
+
+## Can't we just vibe code this?
+
+*Coding After Coders* — NYT magazine.
+
+CEO of Google said devs only working 10% faster; startup is 20x?? Brownfield vs greenfield is the reason.
+
+**AI-ready** — open code for LLMs to read, understand, and improve.
+
+`decepulis/ax-bench` — did better with a composable API.
+
+**Good DX is USUALLY good AX.**
+
+```
+|—————————————-|
+CONFIG          COMPOSE
+defaults        options
+```
+
+Add ladder.
+
+Escape hatches are a config trap.
+
+`VideoJS`
+
+- swapping lego blocks
+- eject skin to get primitives
+
+The right abstraction leads to smaller bundles (for JS, with tree-shaking at least).

--- a/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/agent-swarms/index.html
@@ -21,46 +21,60 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Joel Hooks · Badass Courses · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>Capability is going exponential with Opus 4.5+, and the leverage point is no
-longer the model — it's the <strong>harness</strong>.</p>
+<p><strong>Agent swarms.</strong></p>
+<p>Going exponentially with Opus 4.5+.</p>
+<p><strong>Harness engineering is the state of the art.</strong></p>
 <pre><code>model | harness | context
 </code></pre>
-<p><strong>Harness engineering is the state of the art.</strong> The Claude Code architecture
-diagram is wild once you see everything it bundles: prompts, skills,
-directives, subagents, tools, bundled infra, orchestration logic, hooks,
-middleware, and observability (logs!).</p>
-<p>The takeaway in three words: <strong>own the tools.</strong> <code>opencode</code> gave us the
-opportunity to build our own.</p>
-<h2>Swarms</h2>
-<p>A swarm is <strong>multi-agent coordination to survive context death</strong> — when one
-agent's context fills up, the work survives across the swarm. Useful pattern:
-use the Socratic method to align intent and outcomes, plan, then fan out
-parallel agents.</p>
-<h2>Build a harness that makes you smile</h2>
+<p>The Claude Code arch diagram is wild.</p>
+<p>Harness includes:</p>
 <ul>
-<li><code>SOUL.md</code> — give the agent a personality and an icon. Your harness should
-make you smile.</li>
-<li>There's another harness called <strong>Pi</strong> whose workflow implementation is much
-better than the default. Pi <strong>updates itself</strong> — it reads its own source code
-to add capabilities. Out of the box it's intentionally not featureful.</li>
-<li>Pi subagents run in parallel and chains — a great extension for swarm-style
-work.</li>
-<li><code>pi-cmux</code> — a terminal replacement built on Ghostty, managed by a Pi
-extension.</li>
-<li><code>pi-notes</code> — HTML is <em>not</em> better than markdown; notes should be human
-readable but also agent readable. (<code>mdsvex</code> is the Svelte take on MDX.)</li>
-<li><code>pi-feedback</code> — a support inbox: the last turn of a session sends a diff to
-process feedback. With a lot of users you get a lot of support tickets, so a
-feedback tool that improves the automated support over many turns pays off.</li>
+<li>prompts, skills, directives, subagent</li>
+<li>tools, bundled infra, orchestration logic</li>
+<li>hooks, middleware, observability — logs!</li>
 </ul>
-<p>A recurring theme: <strong>slow down.</strong> Don't do everything, and don't do it quickly
-(cf. <em>Slow Productivity</em>).</p>
-<h2>Worth following</h2>
-<p>Cloudflare Durable Objects for state. Sunil Pai (something called "Think").
-Dillon Mulroy on artifacts, memory, and primitives. Addy Osmani's <strong>"The
-Orchestration Tax"</strong> — cognitive bandwidth is <em>not</em> parallelizable. Agent swarms
-are genuinely hard; the real skill is building systems that can pull any and
-all threads through the context limit.</p>
+<p><strong>Own the tools.</strong></p>
+<p><code>opencode</code> — gave us the opportunity to build.</p>
+<p><strong>Swarm</strong> — multi-agent coordination to survive context death.</p>
+<ul>
+<li>Socratic method to align intent/outcomes</li>
+<li>plan</li>
+<li>parallel agent</li>
+</ul>
+<p>Anthropic nerfed <code>opencode</code>.</p>
+<p>AI Skills — Matt Pocock — <code>mattpocock/skills</code></p>
+<p><strong>OpenClaw!</strong></p>
+<p><code>SOUL.md</code> — give the agent personality, an icon.</p>
+<p>Your harness should make you smile.</p>
+<h2>Pi</h2>
+<p>Other thing: agent harness called <code>Pi</code>.</p>
+<p>Workflow in <code>Pi</code> is better than Claude Code's garbage implementation.</p>
+<p>Follow Mario on X.</p>
+<p><strong>Slow the F</strong>* Down** — don't do everything, and don't do it quickly. (<em>Slow Productivity</em>)</p>
+<p><code>Pi</code> will update itself; it will read its own source code to add stuff. Out of the box is not featureful.</p>
+<p>Nico Bailon — <code>Pi</code> stuff — <code>Pi</code> subagents.</p>
+<ul>
+<li>run parallel and chains — great extension to get swarm</li>
+</ul>
+<p><code>pi-cmux</code> — replacement for Terminal/Ghostty, but built on Ghostty. <code>Pi</code> extension to manage it.</p>
+<p><code>Pi</code> — modify yourself to be better.</p>
+<p><code>pi-notes</code> — Thariq — HTML is not better than markdown.</p>
+<p><code>mdsvx</code> — Svelte version of MDX (which is what?).</p>
+<p>Human readable, but the agent can read it as well.</p>
+<p><code>wzzrd.sh</code> — notes to share with the team.</p>
+<p><strong>Second brain</strong> — better notes.</p>
+<p><code>pi-feedback</code> — support inbox, last turn of the session, sends diff to process the feedback for the session.</p>
+<p><strong>Key metrics</strong> — having a lot of users will lead to a lot of support tickets.</p>
+<p>Feedback tool to improve the automated support, lots of turns.</p>
+<h2>Swarms in the wild</h2>
+<p><code>agentdungeon.ai</code> — agents playing DnD, one is the DM, and the other agents work and collaborate.</p>
+<p>Cloudflare — Durable Objects — state.</p>
+<p>Sunil Pai — follow recommendation. Something called Think.</p>
+<p>Dillon Mulroy — artifacts — memory, primitives.</p>
+<p><strong>Agent swarms are hard, it's true.</strong></p>
+<p>Addy Osmani — The Orchestration Tax.</p>
+<p><strong>Cognitive bandwidth is not parallelizable.</strong></p>
+<p>The real skill is building the systems that can pull any and all of the threads of the system and context limit.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/ai-to-learn/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/ai-to-learn/index.html
@@ -21,34 +21,29 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Daniel Mendoza · Storyblok · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>A talk about using AI to <em>learn</em>, with an honest framing about mental health and
-expectations.</p>
-<h2>The expectation gap</h2>
-<p>We expect ~20% faster. In real tasks, one study found developers were <strong>19%
-slower</strong>. The boost is unevenly distributed: <strong>less experienced devs got the
-boost; more experienced devs got the fuzzy end of the lollipop.</strong> AI is a skill
-to be learned — treat it as risk management, and as the ultimate rubber duck.</p>
-<h2>A learning loop</h2>
-<p>Apply it deliberately:</p>
+<p>mental health</p>
+<p><strong>How to use AI to learn.</strong></p>
+<p>Expectation — productivity 20% faster; <strong>19% slower</strong> though in real tasks.</p>
+<p>Less experienced devs got the boost, more experienced devs got the fuzzy end of the lollipop.</p>
+<p>Risk management — AI is a skill to be learned, the ultimate rubber ducky.</p>
+<h2>How do we apply it with the learning loop?</h2>
 <ul>
-<li><strong>Translate</strong> from something you know to the new subject. Provide context,
-then ask for the <em>differences</em> so you learn the delta.</li>
-<li>Always ask <strong>why</strong> and <strong>how</strong> — not just what.</li>
-<li>Ask Claude to create an <strong>easily digestible diagram</strong>.</li>
-<li>Ask for an <strong>example based on an example</strong> you already understand.</li>
-<li><strong>Acknowledge when AI is moving too fast</strong> and ask clarifying questions.</li>
-<li>Have it <strong>generate quiz questions</strong> to test your knowledge, then get help
-filling the gaps.</li>
-<li>Have a <strong>Socratic conversation</strong>.</li>
-<li><strong>Simulate debugging</strong> to practice.</li>
-<li>Use the <strong>Feynman Technique</strong>: explain what you've learned and check whether
-the explanation matches reality.</li>
+<li>Translate from something you know to the new subject.</li>
+<li>Provide context! Get back the differences to learn.</li>
 </ul>
-<p><strong>Develop skills as you go</strong> — do it once, then turn it into a reusable "tutor"
-skill you can apply on demand.</p>
-<h2>Pair programming with AI</h2>
-<p>Ask: what can we <strong>translate</strong>, and what do we need to <strong>rethink and rewrite</strong>?
-<strong>Refactor together</strong>, then apply what you learned on your own.</p>
+<p><strong>Why and how?</strong></p>
+<ul>
+<li>Ask <code>Claude</code> to create an easily digestible diagram.</li>
+<li>Ask <code>Claude</code> to provide an example based on an example.</li>
+<li>Make sure you acknowledge when AI is moving too fast, ask clarifying questions.</li>
+<li>Ask <code>Claude</code> to generate quiz questions to test our knowledge, and then get help to fill the gaps.</li>
+<li>Have a socratic conversation.</li>
+<li>Simulate debugging.</li>
+</ul>
+<p><strong>Feynman Technique</strong> — explain what you've learned, and see if that matches reality.</p>
+<p>Develop skills as you go — do it once, and then reuse the tutor skill to apply it randomly and as required.</p>
+<p>Peer programming — what can we translate, and what do we need to rethink and rewrite?</p>
+<p><strong>Refactor together</strong> — and then apply what you learn.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/atproto-apps/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/atproto-apps/index.html
@@ -21,15 +21,50 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Brittany Ellich · Bluesky · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>Brittany hosts the Overcommitted podcast (<code>brittanyellich.com</code>). Her pitch: open social isn't a dream — <code>ATProto</code> is what it looks like when it actually works, and the whole thing turns on owning your own data.</p>
-<h2>How did we get here?</h2>
-<p>The typical platform timeline — <strong>launch, growth, monetize, maximize</strong> (see the book <em>Enshittification</em>). Big app platforms weaponize design to trap you: A/B testing, infinite scroll, pull-to-refresh. People stay despite all of it because the apps are hard to leave — they own your data, and they can leave <em>without</em> you (RIP Google+). They exist to maximize revenue, not to connect people.</p>
-<h2>What is ATProto?</h2>
-<p>The "Atmosphere" does for data what open source did for code. <strong>If an app does something you don't like, you can just leave</strong> — your content and your people come with you. Which forces apps to actually be <em>good</em> to keep you.</p>
-<h2>How does it work?</h2>
-<p>Each user gets their own <strong>repo</strong> where their data lives. Sign in and you get a repo plus a <code>DID</code> — a Decentralized ID — and a handle, where handles are DNS records. The repo holds <strong>records</strong> (a piece of JSON, a bit of data) and <strong>blobs</strong> (binaries). Anyone can build their own thing to render content; it doesn't live in <code>Bluesky</code>, the user is in charge. <code>Blacksky</code> is an alternative to Bluesky; <code>Witchsky</code> adds badges and pronouns with a different representation; <code>Anisota</code> is a simplified view.</p>
+<p>Podcast host of <em>Overcommitted</em>.</p>
+<p><code>brittanyellich.com</code></p>
+<h2>How We Got Here</h2>
+<p>The early internet —</p>
+<p>Typical timeline for platforms: <strong>launch, growth, monetize, maximize.</strong></p>
+<p><em>Enshittification</em> book reference.</p>
+<p>Large app platforms use design to trap users — A/B testing, infinite scroll, pull to refresh.</p>
+<p>Many large app platforms continue to exist despite this — <strong>they're hard to leave!</strong> They exist to maximize revenue, not connect people.</p>
+<p>It's hard to leave a platform when they own your data; it may leave without you as well (like Google+).</p>
+<h2>What Is ATproto</h2>
+<p>The Atmosphere — <strong>does for data what open source did for code.</strong></p>
+<p>Apps have to be good to keep people using them!</p>
+<p>If an app is doing something you don't like, you can just leave without losing anything — data, content, and people are yours to take with you.</p>
+<h2>How Does It Work</h2>
+<p>Each user gets their own repo where their data is stored; when they sign in, they get a repo, and a <code>DID</code>.</p>
+<ul>
+<li><strong><code>DID</code></strong> — Decentralized ID</li>
+<li>User gets a handle</li>
+<li>Handles are DNS records</li>
+</ul>
+<p>What lives in repo?</p>
+<ul>
+<li><strong>record</strong> — a piece of JSON, a bit of data</li>
+<li><strong>blob</strong> — binaries</li>
+</ul>
+<p>People can make their own thing to render content — it doesn't live in Bluesky. <strong>The user is in charge.</strong></p>
+<ul>
+<li><code>blacksky</code> — an alternative to Bluesky</li>
+<li><code>witchsky</code> — another; adds badges/pronouns, different representation</li>
+<li><code>anisota</code> — simplified view</li>
+</ul>
 <h2>Exploring the Atmosphere</h2>
-<p>And you don't have to worry about auth anymore. <code>ATStore</code> (<code>atstore.fyi</code>) is a compendium of registered ATProto apps: <code>Sifa.id</code> (professional identity network), <code>Streamplace</code> (open-source livestreaming for video), <code>rpg.actor</code> (make an RPG character), <code>atmo.quest</code> (connect with folks at events). Get your stuff out easily, to multiple destinations. This is what open social looks like when it actually works.</p>
+<p><strong>Don't have to worry about auth anymore!?</strong></p>
+<p><code>ATStore</code> — compendium of registered ATproto apps — <code>atstore.fyi</code></p>
+<ul>
+<li><code>Sifa.id</code> — professional identity network</li>
+<li><code>Streamplace</code> — open source livestreaming app for video and live-streaming</li>
+</ul>
+<p>Get things out easily to multiple destinations.</p>
+<ul>
+<li><code>rpg.actor</code> — create an RPG character</li>
+<li><code>atmo.quest</code> — connect with folks at events</li>
+</ul>
+<p><strong>This is what open social looks like when it actually works.</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/beowulf-stroganoff/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/beowulf-stroganoff/index.html
@@ -21,12 +21,23 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Molly Jean Bennett · Grow Therapy · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>Ancient times — 2022 — <code>DALL-E mini</code>. "AGI" was never a useful term anyway. The phrase that actually sticks is from the OpenAI charter: <strong>"economically valuable work."</strong> And the flip side of optimizing for it is the flattening of culture that follows.</p>
-<p>So the mischievous question: what would happen if we made language models <strong>bad</strong>?</p>
-<h2>Training something useless on purpose</h2>
-<p><strong><code>LoRA</code></strong> — Low-Rank Adaptation — lets you keep the base model frozen and train a little something on top. The v2 recipe: feed in a big text file of inspirational quotes and slogans.</p>
-<p>Is the result better than a programmatic randomizer? <strong>Yes.</strong> Is it useful for creative purposes? <strong>No.</strong></p>
-<p>The point lands anyway: <strong>protect your joy.</strong> Make bad things!</p>
+<p>Ancient times: 2022.</p>
+<p><strong>Dall-E mini!</strong></p>
+<p><strong>AGI</strong> not a useful term.</p>
+<p>"economically valuable work" — from the OpenAI charter.</p>
+<p>Flattening culture.</p>
+<p>What would happen if we made language models <strong>BAD</strong>?</p>
+<p><code>LoRA</code> — Low-Rank Adaptation — keep the base frozen and train on top of it.</p>
+<p>v2 — add a big text file of inspirational quotes and slogans.</p>
+<p>Better than a programmatic randomizer?</p>
+<ul>
+<li>yes</li>
+</ul>
+<p>Useful for creative purposes?</p>
+<ul>
+<li>no</li>
+</ul>
+<p><strong>Protect your joy. Make bad things!</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/biilman-agent-experience/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/biilman-agent-experience/index.html
@@ -21,49 +21,62 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Matt Biilman · Netlify · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>The progression is real: co-pilot → AI agent → AI assistance. We're moving
-from autocomplete toward genuine autonomy, and it changes the economics of
-building software.</p>
-<p><strong>Build vs. buy has flipped.</strong> Things that weren't viable to build before are
-now in reach — even whole HR systems. The SaaS budget is being replaced with a
-dev budget. Autonomous coding agents (e.g. <strong>openclaw.ai</strong>) are still early;
-one fun pattern is repurposing an old laptop as the host for one.</p>
-<p>The analogy that stuck: autonomous cars made us rethink cities; autonomous
-agents make us rethink programming and systems. <strong>Software is now read/write
-for everyone.</strong></p>
-<h2>Chapter II: AX (Agent Experience)</h2>
-<p>Build tools for the people that build tools.</p>
+<p><strong>AI autonomy:</strong></p>
+<pre><code>co-pilot -&gt; AI agent -&gt; AI assistance -&gt;
+</code></pre>
+<p><strong>Build vs. buy has changed</strong> — things that weren't viable before now are. Even whole HR systems.</p>
+<p>The SaaS budget is replaced with a dev budget.</p>
 <ul>
-<li><strong>UX</strong> differentiates products from competitors.</li>
-<li><strong>DX</strong> differentiates platforms.</li>
-<li><strong>AX</strong> differentiates platforms <em>and</em> products.</li>
+<li><code>openclaw.ai</code> — autonomous coding agents, still early.</li>
+<li>Repurpose an old laptop as the host for it.</li>
 </ul>
-<p>The question: what experience do agents have with your tools and products? AX
-is <strong>not</strong> a single feature or protocol — and it's definitely not "just MCP."</p>
-<h2>The four pillars</h2>
-<p><strong>Access</strong> — can agents reach the product at all? <code>netlify.ai</code> is built for
-humans <em>and</em> agents; the database is "batteries included" and available to
-agents directly. Emerging standards matter here too — e.g. WorkOS exploring
-self-authenticating identity for AI agents.</p>
-<p><strong>Context</strong> — does the agent understand the product? Optimize for agent
-consumption: prefer plain text / markdown, negotiate content types. <strong>MCP is UI
-for LLMs</strong> — context is the most important piece. Expose what the agent can act
-on, and steer it.</p>
-<p><strong>Tools</strong> — agents will use your product <em>even if you provide no tools</em>. Every
-product <strong>already has an agent experience</strong> — the only question is whether it's
-good or bad. A CLI is often great DX but bad AX (interactive prompts are
-terrible for agents). API vs. MCP is the same product, different surfaces —
-naively shifting an entire API to MCP overwhelms the context window, so limit
-to a handful of tools. Provide <strong>prompt escape hatches</strong>.</p>
-<p><strong>Orchestration</strong> — can agents do real work? Linear and Notion let you kick off
-longer-running tasks. Nobody wants another chat bot; orchestration lets people
-use tools they're <em>already</em> comfortable with. Agent runners execute in a
-sandbox so they can <strong>actually do the thing</strong> — async agents. The goal: make the
-whole team <strong>builders</strong>.</p>
-<h2>Measuring it</h2>
-<p><strong>Evals</strong> are how you measure agent experience — <code>axis.run</code> actually tries to
-onboard against your product and measure the AX. As this gets more abstract, it
-also gets more required.</p>
+<p>Autonomous cars make us rethink cities; autonomous agents make us rethink programming and systems.</p>
+<p><strong>Software is now read/write for everyone.</strong></p>
+<h2>Chapter II: AX (Agent Experience)</h2>
+<p>Build tools for people that build tools.</p>
+<ul>
+<li><strong>UX</strong> — differentiates products from competitors</li>
+<li><strong>DX</strong> — differentiates platforms</li>
+<li><strong>AX</strong> — differentiates platforms <em>and</em> products</li>
+</ul>
+<p>What experience do agents have with tools and products?</p>
+<p>So… how do we do it?</p>
+<p>Not a feature or a protocol, and definitely not just <code>MCP</code>.</p>
+<p><strong>AX in practice:</strong></p>
+<ul>
+<li><strong>Access</strong> — can they access the product?</li>
+<li><strong>Context</strong> — does it know about it and understand?</li>
+<li><strong>Tools</strong> — work with it?</li>
+<li><strong>Orchestration</strong> — can agents do work with the product?</li>
+</ul>
+<h2>Pillar: Access</h2>
+<p><code>netlify.ai</code> — for humans and agents.</p>
+<ul>
+<li>Launch partners — payments, things to do with the thing.</li>
+<li>Netlify database — available to agents as batteries included.</li>
+</ul>
+<p>Emerging standards — <code>workos</code> — self-authenticating UUID for AI agents.</p>
+<h2>Pillar: Context</h2>
+<p>Optimize for agent optimization.</p>
+<p>Prefer plain text? Markdown? Negotiations about the content type.</p>
+<p><code>MCP</code> is UI for LLMs — context is the most important piece; expose what the agent can do now. Steering context.</p>
+<p><strong>API vs. MCP</strong> — same product, different surfaces.</p>
+<p>Just shifting from API to MCP will overwhelm context — limit to a handful of tools.</p>
+<h2>Pillar: Tools</h2>
+<p>Agents will still use your product even if you don't provide tools.</p>
+<p><strong>Every product ALREADY has an agent experience</strong> — is it GOOD or BAD?</p>
+<p>A CLI is often a great DX, but a bad AX — like, interactive stuff sucks for AX.</p>
+<p><strong>Churn churn churn.</strong></p>
+<p>Provide prompt escape hatches for AX.</p>
+<h2>Pillar: Orchestration</h2>
+<p><code>Linear</code>, <code>Notion</code> — kick off longer-running tasks.</p>
+<p>Chat bot — no one wants to use it; but orchestration lets people use the tools they are already familiar and comfortable with.</p>
+<p>Agent runners — run in sandbox.</p>
+<p><strong>Actually do the thing — async agents!!</strong></p>
+<p><strong>Make the whole team BUILDERS</strong> — our teammates across the business need to be able to build.</p>
+<p>More abstract, and more required.</p>
+<h2>Evals — measuring agent experience</h2>
+<p><code>axis.run</code> — actually measure the AX — try to onboard.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/choosing-typescript/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/choosing-typescript/index.html
@@ -21,17 +21,77 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Filip Sodić · Wasp · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>Keep choosing TypeScript — it matters more than ever. LLM output is <strong>not</strong> "the new machine code"; you should still learn a language well, and <code>TypeScript</code> is the perfect choice.</p>
-<h2>Why the language layer still matters</h2>
-<p>Look at the world we built for agents: a tower of abstractions. <code>0/1</code> at the bottom, then <code>ASM</code>, then compilers down to <code>C</code>, then <code>TS</code>/<code>Go</code>/<code>Python</code>, then frameworks, then applications. We've spent most of our time in the language layer. People who dabble in predictions imagine squashing the lower languages — even the high-level ones. The truth sits in the middle, between "languages become irrelevant" and "English is a programming language." <strong>English is not a good programming language</strong> (per Paul Graham). If the prediction held, we'd be committing prompts instead of code — and we're not, yet.</p>
-<h2>Why TypeScript specifically</h2>
-<p>Software engineering is <strong>compression</strong> — the time spent compressing personal context. Picture nested, overlapping concepts where <code>MEMORY</code> is the outsized layer:</p>
+<p><strong>Keep choosing TypeScript</strong> — it matters more than ever.</p>
+<p><strong>LLM output is not "new machine code."</strong>
+You should learn a language well, and TS is the perfect choice.</p>
+<h2>Why should we care about the language?</h2>
+<p>Consider the world we have built for the agents: a tower of abstractions, <code>0</code>/<code>1</code> at the bottom, climb the tower —</p>
+<pre><code>ASM, compilers -&gt; C, TS/Go/Python -&gt; frameworks -&gt; applications
+</code></pre>
+<p>We spent most of our time in the language layer in years past.</p>
+<p>People who dabble in predictions — where will they land? Squash lower lower languages, including high-level languages.</p>
+<p>The truth is in the middle: between irrelevancy and English being a programming language.</p>
+<p><strong>English is not a good programming language.</strong></p>
+<p>Paul Graham — "… writing in a language…"</p>
+<p>We wouldn't be committing code, we would be committing prompts (and we're not, yet).</p>
+<ul>
+<li><code>WASP</code> — framework</li>
+</ul>
+<h2>Why TypeScript?</h2>
+<p><strong>Software engineering is compression</strong> — time to compress personal context.</p>
 <pre><code>types -&gt; code -&gt; docs -&gt; memory
 </code></pre>
-<p>Shoot first, ask questions later — code is cheap, right? Imagine there's no TypeScript. <strong>Plan A: documentation.</strong> But docs aren't the harness — non-deterministic, no guarantee they match reality; you've just moved memory into docs. <strong>Plan B: tests.</strong> You move some memory into code via coverage and case exhaustion plus the happy path — but you reduce entropy by adding <em>more</em> code, and tests still expect you and the agent to generalize. Pile on tests if you want to throw off 100k lines a day.</p>
-<h2>Start with the types</h2>
-<p><strong>Then: types.</strong> Move context out of memory and code and into types — if <em>you</em> know something, the types should know it too. A prompt is just a specification written in English; step back and define the type <strong>manually</strong>. That's more precise. Fred Brooks: <em>"Show me your flowcharts and conceal your tables…"</em> Reach for the right type and you compress memory <em>and</em> preserve context — discover the domain <em>while</em> you build the model. (<code>GrillMe</code> is a skill for refining domain modeling.)</p>
-<p>He considered branded types, result types, exhaustiveness, smart constructors, edge type safety — and kept it simpler. <code>Rust</code> can do all this and more — maybe more than we need. Meanwhile <code>TS</code> keeps evolving: rewritten in <code>Go</code>, better errors, legacy baggage shed, still the most popular language.</p>
+<p>(overlapping nested concepts)</p>
+<p><strong>MEMORY is outsized in space.</strong></p>
+<p>Shoot first, ask questions later?
+Code is cheap? Right?</p>
+<p>Imagine there is no TypeScript; what's reasonable as far as compressing complexity?</p>
+<p>Did we answer our domain questions? <strong>NO!</strong> Where are the limits, and so on.
+So we didn't compress memory into types.</p>
+<p>So, hey! Let's add documentation!
+We just moved some of our memory to docs.</p>
+<p><strong>Docs are not the harness.</strong>
+Docs are not deterministic, and there is no guarantee that docs match reality.</p>
+<h2>Plan B: Tests</h2>
+<p>We can move some memory into code with test coverage and case exhaustion, and add happy path.</p>
+<p>Just use JS, not TS, and add a bunch of tests if you want to throw off 100k lines of code a day 🤑</p>
+<ul>
+<li>Reduce entropy by adding extra code.</li>
+<li>Tests expect us <em>and</em> the agent to generalize.</li>
+</ul>
+<h2>Types</h2>
+<p><strong>Move context from memory and code to Types.</strong>
+Encode information into the type.</p>
+<p>In the naive case, we still don't answer constraint-related questions.</p>
+<p><strong>If you know something, the types should know it as well!</strong></p>
+<h2>What if we start with the questions? With the Types?</h2>
+<p>Fred Brooks: "Show me your flowcharts and conceal your tables, and I shall continue to be mystified. Show me your tables, and I won't usually need your flowcharts; they'll be obvious."</p>
+<p>We could define what we want in a prompt, which is basically a specification.</p>
+<p>We should instead take a step back and define our type <strong>MANUALLY</strong>. That's better than using English; it's more precise.</p>
+<ul>
+<li>
+<p>We can compress our memory AND preserve context by reaching for the right type.</p>
+</li>
+<li>
+<p>Think about the questions related to our domain, and then define the appropriate types.</p>
+</li>
+<li>
+<p>Discover the domain WHILE building the model.</p>
+</li>
+<li>
+<p><code>GrillMe</code> — skill to help refine domain modeling.</p>
+</li>
+</ul>
+<p>He thought about talking about "branded types", result types, ensuring exhaustiveness, smart constructors, edge type safety — decided to make it simpler.</p>
+<p><code>Rust</code> can do all of this, and other stuff; it may do stuff we don't need.</p>
+<h2>TypeScript continues to evolve</h2>
+<ul>
+<li>modern and safer</li>
+<li>rewritten in Go</li>
+<li>better errors</li>
+<li>most popular language</li>
+<li>removed legacy baggage</li>
+</ul>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/design-tokens/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/design-tokens/index.html
@@ -21,16 +21,41 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Kaelig Deloumeau-Prigent · Design Tokens W3C CG · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>Design is not what ends up getting built. You've got <code>default</code>, <code>primary</code>, <code>special</code> — add <code>primary</code>/<code>muted</code> — and then you tell the agent "use the design system, don't make mistakes." Easier said than done.</p>
-<h2>Not everything belongs in a design system</h2>
-<p>Bind some complicated one-off edge case to every implementation and you've made a mess — too many decisions packed into each component. And every target needs a different language to consume the design system. So: <strong>give the decisions names, give the names values, and give them instructions.</strong> That's a single source of truth for branded targets — design tokens.</p>
-<p>The <strong>Design Tokens Format Module</strong> captures each design decision as a token in JSON, then defines relationships so you can swap values when you want. Lots of tooling already supports the spec — <code>Figma</code>, <code>Sketch</code>, <code>Penpot</code>, and more — coordinated by the <strong>Design Tokens Community Group</strong>.</p>
-<h2>Teaching agents to follow them</h2>
-<p>But how do we teach <em>agents</em> to follow them? Create skills, MCPs, hooks, plugins, CLIs; train a model on your design system and tokens. The loop:</p>
-<pre><code>find tokens (PLAN) --&gt; code (VERIFY, e.g. lint) --&gt; validate the suggestion
+<p><strong>Design.. not what ends up getting built!</strong></p>
+<ul>
+<li><code>default</code>, <code>primary</code>, <code>special</code></li>
+<li>add <code>primary</code> / <code>muted</code></li>
+</ul>
+<blockquote>
+<p>Hey agent! Use the design system, don't make mistakes</p>
+</blockquote>
+<p>Not everything needs to be in a design system though — some complicated thing that's a one-off, we've just bound an extreme edge case to every implementation.</p>
+<p><strong>Too many decisions in each component!</strong></p>
+<p>All of the different targets need a different language to use the design system.</p>
+<ul>
+<li>give them names</li>
+<li>then give them values</li>
+<li>and give them instructions</li>
+</ul>
+<p><strong>Single source-of-truth</strong> for getting branded targets.</p>
+<h2>Design Tokens</h2>
+<ul>
+<li>Design Tokens Form Module — capture design decision in the design token, in JSON files</li>
+<li>then define relationships, swap them when we want</li>
+</ul>
+<p>Lots of tooling that supports the spec, including <code>Figma</code>, <code>Sketch</code>, <code>penpot</code>, and so on.</p>
+<p>Design Tokens Community Group</p>
+<h2>Teaching Agents</h2>
+<p>How do we teach agents to follow these though?</p>
+<p>Create skills! <code>MCP</code>s! hooks! plugins! <code>CLI</code>s! train a model on your design system and tokens.</p>
+<pre><code>find tokens - PLAN
+code       - VERIFY (lint)
+validate suggestion
 </code></pre>
-<p>A lot of teams are investing in getting agents to follow design tokens — and there's little-to-no design-token tooling aimed at AIs yet.</p>
-<p>Join the fight against UI slop. <code>designtokens.org</code>.</p>
+<p>A lot of teams are investing time in getting agents to follow design tokens.</p>
+<p>No to little design-token tooling for AIs.</p>
+<p><strong>Join the fight against UI slop!!</strong></p>
+<p><code>designtokens.org</code></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/hidden-connections-graphs/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/hidden-connections-graphs/index.html
@@ -21,14 +21,57 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Nyah Macklin · Neo4j · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>You fetch from two API endpoints, loop and merge by <code>id</code> — and it breaks because the <code>id</code>s don't match. A connection you wired by hand, mismatched. Now agents are making decisions about <strong>people</strong>, and if the guess is wrong we find out later, in a war room or a post-mortem.</p>
-<h2>The implicit connection</h2>
-<p>The worked example: Jessica works at Apex Global, which sits on the sanctions watchlist. She requests a $25k credit-line increase, and the agent <strong>approves</strong> it. Every fact was present — but the answer is still wrong, because the connection was <em>implicit</em>, not explicit. MIT reports <strong>95% of organizations</strong> see no measurable return from AI: there's no place to keep the context, no proof of work, the connection piece is missed.</p>
-<h2>Knowledge graphs</h2>
-<p>To beat AI's black-box problem, knowledge has to be transparent. Picture three views of an apple — visual, vector, and knowledge-graph. Only the knowledge-graph view is legible to <strong>both</strong> humans and AI: you see the connections and can ask <em>one hop, or more than one?</em></p>
-<p>A <strong>knowledge graph</strong> is an organized, visual representation of relationships between entities — a property graph of nodes, relationships, and properties. Compare a 4-hop compliance check in <code>Cypher</code> to the <code>SQL</code> equivalent and the difference is stark. Text similarity finds documents with similar <em>meaning</em>; <strong>structural</strong> similarity finds entities with similar <em>connections</em> — and almost nobody is building the second one.</p>
-<h2>Context graphs record <em>why</em></h2>
-<p>The newer idea (Dec 2025): the <strong>context graph</strong>, or <code>graph RAG</code> — it traces the decision that was made. Both surface the decision <strong>path</strong>; the context graph supplies the missing "why" plain memory lacks. An audit log records <em>what</em>; a context graph records <em>why</em>. The pitch: cut down hallucinations and force agents to show their work by walking a causal chain — from "I have no idea" to full visibility. Learn more at Neo4j GraphAcademy.</p>
+<p>Fetching from two API endpoints, loop and merge by id — but it breaks because the ids don't match.</p>
+<p>The connection we wired by hand — and mismatched.</p>
+<p>Now agents are making decisions about people. If the guess is wrong, we find out later in a warroom / post-mortem.</p>
+<p>Jessica works at Apex Global — on the sanctions watchlist.</p>
+<ul>
+<li>Jessica requests a $25k credit line increase.</li>
+<li>The agent <strong>APPROVES!</strong></li>
+</ul>
+<p>Every fact was there, but the answer is still wrong. The connection was <strong>IMPLICIT, not EXPLICIT.</strong></p>
+<p><strong>MIT</strong> — 95% of organizations report no measurable return.</p>
+<ul>
+<li>No place to keep the context.</li>
+<li>No proof of work.</li>
+<li>Miss the connection piece.</li>
+</ul>
+<p>To overcome AI's black box problem, we need knowledge to be transparent.</p>
+<p>Visual view of apple, vector view of apple, knowledge graph of an apple.</p>
+<p>Knowledge graph view can be understood by human and AI.</p>
+<ul>
+<li>Find the connections.</li>
+<li>One hop? Or more than one hop?</li>
+</ul>
+<h2>Knowledge Graphs</h2>
+<p>Organized / visual representation of relationships between entities.</p>
+<p><strong>Property graph</strong> — nodes, relationships, properties.</p>
+<p>Example <code>Cypher</code> query for a 4-hop compliance check vs. the <code>SQL</code> example.</p>
+<h2>Similarity</h2>
+<ul>
+<li><strong>Text similarity</strong> — documents with similar meaning.</li>
+<li><strong>Structural similarity</strong> — finds entities with similar connections.</li>
+</ul>
+<p>Almost nobody is building the second one.</p>
+<h2>Context Graph</h2>
+<p><strong>Context graph</strong> — graph RAG.</p>
+<p>Relatively new (Dec 2025).</p>
+<p>Contextual difference — tracing the decision that was made.</p>
+<p>Both context graph and knowledge graph find the decision path.</p>
+<p>The missing "why" — no memory.</p>
+<p>Traditional audit log vs. context graph.</p>
+<ul>
+<li>Records vs. why.</li>
+</ul>
+<h2>Where to Learn More?</h2>
+<ul>
+<li>1 — Build a system that cuts down on hallucinations.</li>
+<li>2 — Force the agents to show their work — force them to walk a causal chain.</li>
+</ul>
+<p><code>neo4j</code> Graph Academy</p>
+<p><code>graphacademy.neo4j.com</code></p>
+<pre><code>You: "I have no idea" -&gt; full visibility
+</code></pre>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/human-in-the-loop/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/human-in-the-loop/index.html
@@ -21,15 +21,25 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Michael Liendo · Auth0 · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>How do we get safety from agents? Put a human in the loop — because agents aren't just answering questions anymore, they're taking actions. Three patterns, ordered by stakes.</p>
+<p>How do we get safety from agents? <strong>Put a human in the loop.</strong></p>
+<p>Agents aren't just answering questions anymore.</p>
 <h2>Pattern 1: Interrupt</h2>
-<p>A mid-task pause — the agent asks, the human answers, the agent continues. Low stakes, synchronous, <strong>one function call</strong>.</p>
+<ul>
+<li>Mid-task pause — agent asks, human answers, agent continues.</li>
+<li>Low stakes, sync, one function call.</li>
+</ul>
 <h2>Pattern 2: Token Vault</h2>
-<p>The agent hits a wall, you authorize it, and it succeeds on retry. The demo runs both patterns in one flow: hand out a <strong>short-lived token scoped ONLY to what's needed</strong>.</p>
+<ul>
+<li>Agent hits a wall, you auth it, agent succeeds on retry.</li>
+</ul>
+<p><strong>DEMO:</strong> both patterns in one flow.</p>
+<p>Give out a short-lived token that is scoped only to what is needed.</p>
 <h2>Pattern 3: CIBA</h2>
-<p><code>CIBA</code> — Client-Initiated Backchannel Authentication. The industry is <strong>already doing this</strong>.</p>
-<h2>Match the pattern to the stakes</h2>
-<p>That's the rule of thumb. <strong>The higher the stakes, the more security you want.</strong></p>
+<ul>
+<li>Client Initiated Backchannel Auth.</li>
+<li>Industry is already doing this.</li>
+</ul>
+<p><strong>Match the pattern to the stakes</strong> — the higher the stakes, the more security we need.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/junior-dev-team/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/junior-dev-team/index.html
@@ -21,32 +21,31 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Dylan Goings · Atomic Object · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>How to successfully build a junior dev team — built on ~300 hours of
-mentorship per junior: technical and consulting, book reading groups, feedback
-practice, demos, and tech talks. What's different here is <strong>the investment.</strong></p>
-<h2>The image we have of juniors is wrong</h2>
-<p>The usual framing:</p>
+<p><strong>How to Successfully Build a Junior Dev Team</strong></p>
+<p>300 hours of mentorship — technical and consulting.</p>
+<p>Book reading groups, feedback practice, demos, tech talks.</p>
+<p><strong>What's different? The investment!</strong></p>
+<h2>What is the image of juniors?</h2>
 <ul>
-<li><strong>Cheap</strong> — there to free up seniors.</li>
-<li><strong>Replaceable</strong> — no institutional knowledge.</li>
-<li><strong>Rentals</strong> — can't build new technical capacity.</li>
+<li><strong>Cheap</strong> — free up seniors</li>
+<li><strong>Replaceable</strong> — no institutional knowledge</li>
+<li><strong>Rentals</strong> — can't build new technical capacity</li>
 </ul>
-<h2>The AI death spiral</h2>
-<p>With AI we're pushing human effort into more complex and chaotic modes of
-working. The trap: AI writes more code → the dev looks more "productive" → free
-them up for higher-level work → more output → <strong>loop</strong>. That's a death spiral if
-you stop investing in people.</p>
-<h2>Reframe</h2>
+<p>What does this mean for the senior devs?</p>
+<p>With AI, we're moving human effort into more complex and chaotic modes of working.</p>
+<h2>The death spiral</h2>
+<p>AI writes more code, the dev is more "productive", free them up for high-level work, which leads to more productive work, and LOOP — <strong>a death spiral.</strong></p>
+<pre><code>more code -&gt; more "productive" -&gt; freed for high-level work -&gt; more productive -&gt; LOOP
+</code></pre>
+<h2>Reframe the juniors</h2>
 <ul>
-<li>Juniors are not cheap — they're an <strong>investment</strong>.</li>
-<li>They are <strong>not replaceable</strong> — they're unique and far more diverse, which
-matters more as the work shifts.</li>
-<li>They're <strong>invaluable, not rentals</strong> — think two years of training, five years
-of retention.</li>
+<li>Think of juniors as <strong>not cheap</strong> — an investment.</li>
+<li><strong>NOT replaceable</strong> — they are very unique and much more diverse (more important as work shifts).</li>
+<li><strong>Invaluable</strong>, not rentals.</li>
 </ul>
-<p>So: <strong>heavily invest in early-career mentorship, hire for fit and the future,
-and do more interesting work.</strong> The skills have changed — but the need for
-people has not.</p>
+<p>Two years of training, 5 year retention.</p>
+<p>Heavily invest in early career mentorship, hire for fit and the future, and do more interesting work.</p>
+<p><strong>The skills have changed! But the need for people has not!</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/karaoke-stems/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/karaoke-stems/index.html
@@ -21,15 +21,69 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Luis Montes · Iced Dev · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>Karaoke in 2026 deserves a better file format than the 1980s gave it — and the pieces to build one are now lying around in open source. The argument: <code>.stem.mp4</code> is a worthy successor to <code>CD+G</code>.</p>
-<h2>The CD+G inheritance</h2>
-<p>The first song ever played dates to 1877, karaoke to the 1980s, and then <code>CD+G</code> — CD plus graphics — arrived backward-compatible. The split is comically lopsided: 2.27% graphics to 97.73% audio, with video squeezed into 26.5 kbit/s. The result is rough — 288x192, 16 of 4096 colors, 6x12 tiles. KJs (karaoke jockeys) still guard deep <code>CD+G</code> catalogs. We can probably do better — and we can render <code>CD+G</code> on a canvas with <code>WebGL</code>.</p>
-<h2>Stems are the DJ's dream</h2>
-<p>The DJ's dream is <strong>stems</strong> — separating a song into its parts so you can beat-match on drums or build mashups and remixes from isolated vocals. Stems were historically expensive, until AI source separation changed the math; by 2024, DJ software shipped it. <code>Demucs</code> (MIT-licensed, <code>PyTorch</code>) is good quality and breaks audio into separate files. Maybe MP4 stems are the new standard? <strong>MP4 isn't a movie file</strong> — it's just a container. And this is <em>real original audio</em>, not a MIDI recreation, so you can ride the vocal volume or mute it entirely.</p>
-<h2>Lyrics, with timing</h2>
-<p><code>Whisper</code> (OpenAI) gives transcription plus timing — feed it the isolated vocals from <code>Demucs</code> and stash the result in the MP4. <code>Whisper</code> isn't perfect: timing drifts and it mangles some lyrics (hence "Hold me closer, Tony Danza"). <strong>LLMs fix the transcription</strong> while preserving the timing, and you can hand them open-source lyrics too.</p>
-<h2>Assembling the file</h2>
-<p>The MP4 spec uses <strong>atoms</strong> — standard atoms, a stem atom, and a <code>kara</code> atom for synced lyrics. Wire it into a pipeline and add an open-source player. (<code>CREPE</code> handles musical key detection; <code>Butterchurn</code> revives the old WinAMP visualizers in <code>WebGL</code>.) See also <code>youmaynotneedelectron.com</code>.</p>
+<p>First song played — 1877.</p>
+<p>Karaoke — 1980s.</p>
+<h2>CD+G (CD + Graphics)</h2>
+<p>Backward compatible.</p>
+<ul>
+<li>2.27% graphics, 97.73% audio</li>
+<li>26.5 kbit/s for video</li>
+</ul>
+<p><strong>It's rough!</strong></p>
+<ul>
+<li>288 x 192 — 16 of 4096 colors</li>
+<li>6x12 tiles</li>
+</ul>
+<p>KJs have a deep catalog of CD+G.</p>
+<p>We could probably do better…</p>
+<p>We can render CD+G in canvas, with <code>WebGL</code>!</p>
+<h2>And now the AI stuff</h2>
+<p><strong>The DJ's Dream (Stems)</strong></p>
+<ul>
+<li>mix two songs together</li>
+<li>have music separated out — drums for beat matching, vocals for mashups and remixes</li>
+</ul>
+<p>It's been expensive to get stems before.</p>
+<h2>AI Source Separation</h2>
+<p>2024 — DJ software includes it.</p>
+<ul>
+<li><code>Demucs</code> — MIT license</li>
+<li>good quality, <code>PyTorch</code></li>
+<li>breaks out files</li>
+</ul>
+<p><strong>MP4 Stems? The new standard?</strong></p>
+<p><code>MP4</code> isn't a movie file, it's just a container.</p>
+<p>Real original audio, <strong>NOT</strong> MIDI recreation!</p>
+<p>Control vocal volume (or mute entirely).</p>
+<h2>Lyrics</h2>
+<p>Okay, so we separated the tracks. What about the lyrics?</p>
+<p><code>Whisper</code> from OpenAI —</p>
+<ul>
+<li>we get transcription and timing</li>
+<li>feed it isolated vocals from <code>Demucs</code></li>
+<li>put it in an <code>MP4</code> file</li>
+</ul>
+<p><code>Whisper</code> isn't perfect; timing can be slightly off. Struggles with some lyrics.</p>
+<p><strong>LLMs for lyrics</strong> — fix the transcription errors but keep the timing right.</p>
+<p>Can also pass along open source lyrics to it.</p>
+<p>"Hold me closer, Tony Danza" 🤣</p>
+<h2>Putting it together</h2>
+<p>Corrected lyrics — we still want a file.</p>
+<p><code>MP4</code> spec — atoms:</p>
+<ul>
+<li>standard atoms</li>
+<li>stem atom</li>
+<li>kara atom — synced lyrics for karaoke</li>
+</ul>
+<p>Putting it all together — a pipeline.</p>
+<p>Also need an open source player.</p>
+<ul>
+<li><code>CREPE</code> can be used for musical key detection.</li>
+<li><code>Butterchurn</code> library — took WinAMP stuff encoded in <code>WebGL</code>.</li>
+</ul>
+<h2>Karaoke in 2026!</h2>
+<p><strong><code>.stem.mp4</code> is a worthy successor to CD+G!</strong></p>
+<p><code>youmaynotneedelectron.com</code> mentioned.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/last-mile-is-code/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/last-mile-is-code/index.html
@@ -21,31 +21,30 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Joe Duffy · Pulumi · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>Agents got really good at code, really fast — and you can represent almost any
-problem as code (one demo: <code>gc.cpp</code>, a million lines transpiled from LISP).</p>
-<p>On SWE-bench, the contamination-resistant <strong>Pro</strong> variant has moved fast:
-quality from ~33 (Aug '24) to 94, with Pro at 78 — and roughly 40 → 70 over the
-year.</p>
-<h2>The stack shifted</h2>
-<pre><code>old: programming language --compiler--&gt; machine code
-new: natural language --LLM--&gt; programming language --compiler--&gt; machine code
+<p><code>gc.cpp</code> — 1 million lines of code transpiled from LISP.</p>
+<p>Agents got really good at code, really fast.</p>
+<p>Represent any sort of problem as code.</p>
+<p><strong><code>SWE Bench</code></strong> — Pro agent is contamination-resistant; quality has moved from 33 in Aug '24 to 94; Pro is 78.</p>
+<p>40 → 70 this year.</p>
+<h2>The Stack Has Changed</h2>
+<p>The old stack:</p>
+<pre><code>programming language --compiler--&gt; machine code
 </code></pre>
-<p>The hard part <strong>isn't the code anymore</strong> — it's everything underneath it:
-ClickOps, infra, API keys, secrets. As Karpathy put it, <em>"Building a modern app
-is a bit like assembling IKEA furniture."</em></p>
-<h2>The last mile</h2>
-<p>For most of this, the last mile has always been <strong>someone else's job</strong> — a
-platform team, an SRE rotation, the person on call. And it's wildly lopsided:
-the agent only has what it was trained on, or what's in context.</p>
-<p>So <strong>put the last mile in code, too.</strong> Take action in code space; a runtime
-(IaC) reflects it back into the cloud. <strong>IaC is like <code>git diff</code> for your infra</strong>
-— you see what it's going to do before it does it. Vibe infra like apps: ask for
-code you can review, approve, and merge.</p>
-<p>This isn't just ergonomics. Per <em>CodeAct (Executable Code Actions Elicit Better
-LLM Agents)</em>, agents do <strong>~20% better</strong> when they act by <strong>writing code</strong> rather
-than emitting config. The shift is already underway: agents now drive <strong>28% of
-deployments</strong>, up from 4% late last year. <strong>Shipping isn't a separate team's job
-anymore.</strong></p>
+<p>The new stack:</p>
+<pre><code>natural language --LLM--&gt; programming language --compiler--&gt; machine code
+</code></pre>
+<p><strong>The hard part isn't the code anymore</strong> — it's everything underneath it: ClickOps, infra, API keys/secrets.</p>
+<p>Andrej Karpathy — <em>"Building a modern app is a bit like assembling IKEA furniture."</em></p>
+<h2>The Last Mile</h2>
+<p>For most of this, this part has always been someone else's job (a platform team, an SRE rotation, the person on call).</p>
+<p>It's wildly lopsided: agents have either what it was trained on, or it's in context.</p>
+<p><strong>Put the last mile in code, too.</strong></p>
+<p>Take action in code space; a runtime (IaC) reflects it back into the cloud.</p>
+<p><code>IaC</code> is like <code>git diff</code>, but for your infra — see what it's going to do before it does it.</p>
+<p>Vibe infra like apps, by asking — code we can review, approve, and merge in code.</p>
+<p><strong>+20%</strong> — agents do better when they act by writing code, not by emitting config (from <em>CodeAct — Executable Code Actions Elicit Better LLM Agents</em>).</p>
+<p>Agents now drive <strong>28% of deployments</strong>, up from 4% late last year.</p>
+<p><strong>Shipping isn't a separate team's job anymore.</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/linked-literate-programming/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/linked-literate-programming/index.html
@@ -21,32 +21,36 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">James Ide · Expo · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>When agents write the code, <strong>where does the intent live?</strong> We still need
-durable intent.</p>
-<h2>The problem with harness memory</h2>
-<p>Agent harnesses have memory, but it's <strong>tightly coupled</strong> to the harness and
-brings lock-in. Markdown files, by contrast, are <strong>portable</strong>. So use markdown
-to hold the "memory."</p>
-<h2>Linked Literate Programming (LLP)</h2>
-<p>LLP = <strong>markdown specs + references from code</strong>. Code links back to the spec
-with a comment:</p>
+<p>When agents write code, where does the intent live?</p>
+<p><strong>We still need durable intent.</strong></p>
+<p>Agent harnesses have memory, but it's tightly coupled — and we have lock-in.</p>
+<p>Markdown files, on the other hand, are portable.</p>
+<p>Use markdown to create "memory."</p>
+<p><strong>LLP</strong> — markdown specs + references from code.</p>
 <pre><code>// @ref LLP 0000mediastream-constructor
 </code></pre>
-<pre><code class="language-markdown"># Constructors [mediastream-constructor]
+<pre><code># Constructors [mediastream-constructor]
 </code></pre>
-<p>The links matter for three things:</p>
+<h2>Why links matter</h2>
+<p>Links matter for coverage, accuracy, and intent.</p>
 <ul>
-<li><strong>Coverage</strong> — you can see whether each part of the spec was implemented.</li>
+<li><strong>Coverage</strong> — we can see if we implemented each part of the spec.</li>
 <li><strong>Accuracy</strong> — does the spec actually match the code?</li>
 <li><strong>Intent</strong> — are decisions visible <em>above</em> the code level?</li>
 </ul>
-<h2>Web specs are great LLP inputs</h2>
-<p>Web specs already have the edge cases considered and the APIs designed. Agents
-import the spec, then leave linking comments back to it. The same spec can drive
-<strong>both web and native</strong> implementations. Pair it with <strong>WPT</strong> (Web Platform
-Tests) to close the loop: set up LLP, pull in the relevant parts of a spec, and
-test coverage against it. LLP + web specs makes the whole thing more
-programmatic.</p>
+<h2>Web specs as inputs</h2>
+<p>Web specs are good inputs for LLP:</p>
+<ul>
+<li>edge cases already considered</li>
+<li>designed APIs</li>
+</ul>
+<p>Agents import the spec, then use linking comments back to the spec.</p>
+<p><strong>LLP pattern</strong> — implementation for web and native apps using the same spec??</p>
+<h2>Workflow</h2>
+<p>Set up LLP, get the relevant parts of a spec, test coverage.</p>
+<p><code>WPT</code> — Web Platform Tests.</p>
+<p>Make a feedback loop with LLP.</p>
+<p><strong>LLP + web specs</strong> — more programmatic.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/modern-css-colors/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/modern-css-colors/index.html
@@ -21,47 +21,62 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">James Steinbach · Delinea · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>Practical refactors you can do today with modern CSS color features. The
-through-line: a lot of what we reached for a preprocessor to do, CSS now does
-natively, <strong>in context</strong>.</p>
-<h2>Theming with <code>light-dark()</code></h2>
-<p><code>light-dark()</code> takes two values — a light-mode color and a dark-mode color (both
-must be colors) — and does the media query's job for you.</p>
-<p>Overrides stay tiny. A six-line override (one block each for dark and light) is
-enough:</p>
+<h2>Theming</h2>
+<p>Practical refactors with modern CSS colors</p>
+<p><code>jds.li/css-colors</code></p>
+<p>CSS abstraction — how do we DRY our CSS?</p>
+<p>Use a pre-processor?</p>
+<p><code>light-dark()</code> — two values: light mode color, dark mode color. Must be a color.</p>
+<p>Already doing the media-query's job.</p>
+<p>What about overrides?</p>
+<p>6-line override (one each for dark and light):</p>
 <pre><code class="language-css">[data-theme="dark"] {
   color-scheme: dark;
 }
 </code></pre>
-<p>Global support is ~87% (check caniuse for the current number); Electron already
-supports it. Tailwind's <code>@theme</code> can lean on <code>light-dark()</code> too.</p>
-<h2>Color manipulation with relative colors</h2>
-<p>Relative color syntax pulls the raw channels out of an existing color:</p>
-<pre><code class="language-css">rgb(from var(--red) r g b / 1);
+<p><strong>87% global support</strong> — get more accurate on <code>caniuse</code>.</p>
+<p><code>Electron</code> already has support.</p>
+<p><code>tailwindcss</code> — <code>@theme</code> — <code>light-dark</code>?</p>
+<h2>Color Manipulation</h2>
+<p>CSS relative colors:</p>
+<pre><code class="language-css">rgb(from var(--red), r, g, b, alpha);
 </code></pre>
-<p><code>from</code> extracts the source color's values. Modern color functions drop the
-commas — but alpha still needs a slash: <code>hsl(120 50% 20% / 0.2)</code>. Alpha is
-implicit regardless of whether you write <code>rgb</code> or <code>rgba</code>.</p>
-<p>This unlocks, all without a preprocessor:</p>
+<p><code>from</code> pulls out the raw color value from the variable.</p>
+<p>Don't need commas anymore in color functions — but alpha needs a slash:</p>
+<pre><code class="language-css">hsl(120 50 20 / 0.2)
+</code></pre>
+<p>Alpha is an implicit value — regardless of whether you use <code>rgba</code> or just <code>rgb</code>.</p>
+<h2>Tints</h2>
+<pre><code class="language-css">from var(--surface-primary) r g 255
+</code></pre>
+<p>Do we need to clamp this? No, we don't.</p>
+<h2>Adjust Alpha</h2>
+<pre><code class="language-css">from var(--surface-primary) r g b / 0.2
+</code></pre>
+<h2>Normalized Lightness</h2>
+<p>Like alpha, but with <code>hsl</code>.</p>
+<h2>Color Math</h2>
+<p>Start from a named color.</p>
 <ul>
-<li><strong>Tints</strong> — <code>rgb(from var(--surface-primary) r g 255)</code>. No clamping needed.</li>
-<li><strong>Adjust alpha</strong> — <code>rgb(from var(--surface-primary) r g b / 0.2)</code>.</li>
-<li><strong>Normalized lightness</strong> — same idea as alpha, but in <code>hsl</code>.</li>
-<li><strong>Color math</strong> — start from a named color and rotate hue: secondary at 120°,
-tertiary at 240°.</li>
+<li>rotate secondary 120°, 67 33</li>
+<li>rotate tertiary 240°, 67 33</li>
 </ul>
-<p>These are the <strong>mixins</strong> we used SASS color functions for — now native (~89%
-support). Change one line to derive a variable and operate on it right there.</p>
-<h2><code>color-mix()</code> and <code>contrast-color()</code></h2>
-<p><code>color-mix()</code> blends colors in real time, in a chosen color space:</p>
+<h2>Mixins</h2>
+<p><code>SASS</code> color functions — requires pre-processor.</p>
+<p>Now we can do this in CSS — set the var and do stuff with it.</p>
+<p>Change one line to get the var — happens in context.</p>
+<p><strong>89% support globally.</strong></p>
+<p>CSS <code>color-mix()</code> — new function to manipulate colors in real time. Color space, use <code>hsl</code>.</p>
 <pre><code class="language-css">color-mix(in hsl, var(--button-color), var(--button-active-color))
 </code></pre>
-<p>(~91% support.)</p>
-<p>For accessibility, <code>contrast-color()</code> returns black or white — whichever
-contrasts better against a given color, regardless of color scheme. It's
-<strong>stackable</strong>: use <code>color-mix()</code> <em>inside</em> <code>contrast-color()</code> with relative
-colors to mix a tint in and still get a legible foreground. Support is only
-~67% today, so progressively enhance.</p>
+<p><strong>91%</strong></p>
+<h2>Automatic Contrast</h2>
+<p>Accessibility.</p>
+<p><code>contrast-color()</code> — returns white or black, regardless of color scheme, whichever is better for contrast.</p>
+<p>Use <code>color-mix()</code> inside <code>contrast-color()</code> — <code>from</code> — with relative colors.</p>
+<p>Mix the tint in.</p>
+<p><strong>All stackable.</strong></p>
+<p>Only <strong>67%</strong> right now.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/on-device-ai-music/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/on-device-ai-music/index.html
@@ -21,18 +21,75 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Alex Hinson · Fleetio · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>AI plus <code>Strudel</code> — a web-based, code-driven music tool where you make music with code. The goal is to <strong>extend creativity, not replace it</strong>: use AI for the technical bits, not to hand the whole thing over. A small model under the hood adds structural awareness.</p>
-<p>The kicker: it all runs in your browser tab. <strong>No API, no cloud — all local.</strong> Why local? Keep cost down (free), reduce latency (no round-trip), and preserve privacy (input never leaves the browser).</p>
-<h2>Picking the model</h2>
-<p>How do you make a small model good at a niche domain? First pick the <em>type</em>. Is the problem translation? Audio classification? Text generation? Each lives in a different model family — text generation made the most sense. <code>transformers.js</code> runs Hugging Face models in the browser.</p>
-<h2>Shaping the I/O</h2>
-<p>AI is good at ambiguity, inference, unstructured input; code is good at precision, rules, structured output. The right answer sits on a continuum between them, with tradeoffs. Off-the-shelf "just ask for code" looks plausible but won't run. "Intent JSON → deterministic engine" turns intent into pseudo-code, but bigger schemas and prompts add latency and stop feeling fluid. A <strong>fine-tuned model</strong> gives structural context: small input, sanitized and parsed output. Optimize further and you drop the deterministic guarantee for a tighter surface — just the right number of tokens.</p>
-<h2>Training data, validated</h2>
-<p>The model didn't know <code>Strudel</code>, and there wasn't much training data. So Alex used LLMs to generate examples — some of it confident nonsense referencing things that don't exist. The fix: <strong>validate, then scale.</strong> Run each example through <code>Strudel</code>; if it doesn't parse, throw it out. Don't scale the hallucinations. Add grounding so the model doesn't freestyle, and reward cross-domain reasoning.</p>
-<p>The ongoing loop:</p>
-<pre><code>identify gap --&gt; generate --&gt; validate --&gt; retrain
+<p><strong>AI and Strudel</strong> — web-based music production tool.</p>
+<p><strong>Make music with code!</strong></p>
+<p>Extend creativity, not replace it — using AI to get help, not handing something to AI to do.</p>
+<p><strong>Structural awareness</strong> — a small model under the hood helping with the technical bits.</p>
+<p><strong>In your browser tab!</strong> No API, no cloud — all local.</p>
+<h2>Why local</h2>
+<p>Alex wants to:</p>
+<ul>
+<li><strong>keep cost down</strong> — free!</li>
+<li><strong>reduce latency</strong> — beats having a round-trip</li>
+<li><strong>privacy</strong> — input never leaves the browser</li>
+</ul>
+<p>So that's why local.</p>
+<h2>Getting a small model good at a niche domain</h2>
+<p>How do you get a small model to be good at a niche domain?</p>
+<p>Pick a model — but first pick <em>which type</em> of model?</p>
+<ul>
+<li><code>transformers.js</code> — HuggingFace models to run in the browser.</li>
+</ul>
+<p>Is this problem translation? Is it audio classification? Each one is in a different model family.</p>
+<p>Text generation made the most sense; what does the interface look like?</p>
+<p>Shaping the model's I/O —</p>
+<ul>
+<li><strong>AI</strong> good at ambiguity, inference, unstructured input</li>
+<li><strong>Code</strong> good at precision, rules, and structured output</li>
+</ul>
+<p>The right answer depends on the need.</p>
+<h2>Finding the AI/code boundary</h2>
+<ul>
+<li><strong>Off-the-shelf model: ask for code</strong> — NOT right! Looks plausible, but won't run.</li>
+<li><strong>Try intent JSON</strong> — deterministic engine; take intent and make pseudo code.</li>
+</ul>
+<p>A continuum of AI <code>&lt;——&gt;</code> code boundary, with tradeoffs between them.</p>
+<p>Latency to get a structured output; bigger schema, bigger prompt — doesn't feel fluid anymore.</p>
+<ul>
+<li><strong>Try fine-tuned</strong> -&gt; structural context. Keep input context small; model output is sanitized and parsed.</li>
+<li><strong>Optimized</strong> — remove the deterministic guarantee for tighter and smaller surface area, just the right amount of tokens.</li>
+</ul>
+<p>But the model didn't know Strudel! Training took a lot more time.</p>
+<h2>Training data</h2>
+<p>There wasn't a lot of training data available — didn't have time to create a lot of examples.</p>
+<p>Alex used LLMs to generate examples; ask for Strudel, see what it does.</p>
+<p>Some things didn't actually exist — <strong>confident nonsense.</strong></p>
+<ul>
+<li>Added validation step — run it through Strudel, throw it out if it doesn't parse.</li>
+<li>Then scale — <strong>DON'T scale the hallucinations.</strong></li>
+</ul>
+<p>Added grounding to what the LLM is being asked to do; don't freestyle, be concise — what is Strudel.</p>
+<p>Cross-domain reasoning.</p>
+<h2>The ongoing loop</h2>
+<p>The work gets focused but doesn't stop; identify gap -&gt; generate -&gt; validate -&gt; retrain.</p>
+<pre><code>identify gap -&gt; generate -&gt; validate -&gt; retrain
 </code></pre>
-<p>The work gets focused but never stops; each loop makes the tool more like something Alex actually wants to play with. Finally, fit it into a browser tab via <strong>quantization</strong> — shrink by reducing precision. Runtime is a few lines: import, await the pipeline, initialize. The questions to keep asking: what's the model task? where's the AI/code boundary? where does the training data come from? does it need to be local?</p>
+<p>Each loop makes the tool better — to become something Alex wants to work with.</p>
+<h2>Shrink it to fit</h2>
+<p>Make something small enough to fit in a browser tab — <strong>shrink it small, ship it small.</strong></p>
+<p><strong>Quantization!</strong></p>
+<ul>
+<li>Shrink down by reducing precision.</li>
+<li>Runtime in a few lines — import, await pipeline, initialize.</li>
+</ul>
+<p><strong>Ideas are endless.</strong></p>
+<h2>Questions to ask</h2>
+<ul>
+<li>Model task?</li>
+<li>AI/code boundary?</li>
+<li>Training data?</li>
+<li>Does it need to be local?</li>
+</ul>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/request-tax/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/request-tax/index.html
@@ -21,18 +21,38 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Alex Moon · WP Engine · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>An intervention: <code>React</code> just turned 13, and how we work has changed. To bundle, or not to bundle?</p>
-<h2>Why we bundle</h2>
-<p>We bundle with <code>webpack</code> and <code>rollup</code> — but also with inlining, data URLs, and sprites. The <em>why</em> is historical: <code>TCP</code> was slow, and <code>HTTP/1.1</code> told us we had to. Caching hated bundling, so <strong>code splitting</strong> was invented to balance bundling against caching.</p>
-<h2>The protocols moved on</h2>
-<p>Then <code>HTTP/2</code> (<code>SPDY</code>) fixed the <code>HTTP/1.1</code> problem — but <code>TCP</code> is still the problem. <code>HTTP/3</code> over <code>QUIC</code> fixed a lot of hard problems. But did we actually <em>fix</em> this?</p>
-<p>Look at request granularity. Under <code>HTTP/1.1</code>, bundling is genuinely faster — the more you split into smaller pieces, the worse it looks, because the overhead of splitting goes up. <code>HTTP/3</code> is the opposite: the more you split, the <strong>better</strong> it looks, and delivery stays consistent. <strong><code>HTTP/3</code> plus caching is a love story.</strong></p>
-<h2>Takeaways, by audience</h2>
+<p>An intervention.</p>
+<p>React turned 13 years old — and how we've worked has changed.</p>
+<h2>To Bundle or Not to Bundle?</h2>
+<p><strong>How</strong> we bundle:</p>
 <ul>
-<li><strong>Average developers</strong> — optimize for <em>caching</em> and stop stressing about the network.</li>
-<li><strong>Framework and bundler maintainers</strong> — is the default still the right answer?</li>
-<li><strong>Cloudflare</strong> — can you get us more data? Follow up on the 2020 article on <code>HTTP/3</code> performance.</li>
-<li><strong>Everyone else</strong> — anyone have cool data?</li>
+<li><code>webpack</code>, <code>rollup</code></li>
+<li>BUT ALSO: inlining, data URLs, sprites</li>
+</ul>
+<p><strong>Why</strong> do we bundle?</p>
+<p>TCP was slow; HTTP/1.1 told us we had to bundle.</p>
+<p>Caching hated it.</p>
+<p>Code splitting invented to find a balance between bundling and caching.</p>
+<h2>HTTP Evolution</h2>
+<p><code>HTTP/2</code> — <code>SPDY</code> fixed the HTTP/1.1 problem.</p>
+<p>But TCP is still the problem.</p>
+<p><code>HTTP/3</code> over <code>QUIC</code> — fixed a lot of hard problems.</p>
+<p>But did we actually <strong>FIX</strong> this?</p>
+<h2>Request Granularity</h2>
+<p>HTTP/1.1 is actually faster when bundling.</p>
+<p>The more we split and make smaller, the better HTTP/3 looks.</p>
+<ul>
+<li><strong>HTTP/1.1</strong> — overhead of splitting goes up</li>
+<li><strong>HTTP/3</strong> — more consistent at delivery</li>
+</ul>
+<pre><code>HTTP/3 + caching = ❤️
+</code></pre>
+<h2>Prompts</h2>
+<ul>
+<li><strong>Average developers:</strong> OPTIMIZE for CACHING, stop stressing about the network.</li>
+<li><strong>Framework / bundler maintainers:</strong> is the default still the answer?</li>
+<li><strong>Cloudflare:</strong> can you get us more data? Can you follow up on the 2020 article on HTTP/3 performance?</li>
+<li>Anyone else have cool data?</li>
 </ul>
 
   </div>

--- a/apps/cascadiajs2026-notes/dist/talks/rethink-everything/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/rethink-everything/index.html
@@ -21,15 +21,102 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Theo · T3 Chat · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>Building software is wildly different now because of AI — the same way the cloud changed everything before it. The same movie, playing again.</p>
-<h2>The cloud already ran this play</h2>
-<p><strong>Before the cloud</strong>, building was capital-intensive: you had to predict the future, and experimentation was expensive. <strong>After</strong>, you start small and scale up, experimentation is cheap, and you don't need God-tier infra devs — Amazon-tier hardware without an Amazon-tier budget. AI is that movie again: <strong>Amazon-scale software without Amazon-scale SWE teams.</strong> The expertise required drops; the things that were rigid aren't anymore.</p>
-<h2>Rethink the assumptions we stopped questioning</h2>
-<p>Why can't we commit <code>.env</code> files? Why can't a public repo have private parts? Why can't a file be in two folders at once? Why do we need a file system to compile my app? Why do we assume our codebases still matter — our packages? Why can't we rebuild everything? <strong>Why can't we boil the ocean?</strong></p>
-<p><code>Salesforce</code> is the opposite of all this — a giant pile of features. Everyone needs a few, the Fortune 500 needs more, and there's a long tail that 1% of users touch. You have to build for every snowflake. Or do you? <strong>Breadth is now trivial to cover; depth isn't the problem</strong> — build a platform and let the client's agents handle the depth. Too broad is hard; too deep isn't good.</p>
-<h2>Boil the ocean</h2>
-<p><strong>Before</strong>: 40 hours to build, 3 hours to deploy. <strong>After</strong>: 30 minutes to build, 3 hours to deploy — now the deploy is the obnoxious part. <code>shoo.dev</code> does auth in two lines (easy, not necessarily secure or good); it didn't ship because it was built too deep in the vertical. So make all the problems go away. Theo went too far and built <code>Lakebed</code> [alpha] — <code>npx lakebed new sup-seattle</code>, then <code>npx lakebed deploy</code>, deployed in seconds; change something, redeploy in seconds. He built the language, compiler, CLI, <em>and</em> deployer. We kid ourselves that we need all the perfect things — just prompt something into existence. <code>lakebed.dev</code>.</p>
-<p><strong>Why haven't we been thinking right?</strong> We are not building big enough. Find the place where going so big makes you feel STUPID. The last 5, 10, 50 years don't matter — where will things be in five? You aren't building big enough.</p>
+<p>Building software is <strong>WAYYYY different</strong> because…</p>
+<p><strong>AI is the cloud!</strong></p>
+<h2>Life before the cloud</h2>
+<ol>
+<li>Building was more capital-intense</li>
+<li>You had to predict the future</li>
+<li>Experimentation was expensive</li>
+</ol>
+<h2>Life after the cloud</h2>
+<ol>
+<li>You can start small and scale up</li>
+<li>Experimentation is cheap</li>
+<li>You don't need to hire God-tier infra devs anymore</li>
+</ol>
+<p>Easy scaling made a lot of things possible.</p>
+<p><strong>Amazon-tier hardware without Amazon-tier budget.</strong></p>
+<p>And AI… we've been through this before…</p>
+<h2>Life before the Claude</h2>
+<ol>
+<li>Building was capital-intense</li>
+<li>You had to predict the future</li>
+<li>Experimentation was expensive</li>
+</ol>
+<p>Amazon-scale software, with Amazon-scale SWE teams.</p>
+<p><strong>Everything we believe is no longer true.</strong></p>
+<p>Expertise required is a lot less now; things that were rigid aren't true anymore.</p>
+<h2>Things we should rethink</h2>
+<p>We may be past where this stuff makes sense:</p>
+<ul>
+<li>Why can't we commit <code>.env</code> files?</li>
+<li>Why can't a public repo have private parts?</li>
+<li>Why can't a file be in two folders at once?</li>
+<li>Why do we need a file system to compile my app?</li>
+<li>Why do we assume our codebases still matter?</li>
+<li>Why do we assume our packages still matter?</li>
+<li>Why can't we rebuild everything?</li>
+<li>Why can't we boil the ocean?</li>
+</ul>
+<h2>Salesforce</h2>
+<p><code>Salesforce</code> is the opposite of everything mentioned…</p>
+<p>Salesforce has a lot of features.</p>
+<p>Everyone needs a small number, Fortune 500 needs some, and then there's the long tail of things 1% of users use.</p>
+<p>Features <code>[company]</code> needs.</p>
+<p>You have to build for every snowflake.</p>
+<p>Or do you?????</p>
+<p>What if you could cover what a company needs trivially?</p>
+<ul>
+<li><strong>breadth of features</strong> — range</li>
+<li><strong>depth of features</strong> — # of features in a given area</li>
+</ul>
+<p>Too broad? Hard. Too deep? Not good.</p>
+<p>But a broad range of things you cover — <strong>it's viable now.</strong></p>
+<p>The depth isn't a problem; build a platform and let the client deal with that with their agents.</p>
+<h2>What does this look like?</h2>
+<p><strong>Before</strong></p>
+<ul>
+<li>build — 40 hours</li>
+<li>deploy — 3 hours</li>
+</ul>
+<p><strong>After</strong></p>
+<ul>
+<li>build — 30 minutes</li>
+<li>deploy — 3 hours</li>
+</ul>
+<p>So obnoxious! Why!! The 3 hours sucks worse now.</p>
+<h2>shoo.dev</h2>
+<ul>
+<li><code>shoo.dev</code></li>
+<li>auth in 2 lines of code</li>
+<li>easy way to add auth, not secure or good necessarily</li>
+<li>didn't ship? built too deep in the vertical</li>
+</ul>
+<p><strong>BOIL THE OCEAN!!!</strong> Make all the problems go away.</p>
+<p>Theo went too far.</p>
+<h2>Lakebed [alpha]</h2>
+<p><strong>LIVE DEMO!!</strong></p>
+<pre><code>npx lakebed new sup-seattle
+</code></pre>
+<ul>
+<li>nothing special on his machine</li>
+</ul>
+<pre><code>npx lakebed deploy
+</code></pre>
+<ul>
+<li>deployed just like that, super quick</li>
+<li>changed something, deployed in seconds</li>
+</ul>
+<p>Built language, compiler, CLI, deployer.</p>
+<p>Holy crap — so simple.</p>
+<p>We kid ourselves that we need all the perfect things, just prompt something into existence.</p>
+<p><code>lakebed.dev</code></p>
+<h2>Why haven't we been thinking right</h2>
+<p><strong>WE ARE NOT BUILDING BIG ENOUGH.</strong></p>
+<p>Find the place where we feel <strong>STUPID</strong> for going so big.</p>
+<p>Where will things be in 5 years? The last 5, 10, 50 years don't matter.</p>
+<p><strong>YOU AREN'T BUILDING BIG ENOUGH.</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/rust-critical-path/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/rust-critical-path/index.html
@@ -21,21 +21,103 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Francesco Ciulla · Zerops · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p>JavaScript winning the web isn't controversial — default for front-ends, huge ecosystem, fast iteration, the thing most web teams already know. The interesting frontier is the <strong>critical path</strong>: product work where performance, latency, memory pressure, and runtime predictability dominate.</p>
-<h2>"Is Rust ready for web development?" is a useless, dumb question</h2>
-<p>Ready for <em>what</em>? "Web development" could mean landing pages, proxies, or <code>WASM</code> — each optimizing for something different. For product-heavy UI work, no. When the constraints change, yes. The web stack is far more than the browser — frontend, edge, and a lot of layers underneath.</p>
-<p>Rust wins when the web becomes <strong>systems programming</strong>: predictable, low-latency, memory-efficient, safe concurrency, fewer runtime surprises. It's not <em>just</em> fast — explicit errors, strong types, <code>WASM</code>-ready, ownership and allocation control, memory safety without a garbage collector. From the outside it looks like web dev; from the inside it behaves like a systems language. Not for everything.</p>
-<h2>One pattern, real examples</h2>
-<p>Rust entering the parts that need stronger guarantees:</p>
+<p><strong>JavaScript winning the web is not controversial</strong> — it's the default choice for front-ends, has a huge ecosystem, fast iteration, and most web teams already know it.</p>
+<p>Web only as product work, performance, latency, memory pressure, runtime predictability =&gt; <strong>this is the critical path.</strong></p>
+<h2>Is Rust Ready for Web Development?</h2>
+<p>This question is useless; it's a dumb question.</p>
+<p><strong>What does web development even mean?</strong></p>
 <ul>
-<li><strong>Cloudflare</strong> built <code>Pingora</code>, an HTTP proxy — 1T+ requests/day on a third of the CPU and memory.</li>
-<li><strong>Discord</strong> rewrote Read States in Rust: GC caused latency spikes, and P99 mattered more than simplicity. A targeted hot-path swap, not an ideological rewrite.</li>
-<li><strong>Shopify Functions</strong> compile to <code>WASM</code> — Rust for portable business logic, fast.</li>
+<li>Landing pages, proxies, <code>WASM</code>, and so on.</li>
 </ul>
-<h2>The stack, and where to reach for it</h2>
-<p>Frameworks <code>Axum</code> + <code>Actix</code>; foundations <code>Hyper</code> + <code>Tower</code>; data <code>SQLx</code>, <code>Diesel</code>, <code>SeaORM</code>; runtime <code>Tokio</code>; observability <code>OpenTelemetry</code>.</p>
-<p>The <code>Tokio</code> mental model is close to Node: an <code>async fn</code> creates a lazy future, and the runtime — executor, scheduler, reactor, timers, async I/O, task spawning — runs it when ready. It's <strong>not a thread</strong>; it's machinery to let many futures make progress. Production engineering starts when many handlers share one runtime. <code>SQLx</code> keeps SQL explicit and moves failures earlier — verifying Rust types against the schema at compile time. Not an ORM, but with compile-time guarantees.</p>
-<p>Rust wins at backend, auth, billing, realtime, proxies, <code>WASM</code>/tooling, queues — <strong>realtime is the biggest win</strong>. It loses when speed of change matters most: landing pages, blogs, classic CMS, three-day MVPs, frontend-heavy apps. It has a cost — learning curve, compile time, async complexity — so pay it when the leverage is worth it. Go is simpler but not the correctness win; Java/Kotlin for tooling and big teams; JS/TS for speed. Keep TypeScript for the frontend, reach for Rust at the constraints. <strong>Hybrid wins.</strong> Rust doesn't need to win the web — it should be on the critical path.</p>
+<p><strong>Ready for what?</strong></p>
+<ul>
+<li>Product-heavy UI work.</li>
+<li>When constraints change? Yes.</li>
+</ul>
+<p>The web stack is much more than the browser — frontend, edge, lots of other stuff.</p>
+<p>Different layers optimize for different things.</p>
+<h2>Where Rust Wins</h2>
+<p><strong>Rust wins when the web becomes system programming</strong> -&gt; operating critical systems.</p>
+<ul>
+<li>Predictable, low latency, memory efficiency, safe concurrency, fewer runtime surprises.</li>
+</ul>
+<p><strong>Rust is not JUST fast</strong> — explicit errors, strong types, safe concurrency, <code>WASM</code>-ready, ownership and allocation control, memory safety without garbage collection.</p>
+<p><strong>Rust is NOT for everything.</strong></p>
+<ul>
+<li>From the outside, looks like web development.</li>
+<li>From the inside, behaves as a system language.</li>
+</ul>
+<h2>Real-World Patterns</h2>
+<p><code>Cloudflare</code> built <code>Pingora</code> — HTTP proxy.</p>
+<ul>
+<li>1T+ requests/day with 1/3 CPU and memory.</li>
+<li>When the web becomes infrastructure, the choice becomes easy.</li>
+</ul>
+<p><code>Discord</code> — Read states rewritten in Rust.</p>
+<ul>
+<li><strong>GARBAGE COLLECTION</strong> caused latency spikes; P99 latency mattered more than simplicity.</li>
+<li>Critical path, GC spikes, hot path, targeted replacement.</li>
+<li>Not an ideological rewrite, a very practical choice.</li>
+</ul>
+<p><code>Shopify</code> Functions -&gt; <code>WASM</code>.</p>
+<ul>
+<li>Rust for portable business logic, fast.</li>
+</ul>
+<p>All three examples — recognizable pattern.</p>
+<p><strong>Rust is entering the parts that need stronger guarantees.</strong></p>
+<h2>Rust Web Stack</h2>
+<ul>
+<li>Web frameworks: <code>Axum</code> + <code>Actix</code></li>
+<li>Foundations: <code>Hyper</code> + <code>Tower</code></li>
+<li>Database layer: <code>SQLx</code>, <code>Diesel</code>, <code>SeaORM</code></li>
+<li>Async runtime: <code>Tokio</code></li>
+<li>Observability: <code>OpenTelemetry</code></li>
+</ul>
+<h2>Tokio and Futures — Mental Model</h2>
+<p>SIMILAR to <code>NodeJS</code> — <code>async fn</code> creates a future — lazy work.</p>
+<p><code>Tokio</code> runtime — executor / scheduler / reactor / timers / async I/O / task spawning.</p>
+<ul>
+<li>When ready, it runs.</li>
+<li>Machinery that lets many futures make progress efficiently.</li>
+<li>It is <strong>NOT a thread.</strong></li>
+</ul>
+<p><code>Axum</code> flow: production engineering starts when many handlers share the same runtime.</p>
+<h2>Database Access</h2>
+<p><code>SQLx</code> keeps SQL <strong>EXPLICIT</strong> and moves more failures earlier.</p>
+<ul>
+<li>Compile time — verifies the Rust types against the schema.</li>
+<li>NOT an ORM, but has compile-time guarantees.</li>
+</ul>
+<h2>Where Does Rust Win?</h2>
+<ul>
+<li>Backend, auth, billing, realtime, proxies, <code>WASM</code>/tooling, queues.</li>
+<li><strong>Realtime is the biggest win.</strong></li>
+</ul>
+<h2>Where Does Rust NOT Win?</h2>
+<ul>
+<li>If speed of change is most important.</li>
+<li>Landing pages, blogs, classic CMS websites.</li>
+<li>Three-day MVPs, frontend-heavy apps.</li>
+</ul>
+<h2>Rust Has a Cost!</h2>
+<p>Adoption costs:</p>
+<ul>
+<li>Learning curve</li>
+<li>Compile time</li>
+<li>Async complexity</li>
+</ul>
+<p><strong>Pay the Rust cost when the leverage is worth it.</strong></p>
+<h2>Different Tools, Different Wins</h2>
+<p><strong>Rust wins WHEN correctness, latency, safety, and predictability matter most.</strong></p>
+<ul>
+<li><code>Go</code> is a more simple choice, but not the correctness win.</li>
+<li><code>Java</code>/<code>Kotlin</code> for tooling / maturity / big teams.</li>
+<li><code>JS</code>/<code>TS</code> for the fastest speed of development.</li>
+</ul>
+<p>Keep <code>TypeScript</code> for the frontend — UI, fast iteration; use Rust for constraints.</p>
+<p><strong>Hybrid wins.</strong></p>
+<p>Reusable business logic — <code>WASM</code>, back-end, CLI.</p>
+<p><strong>Rust does not need to win the web, but it should be in the critical path.</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/shared-components/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/shared-components/index.html
@@ -21,40 +21,37 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Jonathan Keslin · Atlassian · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>Shared components that live <em>beyond</em> the design system. The design system is
-UX foundations and atomicity; above it sits navigation, higher-level UX,
-team-specific components, and design-system candidates.</p>
-<h2>Before you build</h2>
+<p><strong>Shared Components Beyond the Design System</strong></p>
+<p><code>DS</code> == UX foundations, atomicity.</p>
+<p>nav / higher-level UX, team-specific, or design system candidates.</p>
+<h2>Who are you building for?</h2>
+<p>Anchor consumer, then add a second consumer to keep implementation from getting coupled to the anchor consumer's use case.</p>
+<h2>Where are you building it?</h2>
+<p>Keep it separate from the app so it can evolve independently.</p>
+<p>Publish artifacts to avoid bad habits (copy-pasta).</p>
+<h2>Build it thoughtfully</h2>
+<p>Use a higher standard than app code.</p>
+<p>Make API consistent.</p>
+<p><strong>Common case</strong> — little to no effort; the most custom case will require the most effort (layer 1, 2, 3 with progressive complexity).</p>
+<p>Prioritize common use-cases, and don't forget complex but frequent things.</p>
+<p>Hard mode can be hard — that's okay.</p>
+<h2>Principles</h2>
 <ul>
-<li><strong>Who are you building for?</strong> Anchor on one consumer, then add a <em>second</em>
-consumer early so the implementation doesn't get coupled to the anchor's use
-case.</li>
-<li><strong>Where are you building it?</strong> Keep it separate from the app so it can evolve
-independently, and publish artifacts to avoid copy-paste habits.</li>
-<li><strong>Build it thoughtfully</strong> — hold it to a higher standard than app code, and
-keep the API consistent. The common case should take little to no effort; the
-most custom case will take the most effort. Layer the complexity (1 → 2 → 3),
-prioritize common use cases, and don't forget the complex-but-frequent ones.
-Hard mode is allowed to be hard.</li>
+<li><strong>Principle 1:</strong> build UP from the design system</li>
+<li><strong>Principle 2:</strong> design with layered extensibility — <strong>make the right way the easy way</strong> (example: button with icon)</li>
+<li><strong>Principle 3:</strong> don't build a Homer car</li>
+<li><strong>Principle 4:</strong> it's okay to be opinionated</li>
+<li><strong>Principle 5:</strong> consider including batteries — reduce boilerplate, handle data fetching if you can (like <code>Relay</code>'s fragments), keep an escape hatch — don't do everything for consumers in case they need to do something themselves</li>
+<li><strong>Principle 6:</strong> make it maintainable — write thorough tests, document liberally, keep a changelog — what changed and do they need to do anything about it</li>
 </ul>
-<h2>Six principles</h2>
-<ol>
-<li><strong>Build up</strong> from the design system.</li>
-<li><strong>Design with layered extensibility</strong> — make the right way the easy way (e.g.
-a button with an icon).</li>
-<li><strong>Don't build a Homer car</strong> — don't cram in every feature.</li>
-<li><strong>It's okay to be opinionated.</strong></li>
-<li><strong>Consider including batteries</strong> — reduce boilerplate, handle data fetching
-where you can (like Relay's fragments), but keep an escape hatch so consumers
-can do it themselves when needed.</li>
-<li><strong>Make it maintainable</strong> — thorough tests, liberal docs, and a changelog
-that says what changed and whether consumers need to act.</li>
-</ol>
-<h2>Ecosystem and governance</h2>
-<p>Shared components are valuable, so invest in <strong>discoverability</strong> — a docs site
-or marketplace; good docs matter more than ever. Provide <strong>governance</strong>: define
-patterns and practices, use a quality scale (Home Assistant's bronze / silver /
-gold is a nice model), and <strong>recognize authors</strong> for their contributions.</p>
+<h2>Foster an ecosystem</h2>
+<p>Shared components are super valuable.</p>
+<p>Discoverability — doc site / marketplace.</p>
+<p><strong>Good docs matter more than ever.</strong></p>
+<h2>Provide governance</h2>
+<p>Define patterns and practices.</p>
+<p><code>Home Assistant</code> — Quality Scale — bronze / silver / gold.</p>
+<p>Recognize authors for their contributions.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/skeptics-to-champions/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/skeptics-to-champions/index.html
@@ -21,24 +21,31 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Jeff Otaño · Onebrief · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>How to make AI <em>real</em> inside an org and turn skeptics into champions — a
-"startup inside a startup," built on a decade of infra.</p>
-<h2>The first attempt missed</h2>
-<p>We built the impressive-sounding stuff — a skills/repo marketplace, sandboxes,
-guardrails, an AI bug diagnoser — but <strong>didn't ask whether anyone actually
-needed it.</strong> Nobody has time to do the AI's homework. The result: a <strong>16% merge
-rate</strong>, with no comments and no feedback.</p>
-<h2>What actually worked</h2>
+<p><strong>Make AI real.</strong></p>
+<p>Stripe Minion? A decade of infra.</p>
+<p>A startup in a startup.</p>
 <ul>
-<li><strong>Undeniable beats impressive.</strong> Target tiny, annoying fixes. A sandbox makes
-sense when it <em>eases the pain</em>; curate skills, on by default.</li>
-<li>Don't ask people to build a knowledge graph or chase metrics before there's
-value. <strong>Create a feedback loop.</strong></li>
-<li>The homework was <strong>already done</strong> — 1,000 fixes from the last year were
-already in the repo. So <strong>replay the agent</strong> against them.</li>
+<li>Skills repo marketplace</li>
+<li>Sandboxes</li>
+<li>Guardrails</li>
 </ul>
-<p>That replay pushed clean fixes from 16% to <strong>36%</strong>.</p>
-<p>The mantra: <strong>try it, measure it, delete what doesn't work.</strong></p>
+<p>Didn't ask if anyone actually needed any of this.</p>
+<h2>AI Bug Diagnoser</h2>
+<p>Nobody has time to do the AI's homework.</p>
+<ul>
+<li>Tiny, annoying fixes</li>
+<li>Sandbox makes sense when it eases the pain</li>
+<li>Curated skills, by default</li>
+</ul>
+<p>Build a knowledge graph? Show metrics before we take this on?</p>
+<p><strong>Undeniable beats impressive!</strong></p>
+<p>Create a feedback loop.</p>
+<p>16% merge rate — no comments or feedback.</p>
+<h2>The Homework Was Already Done</h2>
+<p>1000 fixes from the last year — already in the repo.</p>
+<p>Replay the agent.</p>
+<p><strong>Improved to 36% clean fixes!</strong></p>
+<p><strong>Try it, measure it, delete what doesn't work.</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/spec-driven-development/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/spec-driven-development/index.html
@@ -21,46 +21,56 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Erik Hanchett · AWS · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>Specs are the <strong>primary contract</strong> for code generation. (Context: AWS's Kiro,
-which started life as a VS Code fork — Alexa lineage at AWS.)</p>
-<h2>Why specs?</h2>
-<p>Treat the AI like an intern: one small deviation can produce wildly different
-results. So get planning and product involved, and write the contract down.</p>
-<p>Can't the latest frontier models just do everything? A few things to keep in
-mind:</p>
+<p>Specs are the primary contract for generation of code.</p>
+<p>Why?</p>
+<p><strong>AI as intern</strong> — one small deviation can result in very different results. Get planning and product involved.</p>
+<p>Can't the latest frontier models do everything??</p>
+<p>Let's keep a few things in mind:</p>
 <ul>
-<li><strong>Too much context</strong> confuses models. Keep <code>AGENTS.md</code> / steering files
-targeted. Use skills to create specs and implement them; agents can help with
-the implementation plan.</li>
-<li><strong>Too much trust</strong> is a trap. Are we code reviewing? We're the human in the
-loop — that matters. Set up AI code reviews as a second pass too.</li>
-<li>Watch for <strong>outcome divergence</strong> (drifting off the intended target) and
-<strong>speed over maintainability</strong> (what patterns are we creating?).</li>
+<li><strong>Too much context!!</strong> Models get confused.</li>
+<li><code>AGENTS.md</code> / steering — keep it targeted.</li>
+<li>Use skills — create specs and implement, and agents can help with the implementation plan.</li>
+<li><strong>Too much trust!!</strong> Are we code reviewing? We are the human in the loop, it's important.</li>
+<li>Set up AI code reviews as well / task rabbit etc.</li>
 </ul>
-<h2>Doing it without Kiro</h2>
-<p>Tell the AI IDE what to produce, in order:</p>
-<ol>
-<li><strong>User requirements</strong></li>
-<li>A <strong>design document</strong> derived from them</li>
-<li><strong>Implementation details</strong> derived from both</li>
-</ol>
-<p>Tools in this space: Spec-Kit, OpenSpec, BMad. Kiro's spec mode also works in a
-<strong>brownfield</strong> app. Use <strong>EARS</strong> (Easy Approach to Requirements Syntax) to go
-from requirements → design phase. Review the markdown, approve, then move to
-implementation — which can happen out of order. Create an MVP from the steps by
-taking a <strong>vertical slice</strong>, pedantically; keep it short and tight, and keep
-reviewing.</p>
-<h2>MCP and spec-driven development</h2>
-<p>Isn't MCP dead? It's less hyped now — switching to CLIs is common — but it may
-still be valuable <em>for spec-driven development</em>:</p>
+<p>Don't get off the intended target — <strong>outcome divergence</strong>.</p>
+<p>Speed over maintainability — what patterns are being created?</p>
+<p>History lesson — Alexa at AWS, Kiro, first as VS Code fork.</p>
+<h2>Iterating on spec-driven development</h2>
+<p>How do you do this stuff WITHOUT Kiro?</p>
+<p>Tell the AI IDE what it should do:</p>
 <ul>
-<li>Specs can be <strong>pulled from a project-management service</strong>.</li>
-<li>You can take an existing app/PoC and <strong>reverse-engineer</strong> a spec from it.</li>
-<li>It will follow the rules set in your steering files.</li>
+<li>include the following
+<ul>
+<li>user requirements</li>
+<li>design document from that</li>
+<li>take both of those and create implementation details</li>
+<li><code>Spec-kit</code> / <code>Open Spec</code> / <code>BMad</code></li>
 </ul>
-<p>Close the loop with <strong>property-based tests</strong> that run as regression tests
-against the requirements: "take all these steps and create the few checks I can
-use to prove this works." Conceptually — does it work the way I expect?</p>
+</li>
+</ul>
+<p>Can use Kiro spec mode in a brownfield application.</p>
+<p><strong>EARS</strong> — Easy Approach to Requirements Syntax.</p>
+<pre><code>requirements -&gt; design phase
+</code></pre>
+<p>Review the markdown, approve, move to implementation. Implementation phase can be out of order.</p>
+<p>Create an MVP from the steps — take a vertical slice, pedantically.</p>
+<ul>
+<li>Keep it short and tight, continue to review.</li>
+</ul>
+<h2>MCP</h2>
+<p>Isn't <code>MCP</code> dead? It's not as popular now… maybe still valuable for spec-driven development?</p>
+<p>Switching to CLIs is pretty common.</p>
+<pre><code>MCP &lt;-&gt; Spec Driven Development
+</code></pre>
+<ul>
+<li>specs can be pulled from project management service</li>
+<li>pulled from PM — take app/PoC and reverse-engineer it</li>
+<li>will follow rules set forth in your steering files</li>
+</ul>
+<p><strong>Property-based tests</strong> — testing to run regression tests against the requirements.</p>
+<p>"Take all these steps and create the four that I can use to prove that this works."</p>
+<p>Conceptually, does it work as I expect?</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/teaching-llms-new-tricks/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/teaching-llms-new-tricks/index.html
@@ -21,15 +21,52 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Marty Nelson · Works Real Estate · Day 2</p>
   </header>
   <div class="notes mt-8">
-<p><code>Azoth</code> is an open-source library Marty built in winter 2023-24, shelved when AI hit, then revived in Nov 2025 — the AI era changed the math and brought it back. The lesson it taught him: you don't onboard an LLM to a new framework, you <strong>subtract abstractions</strong> until the model already knows the problem.</p>
-<h2>The setup</h2>
-<p>Building a dashboard for a real estate brokerage on <code>Google Looker</code>, Marty needed a visually intensive component that wasn't in the "vending machine." Why not just write HTML and CSS? Because <code>JSX</code> is everywhere and the AI defaults to <code>React</code> — <strong>same syntax, wrong semantics</strong>. <code>Azoth</code> has no virtual DOM and controls rendering: <code>&lt;p&gt;Hello&lt;/p&gt;</code> just returns a real <code>p</code> element.</p>
-<h2>The wrong move</h2>
-<p>The first instinct was to treat the new framework like a new framework — borrow an adjacent concept, "just use it a bit." It backfired: leaning on the incumbent's language confuses the LLM. So Marty wrote a "Don't say… / Say instead" map. But <strong>describing your thing in the negative space of someone else's thing is still the wrong move</strong> — <em>don't think about a pink elephant.</em></p>
-<h2>The unlock: subtract</h2>
-<p>The real unlock is a shared mental model — a system metaphor you both hold, so you can talk about the thing AS IT IS. Don't onboard the LLM; <strong>hire it as the new senior maintainer</strong>, and they're curious about your tech. <code>Azoth</code>'s <code>JSX</code> is real DOM: it compiles HTML to a template, the JS creates no DOM, no factory function builds it — you add small, deduplicated binding helpers. What you opt INTO with <code>React</code>, you opt OUT of with <code>Azoth</code>. It accepts everything <code>JSX</code> already has — no proprietary primitives, just JS.</p>
-<p>Notice the shape: <strong>remove the abstraction.</strong> Don't replace the vDOM; subtract it. Reduce everything to a DOM problem — a component is, literally, a constructor — and the LLM reaches for a tool that fits.</p>
-<p>So prompts aren't engineering instructions; they're navigation. Push AWAY from what you're subtracting, pull TOWARD what you've unlocked. Two budgets matter now: <strong>Context</strong> (what you carry in) and <strong>Corpus</strong> (what's already in the model — spend it wisely). Subtract your abstractions, unlock the corpus.</p>
+<p><code>Azoth</code> — open source library.</p>
+<ul>
+<li>Winter 2023–24: built it.</li>
+<li>When AI hit: shelved it.</li>
+<li>Nov 2025: AI changed the math, and brought back <code>Azoth</code>!</li>
+</ul>
+<p>Creating a dashboard for a real estate brokerage — Google Looker — couldn't find the right thing in the "vending machine."</p>
+<p>Visually intensive components — just write HTML and CSS?</p>
+<p>Combining a brokerage with a property developer.</p>
+<p>Added integration analysis — high user touch.</p>
+<p><code>JSX</code> everywhere; the AI defaults to <code>React</code> — <strong>same syntax, wrong semantics.</strong></p>
+<p><code>Azoth</code> — without vDOM, controlling renderer, no JS creating the DOM — <code>&lt;p&gt;Hello&lt;/p&gt;</code> just returns a <code>p</code> tag!</p>
+<p>First instinct: treat the new framework like a new framework (take an adjacent concept); just use it a bit.</p>
+<p><strong>This backfired!</strong> Use the language, then it confuses the LLM.</p>
+<h2>"Don't Say…, Say Instead" Map</h2>
+<p>Don't confuse our innovation with the incumbent's.</p>
+<p><strong>Don't onboard the LLM: hire it as the new senior maintainer.</strong></p>
+<p>AND… they're curious about your tech!</p>
+<p>Shared mental model: a system metaphor that is shared; start a conversation.</p>
+<p>Don't describe in negative space against something else — talk about the thing as it is.</p>
+<h2>Azoth JSX is real DOM</h2>
+<ul>
+<li>What does it compile to? Doesn't interfere with JavaScript.</li>
+<li>Takes the HTML and makes a template (the JS creates no DOM).</li>
+<li>Doesn't use a factory function to make the DOM.</li>
+<li>Add how to bind, small helper functions — deduplicated.</li>
+</ul>
+<p>Like the opposite of <code>React</code> — what you opt <em>into</em> with <code>React</code> you opt <em>out of</em> with <code>Azoth</code>.</p>
+<h2>Subtraction, not replacement</h2>
+<p>Don't replace the vDOM, <strong>subtract it.</strong></p>
+<p>The leap: closures and DOM — reduce to a DOM problem.</p>
+<p><code>component = constructor</code>, literally.</p>
+<p>LLM, hey, <strong>THIS IS DOM!</strong> Reach for a tool that makes sense for the problem.</p>
+<p><code>Azoth</code> basically accepts everything that <code>JSX</code> already has. No proprietary primitives, just JS.</p>
+<p><strong>Notice the shape</strong> — this was the unlock. <strong>REMOVE the abstraction.</strong></p>
+<p>New mapping is <strong>SUBTRACT and unlock</strong>, not "don't say, say this instead."</p>
+<h2>Prompts as Navigation</h2>
+<p>Prompts aren't engineering instructions. <strong>They're navigation.</strong></p>
+<p>Push away from what is being subtracted, and pull towards what's unlocked.</p>
+<p>Avoid NEGATION, like "Don't think about a pink elephant."</p>
+<h2>Law of AI Era Innovation</h2>
+<ul>
+<li><strong>Context</strong> — what you carry into the conversation.</li>
+<li><strong>Corpus</strong> — what's already in the model — your budget! Be smart about this!</li>
+</ul>
+<p><strong>Subtract your abstractions, unlock the corpus.</strong></p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/web-workers/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/web-workers/index.html
@@ -21,43 +21,54 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Courtney Yatteau · Esri · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>UX responsiveness is a workload problem. <strong>Jank is a workload problem.</strong> When
-the main thread is busy, the UI freezes — so move the heavy work off it.</p>
-<h2>The mental model</h2>
-<p>The main thread is the <strong>front desk</strong>: clicks, paints, UI updates — and any
-heavy JS blocks the line. A worker is <strong>not</strong> a second UI; the main thread
-still owns the user experience. A worker thread is for plain data calculation:
-the main thread requests work, the worker returns a result.</p>
-<h2>THREAD — the method</h2>
-<ol>
-<li><strong>Trigger</strong> the stutter — reproduce the freeze.</li>
-<li><strong>Hunt</strong> for the blocker — dev tools, code review, performance recording.</li>
-<li><strong>Relocate</strong> the blocker — move it out of the UI thread.</li>
-<li><strong>Establish</strong> the protocol for handing work to/from the worker.</li>
-<li><strong>Add</strong> guardrails — progress, debounce, cancellation.</li>
-<li><strong>Decide</strong> where the work belongs.</li>
-</ol>
-<h2>Trigger / hunt</h2>
-<p>The demo: a heartbeat UI that freezes when a click kicks off an expensive task
-(sin/cos math over state data). Do a performance recording and you can see the
-JS work blocking the main thread.</p>
-<h2>Relocate</h2>
-<p>Offload the CPU-heavy work to a worker and the main thread is no longer
-UI-blocked.</p>
-<h2>Establish / guardrails</h2>
+<p>Keep the Main Thread Free with Web Workers</p>
+<p>UX responsiveness</p>
 <ul>
-<li><strong>Make worker messages boring.</strong> Boring is good when two threads talk — e.g.
-<code>{ type, requestId, payload }</code>.</li>
-<li><strong>Make requests cancellable.</strong> A request can become stale; preempt when a new
-message arrives by treating the latest message's <code>requestId</code> as the live one.</li>
-<li>Add the usual usability guardrails: <strong>debounce</strong> (wait), <strong>progress</strong>
-(inform), <strong>cancel</strong> (stop). For fast filters, ask whether the worker <em>can</em>
-do the work — and whether it can do <em>only enough</em> of it.</li>
+<li><code>github.com/cyatteau</code></li>
+<li><code>cascadiajs-2026-web-workers</code></li>
 </ul>
+<p><strong>Feel the freeze, prove the blocker, move the work, add guardrails, use the pattern.</strong></p>
+<p><strong>Jank is a workload problem.</strong></p>
+<h2>Thread</h2>
+<ul>
+<li>Trigger the stutter</li>
+<li>Hunt for the blocker (dev tools, code review)</li>
+<li>Relocate the blocker to move it out of the UI</li>
+<li>Establish the protocol for handling the blocker</li>
+<li>Add progress / debounce / cancellation</li>
+<li>Decide where the process belongs</li>
+</ul>
+<h2>Trigger / Hunt</h2>
+<p>Heartbeat freezes — click causes expensive task (sin/cos maths on state data).</p>
+<p>CPU-heavy process in any case.</p>
+<p>Synthetic UI.</p>
+<p>Do a performance recording — see what's going on.</p>
+<p>JS work blocking main thread.</p>
+<p><strong>Mental model: the main thread is the front desk experience</strong> — clicks, paints, UI updates, and <strong>HEAVY JS</strong> blocks the line at the front desk.</p>
+<p>A worker is <strong>NOT a second UI</strong> — main thread still owns the user experience.</p>
+<p>Worker thread is for plain data calculation.</p>
+<pre><code>main thread -&gt; requests -&gt; worker -&gt; returns result
+</code></pre>
+<h2>Relocate</h2>
+<p>Move the work to a different thread.</p>
+<p>Main thread blocked — offload to worker, and <strong>no longer UI-blocked!</strong></p>
+<h2>Establish / Add Guardrails</h2>
+<p>Make worker messages boring — <strong>boring is good when two threads talk.</strong></p>
+<ul>
+<li>e.g. <code>type</code>, <code>requestId</code>, <code>payload</code></li>
+</ul>
+<p>Make cancellable — request becomes stale.</p>
+<p>Preemptive if there's a new message — take the latest message as the <code>requestId</code>.</p>
+<p><strong>Guardrails</strong> — make this even more usable:</p>
+<ul>
+<li>debouncing — wait</li>
+<li>progress — inform</li>
+<li>cancel — stop state</li>
+</ul>
+<p>Fast filters — worker filter flow. Can the worker do the work? Yes — and can it only do <em>enough</em> work.</p>
 <h2>Decide</h2>
-<p>Workers add complexity, so they're worth it for genuinely heavy computation —
-but <strong>too heavy-handed for ordinary UI work.</strong> Use the pattern where it earns
-its keep.</p>
+<p>Workers are more expensive in complexity.</p>
+<p>Too heavy for UI work.</p>
 
   </div>
 

--- a/apps/cascadiajs2026-notes/dist/talks/wrong-abstraction/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/wrong-abstraction/index.html
@@ -21,55 +21,76 @@
     <p class="mt-2 text-[color:var(--fg-muted)]">Darius Cepulis · Mux · Day 1</p>
   </header>
   <div class="notes mt-8">
-<p>A war story: a component starts simple and gets out of control. What went
-wrong, and what else could we have done?</p>
-<p>Material UI is fantastic <em>when you start</em>. Then you outgrow it — the migration
-path was Material UI → Base UI (components you can compose).</p>
-<h2>Programming interfaces are user interfaces</h2>
-<p>From Mike Bostock's 2016 essay <em>What Makes Software Good?</em>:</p>
-<blockquote>
-<p>Programming interfaces are user interfaces. Programmers are people, too.</p>
-</blockquote>
-<ul>
-<li><strong>Form must communicate function.</strong></li>
-<li>Functions that take many arguments are not good functions.</li>
-<li><code>chart.js</code> vs. D3 is a <strong>vending machine vs. a kitchen</strong>.</li>
-</ul>
-<h2>Configuration vs. composition</h2>
-<p>The "right" abstraction question is really config-type APIs vs. composable
-APIs. <strong>Composable APIs are independent and stackable:</strong></p>
-<ul>
-<li><strong>Independent</strong> — each part does one thing well (select, find, extend; read,
-filter, count). Lego blocks.</li>
-<li><strong>Stackable</strong> — the type of the input equals the type of the output, so they
-stack. (cf. Fernando Rojo's <em>Composition Is All You Need</em>, React Universe
-Conf 2025.)</li>
-</ul>
-<p>But composable APIs <strong>aren't free.</strong> Configuration cost is linear; composition
-is log(n) — and someone asks "isn't this a bit complex?" So <strong>lower the cost of
-composition</strong>: good docs, good idioms, sensible defaults, errors that teach,
-types, consistency, discoverability, examples.</p>
-<h2>The abstraction ladder</h2>
-<p>Don't make developers spend all their time learning the Lego blocks. Provide a
-ladder:</p>
-<ul>
-<li><strong>Lowest rung</strong> — low-level code for constructing views.</li>
-<li><strong>Higher rung</strong> — a visual editor.</li>
-</ul>
-<p>You should be able to ascend or descend <strong>without starting over</strong>:</p>
-<pre><code class="language-js">const chart = Plot.plot()
-d3(chart) // descend the ladder to the lower-level primitive
+<p><strong>Choosing the Wrong Abstraction (And What It Cost Us)</strong></p>
+<p>A component that starts simple — and it gets out of control!</p>
+<p>What went wrong? What else could have been done?</p>
+<p><code>Material UI</code> — when you start, it's fantastic!</p>
+<pre><code>Material UI -&gt; Base UI
 </code></pre>
-<p>Examples: D3 ↔ Plot, chart.js ↔ Observable Plot, shadcn → Base UI → HTML/CSS,
-Video.js (eject the skin to get the primitives). <strong>Escape hatches are a config
-trap</strong> — design the ladder instead.</p>
-<h2>"Can't we just vibe-code this?"</h2>
-<p>Per <em>Coding After Coders</em> (NYT Magazine): the Google CEO said devs are only ~10%
-faster, while a startup claimed 20×. The difference is <strong>brownfield vs.
-greenfield.</strong> Make code <strong>AI-ready</strong> — open for LLMs to read, understand, and
-improve. <code>decepulis/ax-bench</code> did better with a composable API. <strong>Good DX is
-usually good AX.</strong> And the right abstraction leads to smaller bundles (with
-tree-shaking, at least).</p>
+<p>Components that can be composed.</p>
+<p>2016 essay — Mike Bostock — <em>What Makes Software Good?</em></p>
+<p><strong>Programming interfaces are user interfaces. Programmers are people, too.</strong></p>
+<p>Form must communicate function.</p>
+<p>Functions that take many arguments are not good functions.</p>
+<p><code>chart.js</code> vs <code>D3</code></p>
+<pre><code>vending machine vs kitchen
+</code></pre>
+<h2>What IS the "right" abstraction?</h2>
+<p>Configuration-type APIs vs composable APIs.</p>
+<p><strong>Composable APIs are INDEPENDENT and STACKABLE.</strong></p>
+<ul>
+<li><strong>Independent</strong> — each part does one thing well; <code>select</code>, <code>find</code>, <code>extend</code>; <code>read</code>, <code>filter</code>, <code>count</code>. Lego blocks.</li>
+<li><strong>Stackable</strong> — the type of the input == the type of the output — stackkkkkkk!!!</li>
+</ul>
+<p><em>Composition is All You Need</em> — Fernando Rojo — 2025 React Universe Conf.</p>
+<p>"isn't this a bit complex?"</p>
+<p><strong>Composable APIs AREN'T FREE.</strong></p>
+<p>Configuration is linear, but composition is log(n).</p>
+<p><strong>Lower the cost of composition!</strong></p>
+<p>Why do we have the developers spend all their time learning the lego blocks?</p>
+<p>Lower the cost:</p>
+<ul>
+<li>good docs</li>
+<li>good idioms</li>
+<li>defaults</li>
+<li>errors that teach</li>
+<li>types</li>
+<li>consistency</li>
+<li>discoverability</li>
+<li>examples</li>
+</ul>
+<h2>Provide an abstraction ladder</h2>
+<ul>
+<li>lowest rung — low-level code for constructing views</li>
+<li>higher rung — visual editor</li>
+</ul>
+<p>Gives a tradeoff of getting started quickly and getting more power.</p>
+<p><code>D3</code> vs <code>Plot</code></p>
+<p><code>chart.js</code> vs <code>Observable Plot</code></p>
+<p>You should be able to descend or ascend the ladder without having to start all over.</p>
+<pre><code>const chart = Plot.plot()
+d3(chart)   // now descending the ladder
+</code></pre>
+<pre><code>shadcn -&gt; BaseUI -&gt; HTML/CSS
+</code></pre>
+<h2>Can't we just vibe code this?</h2>
+<p><em>Coding After Coders</em> — NYT magazine.</p>
+<p>CEO of Google said devs only working 10% faster; startup is 20x?? Brownfield vs greenfield is the reason.</p>
+<p><strong>AI-ready</strong> — open code for LLMs to read, understand, and improve.</p>
+<p><code>decepulis/ax-bench</code> — did better with a composable API.</p>
+<p><strong>Good DX is USUALLY good AX.</strong></p>
+<pre><code>|—————————————-|
+CONFIG          COMPOSE
+defaults        options
+</code></pre>
+<p>Add ladder.</p>
+<p>Escape hatches are a config trap.</p>
+<p><code>VideoJS</code></p>
+<ul>
+<li>swapping lego blocks</li>
+<li>eject skin to get primitives</li>
+</ul>
+<p>The right abstraction leads to smaller bundles (for JS, with tree-shaking at least).</p>
 
   </div>
 


### PR DESCRIPTION
The published bodies read as dense prose, which flattened the open,
line-by-line rhythm of the original notes. This rewrites all 24 talk
bodies (both days) in an airy note layout — short lines, bullets for list
runs, section headings, and code fences for diagrams — so the site reads
like the notes it is. Content is unchanged; only the presentation. Also
completes the Fred Brooks quote in the TypeScript talk.

Closes #727.