### PR TITLE
fix(apps/cascadiajs2026-notes): strike through AI in rethink note

### DIFF
--- a/apps/cascadiajs2026-notes/content/talks/rethink-everything.md
+++ b/apps/cascadiajs2026-notes/content/talks/rethink-everything.md
@@ -1,6 +1,6 @@
 Building software is **WAYYYY different** because…
 
-**AI is the cloud!**
+**~~AI~~ the cloud!**
 
 ## Life before the cloud
 

--- a/apps/cascadiajs2026-notes/dist/talks/rethink-everything/index.html
+++ b/apps/cascadiajs2026-notes/dist/talks/rethink-everything/index.html
@@ -22,7 +22,7 @@
   </header>
   <div class="notes mt-8">
 <p>Building software is <strong>WAYYYY different</strong> because…</p>
-<p><strong>AI is the cloud!</strong></p>
+<p><strong><del>AI</del> the cloud!</strong></p>
 <h2>Life before the cloud</h2>
 <ol>
 <li>Building was more capital-intense</li>


### PR DESCRIPTION
The opening line rendered as "AI is the cloud!"; it should be the original
note — "AI the cloud!" with AI struck through — the rhetorical setup for
Theo's AI-is-the-new-cloud parallel. Uses GFM strikethrough, already
enabled in build-site. dist/ regenerated.