### PR TITLE
feat(infra/home): install shakaShim on the global user PATH

### DIFF
--- a/infra/home/flake.lock
+++ b/infra/home/flake.lock
@@ -49,12 +49,12 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780276259,
-        "narHash": "sha256-p+SPD4LtbnLC198WqhqfaDj17RUAmW98qUVB0M9CbR0=",
-        "rev": "1da2eba744f1b2665c9bc7e5ff6f047724b56f66",
-        "revCount": 468,
+        "lastModified": 1780553198,
+        "narHash": "sha256-U4ozfZOTL820x55BKpgEow7sck0mrlZEM0B3f1USJrE=",
+        "rev": "b791c7aad76cd0318a84e6f4d3bcab7db328d455",
+        "revCount": 507,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.468%2Brev-1da2eba744f1b2665c9bc7e5ff6f047724b56f66/019e80cb-c6d6-7941-be69-02e6212ec251/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/kolohelios-nix/0.1.507%2Brev-b791c7aad76cd0318a84e6f4d3bcab7db328d455/019e9141-884c-7a40-90dd-a51cc2198e33/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/infra/home/flake.nix
+++ b/infra/home/flake.nix
@@ -46,7 +46,7 @@
 
       darwinConfigurations.Jons-MacBook-Pro = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        specialArgs = { inherit claude-hooks; };
+        specialArgs = { inherit claude-hooks kolohelios-nix; };
         modules = [
           home-manager.darwinModules.home-manager
           ./modules/darwin.nix
@@ -55,15 +55,15 @@
 
       # NixOS module — imported by `infra/devbox` to apply this user's
       # home-manager profile to the `jon` account on the devbox.
-      # `_module.args.claude-hooks` is the NixOS equivalent of the
-      # `specialArgs` plumbing above so `infra/devbox` doesn't have
-      # to know about it.
+      # `_module.args` is the NixOS equivalent of the `specialArgs`
+      # plumbing above (claude-hooks, kolohelios-nix) so `infra/devbox`
+      # doesn't have to know about them.
       nixosModules.home = {
         imports = [
           home-manager.nixosModules.home-manager
           ./modules/linux.nix
         ];
-        _module.args = { inherit claude-hooks; };
+        _module.args = { inherit claude-hooks kolohelios-nix; };
       };
 
       formatter = kolohelios-nix.formatter;

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -2,7 +2,12 @@
 # (via nix-darwin) and Linux (via NixOS). `home.username` and
 # `home.homeDirectory` are set by the host system's user list; this
 # module stays platform-agnostic.
-{ pkgs, claude-hooks, ... }:
+{
+  pkgs,
+  claude-hooks,
+  kolohelios-nix,
+  ...
+}:
 
 {
   home.stateVersion = "25.05";
@@ -30,6 +35,14 @@
     # globally lets the hook fire in any working directory, not just
     # inside the kolohelios checkout.
     claude-hooks.packages.${pkgs.stdenv.hostPlatform.system}.default
+    # `shaka` PATH shim from the shared lib. Same rationale as
+    # `claude-hooks` above: on PATH globally it resolves `shaka` in any
+    # bare shell (login shell, non-direnv terminal, agent harness)
+    # whenever `cwd` is inside the kolohelios checkout — not only inside
+    # a project devshell. The shim walks up from `cwd` to the canonical
+    # `tools/shaka/bin/shaka` wrapper; outside a checkout it's a no-op
+    # that exits non-zero, so installing it globally is safe (#755).
+    (kolohelios-nix.lib.shakaShim pkgs)
   ];
 
   programs.git = {

--- a/infra/home/project.cue
+++ b/infra/home/project.cue
@@ -29,7 +29,7 @@ package project
 		extra: """
       darwinConfigurations.Jons-MacBook-Pro = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        specialArgs = { inherit claude-hooks; };
+        specialArgs = { inherit claude-hooks kolohelios-nix; };
         modules = [
           home-manager.darwinModules.home-manager
           ./modules/darwin.nix
@@ -38,15 +38,15 @@ package project
 
       # NixOS module — imported by `infra/devbox` to apply this user's
       # home-manager profile to the `jon` account on the devbox.
-      # `_module.args.claude-hooks` is the NixOS equivalent of the
-      # `specialArgs` plumbing above so `infra/devbox` doesn't have
-      # to know about it.
+      # `_module.args` is the NixOS equivalent of the `specialArgs`
+      # plumbing above (claude-hooks, kolohelios-nix) so `infra/devbox`
+      # doesn't have to know about them.
       nixosModules.home = {
         imports = [
           home-manager.nixosModules.home-manager
           ./modules/linux.nix
         ];
-        _module.args = { inherit claude-hooks; };
+        _module.args = { inherit claude-hooks kolohelios-nix; };
       };
 """
 	}


### PR DESCRIPTION
shaka was only on PATH inside a project devshell, so bare shells, agent
harnesses, and non-direnv terminals fell back to invoking
`tools/shaka/bin/shaka` by full path. Add the shared lib's shakaShim to
the home-manager package set — mirroring the claude-hooks plumbing
through specialArgs/_module.args — so `shaka` resolves from any shell
whenever cwd is inside the checkout.

The shim is repo-bound by design: outside a kolohelios checkout it exits
non-zero, so installing it globally is safe.

Closes #755