### PR TITLE
feat(infra/home): install Ghostty via homebrew cask on macOS

### DIFF
--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -57,6 +57,12 @@
     };
     casks = [
       "claude-code@latest"
+      # `pkgs.ghostty` is Linux-only (`meta.platforms` lists no darwin —
+      # the macOS app needs the Xcode toolchain nixpkgs can't build), so
+      # the Mac install rides the same cask path as `claude-code`. The
+      # ghostty config is already managed via `xdg.configFile` in
+      # `common.nix`. Linux uses the host's built-in terminal (#735).
+      "ghostty"
     ];
   };
 


### PR DESCRIPTION
pkgs.ghostty is Linux-only in nixpkgs (the macOS app needs the Xcode
toolchain it can't build), so it follows the same path as claude-code:
declared as a homebrew cask in darwin.nix. The ghostty config is already
managed via the xdg.configFile symlink in common.nix.

Closes #735