### PR TITLE
feat(nix): export shakaShim from kolohelios-nix lib

### DIFF
--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -76,7 +76,12 @@
     in
     {
       lib = {
-        inherit supportedSystems forEachSupportedSystem workflowPackages;
+        inherit
+          supportedSystems
+          forEachSupportedSystem
+          workflowPackages
+          shakaShim
+          ;
       };
 
       formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt-rfc-style);

--- a/nix/kolohelios-nix/project.cue
+++ b/nix/kolohelios-nix/project.cue
@@ -75,7 +75,12 @@ package project
     in
     {
       lib = {
-        inherit supportedSystems forEachSupportedSystem workflowPackages;
+        inherit
+          supportedSystems
+          forEachSupportedSystem
+          workflowPackages
+          shakaShim
+          ;
       };
 
       formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt-rfc-style);


### PR DESCRIPTION
shakaShim was a local let-binding reachable only through workflowPackages,
which bundles the entire workflow toolchain. Export it from lib so a
consumer flake can place just the `shaka` PATH shim in its package set.

Prerequisite for adding the shim to the home-manager profile (#755) so
`shaka` resolves in bare shells inside the repo, not only devshells.

Part of #755