### PR TITLE
feat(shaka): add #Worker block to project schema

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -45,6 +45,52 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	cache?:       #CacheRules
 }
 
+// Worker runtime/build config that drives `wrangler.toml` for a
+// `rust-worker` project. `shaka deploy generate-wrangler` (#113) emits
+// `wrangler.toml` from this block and drift-checks it in preflight, so
+// the hand-maintained TOML in `apps/*/wrangler.toml` becomes generated.
+// Distinct from `#Deploy` (DNS + cache rules, emitted as Terraform):
+// this block is everything wrangler itself needs to build and run the
+// worker. The project's top-level `name` is the source of truth for the
+// worker name — not duplicated here.
+//
+// Covers the two real shapes in the repo: pollen-alert (`build` + `cron`
+// + `vars`) and the portfolio (`assets`, no triggers/vars). Every field
+// past `main`/`compatibility_date` is optional so both validate.
+#Worker: {
+	// Entry point wrangler uploads — the `worker-build` shim, e.g.
+	// `build/worker/shim.mjs`.
+	main: string & !=""
+
+	// Cloudflare runtime compatibility date, `YYYY-MM-DD`.
+	compatibility_date: string & =~"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+
+	// Custom build step (`[build].command`). Omit when the artifact is
+	// produced upstream of `wrangler deploy` (the portfolio builds in a
+	// dedicated CI/devshell step instead).
+	build?: {
+		command: string & !=""
+	}
+
+	// Workers Static Assets (`[assets].directory`) — CF serves these
+	// files at the edge, unmatched paths fall through to `main`.
+	assets?: {
+		directory: string & !=""
+	}
+
+	// Scheduled triggers (`[triggers].crons`): standard 5-field UTC cron
+	// expressions.
+	cron?: [...string & =~"^(\\S+\\s+){4}\\S+$"]
+
+	// Non-secret runtime config (`[vars]`).
+	vars?: {[string]: string}
+
+	// Secret names declared for the worker (set out-of-band via
+	// `wrangler secret put`); values never live in the repo. Names only,
+	// so the generator can surface them as a comment.
+	secrets?: [...string & =~"^[A-Z][A-Z0-9_]*$"]
+}
+
 // Publication target for a `#CiBuild` job. Each variant emits a
 // different post-`nix build` step in the generated `main.yaml` job:
 // `flakehub` runs `DeterminateSystems/flakehub-push`; `artifact` runs
@@ -234,6 +280,7 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 		}
 	}
 	deploy?: #Deploy
+	worker?: #Worker
 	ci?: {
 		deploy?: #CiDeploy
 	}

--- a/tools/shaka/tests/fixtures/schema/invalid/worker-bad-compatibility-date.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/worker-bad-compatibility-date.cue
@@ -1,0 +1,12 @@
+package project
+
+// `compatibility_date` must be `YYYY-MM-DD`; `2026-5-1` (unpadded) does
+// not match the pattern.
+#Project & {
+	name: "pollen-alert"
+	kind: "rust-worker"
+	worker: {
+		main:               "build/worker/shim.mjs"
+		compatibility_date: "2026-5-1"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/worker-missing-main.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/worker-missing-main.cue
@@ -1,0 +1,10 @@
+package project
+
+// `main` is required on `#Worker` — wrangler needs an entry point.
+#Project & {
+	name: "pollen-alert"
+	kind: "rust-worker"
+	worker: {
+		compatibility_date: "2026-05-14"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/worker-on-rust.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/worker-on-rust.cue
@@ -1,0 +1,15 @@
+package project
+
+// `worker` lives on `rust-worker`, not `rust-cli` — wrangler config
+// only makes sense for a wasm worker build.
+#Project & {
+	name: "pollen-alert"
+	kind: "rust-cli"
+	cli: {
+		binaryName: "pollen-alert"
+	}
+	worker: {
+		main:               "build/worker/shim.mjs"
+		compatibility_date: "2026-05-14"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-worker-assets.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-worker-assets.cue
@@ -1,0 +1,15 @@
+package project
+
+// Worker app using Workers Static Assets (the portfolio shape): a
+// `worker` block with `assets.directory` and no triggers/vars/build.
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust-worker"
+	worker: {
+		main:               "build/worker/shim.mjs"
+		compatibility_date: "2026-05-01"
+		assets: {
+			directory: "./dist"
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-worker-build-cron-vars.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-worker-build-cron-vars.cue
@@ -1,0 +1,26 @@
+package project
+
+// Worker app with a custom build, a scheduled cron trigger, non-secret
+// vars, and declared secret names (the pollen-alert shape). Exercises
+// every optional field of `#Worker` at once.
+#Project & {
+	name: "pollen-alert"
+	kind: "rust-worker"
+	worker: {
+		main:               "build/worker/shim.mjs"
+		compatibility_date: "2026-05-14"
+		build: {
+			command: "cargo install -q worker-build --locked && worker-build --release"
+		}
+		cron: ["0 2 * * *"]
+		vars: {
+			DRY_RUN:               "true"
+			LAT:                   "47.625"
+			LON:                   "-122.5"
+			MIN_CONSECUTIVE_HOURS: "3"
+			THRESHOLD:             "5"
+			TZ:                    "America/Los_Angeles"
+		}
+		secrets: ["PUSHOVER_APP_TOKEN", "PUSHOVER_USER_KEY"]
+	}
+}


### PR DESCRIPTION
Cloudflare worker projects still hand-maintain wrangler.toml — the
shipped deploy pivot (#327-#330) put DNS/cache on project.cue's deploy
block and emits Terraform, but never covered wrangler's own build/runtime
config. #Worker fills that gap on project.cue (not a separate config.cue),
keeping one source of truth: shaka deploy generate-wrangler (#113) will
emit wrangler.toml from it and drift-check in preflight.

Covers the two real shapes in the repo — pollen-alert (build + cron +
vars + secrets) and the portfolio (assets-only) — with everything past
main/compatibility_date optional. The project's top-level name stays the
source of truth for the worker name, so #Worker omits it. Schema only;
the generator is #113.

Closes #112