### PR TITLE
feat(shaka): add --json output to repo audit

### DIFF
--- a/tools/shaka/src/commit.rs
+++ b/tools/shaka/src/commit.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::process::Command;
 
 use clap::Subcommand;
+use serde::Serialize;
 
 use crate::jj;
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
@@ -28,6 +29,9 @@ pub enum CommitCommand {
         /// docs sweeps, exploratory branches).
         #[arg(long)]
         allow_no_issue_link: bool,
+        /// Emit a machine-readable JSON report instead of prose
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -36,11 +40,29 @@ pub fn run(cmd: CommitCommand) {
         CommitCommand::Lint {
             revset,
             allow_no_issue_link,
-        } => lint(&revset, allow_no_issue_link),
+            json,
+        } => lint(&revset, allow_no_issue_link, json),
     }
 }
 
-fn lint(revset: &str, allow_no_issue_link: bool) {
+/// Machine-readable `commit lint` result, emitted under `--json`.
+#[derive(Serialize)]
+struct LintReport {
+    commits: Vec<CommitReport>,
+    total_errors: usize,
+    total_warnings: usize,
+    clean: usize,
+    success: bool,
+}
+
+#[derive(Serialize)]
+struct CommitReport {
+    change_id: String,
+    title: String,
+    findings: Vec<Finding>,
+}
+
+fn lint(revset: &str, allow_no_issue_link: bool, json: bool) {
     let commits = match collect_commits(revset) {
         Ok(c) => c,
         Err(e) => {
@@ -50,7 +72,16 @@ fn lint(revset: &str, allow_no_issue_link: bool) {
     };
 
     if commits.is_empty() {
-        println!("no commits found in revset {revset:?}");
+        let report = LintReport {
+            commits: Vec::new(),
+            total_errors: 0,
+            total_warnings: 0,
+            clean: 0,
+            success: true,
+        };
+        crate::output::emit(json, &report, |_| {
+            println!("no commits found in revset {revset:?}");
+        });
         return;
     }
 
@@ -59,65 +90,87 @@ fn lint(revset: &str, allow_no_issue_link: bool) {
         tied_issues: gather_tied_issues(revset),
     };
 
+    let mut commit_reports: Vec<CommitReport> = Vec::new();
     let mut total_errors = 0usize;
     let mut total_warnings = 0usize;
     let mut clean = 0usize;
 
     for commit in &commits {
         let findings = lint_commit(commit, &ctx);
-        let errors = findings
+        total_errors += findings
             .iter()
             .filter(|f| matches!(f.severity, Severity::Error))
             .count();
-        let warnings = findings
+        total_warnings += findings
             .iter()
             .filter(|f| matches!(f.severity, Severity::Warn))
             .count();
-
         if findings.is_empty() {
             clean += 1;
-        } else {
-            print_commit_findings(commit, &findings);
         }
 
-        total_errors += errors;
-        total_warnings += warnings;
+        let title = commit
+            .description
+            .lines()
+            .next()
+            .unwrap_or("(empty)")
+            .to_string();
+        commit_reports.push(CommitReport {
+            change_id: commit.change_id.clone(),
+            title,
+            findings,
+        });
     }
 
-    println!();
-    if total_errors > 0 {
-        eprintln!(
-            "{RED}{BOLD}commit lint failed{RESET} ({} commit(s), {total_errors} error(s), {total_warnings} warning(s))",
-            commits.len()
-        );
+    let report = LintReport {
+        commits: commit_reports,
+        total_errors,
+        total_warnings,
+        clean,
+        success: total_errors == 0,
+    };
+
+    crate::output::emit(json, &report, render_human);
+
+    if !report.success {
         std::process::exit(1);
     }
-    let warn_str = if total_warnings > 0 {
-        format!(" ({total_warnings} warning(s))")
+}
+
+fn render_human(report: &LintReport) {
+    for c in &report.commits {
+        if c.findings.is_empty() {
+            continue;
+        }
+        let short = &c.change_id[..c.change_id.len().min(8)];
+        println!("\n{BOLD}{short} {DIM}{}{RESET}", c.title);
+        for f in &c.findings {
+            let label = match f.severity {
+                Severity::Error => format!("{RED}{BOLD}error{RESET}"),
+                Severity::Warn => format!("{YELLOW}{BOLD}warn{RESET} "),
+            };
+            println!("  {label}  {}", f.message);
+        }
+    }
+
+    let n = report.commits.len();
+    println!();
+    if report.total_errors > 0 {
+        eprintln!(
+            "{RED}{BOLD}commit lint failed{RESET} ({n} commit(s), {} error(s), {} warning(s))",
+            report.total_errors, report.total_warnings
+        );
+        return;
+    }
+    let warn_str = if report.total_warnings > 0 {
+        format!(" ({} warning(s))", report.total_warnings)
     } else {
         String::new()
     };
     println!(
-        "{GREEN}{BOLD}commit lint passed{RESET} ({clean}/{} clean){warn_str}",
-        commits.len()
+        "{GREEN}{BOLD}commit lint passed{RESET} ({}/{n} clean){warn_str}",
+        report.clean
     );
-}
-
-fn print_commit_findings(commit: &Commit, findings: &[Finding]) {
-    let title = commit
-        .description
-        .lines()
-        .next()
-        .unwrap_or("(empty)")
-        .to_string();
-    println!("\n{BOLD}{} {DIM}{}{RESET}", commit.short_id(), title);
-    for f in findings {
-        let label = match f.severity {
-            Severity::Error => format!("{RED}{BOLD}error{RESET}"),
-            Severity::Warn => format!("{YELLOW}{BOLD}warn{RESET} "),
-        };
-        println!("  {label}  {}", f.message);
-    }
 }
 
 #[derive(Debug)]
@@ -145,19 +198,14 @@ struct LintContext {
     tied_issues: Vec<u64>,
 }
 
-impl Commit {
-    fn short_id(&self) -> &str {
-        &self.change_id[..self.change_id.len().min(8)]
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 enum Severity {
     Error,
     Warn,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct Finding {
     severity: Severity,
     message: String,
@@ -759,5 +807,46 @@ mod tests {
             !findings.iter().any(|f| f.message.contains("Closes #")),
             "expected suppression, got: {findings:?}"
         );
+    }
+
+    #[test]
+    fn lint_report_json_shape_is_stable() {
+        let report = LintReport {
+            commits: vec![
+                CommitReport {
+                    change_id: "abcdef1234567890".to_string(),
+                    title: "feat(x): clean one".to_string(),
+                    findings: vec![],
+                },
+                CommitReport {
+                    change_id: "0011223344556677".to_string(),
+                    title: "bad title".to_string(),
+                    findings: vec![
+                        Finding {
+                            severity: Severity::Error,
+                            message: "title must follow <type>(<scope>): <subject>".to_string(),
+                        },
+                        Finding {
+                            severity: Severity::Warn,
+                            message: "commit spans multiple projects".to_string(),
+                        },
+                    ],
+                },
+            ],
+            total_errors: 1,
+            total_warnings: 1,
+            clean: 1,
+            success: false,
+        };
+        let v: serde_json::Value = serde_json::to_value(&report).unwrap();
+
+        assert_eq!(v["success"], false);
+        assert_eq!(v["total_errors"], 1);
+        assert_eq!(v["total_warnings"], 1);
+        assert_eq!(v["clean"], 1);
+        assert_eq!(v["commits"][0]["change_id"], "abcdef1234567890");
+        assert_eq!(v["commits"][0]["findings"].as_array().unwrap().len(), 0);
+        assert_eq!(v["commits"][1]["findings"][0]["severity"], "error");
+        assert_eq!(v["commits"][1]["findings"][1]["severity"], "warn");
     }
 }

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -81,6 +81,9 @@ enum Commands {
         /// Skip checks whose path scope does not intersect changes since this git ref
         #[arg(long, value_name = "REF")]
         since: Option<String>,
+        /// Emit a machine-readable JSON report instead of streaming progress
+        #[arg(long)]
+        json: bool,
     },
     /// Project tooling (schema validation, justfile generation, etc.)
     Project {
@@ -133,7 +136,11 @@ fn main() {
         Commands::Domain { command } => domain::run(command),
         Commands::Issue { command } => issue::run(command),
         Commands::ObjectStore { command } => object_store::run(command),
-        Commands::Preflight { keep_going, since } => preflight::run(keep_going, since),
+        Commands::Preflight {
+            keep_going,
+            since,
+            json,
+        } => preflight::run(keep_going, since, json),
         Commands::Project { command } => project::run(command),
         Commands::Repo { command } => repo::run(command),
         Commands::Terraform { command } => terraform::run(command),

--- a/tools/shaka/src/main.rs
+++ b/tools/shaka/src/main.rs
@@ -12,6 +12,7 @@ mod gh;
 mod issue;
 mod jj;
 mod object_store;
+mod output;
 mod preflight;
 mod project;
 mod repo;

--- a/tools/shaka/src/output.rs
+++ b/tools/shaka/src/output.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+use crate::term::{BOLD, RED, RESET};
+
+/// Emit a command result either as pretty-printed JSON (when `json` is
+/// true) or via the provided human renderer.
+///
+/// Centralizes the json/human switch every structured-output command
+/// shares: in JSON mode a serialization failure prints to stderr and
+/// exits non-zero, matching the error convention used across `shaka`.
+/// In human mode the closure renders as before.
+pub fn emit<T: Serialize>(json: bool, value: &T, render_human: impl FnOnce(&T)) {
+    if json {
+        match serde_json::to_string_pretty(value) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} failed to serialize output: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        render_human(value);
+    }
+}

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -1,8 +1,35 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use serde::Serialize;
 
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+
+/// Set in `--json` mode: checks capture subprocess output into their
+/// `detail` instead of streaming it to the terminal, so stdout stays a
+/// clean JSON document and failure detail carries the tool's own output.
+static CAPTURE_OUTPUT: AtomicBool = AtomicBool::new(false);
+
+fn capture_output() -> bool {
+    CAPTURE_OUTPUT.load(Ordering::Relaxed)
+}
+
+/// Combine a child process's stdout and stderr into one trimmed string
+/// for a failed check's `detail`.
+fn combined_output(out: &Output) -> String {
+    let mut s = String::from_utf8_lossy(&out.stdout).into_owned();
+    let err = String::from_utf8_lossy(&out.stderr);
+    if !err.trim().is_empty() {
+        if !s.trim().is_empty() {
+            s.push('\n');
+        }
+        s.push_str(&err);
+    }
+    s.trim().to_string()
+}
 
 enum CheckResult {
     Pass,
@@ -15,6 +42,36 @@ struct Check {
     /// Empty list means "always run regardless of changed files".
     paths: &'static [&'static str],
     run: fn() -> CheckResult,
+}
+
+/// Machine-readable preflight result, emitted under `--json`. Stable
+/// enough for CI parsers and assistant fix-routing to depend on.
+#[derive(Serialize)]
+struct PreflightReport {
+    checks: Vec<CheckReport>,
+    total: usize,
+    passed: usize,
+    failed: usize,
+    skipped: usize,
+    success: bool,
+}
+
+#[derive(Serialize)]
+struct CheckReport {
+    name: String,
+    /// `"repo"` for cross-project checks, `"project"` for a per-project
+    /// `just validate`.
+    kind: &'static str,
+    /// `"pass"`, `"fail"`, or `"skipped"` (path scope didn't intersect
+    /// `--since`).
+    status: &'static str,
+    duration_ms: u128,
+    /// Tool stderr / failure detail; present only for failed checks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    /// Path scope that selects this check: glob patterns for repo
+    /// checks, the project directory for project checks.
+    paths: Vec<String>,
 }
 
 const CHECKS: &[Check] = &[
@@ -151,7 +208,12 @@ const CHECKS: &[Check] = &[
     },
 ];
 
-pub fn run(keep_going: bool, since: Option<String>) {
+pub fn run(keep_going: bool, since: Option<String>, json: bool) {
+    // JSON mode emits a single document at the end, so suppress the
+    // streaming per-check progress lines and have checks capture their
+    // subprocess output into `detail` rather than printing to stdout.
+    let stream = !json;
+    CAPTURE_OUTPUT.store(json, Ordering::Relaxed);
     let changed = match since.as_deref() {
         Some(r) => match changed_paths(r) {
             Ok(p) => Some(p),
@@ -179,18 +241,36 @@ pub fn run(keep_going: bool, since: Option<String>) {
     let total = repo_to_run.len() + project_to_run.len();
     let total_skipped = repo_skipped.len() + project_skipped.len();
 
+    let mut checks: Vec<CheckReport> = Vec::new();
     let mut passed = 0usize;
-    let mut failures: Vec<(String, CheckResult)> = Vec::new();
+    let mut failed = 0usize;
     let mut bail = false;
 
-    if changed.is_some() {
-        if total_skipped == 0 {
-            println!(
-                "{BOLD}preflight:{RESET} running {} repo + {} project checks",
-                repo_to_run.len(),
-                project_to_run.len()
-            );
-        } else {
+    // Path-scope skips: record as `skipped` entries so a JSON consumer
+    // sees the full check inventory, not just what ran.
+    for c in &repo_skipped {
+        checks.push(CheckReport {
+            name: c.name.to_string(),
+            kind: "repo",
+            status: "skipped",
+            duration_ms: 0,
+            detail: None,
+            paths: c.paths.iter().map(|p| (*p).to_string()).collect(),
+        });
+    }
+    for p in &project_skipped {
+        checks.push(CheckReport {
+            name: project_label(p),
+            kind: "project",
+            status: "skipped",
+            duration_ms: 0,
+            detail: None,
+            paths: vec![project_label(p)],
+        });
+    }
+
+    if stream {
+        if changed.is_some() && total_skipped > 0 {
             println!(
                 "{BOLD}preflight:{RESET} running {} repo + {} project checks ({YELLOW}skipped:{RESET} {} repo, {} projects)",
                 repo_to_run.len(),
@@ -198,34 +278,59 @@ pub fn run(keep_going: bool, since: Option<String>) {
                 repo_skipped.len(),
                 project_skipped.len()
             );
+        } else {
+            println!(
+                "{BOLD}preflight:{RESET} running {} repo + {} project checks",
+                repo_to_run.len(),
+                project_to_run.len()
+            );
         }
-    } else {
-        println!(
-            "{BOLD}preflight:{RESET} running {} repo + {} project checks",
-            repo_to_run.len(),
-            project_to_run.len()
-        );
     }
 
     let mut idx = 0usize;
     for check in &repo_to_run {
         idx += 1;
-        let label = format!("[repo {}/{}] {}", idx, repo_to_run.len(), check.name);
-        print!("  {label} ... ");
-        std::io::stdout().flush().ok();
+        if stream {
+            let label = format!("[repo {}/{}] {}", idx, repo_to_run.len(), check.name);
+            print!("  {label} ... ");
+            std::io::stdout().flush().ok();
+        }
 
+        let start = Instant::now();
         let result = (check.run)();
-        match &result {
+        let duration_ms = start.elapsed().as_millis();
+        let paths: Vec<String> = check.paths.iter().map(|p| (*p).to_string()).collect();
+        match result {
             CheckResult::Pass => {
-                println!("{GREEN}{BOLD}ok{RESET}");
-                passed += 1;
-            }
-            CheckResult::Fail { detail, .. } => {
-                println!("{RED}{BOLD}FAIL{RESET}");
-                if !detail.is_empty() {
-                    println!("    {DIM}{detail}{RESET}");
+                if stream {
+                    println!("{GREEN}{BOLD}ok{RESET}");
                 }
-                failures.push((check.name.to_string(), result));
+                passed += 1;
+                checks.push(CheckReport {
+                    name: check.name.to_string(),
+                    kind: "repo",
+                    status: "pass",
+                    duration_ms,
+                    detail: None,
+                    paths,
+                });
+            }
+            CheckResult::Fail { detail } => {
+                if stream {
+                    println!("{RED}{BOLD}FAIL{RESET}");
+                    if !detail.is_empty() {
+                        println!("    {DIM}{detail}{RESET}");
+                    }
+                }
+                failed += 1;
+                checks.push(CheckReport {
+                    name: check.name.to_string(),
+                    kind: "repo",
+                    status: "fail",
+                    duration_ms,
+                    detail: Some(detail),
+                    paths,
+                });
                 if !keep_going {
                     bail = true;
                     break;
@@ -237,27 +342,51 @@ pub fn run(keep_going: bool, since: Option<String>) {
     if !bail {
         for (i, project) in project_to_run.iter().enumerate() {
             let display = project_label(project);
-            let label = format!(
-                "[proj {}/{}] {} (just validate)",
-                i + 1,
-                project_to_run.len(),
-                display
-            );
-            print!("  {label} ... ");
-            std::io::stdout().flush().ok();
+            if stream {
+                let label = format!(
+                    "[proj {}/{}] {} (just validate)",
+                    i + 1,
+                    project_to_run.len(),
+                    display
+                );
+                print!("  {label} ... ");
+                std::io::stdout().flush().ok();
+            }
 
+            let start = Instant::now();
             let result = just_validate(project);
-            match &result {
+            let duration_ms = start.elapsed().as_millis();
+            match result {
                 CheckResult::Pass => {
-                    println!("{GREEN}{BOLD}ok{RESET}");
-                    passed += 1;
-                }
-                CheckResult::Fail { detail, .. } => {
-                    println!("{RED}{BOLD}FAIL{RESET}");
-                    if !detail.is_empty() {
-                        println!("    {DIM}{detail}{RESET}");
+                    if stream {
+                        println!("{GREEN}{BOLD}ok{RESET}");
                     }
-                    failures.push((display, result));
+                    passed += 1;
+                    checks.push(CheckReport {
+                        name: display,
+                        kind: "project",
+                        status: "pass",
+                        duration_ms,
+                        detail: None,
+                        paths: vec![project_label(project)],
+                    });
+                }
+                CheckResult::Fail { detail } => {
+                    if stream {
+                        println!("{RED}{BOLD}FAIL{RESET}");
+                        if !detail.is_empty() {
+                            println!("    {DIM}{detail}{RESET}");
+                        }
+                    }
+                    failed += 1;
+                    checks.push(CheckReport {
+                        name: display,
+                        kind: "project",
+                        status: "fail",
+                        duration_ms,
+                        detail: Some(detail),
+                        paths: vec![project_label(project)],
+                    });
                     if !keep_going {
                         break;
                     }
@@ -266,24 +395,42 @@ pub fn run(keep_going: bool, since: Option<String>) {
         }
     }
 
-    println!();
-    if failures.is_empty() {
-        println!(
-            "{GREEN}{BOLD}preflight passed{RESET} ({passed}/{total}{})",
-            if total_skipped > 0 {
-                format!(", {total_skipped} skipped")
-            } else {
-                String::new()
-            }
-        );
-        return;
-    }
+    let report = PreflightReport {
+        checks,
+        total,
+        passed,
+        failed,
+        skipped: total_skipped,
+        success: failed == 0,
+    };
 
-    eprintln!(
-        "{RED}{BOLD}preflight failed{RESET} ({passed} passed, {} failed of {total})",
-        failures.len()
-    );
-    std::process::exit(1);
+    crate::output::emit(json, &report, render_human_summary);
+
+    if !report.success {
+        std::process::exit(1);
+    }
+}
+
+/// Trailing summary line for human mode; the per-check lines were already
+/// streamed as the checks ran.
+fn render_human_summary(report: &PreflightReport) {
+    println!();
+    if report.success {
+        let skipped = if report.skipped > 0 {
+            format!(", {} skipped", report.skipped)
+        } else {
+            String::new()
+        };
+        println!(
+            "{GREEN}{BOLD}preflight passed{RESET} ({}/{}{skipped})",
+            report.passed, report.total
+        );
+    } else {
+        eprintln!(
+            "{RED}{BOLD}preflight failed{RESET} ({} passed, {} failed of {})",
+            report.passed, report.failed, report.total
+        );
+    }
 }
 
 /// Render a project path like "tools/shaka" — drops a leading `./` when present.
@@ -424,6 +571,25 @@ fn vale_check() -> CheckResult {
         return CheckResult::Pass;
     }
 
+    // JSON mode: the suggestion-level display pass exists only for live
+    // human output, so skip it and run a single warning-level pass with
+    // captured output feeding the report's `detail` on failure.
+    if capture_output() {
+        return match Command::new("vale")
+            .args(["--minAlertLevel=warning"])
+            .args(&md_files)
+            .output()
+        {
+            Ok(out) if out.status.success() => CheckResult::Pass,
+            Ok(out) => CheckResult::Fail {
+                detail: combined_output(&out),
+            },
+            Err(e) => CheckResult::Fail {
+                detail: format!("failed to spawn vale: {e}"),
+            },
+        };
+    }
+
     // Two passes so suggestions print but don't gate. Vale's
     // `--minAlertLevel` controls both display and exit code, so to honor
     // "show suggestions, fail on warnings" we display once at suggestion
@@ -512,6 +678,25 @@ fn spawn_self(args: &[&str]) -> CheckResult {
 }
 
 fn run_command(cmd: &mut Command) -> CheckResult {
+    if capture_output() {
+        // JSON mode: capture combined output so the report's `detail`
+        // carries the tool's own stderr/stdout, and the parent's stdout
+        // stays a clean JSON document.
+        return match cmd
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+        {
+            Ok(out) if out.status.success() => CheckResult::Pass,
+            Ok(out) => CheckResult::Fail {
+                detail: combined_output(&out),
+            },
+            Err(e) => CheckResult::Fail {
+                detail: format!("failed to spawn: {e}"),
+            },
+        };
+    }
+
     // Stream stdout/stderr to the parent so progress is visible as it
     // happens. With nix-heavy per-project commands (cargo build, nix
     // develop closures), capturing output keeps the user staring at a
@@ -533,6 +718,58 @@ fn run_command(cmd: &mut Command) -> CheckResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn report_json_shape_is_stable() {
+        let report = PreflightReport {
+            checks: vec![
+                CheckReport {
+                    name: "typos".to_string(),
+                    kind: "repo",
+                    status: "pass",
+                    duration_ms: 12,
+                    detail: None,
+                    paths: vec![],
+                },
+                CheckReport {
+                    name: "tools/shaka".to_string(),
+                    kind: "project",
+                    status: "fail",
+                    duration_ms: 3400,
+                    detail: Some("clippy: unused import".to_string()),
+                    paths: vec!["tools/shaka".to_string()],
+                },
+                CheckReport {
+                    name: "infra/devbox".to_string(),
+                    kind: "project",
+                    status: "skipped",
+                    duration_ms: 0,
+                    detail: None,
+                    paths: vec!["infra/devbox".to_string()],
+                },
+            ],
+            total: 2,
+            passed: 1,
+            failed: 1,
+            skipped: 1,
+            success: false,
+        };
+        let v: serde_json::Value = serde_json::to_value(&report).unwrap();
+
+        assert_eq!(v["success"], false);
+        assert_eq!(v["total"], 2);
+        assert_eq!(v["passed"], 1);
+        assert_eq!(v["failed"], 1);
+        assert_eq!(v["skipped"], 1);
+
+        // Passing checks omit `detail`; failing checks carry the tool output.
+        assert!(v["checks"][0].get("detail").is_none());
+        assert_eq!(v["checks"][0]["status"], "pass");
+        assert_eq!(v["checks"][1]["status"], "fail");
+        assert_eq!(v["checks"][1]["detail"], "clippy: unused import");
+        assert_eq!(v["checks"][2]["status"], "skipped");
+        assert_eq!(v["checks"][1]["kind"], "project");
+    }
 
     #[test]
     fn matches_exact_path() {

--- a/tools/shaka/src/repo.rs
+++ b/tools/shaka/src/repo.rs
@@ -24,6 +24,11 @@ pub enum RepoCommand {
         /// Apply recommended settings automatically
         #[arg(long)]
         fix: bool,
+
+        /// Emit a machine-readable JSON report instead of grouped tables.
+        /// Read-only, so it cannot be combined with --fix.
+        #[arg(long, conflicts_with = "fix")]
+        json: bool,
     },
     /// Fetch from origin and rebase the current change onto main@origin
     Sync {
@@ -196,7 +201,7 @@ pub enum RepoCommand {
 
 pub fn run(cmd: RepoCommand) {
     match cmd {
-        RepoCommand::Audit { repo, fix } => audit::run(repo, fix),
+        RepoCommand::Audit { repo, fix, json } => audit::run(repo, fix, json),
         RepoCommand::Sync {
             dry_run,
             no_cleanup_hint,

--- a/tools/shaka/src/repo/audit.rs
+++ b/tools/shaka/src/repo/audit.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 
 use crate::gh;
@@ -8,7 +9,8 @@ use crate::repo::policy::{
 };
 use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
 enum Status {
     Pass,
     Fail,
@@ -16,10 +18,26 @@ enum Status {
     Error,
 }
 
+#[derive(Serialize)]
 struct Check {
     name: &'static str,
     status: Status,
     detail: String,
+}
+
+/// Machine-readable `repo audit` result, emitted under `--json`. Mirrors
+/// the grouped human output 1:1.
+#[derive(Serialize)]
+struct AuditReport {
+    repo: String,
+    groups: Vec<Group>,
+    success: bool,
+}
+
+#[derive(Serialize)]
+struct Group {
+    title: String,
+    checks: Vec<Check>,
 }
 
 impl Check {
@@ -69,7 +87,7 @@ impl Check {
     }
 }
 
-pub fn run(repo_arg: Option<String>, fix: bool) {
+pub fn run(repo_arg: Option<String>, fix: bool, json: bool) {
     // Policy source decision: when --repo is explicit, fetch the
     // target's own .shaka/repo.cue via the GitHub contents API.
     // Using cwd's policy across repos compared the wrong policy
@@ -128,26 +146,42 @@ pub fn run(repo_arg: Option<String>, fix: bool) {
         }
     };
 
-    println!("{BOLD}Auditing {repo}{RESET}\n");
+    // JSON mode emits a single document at the end, so suppress the
+    // streamed header and per-group tables; human mode keeps them.
+    let stream = !json;
+    if stream {
+        println!("{BOLD}Auditing {repo}{RESET}\n");
+    }
 
+    let mut groups: Vec<Group> = Vec::new();
     let mut has_failure = false;
 
     let (checks, _repo_data) = check_general(&repo, &policy);
-    print_group("Repository Settings", &checks);
     has_failure |= checks.iter().any(|c| c.status == Status::Fail);
-
+    if stream {
+        print_group("Repository Settings", &checks);
+    }
     if fix {
         fix_general(&repo, &checks, &policy);
     }
+    groups.push(Group {
+        title: "Repository Settings".to_string(),
+        checks,
+    });
 
     if let Some(bp) = &policy.branch_protection {
         let checks = check_branch_protection(&repo, bp);
-        print_group("Branch Protection (main)", &checks);
         has_failure |= checks.iter().any(|c| c.status == Status::Fail);
-
+        if stream {
+            print_group("Branch Protection (main)", &checks);
+        }
         if fix {
             fix_branch_protection(&repo, &checks, bp);
         }
+        groups.push(Group {
+            title: "Branch Protection (main)".to_string(),
+            checks,
+        });
     }
 
     if let Some(rs) = &policy.rulesets {
@@ -155,32 +189,53 @@ pub fn run(repo_arg: Option<String>, fix: bool) {
         let expected_checks = bp_ref.map(|bp| bp.required_checks.as_slice());
         let expected_strict = bp_ref.map(|bp| bp.strict_status_checks);
         let checks = check_rulesets(&repo, rs, expected_checks, expected_strict);
-        print_group("Rulesets", &checks);
         has_failure |= checks.iter().any(|c| c.status == Status::Fail);
-
+        if stream {
+            print_group("Rulesets", &checks);
+        }
         if fix {
             fix_rulesets(&repo, &checks, expected_strict);
         }
+        groups.push(Group {
+            title: "Rulesets".to_string(),
+            checks,
+        });
     }
 
     if let Some(sec) = &policy.security {
         let checks = check_security(&repo, sec);
-        print_group("Security", &checks);
         has_failure |= checks.iter().any(|c| c.status == Status::Fail);
-
+        if stream {
+            print_group("Security", &checks);
+        }
         if fix {
             fix_security(&repo, &checks);
         }
+        groups.push(Group {
+            title: "Security".to_string(),
+            checks,
+        });
     }
 
-    println!();
-    if has_failure {
-        if !fix {
+    let report = AuditReport {
+        repo,
+        groups,
+        success: !has_failure,
+    };
+
+    // Human mode already streamed the group tables above; the renderer
+    // only adds the trailing summary line.
+    crate::output::emit(json, &report, |r| {
+        println!();
+        if r.success {
+            println!("{GREEN}{BOLD}All checks passed{RESET}");
+        } else if !fix {
             println!("{YELLOW}Run with --fix to apply recommended settings{RESET}");
         }
+    });
+
+    if has_failure {
         std::process::exit(1);
-    } else {
-        println!("{GREEN}{BOLD}All checks passed{RESET}");
     }
 }
 
@@ -703,5 +758,39 @@ fn bool_check(name: &'static str, pass: bool, pass_msg: &str, fail_msg: &str) ->
         Check::pass(name, pass_msg)
     } else {
         Check::fail(name, fail_msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_report_json_shape_is_stable() {
+        let report = AuditReport {
+            repo: "owner/repo".to_string(),
+            groups: vec![Group {
+                title: "Security".to_string(),
+                checks: vec![
+                    Check::pass("Dependabot alerts", "enabled"),
+                    Check::fail("Secret scanning", "disabled"),
+                    Check::warn("Code scanning", "no default setup"),
+                    Check::error("Unknown", "api error"),
+                ],
+            }],
+            success: false,
+        };
+        let v: serde_json::Value = serde_json::to_value(&report).unwrap();
+
+        assert_eq!(v["repo"], "owner/repo");
+        assert_eq!(v["success"], false);
+        assert_eq!(v["groups"][0]["title"], "Security");
+        let checks = &v["groups"][0]["checks"];
+        assert_eq!(checks[0]["status"], "pass");
+        assert_eq!(checks[0]["name"], "Dependabot alerts");
+        assert_eq!(checks[0]["detail"], "enabled");
+        assert_eq!(checks[1]["status"], "fail");
+        assert_eq!(checks[2]["status"], "warn");
+        assert_eq!(checks[3]["status"], "error");
     }
 }

--- a/tools/shaka/src/repo/describe.rs
+++ b/tools/shaka/src/repo/describe.rs
@@ -118,21 +118,13 @@ pub fn run(json: bool) {
         }
     };
 
-    if json {
-        match serde_json::to_string_pretty(&description) {
-            Ok(s) => println!("{s}"),
-            Err(e) => {
-                eprintln!("{RED}{BOLD}error:{RESET} failed to serialize description: {e}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        println!("{}", description.title);
-        if !description.body.is_empty() {
+    crate::output::emit(json, &description, |d| {
+        println!("{}", d.title);
+        if !d.body.is_empty() {
             println!();
-            println!("{}", description.body);
+            println!("{}", d.body);
         }
-    }
+    });
 }
 
 #[cfg(test)]

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -91,7 +91,7 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, no_auto_merge: bool, dry_r
         println!(
             "{BOLD}main@origin advanced — re-running preflight{RESET} {DIM}(rebase pulled in new ancestors){RESET}"
         );
-        preflight::run(false, Some("main@origin".to_string()));
+        preflight::run(false, Some("main@origin".to_string()), false);
     }
 
     println!("{BOLD}setting bookmark {bookmark}{RESET}");

--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -78,6 +78,7 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
     commit::run(CommitCommand::Lint {
         revset: SHIP_REVSET.to_string(),
         allow_no_issue_link: false,
+        json: false,
     });
 
     println!("{BOLD}step 4/6: self-review diff{RESET} {DIM}({SHIP_REVSET}){RESET}");

--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -90,7 +90,7 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
         println!("{BOLD}step 5/6: preflight{RESET} {DIM}(skipped via --skip-preflight){RESET}");
     } else {
         println!("{BOLD}step 5/6: preflight{RESET}");
-        preflight::run(false, None);
+        preflight::run(false, None, false);
     }
 
     println!("{BOLD}step 6/6: handing off to repo send{RESET}");

--- a/tools/shaka/src/repo/status.rs
+++ b/tools/shaka/src/repo/status.rs
@@ -44,17 +44,7 @@ pub fn run(json: bool) {
             std::process::exit(1);
         }
     };
-    if json {
-        match serde_json::to_string_pretty(&status) {
-            Ok(s) => println!("{s}"),
-            Err(e) => {
-                eprintln!("{RED}{BOLD}error:{RESET} failed to serialize status: {e}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        render_human(&status);
-    }
+    crate::output::emit(json, &status, render_human);
 }
 
 fn collect() -> Result<Status, String> {


### PR DESCRIPTION
Centralize the json/human output switch that repo status and repo
describe each duplicated inline. The helper keeps the serialize-error
to stderr plus non-zero exit convention so behavior is unchanged, and
gives the upcoming preflight, commit lint, and repo audit --json work
a single seam to route through.

Emit a machine-readable report (per-check name, kind, status, duration,
and on failure the tool output and path scope, plus run-level totals)
under --json so CI parsers and the assistant can route fixes without
re-parsing prose.

JSON mode goes silent until the final document: progress streaming is
suppressed and each check captures its subprocess output into the
report's detail field instead of inheriting the parent's stdout, keeping
the document clean for piping to jq.

Replace the wall of per-commit prose with an opt-in --json report: a
per-commit list of change id, title, and findings (severity + message)
plus run-level error/warning/clean totals and a success flag. Human
output is unchanged; rendering now reads from the same collected report
so the two modes can't drift.

Add an opt-in --json report mirroring the grouped human tables 1:1:
per-group check lists with name, status (pass/fail/warn/error), and
detail, plus the repo slug and an overall success flag. Human mode
streams the tables as before; the helper renders only the trailing
summary. --json is read-only and conflicts with --fix.

Closes #68