### PR TITLE
test(shaka): ratchet coverage line.fail to 62

### DIFF
--- a/tools/shaka/project.cue
+++ b/tools/shaka/project.cue
@@ -53,7 +53,7 @@ package project
 	}
 	coverage: {
 		line: {
-			fail: 30
+			fail: 62
 		}
 	}
 	ci: {

--- a/tools/shaka/src/ci/generate.rs
+++ b/tools/shaka/src/ci/generate.rs
@@ -273,3 +273,73 @@ fn check_drift(items: &[(PathBuf, String)]) {
         println!("{GREEN}{BOLD}generate-workflows --check passed{RESET}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply_fixture() -> Workflow {
+        build_apply_workflow(
+            "cloudflare-dns",
+            Path::new("./infra/cloudflare-dns"),
+            &CiApply {
+                reusable_workflow: "./.github/workflows/tf-apply.yml".to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn apply_workflow_strips_leading_dot_slash_from_paths() {
+        let yaml = workflow::emit(&apply_fixture());
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid YAML");
+        let paths = parsed["on"]["push"]["paths"]
+            .as_sequence()
+            .expect("push paths");
+        // Globs must read as `infra/...`, never `./infra/...`.
+        assert!(paths
+            .iter()
+            .any(|p| p.as_str() == Some("infra/cloudflare-dns/**")));
+        for p in paths {
+            let s = p.as_str().unwrap();
+            assert!(!s.starts_with("./"), "path leaked a ./ prefix: {s}");
+        }
+    }
+
+    #[test]
+    fn apply_workflow_watches_itself_and_the_reusable_workflow() {
+        let yaml = workflow::emit(&apply_fixture());
+        // A refactor of either the wrapper or the reusable workflow it
+        // calls should re-apply on the next main-merge.
+        assert!(yaml.contains(".github/workflows/cloudflare-dns-apply.yml"));
+        assert!(yaml.contains(".github/workflows/tf-apply.yml"));
+    }
+
+    #[test]
+    fn apply_workflow_requests_oidc_and_serializes_applies() {
+        let yaml = workflow::emit(&apply_fixture());
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(parsed["name"].as_str(), Some("cloudflare-dns apply"));
+        assert_eq!(parsed["permissions"]["id-token"].as_str(), Some("write"));
+        // Applies must not cancel each other mid-flight.
+        assert_eq!(
+            parsed["concurrency"]["cancel-in-progress"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            parsed["concurrency"]["group"].as_str(),
+            Some("cloudflare-dns-apply")
+        );
+    }
+
+    #[test]
+    fn read_meta_errors_when_project_cue_is_absent() {
+        let dir = std::env::temp_dir().join("shaka-ci-generate-no-cue");
+        // No project.cue here — read_meta should short-circuit before
+        // ever spawning `cue`.
+        let err = match read_meta(Path::new("/nonexistent-schema.cue"), &dir) {
+            Err(e) => e,
+            Ok(_) => panic!("missing project.cue must error"),
+        };
+        assert!(err.contains("missing project.cue"), "{err}");
+    }
+}

--- a/tools/shaka/src/ci/main_workflow.rs
+++ b/tools/shaka/src/ci/main_workflow.rs
@@ -578,3 +578,146 @@ fn gate_job(specs: &[MainBuildSpec]) -> InlineJob {
         })],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flakehub_spec() -> MainBuildSpec {
+        MainBuildSpec {
+            project_dir: PathBuf::from("tools/shaka"),
+            project_name: "shaka".to_string(),
+            build: CiBuild {
+                filter_key: "shaka".to_string(),
+                job_id: "shaka".to_string(),
+                display_name: "shaka".to_string(),
+                nix_command: "build".to_string(),
+                attr: None,
+                publish: Publish::Flakehub(PublishFlakehub {
+                    name: "kolohelios/shaka".to_string(),
+                    visibility: "public".to_string(),
+                    rolling: true,
+                    populate_consumer_cache: false,
+                }),
+                dispatch: vec![],
+            },
+        }
+    }
+
+    fn parse(specs: &[MainBuildSpec]) -> serde_yaml_ng::Value {
+        let yaml = super::super::workflow::emit(&build(specs));
+        serde_yaml_ng::from_str(&yaml).expect("valid YAML")
+    }
+
+    #[test]
+    fn always_emits_changes_preflight_and_gate() {
+        let parsed = parse(&[flakehub_spec()]);
+        let jobs = parsed["jobs"].as_mapping().expect("jobs mapping");
+        for job in ["changes", "preflight", "gate"] {
+            assert!(jobs.contains_key(job), "missing fixed job: {job}");
+        }
+        assert_eq!(parsed["name"].as_str(), Some("CI"));
+    }
+
+    #[test]
+    fn build_job_id_is_prefixed_and_gate_depends_on_it() {
+        let parsed = parse(&[flakehub_spec()]);
+        assert!(parsed["jobs"].get("build-shaka").is_some());
+        let needs = parsed["jobs"]["gate"]["needs"]
+            .as_sequence()
+            .expect("gate needs list");
+        assert!(needs.iter().any(|n| n.as_str() == Some("build-shaka")));
+        // `gate` runs even when upstreams skip, so branch protection
+        // stays green on path-filtered PRs.
+        assert_eq!(parsed["jobs"]["gate"]["if"].as_str(), Some("always()"));
+    }
+
+    #[test]
+    fn flakehub_publish_step_carries_name_and_visibility() {
+        let parsed = parse(&[flakehub_spec()]);
+        let steps = parsed["jobs"]["build-shaka"]["steps"]
+            .as_sequence()
+            .expect("steps");
+        let push = steps
+            .iter()
+            .find(|s| s["uses"].as_str() == Some("DeterminateSystems/flakehub-push@main"))
+            .expect("flakehub-push step");
+        assert_eq!(push["with"]["name"].as_str(), Some("kolohelios/shaka"));
+        assert_eq!(push["with"]["visibility"].as_str(), Some("public"));
+        assert_eq!(push["with"]["rolling"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn populate_consumer_cache_adds_a_flakehub_url_rebuild() {
+        let mut spec = flakehub_spec();
+        if let Publish::Flakehub(ref mut fh) = spec.build.publish {
+            fh.populate_consumer_cache = true;
+        }
+        let yaml = super::super::workflow::emit(&build(&[spec]));
+        assert!(yaml.contains("nix build 'https://flakehub.com/f/kolohelios/shaka/*.tar.gz'"));
+    }
+
+    #[test]
+    fn artifact_publish_uploads_with_retention() {
+        let mut spec = flakehub_spec();
+        spec.build.publish = Publish::Artifact(PublishArtifact {
+            name: "site".to_string(),
+            path: "dist".to_string(),
+            retention_days: 7,
+            compression_level: 6,
+        });
+        let yaml = super::super::workflow::emit(&build(&[spec]));
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        let steps = parsed["jobs"]["build-shaka"]["steps"]
+            .as_sequence()
+            .unwrap();
+        let upload = steps
+            .iter()
+            .find(|s| s["uses"].as_str() == Some("actions/upload-artifact@v7"))
+            .expect("upload-artifact step");
+        assert_eq!(upload["with"]["name"].as_str(), Some("site"));
+        assert_eq!(upload["with"]["retention-days"].as_u64(), Some(7));
+    }
+
+    #[test]
+    fn nix_check_command_uses_flake_check_verb() {
+        let mut spec = flakehub_spec();
+        spec.build.nix_command = "check".to_string();
+        let yaml = super::super::workflow::emit(&build(&[spec]));
+        assert!(yaml.contains("nix flake check ./tools/shaka"));
+    }
+
+    #[test]
+    fn attr_suffix_appends_to_the_nix_target() {
+        let mut spec = flakehub_spec();
+        spec.build.attr = Some("packages.x86_64-linux.default".to_string());
+        let yaml = super::super::workflow::emit(&build(&[spec]));
+        assert!(yaml.contains("nix build ./tools/shaka#packages.x86_64-linux.default"));
+    }
+
+    #[test]
+    fn dispatch_mints_a_bot_token_and_posts_to_target_repo() {
+        let mut spec = flakehub_spec();
+        spec.build.dispatch = vec![Dispatch {
+            repo: "kolohelios/blogs-and-posts".to_string(),
+            event_type: "shaka-published".to_string(),
+        }];
+        let yaml = super::super::workflow::emit(&build(&[spec]));
+        assert!(yaml.contains("actions/create-github-app-token@v3"));
+        assert!(yaml.contains("repos/kolohelios/blogs-and-posts/dispatches"));
+        assert!(yaml.contains("event_type=shaka-published"));
+    }
+
+    #[test]
+    fn changes_filter_lists_each_project_filter_key() {
+        let parsed = parse(&[flakehub_spec()]);
+        let filters = parsed["jobs"]["changes"]["steps"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find_map(|s| s["with"].get("filters").and_then(|f| f.as_str()))
+            .expect("filters body");
+        assert!(filters.contains("shaka:"), "{filters}");
+        assert!(filters.contains("tools/shaka/**"), "{filters}");
+    }
+}

--- a/tools/shaka/src/ci/worker_deploy_workflow.rs
+++ b/tools/shaka/src/ci/worker_deploy_workflow.rs
@@ -319,3 +319,127 @@ fn filename_of(path: &str) -> String {
         .expect("reusable_workflow has a filename")
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_spec() -> WorkerDeploySpec {
+        WorkerDeploySpec {
+            project_dir: PathBuf::from("apps/portfolio"),
+            project_name: "portfolio".to_string(),
+            deploy: CiDeploy {
+                reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
+                preview_script_prefix: "portfolio".to_string(),
+            },
+        }
+    }
+
+    fn emit_fixture() -> serde_yaml_ng::Value {
+        let yaml = super::super::workflow::emit(&build(&fixture_spec()));
+        serde_yaml_ng::from_str(&yaml).expect("valid YAML")
+    }
+
+    #[test]
+    fn emits_five_lifecycle_jobs() {
+        let parsed = emit_fixture();
+        let jobs = parsed["jobs"].as_mapping().expect("jobs is a mapping");
+        // The deploy workflow is exactly these five jobs in order;
+        // `cleanup` lives in the generated sibling, not here.
+        for job in ["changes", "verify", "preview", "comment", "deploy"] {
+            assert!(jobs.contains_key(job), "missing job: {job}");
+        }
+        assert!(
+            !jobs.contains_key("cleanup"),
+            "cleanup belongs in the sibling file"
+        );
+        assert_eq!(parsed["name"].as_str(), Some("portfolio deploy"));
+    }
+
+    #[test]
+    fn triggers_on_pr_push_main_and_dispatch() {
+        let parsed = emit_fixture();
+        assert!(parsed["on"].get("pull_request").is_some());
+        assert_eq!(parsed["on"]["push"]["branches"][0].as_str(), Some("main"));
+        assert!(parsed["on"].get("workflow_dispatch").is_some());
+    }
+
+    #[test]
+    fn permissions_allow_oidc_and_pr_comments() {
+        let parsed = emit_fixture();
+        let perms = &parsed["permissions"];
+        assert_eq!(perms["id-token"].as_str(), Some("write"));
+        assert_eq!(perms["contents"].as_str(), Some("read"));
+        // The `comment` job needs write to post the sticky URL comment.
+        assert_eq!(perms["pull-requests"].as_str(), Some("write"));
+    }
+
+    #[test]
+    fn concurrency_group_is_per_project() {
+        let parsed = emit_fixture();
+        let group = parsed["concurrency"]["group"]
+            .as_str()
+            .expect("group is a string");
+        assert!(group.starts_with("portfolio-deploy-"), "got: {group}");
+    }
+
+    #[test]
+    fn verify_call_gates_on_pr_and_runs_verify_only() {
+        let parsed = emit_fixture();
+        let verify = &parsed["jobs"]["verify"];
+        assert_eq!(
+            verify["uses"].as_str(),
+            Some("./.github/workflows/cf-deploy.yml")
+        );
+        assert_eq!(verify["with"]["verify_only"].as_bool(), Some(true));
+        let if_ = verify["if"].as_str().expect("verify has an if");
+        assert!(if_.contains("github.event_name == 'pull_request'"), "{if_}");
+    }
+
+    #[test]
+    fn preview_overrides_script_name_with_pr_number() {
+        let parsed = emit_fixture();
+        let preview = &parsed["jobs"]["preview"];
+        assert_eq!(
+            preview["with"]["script_name_override"].as_str(),
+            Some("portfolio-pr-${{ github.event.pull_request.number }}")
+        );
+        // Sequenced after verify so broken creds don't burn a deploy.
+        let needs = preview["needs"].as_sequence().expect("needs is a list");
+        assert!(needs.iter().any(|n| n.as_str() == Some("verify")));
+    }
+
+    #[test]
+    fn deploy_call_runs_on_push_main_or_dispatch_not_verify_only() {
+        let parsed = emit_fixture();
+        let deploy = &parsed["jobs"]["deploy"];
+        assert_eq!(deploy["with"]["verify_only"].as_bool(), Some(false));
+        let if_ = deploy["if"].as_str().expect("deploy has an if");
+        assert!(if_.contains("github.event_name == 'push'"), "{if_}");
+        assert!(
+            if_.contains("github.event_name == 'workflow_dispatch'"),
+            "{if_}"
+        );
+    }
+
+    #[test]
+    fn comment_job_carries_a_project_scoped_marker() {
+        let yaml = super::super::workflow::emit(&build(&fixture_spec()));
+        // The HTML marker lets later runs find and edit the existing
+        // comment instead of posting a new one each push.
+        assert!(yaml.contains("<!-- preview-deploy:portfolio -->"));
+    }
+
+    #[test]
+    fn changes_filter_watches_project_and_reusable_workflow() {
+        let parsed = emit_fixture();
+        let filters = parsed["jobs"]["changes"]["steps"]
+            .as_sequence()
+            .expect("steps")
+            .iter()
+            .find_map(|s| s["with"].get("filters").and_then(|f| f.as_str()))
+            .expect("paths-filter step with a filters body");
+        assert!(filters.contains("apps/portfolio/**"), "{filters}");
+        assert!(filters.contains("cf-deploy.yml"), "{filters}");
+    }
+}

--- a/tools/shaka/tests/ci_generate.rs
+++ b/tools/shaka/tests/ci_generate.rs
@@ -1,0 +1,137 @@
+//! Integration tests for `shaka ci generate-workflows` and
+//! `shaka ci audit-workflows`.
+//!
+//! Both subcommands `cue export` every discovered `project.cue` and
+//! touch `.github/workflows/`, so they need a real temp repo with a
+//! `cue.mod` (planted by `common::write_test_module`) and at least one
+//! project carrying a `ci.build` block. We stage `apps/widget` from
+//! `tests/fixtures/ci-generate/`, then drive the binary against that
+//! tempdir as cwd — exit code plus the on-disk workflow file are the
+//! contract.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+mod common;
+
+const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+
+fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ci-generate")
+}
+
+/// Stage `apps/widget` (a buildable rust-cli) into a fresh temp repo
+/// with a resolvable cue module, returning the repo root.
+fn staged_repo() -> tempfile::TempDir {
+    let root = tempfile::TempDir::new().unwrap();
+    common::write_test_module(root.path());
+
+    let dst = root.path().join("apps/widget");
+    std::fs::create_dir_all(&dst).unwrap();
+    // The fixture carries a `.fixture` suffix so the source tree never
+    // holds a stray `project.cue` (rejected by schema-check, #95).
+    std::fs::copy(
+        fixtures_root().join("widget/project.cue.fixture"),
+        dst.join("project.cue"),
+    )
+    .unwrap();
+
+    root
+}
+
+fn run(root: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(SHAKA_BIN)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("spawn shaka")
+}
+
+#[test]
+fn generate_workflows_emits_main_yaml_for_a_build_project() {
+    let repo = staged_repo();
+    let out = run(repo.path(), &["ci", "generate-workflows"]);
+    assert!(
+        out.status.success(),
+        "generate-workflows failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let main_yaml = repo.path().join(".github/workflows/main.yaml");
+    let content = std::fs::read_to_string(&main_yaml).expect("main.yaml written");
+    // The widget's ci.build block becomes a `build-widget` job that
+    // publishes to its declared FlakeHub name.
+    assert!(content.contains("build-widget:"), "{content}");
+    assert!(content.contains("kolohelios/widget"), "{content}");
+}
+
+#[test]
+fn generate_workflows_check_passes_after_generating() {
+    let repo = staged_repo();
+    // First write, then `--check` must agree byte-for-byte.
+    assert!(run(repo.path(), &["ci", "generate-workflows"])
+        .status
+        .success());
+    let out = run(repo.path(), &["ci", "generate-workflows", "--check"]);
+    assert!(
+        out.status.success(),
+        "--check drifted right after generate: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn generate_workflows_check_detects_drift() {
+    let repo = staged_repo();
+    assert!(run(repo.path(), &["ci", "generate-workflows"])
+        .status
+        .success());
+    // Corrupt the generated file; `--check` must now fail.
+    let main_yaml = repo.path().join(".github/workflows/main.yaml");
+    std::fs::write(&main_yaml, "name: tampered\n").unwrap();
+    let out = run(repo.path(), &["ci", "generate-workflows", "--check"]);
+    assert!(!out.status.success(), "drift should fail --check");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("DRIFT") || combined.contains("drifted"),
+        "{combined}"
+    );
+}
+
+#[test]
+fn audit_workflows_accepts_a_generated_main_yaml() {
+    let repo = staged_repo();
+    assert!(run(repo.path(), &["ci", "generate-workflows"])
+        .status
+        .success());
+    let out = run(repo.path(), &["ci", "audit-workflows"]);
+    assert!(
+        out.status.success(),
+        "audit-workflows rejected a generated file: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn audit_workflows_flags_an_unaccounted_workflow() {
+    let repo = staged_repo();
+    let wf_dir = repo.path().join(".github/workflows");
+    std::fs::create_dir_all(&wf_dir).unwrap();
+    // A hand-dropped workflow that is neither generated nor allowlisted.
+    std::fs::write(wf_dir.join("rogue.yml"), "name: rogue\n").unwrap();
+    let out = run(repo.path(), &["ci", "audit-workflows"]);
+    assert!(
+        !out.status.success(),
+        "rogue workflow should fail the audit"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(combined.contains("rogue.yml"), "{combined}");
+}

--- a/tools/shaka/tests/fixtures/ci-generate/widget/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/ci-generate/widget/project.cue.fixture
@@ -1,0 +1,23 @@
+package project
+
+// A minimal buildable rust-cli project used by `tests/ci_generate.rs`
+// to exercise `shaka ci generate-workflows` and `audit-workflows`
+// end-to-end. The `ci.build` block makes the generator emit a
+// `build-widget` job into `main.yaml`.
+#Project & {
+	name: "widget"
+	kind: "rust-cli"
+	coverage: line: fail: 50
+	cli: binaryName: "widget"
+	ci: build: {
+		filterKey:   "widget"
+		jobId:       "widget"
+		displayName: "Widget"
+		publish: {
+			kind:       "flakehub"
+			name:       "kolohelios/widget"
+			visibility: "public"
+			rolling:    true
+		}
+	}
+}


### PR DESCRIPTION
The ci workflow emitters were at 0% line coverage despite being pure,
deterministic builders — the kind of code that is cheapest to test and
most expensive to get subtly wrong (a malformed generated workflow only
surfaces in CI).

Add inline unit tests for `main_workflow::build` (flakehub vs artifact
publish, dispatch, nix check/build verbs, attr suffix, gate wiring),
`worker_deploy_workflow::build` (the five lifecycle jobs, pr gating,
preview script override), and `generate::build_apply_workflow`. Add an
integration test that drives `shaka ci generate-workflows` and
`audit-workflows` against a staged temp repo so the cue-export and
drift/audit paths run end to end.

The threshold was a placeholder (30) the codebase cleared by a wide
margin. With the new ci generator tests, measured line coverage is
64.2%, so raise the fail gate to 62 to make it a real bar.

Branch coverage from the original issue is intentionally not set:
`cargo llvm-cov --branch` requires nightly, incompatible with the
pinned stable toolchain, so the schema is line-only. #770 tracks
pushing line coverage toward 70.

Closes #97