### PR TITLE
ci: retry cloudflare-deploy custom-domain apply on missing worker

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -54,7 +54,20 @@ jobs:
         # `.env` is gitignored; copy from the in-repo example so the
         # recipe's `_env-check` precondition passes. `.env.example`
         # already holds the `op://` refs the SA token will resolve.
+        #
+        # `--retry-on "This Worker does not exist"` absorbs the
+        # first-deploy race (#714): on a brand-new `rust-worker`, the
+        # `cloudflare_workers_custom_domain` attach in this apply runs
+        # concurrently with the project's `wrangler deploy`, and on a
+        # script that doesn't exist yet Cloudflare rejects the attach
+        # with that message. `tofu apply` is idempotent, so re-running
+        # self-heals once the parallel deploy lands the script. The
+        # retry rides along on every infra project that calls this
+        # reusable workflow (cloudflare-dns, cloudflare-tokens), but the
+        # substring only ever matches the worker-domain race, so it's a
+        # no-op elsewhere.
         run: |
           cp .env.example .env
-          nix develop . --command shaka ci mask-and-run --env-file=.env -- \
+          nix develop . --command shaka ci mask-and-run --env-file=.env \
+            --retry-on "This Worker does not exist" --max-retries 5 --retry-delay 30 -- \
             just apply -auto-approve -input=false

--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -42,11 +42,30 @@ pub enum CiCommand {
     /// AWS_SECRET_ACCESS_KEY, etc.). This wrapper enumerates the resolved
     /// env first, emits a mask command for each non-empty new/changed
     /// value, then execs `op run --env-file=<file> -- <args...>`.
+    ///
+    /// `--retry-on <text>` opts into bounded retries: when the command
+    /// exits non-zero and its combined output contains `<text>`, the
+    /// wrapper re-runs it (up to `--max-retries` times, waiting
+    /// `--retry-delay` seconds between attempts). Used to absorb the
+    /// first-deploy race where `cloudflare-deploy apply` attaches a
+    /// custom domain before the parallel `wrangler deploy` has created
+    /// the Worker script (#714). Without `--retry-on`, the wrapper execs
+    /// the command directly as before — no behaviour change.
     #[command(name = "mask-and-run")]
     MaskAndRun {
         /// Path passed through to `op run --env-file=<path>`.
         #[arg(long)]
         env_file: PathBuf,
+        /// Retry while the command's combined output contains this
+        /// substring and it exited non-zero. Empty disables retries.
+        #[arg(long, default_value = "")]
+        retry_on: String,
+        /// Maximum number of retries after the first attempt.
+        #[arg(long, default_value_t = 0)]
+        max_retries: u32,
+        /// Seconds to wait between retry attempts.
+        #[arg(long, default_value_t = 30)]
+        retry_delay: u64,
         /// Command and args to run under `op run` (separated by `--`).
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
         args: Vec<String>,
@@ -58,6 +77,12 @@ pub fn run(cmd: CiCommand) {
         CiCommand::Gate { needs } => gate::run(needs),
         CiCommand::GenerateWorkflows { check } => generate::run(check),
         CiCommand::AuditWorkflows => audit_workflows::run(),
-        CiCommand::MaskAndRun { env_file, args } => mask_and_run::run(env_file, args),
+        CiCommand::MaskAndRun {
+            env_file,
+            retry_on,
+            max_retries,
+            retry_delay,
+            args,
+        } => mask_and_run::run(env_file, args, retry_on, max_retries, retry_delay),
     }
 }

--- a/tools/shaka/src/ci/mask_and_run.rs
+++ b/tools/shaka/src/ci/mask_and_run.rs
@@ -1,19 +1,47 @@
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use crate::term::{BOLD, RED, RESET};
+use crate::term::{BOLD, RED, RESET, YELLOW};
 
-pub fn run(env_file: PathBuf, args: Vec<String>) {
-    if let Err(e) = mask_and_run(&env_file, &args) {
-        eprintln!("{RED}{BOLD}error:{RESET} {e}");
-        std::process::exit(1);
+/// Bounded retry policy for the consumer command. Active only when
+/// `retry_on` is non-empty and `max_retries > 0`.
+struct RetryConfig {
+    retry_on: String,
+    max_retries: u32,
+    retry_delay: Duration,
+}
+
+pub fn run(
+    env_file: PathBuf,
+    args: Vec<String>,
+    retry_on: String,
+    max_retries: u32,
+    retry_delay: u64,
+) {
+    let retry = (!retry_on.is_empty() && max_retries > 0).then(|| RetryConfig {
+        retry_on,
+        max_retries,
+        retry_delay: Duration::from_secs(retry_delay),
+    });
+    match mask_and_run(&env_file, &args, retry.as_ref()) {
+        Ok(code) => std::process::exit(code),
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
     }
 }
 
-fn mask_and_run(env_file: &PathBuf, args: &[String]) -> Result<(), String> {
+fn mask_and_run(
+    env_file: &PathBuf,
+    args: &[String],
+    retry: Option<&RetryConfig>,
+) -> Result<i32, String> {
     // Phase 1: enumerate the resolved env without running the consumer.
     // `env -0` separates entries with NUL so values containing newlines or
     // `=` survive parsing.
@@ -52,12 +80,123 @@ fn mask_and_run(env_file: &PathBuf, args: &[String]) -> Result<(), String> {
     out.flush().map_err(|e| format!("flush stdout: {e}"))?;
     drop(out);
 
-    // Phase 3: replace this process with the real `op run`. On failure,
-    // `exec` returns; on success, it does not.
-    let mut cmd = Command::new("op");
-    cmd.arg("run").arg("--env-file").arg(env_file).arg("--");
-    cmd.args(args);
-    Err(format!("exec `op run`: {}", cmd.exec()))
+    let make_cmd = || {
+        let mut cmd = Command::new("op");
+        cmd.arg("run").arg("--env-file").arg(env_file).arg("--");
+        cmd.args(args);
+        cmd
+    };
+
+    match retry {
+        // Phase 3 (retry mode): spawn, stream, and re-run on a matching
+        // transient failure. Can't `exec` here — we need to observe the
+        // exit code and output to decide whether to retry.
+        Some(cfg) => run_with_retry(make_cmd, cfg),
+        // Phase 3 (default): replace this process with the real `op run`.
+        // On failure, `exec` returns; on success, it does not.
+        None => {
+            let mut cmd = make_cmd();
+            Err(format!("exec `op run`: {}", cmd.exec()))
+        }
+    }
+}
+
+/// Run `make_cmd()` until it succeeds or retries are exhausted, streaming
+/// its stdout/stderr through to ours while capturing them for matching.
+/// Returns the final exit code (0 on success, the last child's code on
+/// exhaustion). A retry fires only when the exit is non-zero *and* the
+/// combined output contains `cfg.retry_on`; any other failure propagates
+/// immediately so real errors aren't masked.
+fn run_with_retry(make_cmd: impl Fn() -> Command, cfg: &RetryConfig) -> Result<i32, String> {
+    let mut attempt: u32 = 0;
+    loop {
+        let mut cmd = make_cmd();
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = cmd.spawn().map_err(|e| format!("spawn `op run`: {e}"))?;
+
+        // Drain both pipes concurrently so the child never blocks on a
+        // full pipe; tee each to the parent stream and accumulate a
+        // combined copy for the retry-pattern check.
+        let buffer = Arc::new(Mutex::new(String::new()));
+        let out_h = tee(
+            child.stdout.take().expect("stdout piped"),
+            Stream::Out,
+            Arc::clone(&buffer),
+        );
+        let err_h = tee(
+            child.stderr.take().expect("stderr piped"),
+            Stream::Err,
+            Arc::clone(&buffer),
+        );
+
+        let status = child.wait().map_err(|e| format!("wait `op run`: {e}"))?;
+        out_h.join().ok();
+        err_h.join().ok();
+
+        if status.success() {
+            return Ok(0);
+        }
+        let code = status.code().unwrap_or(1);
+
+        let matched = buffer
+            .lock()
+            .map(|b| b.contains(&cfg.retry_on))
+            .unwrap_or(false);
+        if attempt < cfg.max_retries && matched {
+            attempt += 1;
+            eprintln!(
+                "{YELLOW}{BOLD}retry:{RESET} attempt {attempt}/{} after transient failure matching {:?}; \
+                 waiting {}s",
+                cfg.max_retries,
+                cfg.retry_on,
+                cfg.retry_delay.as_secs()
+            );
+            std::thread::sleep(cfg.retry_delay);
+            continue;
+        }
+        return Ok(code);
+    }
+}
+
+/// Which parent stream a `tee` thread writes through to.
+enum Stream {
+    Out,
+    Err,
+}
+
+/// Spawn a thread that copies `reader` to the chosen parent stream and
+/// appends every byte to `buffer` (as lossy UTF-8) for pattern matching.
+fn tee<R: Read + Send + 'static>(
+    mut reader: R,
+    stream: Stream,
+    buffer: Arc<Mutex<String>>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    let chunk = &buf[..n];
+                    match stream {
+                        Stream::Out => {
+                            let mut w = std::io::stdout().lock();
+                            let _ = w.write_all(chunk);
+                            let _ = w.flush();
+                        }
+                        Stream::Err => {
+                            let mut w = std::io::stderr().lock();
+                            let _ = w.write_all(chunk);
+                            let _ = w.flush();
+                        }
+                    }
+                    if let Ok(mut b) = buffer.lock() {
+                        b.push_str(&String::from_utf8_lossy(chunk));
+                    }
+                }
+            }
+        }
+    })
 }
 
 /// Parse the NUL-separated output of `env -0` into a map of `KEY -> VALUE`.
@@ -153,5 +292,82 @@ mod tests {
             resolved_secrets(&parent, &child),
             vec!["shared".to_string(), "unique".to_string()]
         );
+    }
+
+    fn zero_delay(retry_on: &str, max_retries: u32) -> RetryConfig {
+        RetryConfig {
+            retry_on: retry_on.to_string(),
+            max_retries,
+            retry_delay: Duration::ZERO,
+        }
+    }
+
+    /// Build a `sh -c` command that fails (printing `msg` to stderr) for
+    /// the first `fail_times` invocations, then succeeds — tracking the
+    /// attempt count in a counter file so retries are observable.
+    fn flaky_cmd(counter: &std::path::Path, fail_times: u32, msg: &str) -> Command {
+        let script = format!(
+            "n=$(cat '{f}' 2>/dev/null || echo 0); n=$((n+1)); echo $n > '{f}'; \
+             if [ \"$n\" -le {fail_times} ]; then echo '{msg}' >&2; exit 1; fi; echo ok",
+            f = counter.display(),
+        );
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(script);
+        cmd
+    }
+
+    fn counter_path(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("shaka-mask-and-run-{}-{}", std::process::id(), tag))
+    }
+
+    fn read_count(path: &std::path::Path) -> u32 {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn retry_succeeds_once_transient_failure_clears() {
+        let counter = counter_path("clears");
+        let _ = std::fs::remove_file(&counter);
+        let cfg = zero_delay("This Worker does not exist", 5);
+        let code = run_with_retry(
+            || flaky_cmd(&counter, 2, "This Worker does not exist"),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(code, 0);
+        // Two failures + one success.
+        assert_eq!(read_count(&counter), 3);
+        let _ = std::fs::remove_file(&counter);
+    }
+
+    #[test]
+    fn retry_exhausts_and_propagates_exit_code() {
+        let counter = counter_path("exhausts");
+        let _ = std::fs::remove_file(&counter);
+        let cfg = zero_delay("This Worker does not exist", 2);
+        // Always fails; 1 initial + 2 retries = 3 attempts, then gives up.
+        let code = run_with_retry(
+            || flaky_cmd(&counter, 999, "This Worker does not exist"),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(code, 1);
+        assert_eq!(read_count(&counter), 3);
+        let _ = std::fs::remove_file(&counter);
+    }
+
+    #[test]
+    fn non_matching_failure_is_not_retried() {
+        let counter = counter_path("nomatch");
+        let _ = std::fs::remove_file(&counter);
+        let cfg = zero_delay("This Worker does not exist", 5);
+        // Fails with an unrelated message; must not retry.
+        let code = run_with_retry(|| flaky_cmd(&counter, 999, "some other error"), &cfg).unwrap();
+        assert_eq!(code, 1);
+        assert_eq!(read_count(&counter), 1);
+        let _ = std::fs::remove_file(&counter);
     }
 }


### PR DESCRIPTION
`mask-and-run` now accepts `--retry-on`, `--max-retries`, and
`--retry-delay`. When the wrapped command exits non-zero and its
combined output contains the `--retry-on` substring, the wrapper
re-runs it (waiting `--retry-delay` seconds, up to `--max-retries`
times) instead of `exec`-ing once. Without those flags it execs as
before, so existing callers are unchanged.

This is the mechanism for absorbing the first-deploy race in #714,
where a `tofu apply` attaches a Worker custom domain before the
parallel `wrangler deploy` has created the script.

A brand-new rust-worker merge fires the project deploy and the
cloudflare-deploy apply concurrently on push:main. The custom-domain
attach needs the Worker script to already exist, so on a first deploy
the apply loses the race and Cloudflare rejects it with "This Worker
does not exist". Pass `--retry-on` through to mask-and-run so the
idempotent `tofu apply` self-heals once the parallel deploy lands the
script, removing the one-time manual `gh run rerun --failed`.

The retry rides along on every infra project that calls tf-apply.yml,
but the substring only matches the worker-domain race, so it is a no-op
for cloudflare-dns and cloudflare-tokens.

Closes #714