### PR TITLE
docs(infra/home): file-issue skill uses shaka issue create

### DIFF
--- a/infra/home/dotfiles/claude/commands/file-issue.md
+++ b/infra/home/dotfiles/claude/commands/file-issue.md
@@ -1,13 +1,16 @@
 ---
-description: File a new GitHub issue with a duplicate-search gate (the well-lit path; a PreToolUse hook may also be configured per-repo as the safety net)
-allowed-tools: Bash(gh issue *), Read
+description: File a new GitHub issue via `shaka issue create`, which enforces a canonical scope label and a conventional-commit title, behind a duplicate-search gate up front
+allowed-tools: Bash(shaka issue *), Read
 ---
 
 File a new GitHub issue. This skill is the well-lit path that runs the
-search up front so you see candidates before drafting a body. Some
-repos also configure a `PreToolUse` hook on `gh issue create` as a
-safety net (kolohelios is one); the skill works the same with or
-without the hook.
+search up front so you see candidates before drafting a body, then files
+through `shaka issue create` — which enforces a canonical scope label
+(from `.shaka/labels.cue`) and validates the title the same way
+`shaka commit lint` does. The
+search-first step below is the duplicate gate: the repo's `PreToolUse`
+dup-check hook only intercepts `gh issue create`, so it does **not** fire
+on `shaka issue create`.
 
 ## Workflow
 
@@ -16,7 +19,7 @@ without the hook.
 Take the topic the user wants to file. Run:
 
 ```
-gh issue list --state open --search "<keywords>" --limit 10
+shaka issue list --search "<keywords>"
 ```
 
 Pick keywords from the topic — typically the project scope plus the
@@ -50,41 +53,52 @@ issue shape:
 - `## Acceptance criteria` — checklist
 - `## Out of scope` — what we're explicitly deferring
 
-Stop, show the draft, and wait for the user to confirm or tweak.
+The title must be conventional-commit form (`<type>(<scope>): <subject>`)
+or `shaka issue create` rejects it. Stop, show the draft, and wait for
+the user to confirm or tweak.
 
 ### 4. File
 
-Run `gh issue create --title "<title>" --body "<body>" [--label ...]`.
-
-If the repo has a `PreToolUse` hook configured, it will re-run the
-search and block on matches. If the hook blocks but the user has
-already confirmed in step 2 that filing is intended, re-run with a
-`BYPASS_ISSUE_DUP_CHECK=1` prefix (kolohelios convention; other repos
-may use a different bypass mechanism):
+Write the drafted body to a temp file and run:
 
 ```
-BYPASS_ISSUE_DUP_CHECK=1 gh issue create --title ... --body ...
+shaka issue create --title "<title>" --scope <scope> --body-file <path> [--label ...] [--parent <N>]
 ```
+
+- `--scope` (required) — the canonical scope label from
+  `.shaka/labels.cue`; usually the project name (`shaka`, `infra/home`).
+  `shaka` attaches it and fails if it isn't canonical.
+- `--label` (repeatable) — extra labels beyond the scope label
+  (for example, `enhancement`).
+- `--parent <N>` — link as a sub-issue via GitHub's native sub-issue
+  API; use this instead of freeform "Part of #N" body text.
+- `--body-file <path>` — read the body from a file (cleaner than
+  `--body` for multi-line). `--body "<text>"` also works.
+- `--dry-run` — print the planned `gh` calls without executing, to
+  preview before filing.
 
 ### 5. Report
 
 Print the issue number and URL. If the issue is the first sub-task
 of a tracking issue, mention it so the user can decide whether to
-update the tracker.
+update the tracker (or pass `--parent <N>` in step 4 to link it
+natively).
 
 ## Conventions
 
-- Labels are scoped per project — use the ones that already exist;
-  `gh label list` if unsure.
+- Scope label comes from `--scope` — one of the canonical labels in
+  `.shaka/labels.cue`. Use `--label` for any extras on top.
 - One issue per discrete feature/bug. Sub-tasks of a larger effort
-  get their own issues with a `Blocked by` or `Part of` line.
+  get their own issues, linked with `--parent <N>`.
 - Conventional commit type belongs in the title:
-  `feat(<scope>): <subject>` / `fix(<scope>): <subject>` / etc.
+  `feat(<scope>): <subject>` / `fix(<scope>): <subject>` / etc. `shaka`
+  validates this.
 
 ## Stop conditions
 
 - Search returns matches → stop, show them, wait for user.
-- No clear conventional-commit type for the title → stop and ask.
+- No clear conventional-commit type for the title → stop and ask
+  (`shaka` rejects a non-conforming title).
+- No canonical scope label fits the topic → stop and ask which scope
+  to use (or whether to add a label to `.shaka/labels.cue` first).
 - Issue body draft → stop, show it, wait for confirmation.
-- Hook blocks the create despite step-2 confirmation → ask before
-  using `BYPASS_ISSUE_DUP_CHECK=1`.


### PR DESCRIPTION
The file-issue skill walked through `gh issue create`, which skips the
two guardrails the repo standardizes on: a canonical scope label and a
conventional-commit title. Route it through `shaka issue create` so
every issue lands with an enforced `--scope` label and a validated
title.

The repo's PreToolUse dup-check hook only intercepts `gh issue create`,
so it no longer fires on this skill; the search-first step is now the
sole duplicate gate, which the skill states explicitly.

Closes #753