### PR TITLE
feat(shaka): add issue next subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,14 @@ this before scripting against `jj`:
 Work is tracked in **GitHub Issues**. References like `#21` are GitHub issue
 numbers; use `gh issue view <n>` to read them.
 
+When asked "what's next" (or to suggest work to pick up), run **`shaka issue
+next`** — don't hand-roll `gh issue list` filtered by intuition. `issue next`
+returns only issues that aren't already in flight: it drops any issue with an
+assignee, an open PR that would close it, or a local `i<N>` workspace. Pair
+it with `--json` when routing programmatically. Because `shaka workspace new
+--issue <N>` (which `/start` calls) self-assigns you on GitHub, starting an
+issue removes it from `issue next` automatically.
+
 ## Secrets
 
 **1Password** is the canonical secret store for local development

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -792,6 +792,94 @@ pub(crate) fn parse_open_prs(body: &str) -> Result<Vec<OpenPr>, GhError> {
         .collect()
 }
 
+/// Issue numbers that an open PR in `repo` would auto-close on merge.
+///
+/// One `gh pr list` call fetches every open PR's body; each is parsed
+/// for `Closes #N` / `Fixes #N` / `Resolves #N` autoclose references
+/// via [`crate::commit::issue_ref::extract_autoclose_refs`]. The union
+/// is the set of issues "already in flight" behind a PR — used by
+/// `shaka issue next` to drop them from the available list.
+pub fn open_pr_issue_refs(repo: &str) -> Result<std::collections::BTreeSet<u64>, GhError> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,body",
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: "gh pr list".to_string(),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout);
+    parse_open_pr_issue_refs(&body)
+}
+
+pub(crate) fn parse_open_pr_issue_refs(
+    body: &str,
+) -> Result<std::collections::BTreeSet<u64>, GhError> {
+    let value: Value = serde_json::from_str(body).context(JsonParseSnafu {
+        context: "failed to parse gh pr list JSON".to_string(),
+    })?;
+    let arr = value.as_array().context(SchemaSnafu {
+        message: "gh pr list did not return an array",
+    })?;
+
+    let mut refs = std::collections::BTreeSet::new();
+    for pr in arr {
+        let pr_body = pr["body"].as_str().unwrap_or("");
+        for n in crate::commit::issue_ref::extract_autoclose_refs(pr_body) {
+            refs.insert(n);
+        }
+    }
+    Ok(refs)
+}
+
+/// Self-assign the authenticated GitHub viewer to `{repo}#{n}`.
+///
+/// Uses `gh issue edit --add-assignee @me`, which `gh` resolves to the
+/// current user. Callers treat failure as non-fatal: assignment is a
+/// convenience signal, not a correctness gate.
+pub fn assign_issue_to_me(repo: &str, n: u64) -> Result<(), GhError> {
+    let number = n.to_string();
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "edit",
+            &number,
+            "--repo",
+            repo,
+            "--add-assignee",
+            "@me",
+        ])
+        .output()
+        .context(SpawnSnafu)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return GhCommandSnafu {
+            command: format!("gh issue edit {number} --add-assignee @me"),
+            stderr: stderr.trim().to_string(),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ListState {
     Open,
@@ -833,6 +921,8 @@ pub struct IssueSummary {
     pub url: String,
     pub created_at: String,
     pub updated_at: String,
+    /// GitHub logins of the issue's assignees. Empty when unassigned.
+    pub assignees: Vec<String>,
 }
 
 /// List GitHub issues from `repo` matching the given filters.
@@ -860,7 +950,7 @@ pub fn list_issues(
         "--limit".into(),
         limit,
         "--json".into(),
-        "number,title,state,labels,url,createdAt,updatedAt".into(),
+        "number,title,state,labels,url,createdAt,updatedAt,assignees".into(),
     ];
     for label in labels {
         args.push("--label".into());
@@ -938,6 +1028,14 @@ pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError>
                 .to_string();
             let created_at = v["createdAt"].as_str().unwrap_or("").to_string();
             let updated_at = v["updatedAt"].as_str().unwrap_or("").to_string();
+            let assignees = v["assignees"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|u| u["login"].as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
             Ok(IssueSummary {
                 number,
                 title,
@@ -946,6 +1044,7 @@ pub(crate) fn parse_issue_list(body: &str) -> Result<Vec<IssueSummary>, GhError>
                 url,
                 created_at,
                 updated_at,
+                assignees,
             })
         })
         .collect()
@@ -1394,5 +1493,43 @@ mod tests {
         let body: Value =
             serde_json::from_str(r#"{"data":{"repository":{"issue":null}}}"#).unwrap();
         assert_eq!(parse_issue_parent_graphql(&body), None);
+    }
+
+    #[test]
+    fn parse_open_pr_issue_refs_unions_autoclose_refs() {
+        let body = r#"[
+            {"number": 730, "body": "Add --json output.\n\nCloses #68"},
+            {"number": 712, "body": "Fixes #711 and resolves #709"},
+            {"number": 700, "body": "No issue reference here"},
+            {"number": 699, "body": "Refs #500 (not an autoclose keyword)"}
+        ]"#;
+        let refs = parse_open_pr_issue_refs(body).unwrap();
+        assert!(refs.contains(&68));
+        assert!(refs.contains(&711));
+        assert!(refs.contains(&709));
+        // `Refs #500` is a mention, not an autoclose keyword.
+        assert!(!refs.contains(&500));
+        assert_eq!(refs.len(), 3);
+    }
+
+    #[test]
+    fn parse_open_pr_issue_refs_empty_when_no_prs() {
+        let refs = parse_open_pr_issue_refs("[]").unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn parse_issue_list_extracts_assignees() {
+        let body = r#"[
+            {"number": 1, "title": "taken", "state": "OPEN", "labels": [],
+             "url": "https://x/1", "createdAt": "", "updatedAt": "",
+             "assignees": [{"login": "jedwards"}]},
+            {"number": 2, "title": "free", "state": "OPEN", "labels": [],
+             "url": "https://x/2", "createdAt": "", "updatedAt": "",
+             "assignees": []}
+        ]"#;
+        let issues = parse_issue_list(body).unwrap();
+        assert_eq!(issues[0].assignees, vec!["jedwards".to_string()]);
+        assert!(issues[1].assignees.is_empty());
     }
 }

--- a/tools/shaka/src/issue.rs
+++ b/tools/shaka/src/issue.rs
@@ -4,6 +4,7 @@ mod create;
 mod label;
 mod labels;
 mod list;
+mod next;
 
 use clap::{ArgGroup, Subcommand, ValueEnum};
 
@@ -112,6 +113,19 @@ pub enum IssueCommand {
         #[arg(long)]
         json: bool,
     },
+    /// List open issues not already in flight (no assignee, no open PR,
+    /// no local `i<N>` workspace) — the unstarted work to pick from.
+    Next {
+        /// Repository in owner/repo format (auto-detected from git remote if omitted)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Maximum number of open issues to consider before filtering
+        #[arg(long, default_value_t = 200)]
+        limit: u32,
+        /// Emit normalized JSON instead of the human-readable tree
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -174,5 +188,6 @@ pub fn run(cmd: IssueCommand) {
             limit,
             json,
         } => list::run(repo, state.into(), labels, milestone, search, limit, json),
+        IssueCommand::Next { repo, limit, json } => next::run(repo, limit, json),
     }
 }

--- a/tools/shaka/src/issue/list.rs
+++ b/tools/shaka/src/issue/list.rs
@@ -200,6 +200,7 @@ mod tests {
             url: format!("https://github.com/o/r/issues/{number}"),
             created_at: "2026-05-06T00:00:00Z".to_string(),
             updated_at: "2026-05-06T00:00:00Z".to_string(),
+            assignees: Vec::new(),
         }
     }
 

--- a/tools/shaka/src/issue/next.rs
+++ b/tools/shaka/src/issue/next.rs
@@ -1,0 +1,212 @@
+use std::collections::BTreeSet;
+
+use serde_json::{json, Value};
+
+use crate::gh::{self, IssueSummary, ListState};
+use crate::term::{BOLD, DIM, GREEN, RED, RESET};
+use crate::workspace;
+
+/// List open issues that are *not* already in flight: no assignee, no
+/// open PR that would close them, and no local `i<N>` workspace.
+pub fn run(repo_arg: Option<String>, limit: u32, json_out: bool) {
+    let repo = match repo_arg {
+        Some(r) => r,
+        None => match gh::detect_repo() {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} {e}");
+                eprintln!("Hint: pass --repo owner/repo explicitly");
+                std::process::exit(1);
+            }
+        },
+    };
+
+    let issues = match gh::list_issues(&repo, ListState::Open, &[], None, None, limit) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    let open_pr_refs = match gh::open_pr_issue_refs(&repo) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    };
+    // Local-only; degrades to an empty set rather than failing.
+    let workspace_issues = workspace::active_issue_numbers();
+
+    let available: Vec<&IssueSummary> = issues
+        .iter()
+        .filter(|i| is_available(i, &open_pr_refs, &workspace_issues))
+        .collect();
+
+    if json_out {
+        let payload = build_payload(&repo, &available);
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("{RED}{BOLD}error:{RESET} serialize JSON: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        print!("{}", render_tree(&repo, &available));
+    }
+}
+
+/// An issue is "available" when nothing signals it's already being
+/// worked: unassigned, no open PR closing it, no local workspace.
+fn is_available(
+    issue: &IssueSummary,
+    open_pr_refs: &BTreeSet<u64>,
+    workspace_issues: &BTreeSet<u64>,
+) -> bool {
+    issue.assignees.is_empty()
+        && !open_pr_refs.contains(&issue.number)
+        && !workspace_issues.contains(&issue.number)
+}
+
+fn render_tree(repo: &str, issues: &[&IssueSummary]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{BOLD}shaka issue next{RESET}\n"));
+    out.push_str(&format!(
+        "{DIM}├── repo: {repo}  available: {}  (no assignee, no open PR, no workspace){RESET}\n",
+        issues.len()
+    ));
+
+    if issues.is_empty() {
+        out.push_str(&format!("{DIM}└── (nothing available){RESET}\n"));
+        return out;
+    }
+
+    out.push_str(&format!("{DIM}│{RESET}\n"));
+    let n_width = issues
+        .iter()
+        .map(|i| digit_count(i.number))
+        .max()
+        .unwrap_or(1);
+    for issue in issues {
+        let labels_str = if issue.labels.is_empty() {
+            "(none)".to_string()
+        } else {
+            issue.labels.join(", ")
+        };
+        out.push_str(&format!(
+            "├── {BOLD}#{:<width$}{RESET}  {GREEN}OPEN{RESET}  {}\n",
+            issue.number,
+            issue.title,
+            width = n_width,
+        ));
+        out.push_str(&format!("{DIM}│   labels: {labels_str}{RESET}\n"));
+    }
+    out.push_str(&format!("{DIM}└── {} available{RESET}\n", issues.len()));
+    out
+}
+
+fn build_payload(repo: &str, issues: &[&IssueSummary]) -> Value {
+    let issues_value: Vec<Value> = issues
+        .iter()
+        .map(|i| {
+            json!({
+                "number": i.number,
+                "title": i.title,
+                "labels": i.labels,
+                "url": i.url,
+                "createdAt": i.created_at,
+                "updatedAt": i.updated_at,
+            })
+        })
+        .collect();
+    json!({
+        "repo": repo,
+        "count": issues.len(),
+        "issues": issues_value,
+    })
+}
+
+fn digit_count(n: u64) -> usize {
+    if n == 0 {
+        1
+    } else {
+        let mut c = 0;
+        let mut x = n;
+        while x > 0 {
+            c += 1;
+            x /= 10;
+        }
+        c
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gh::IssueState;
+
+    fn issue(number: u64, assignees: &[&str]) -> IssueSummary {
+        IssueSummary {
+            number,
+            title: format!("issue {number}"),
+            state: IssueState::Open,
+            labels: vec!["shaka".to_string()],
+            url: format!("https://github.com/o/r/issues/{number}"),
+            created_at: String::new(),
+            updated_at: String::new(),
+            assignees: assignees.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn set(nums: &[u64]) -> BTreeSet<u64> {
+        nums.iter().copied().collect()
+    }
+
+    #[test]
+    fn available_when_no_signals() {
+        let i = issue(100, &[]);
+        assert!(is_available(&i, &set(&[]), &set(&[])));
+    }
+
+    #[test]
+    fn unavailable_when_assigned() {
+        let i = issue(100, &["jedwards"]);
+        assert!(!is_available(&i, &set(&[]), &set(&[])));
+    }
+
+    #[test]
+    fn unavailable_when_open_pr_closes_it() {
+        let i = issue(100, &[]);
+        assert!(!is_available(&i, &set(&[100]), &set(&[])));
+    }
+
+    #[test]
+    fn unavailable_when_workspace_exists() {
+        let i = issue(100, &[]);
+        assert!(!is_available(&i, &set(&[]), &set(&[100])));
+    }
+
+    #[test]
+    fn payload_lists_only_available_fields() {
+        let a = issue(7, &[]);
+        let b = issue(9, &[]);
+        let refs: Vec<&IssueSummary> = vec![&a, &b];
+        let payload = build_payload("o/r", &refs);
+        assert_eq!(payload["repo"], "o/r");
+        assert_eq!(payload["count"], 2);
+        assert_eq!(payload["issues"][0]["number"], 7);
+        assert_eq!(payload["issues"][1]["number"], 9);
+        // Available issues are unassigned by construction, so the payload
+        // doesn't carry an assignees field.
+        assert!(payload["issues"][0].get("assignees").is_none());
+    }
+
+    #[test]
+    fn render_tree_empty_has_nothing_available_branch() {
+        let out = render_tree("o/r", &[]);
+        assert!(out.contains("shaka issue next"));
+        assert!(out.contains("available: 0"));
+        assert!(out.contains("(nothing available)"));
+    }
+}

--- a/tools/shaka/src/workspace.rs
+++ b/tools/shaka/src/workspace.rs
@@ -92,6 +92,31 @@ pub fn find_for_issue(n: u64) -> Option<WorkspaceRef> {
     None
 }
 
+/// Issue numbers that currently have a linked workspace (excluding the
+/// default workspace and any without a persisted link). Used by
+/// `shaka issue next` to drop issues already being worked locally.
+///
+/// Returns an empty set if the workspace listing can't be read, so the
+/// caller degrades to "no local filter" rather than failing.
+pub fn active_issue_numbers() -> std::collections::BTreeSet<u64> {
+    let mut out = std::collections::BTreeSet::new();
+    let Ok(primary) = jj::primary_workspace_root() else {
+        return out;
+    };
+    let Ok(workspaces) = jj::workspaces() else {
+        return out;
+    };
+    for ws in workspaces {
+        if ws.name == "default" {
+            continue;
+        }
+        if let Some(link) = issue_link::read(&primary, &ws.name).ok().flatten() {
+            out.insert(link.issue);
+        }
+    }
+    out
+}
+
 /// Path where a workspace directory lives, by convention:
 /// `<repo-root>/../<repo-basename>-<name>`. Tying the prefix to the repo
 /// basename keeps tests hermetic (each tempdir gets its own prefix) and

--- a/tools/shaka/src/workspace/new.rs
+++ b/tools/shaka/src/workspace/new.rs
@@ -1,5 +1,5 @@
 use super::issue_link::{self, IssueLink};
-use super::{die, workspace_path, BOLD, DIM, GREEN, RESET};
+use super::{die, workspace_path, BOLD, DIM, GREEN, RESET, YELLOW};
 use crate::{gh, jj};
 
 pub fn run(name: Option<&str>, issue: Option<u64>) {
@@ -43,6 +43,22 @@ pub fn run(name: Option<&str>, issue: Option<u64>) {
         // after `repo sync` deletes the local bookmark (see issue #164).
         if let Err(e) = issue_link::write(&repo_root, &derived_name, &IssueLink { issue: n }) {
             die(&format!("failed to record issue link: {e}"));
+        }
+        // Best-effort self-assign on GitHub so `shaka issue next` and the
+        // GitHub UI both show the issue as taken. A failure here (no write
+        // access, offline) must not fail workspace creation — the workspace
+        // and its local issue link already exist and are the source of truth.
+        match gh::detect_repo() {
+            Ok(repo) => {
+                if let Err(e) = gh::assign_issue_to_me(&repo, n) {
+                    eprintln!("{YELLOW}warning:{RESET} could not self-assign issue #{n}: {e}");
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "{YELLOW}warning:{RESET} could not detect repo to self-assign issue #{n}: {e}"
+                );
+            }
         }
         println!(
             "{GREEN}{BOLD}created{RESET} workspace {BOLD}{derived_name}{RESET} at \


### PR DESCRIPTION
Groundwork for `shaka issue next`'s in-flight filter. Add assignees to
the issue list JSON projection and IssueSummary; add open_pr_issue_refs
to union every open PR's autoclose targets (reusing the commit issue-ref
parser) in one API call; add assign_issue_to_me for the workspace
self-assign signal.

After recording the issue link, best-effort assign the GitHub viewer to
the issue so it reads as taken in the GitHub UI and drops out of
`shaka issue next`. Assignment failure (no write access, offline) warns
but never fails workspace creation: the workspace and local issue link
already exist and remain the source of truth.

`shaka issue next` lists open issues that aren't already in flight: it
drops any issue with an assignee, an open PR that would close it, or a
local i<N> workspace. Mirrors `issue list`'s tree/--json output. Adds a
workspace::active_issue_numbers helper for the local-workspace filter,
and points CLAUDE.md's "what's next" guidance at the command.

Closes #688