### PR TITLE
build(nix): bump nixpkgs for importCargoLock static.crates.io fetch

### DIFF
--- a/nix/kolohelios-nix/flake.lock
+++ b/nix/kolohelios-nix/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777077449,
-        "narHash": "sha256-AIiMJiqvGrN4HyLEbKAoCSRRYn0rnlW5VbKNIMIYqm4=",
-        "rev": "a4bf06618f0b5ee50f14ed8f0da77d34ecc19160",
-        "revCount": 911667,
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "revCount": 1005180,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.911667%2Brev-a4bf06618f0b5ee50f14ed8f0da77d34ecc19160/019dcae8-75b0-71d1-abd5-feab9658f0fa/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2605.1005180%2Brev-b51242d7d43689db2f3be91bd05d5b24fbb469c4/019e820b-3e9f-7ad0-acdd-dab08fdf665f/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
crates.io user-agent gates the default curl UA that nixpkgs'
importCargoLock sends via fetchurl, so any new Cargo dep pulling an
uncached transitive crate 403'd in CI. nixpkgs f830e6112 switches
importCargoLock to download from static.crates.io (the CDN, which does
not UA-gate); bumping the shared nixpkgs lock to a revision carrying the
fix unblocks new dependencies across every consumer.

Closes #593