### PR TITLE
feat(aof): render the areas tree end to end

### DIFF
--- a/tools/aof/flake.nix
+++ b/tools/aof/flake.nix
@@ -63,12 +63,24 @@
             version = "0.1.0";
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
-            nativeBuildInputs = [ pkgs.installShellFiles ];
+            nativeBuildInputs = [
+              pkgs.makeWrapper
+              pkgs.installShellFiles
+            ];
             postInstall = ''
               installShellCompletion --cmd aof \
                 --bash <($out/bin/aof completions bash) \
                 --fish <($out/bin/aof completions fish) \
                 --zsh  <($out/bin/aof completions zsh)
+            '';
+            postFixup = ''
+              wrapProgram $out/bin/aof \
+                --prefix PATH : ${
+                  pkgs.lib.makeBinPath [
+                    pkgs.cue
+                    pkgs.d2
+                  ]
+                }
             '';
           };
         }
@@ -90,6 +102,7 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
+              pkgs.d2
             ]
             ++ (workflowPackages pkgs)
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;

--- a/tools/aof/project.cue
+++ b/tools/aof/project.cue
@@ -7,6 +7,13 @@ package project
 		binaryName:       "aof"
 		package:          true
 		shellCompletions: true
+		// `aof render` shells out to `cue export` (load the areas tree)
+		// and `d2` (emit the diagram SVG). Wrap both onto the packaged
+		// binary's PATH so it's self-contained off FlakeHub; `cue` also
+		// rides along in the devShell via `workflowPackages`, but `d2`
+		// is aof-specific.
+		runtimePathDeps: ["cue", "d2"]
+		extraDevShellPackages: ["d2"]
 	}
 	coverage: {
 		line: {

--- a/tools/aof/src/diagram.rs
+++ b/tools/aof/src/diagram.rs
@@ -1,0 +1,266 @@
+//! Turn the areas-of-focus tree into a picture.
+//!
+//! Two steps, each a thin shell-out:
+//!
+//! 1. Load the tree by running `cue export <dir>` over the areas CUE
+//!    package (schema plus data live in the same package, so the whole
+//!    directory is evaluated together) and deserializing the JSON.
+//! 2. Emit a D2 source document from the tree and pipe it through
+//!    `d2 - -` (read source from stdin, write SVG to stdout). The SVG
+//!    bytes are handed to the renderer in `render.rs`.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum DiagramError {
+    #[snafu(display("could not spawn `cue`: {source} (is `cue` on PATH?)"))]
+    SpawnCue { source: std::io::Error },
+
+    #[snafu(display("`cue export {dir}` exited {status}: {stderr}"))]
+    CueExport {
+        dir: String,
+        status: i32,
+        stderr: String,
+    },
+
+    #[snafu(display("failed to parse `cue export` JSON: {source}"))]
+    ParseExport { source: serde_json::Error },
+
+    #[snafu(display("could not spawn `d2`: {source} (is `d2` on PATH?)"))]
+    SpawnD2 { source: std::io::Error },
+
+    #[snafu(display("failed to write D2 source to d2 stdin: {source}"))]
+    WriteD2Stdin { source: std::io::Error },
+
+    #[snafu(display("failed to wait on `d2`: {source}"))]
+    WaitD2 { source: std::io::Error },
+
+    #[snafu(display("`d2` exited {status}: {stderr}"))]
+    D2Exit { status: i32, stderr: String },
+}
+
+/// A single area-of-focus node. Mirrors `#Area` in `data/schema.cue`:
+/// a name, an optional description, and zero or more child areas. The
+/// tree shape is enforced by the schema, so there's no cycle handling
+/// here by construction.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct Area {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub children: Vec<Area>,
+}
+
+/// A forest of root areas. `cue export` emits a top-level object whose
+/// values are the root `#Area`s — the CUE field names are bookkeeping,
+/// not part of the model — so a document with several top-level areas
+/// renders as several roots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tree {
+    pub roots: Vec<Area>,
+}
+
+impl Tree {
+    /// Load the areas tree by evaluating the CUE package in `dir` (schema
+    /// plus data) and deserializing the resulting JSON.
+    pub fn load(dir: &Path) -> Result<Self, DiagramError> {
+        // `cue` reads a bare relative arg like `data` as a standard-library
+        // import path; prefixing with `./` forces it to treat the arg as a
+        // filesystem directory. Joining onto "." leaves absolute paths
+        // untouched.
+        let arg = Path::new(".").join(dir);
+        let output = Command::new("cue")
+            .arg("export")
+            .arg(&arg)
+            .output()
+            .context(SpawnCueSnafu)?;
+        if !output.status.success() {
+            return CueExportSnafu {
+                dir: arg.display().to_string(),
+                status: output.status.code().unwrap_or(-1),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            }
+            .fail();
+        }
+        Self::from_export(&output.stdout)
+    }
+
+    /// Parse a `cue export` JSON document into a `Tree`. Split out from
+    /// `load` so the JSON-to-model mapping is testable without invoking
+    /// `cue`.
+    pub fn from_export(json: &[u8]) -> Result<Self, DiagramError> {
+        let map: BTreeMap<String, Area> = serde_json::from_slice(json).context(ParseExportSnafu)?;
+        Ok(Tree {
+            roots: map.into_values().collect(),
+        })
+    }
+}
+
+/// Emit a D2 source document for `tree`. Each area becomes a node whose
+/// label is the area name; parent-child relationships become `->` edges,
+/// which D2's default layout draws as a top-down tree.
+///
+/// Nodes are given synthetic `nN` identifiers so we never have to worry
+/// about escaping area names into valid D2 identifiers — the name rides
+/// entirely in the quoted label, and duplicate names across the tree
+/// (for example two "Health" areas under different parents) stay
+/// distinct.
+pub fn tree_to_d2(tree: &Tree) -> String {
+    let mut out = String::new();
+    let mut next_id = 0usize;
+    for root in &tree.roots {
+        emit_node(&mut out, root, None, &mut next_id);
+    }
+    out
+}
+
+fn emit_node(out: &mut String, area: &Area, parent_id: Option<&str>, next_id: &mut usize) {
+    let id = format!("n{}", *next_id);
+    *next_id += 1;
+
+    out.push_str(&id);
+    out.push_str(": ");
+    out.push_str(&quote_label(&area.name));
+    out.push('\n');
+
+    if let Some(parent) = parent_id {
+        out.push_str(parent);
+        out.push_str(" -> ");
+        out.push_str(&id);
+        out.push('\n');
+    }
+
+    for child in &area.children {
+        emit_node(out, child, Some(&id), next_id);
+    }
+}
+
+/// Wrap `s` in a D2 double-quoted string, escaping backslashes and
+/// double quotes so labels containing either stay well-formed.
+fn quote_label(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Render a D2 source document to SVG bytes by piping it through
+/// `d2 - -` (source on stdin, SVG on stdout). On success `d2` writes a
+/// `success:` line to stderr, which we ignore.
+pub fn d2_to_svg(source: &str) -> Result<Vec<u8>, DiagramError> {
+    let mut child = Command::new("d2")
+        .args(["-", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context(SpawnD2Snafu)?;
+
+    // Write the full source and close stdin before collecting output.
+    // `d2` reads its entire input before laying out, so it produces no
+    // meaningful stdout until stdin closes — no risk of a pipe deadlock
+    // for the diagram sizes we emit.
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped above")
+        .write_all(source.as_bytes())
+        .context(WriteD2StdinSnafu)?;
+
+    let output = child.wait_with_output().context(WaitD2Snafu)?;
+    if !output.status.success() {
+        return D2ExitSnafu {
+            status: output.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        }
+        .fail();
+    }
+    Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn area(name: &str, children: Vec<Area>) -> Area {
+        Area {
+            name: name.to_string(),
+            description: None,
+            children,
+        }
+    }
+
+    #[test]
+    fn from_export_maps_top_level_values_to_roots() {
+        let json = br#"{"example":{"name":"Example","children":[{"name":"Work"}]}}"#;
+        let tree = Tree::from_export(json).expect("valid export parses");
+        assert_eq!(tree.roots.len(), 1);
+        assert_eq!(tree.roots[0].name, "Example");
+        assert_eq!(tree.roots[0].children[0].name, "Work");
+    }
+
+    #[test]
+    fn from_export_treats_missing_children_as_empty() {
+        let json = br#"{"a":{"name":"Leaf"}}"#;
+        let tree = Tree::from_export(json).expect("leaf parses");
+        assert!(tree.roots[0].children.is_empty());
+    }
+
+    #[test]
+    fn from_export_supports_multiple_roots() {
+        // Two top-level CUE fields => two roots. BTreeMap orders by key,
+        // so the output order is deterministic.
+        let json = br#"{"b":{"name":"Beta"},"a":{"name":"Alpha"}}"#;
+        let tree = Tree::from_export(json).expect("forest parses");
+        let names: Vec<&str> = tree.roots.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, ["Alpha", "Beta"]);
+    }
+
+    #[test]
+    fn tree_to_d2_emits_a_node_per_area_and_edge_per_child() {
+        let tree = Tree {
+            roots: vec![area(
+                "Example",
+                vec![
+                    area("Work", vec![]),
+                    area("Personal", vec![area("Health", vec![])]),
+                ],
+            )],
+        };
+        let d2 = tree_to_d2(&tree);
+        // Four nodes (Example, Work, Personal, Health) => four label lines.
+        assert_eq!(d2.matches(": \"").count(), 4);
+        assert!(d2.contains("n0: \"Example\""));
+        // Three edges: Example->Work, Example->Personal, Personal->Health.
+        assert_eq!(d2.matches(" -> ").count(), 3);
+        // Health hangs off Personal, not the root.
+        assert!(d2.contains("n2 -> n3"));
+    }
+
+    #[test]
+    fn tree_to_d2_keeps_duplicate_names_distinct() {
+        // Two "Health" areas under different parents must get distinct
+        // node ids so the diagram doesn't collapse them into one.
+        let tree = Tree {
+            roots: vec![
+                area("Body", vec![area("Health", vec![])]),
+                area("Mind", vec![area("Health", vec![])]),
+            ],
+        };
+        let d2 = tree_to_d2(&tree);
+        assert_eq!(d2.matches("\"Health\"").count(), 2);
+        assert!(d2.contains("n0 -> n1"));
+        assert!(d2.contains("n2 -> n3"));
+    }
+
+    #[test]
+    fn quote_label_escapes_quotes_and_backslashes() {
+        assert_eq!(quote_label(r#"a"b\c"#), r#""a\"b\\c""#);
+    }
+}

--- a/tools/aof/src/lib.rs
+++ b/tools/aof/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod diagram;
 pub mod render;
 pub mod todoist;

--- a/tools/aof/src/main.rs
+++ b/tools/aof/src/main.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use aof::{render, todoist};
+use aof::{diagram, render, todoist};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 
@@ -27,11 +27,15 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// Render an SVG diagram inline in the current terminal
+    /// Render the areas-of-focus tree as a diagram inline in the terminal
     Render {
-        /// Path to the SVG file to render
-        #[arg(long)]
-        from: PathBuf,
+        /// Directory holding the areas CUE package (schema + data).
+        #[arg(long, default_value = "data")]
+        data: PathBuf,
+        /// Render this pre-rendered SVG directly, bypassing the
+        /// cue/d2 pipeline. A debug escape hatch.
+        #[arg(long, conflicts_with = "data")]
+        from: Option<PathBuf>,
     },
     #[command(hide = true)]
     Completions { shell: Shell },
@@ -51,7 +55,7 @@ fn main() -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Command::Render { from } => match run_render(&from) {
+        Command::Render { data, from } => match run_render(&data, from.as_deref()) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("aof render: {e}");
@@ -67,8 +71,17 @@ fn main() -> ExitCode {
     }
 }
 
-fn run_render(from: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let svg = std::fs::read(from)?;
+fn run_render(data: &Path, from: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+    let svg = match from {
+        // Escape hatch: render a pre-built SVG without touching cue/d2.
+        Some(path) => std::fs::read(path)?,
+        // Default: load the areas tree, emit D2, render to SVG.
+        None => {
+            let tree = diagram::Tree::load(data)?;
+            let source = diagram::tree_to_d2(&tree);
+            diagram::d2_to_svg(&source)?
+        }
+    };
     render::render_svg(&svg)?;
     Ok(())
 }

--- a/tools/aof/tests/diagram.rs
+++ b/tools/aof/tests/diagram.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+use std::process::Command;
+
+use aof::diagram::{self, Area, Tree};
+
+/// True when `bin` answers `--version`. The diagram pipeline shells out
+/// to `cue` and `d2`; both are on PATH inside the project devShell (where
+/// `just validate` runs), but a bare `cargo test` outside it would fail
+/// on spawn. Skip rather than fail in that case.
+fn available(bin: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn tree_to_d2_output_renders_to_svg() {
+    if !available("d2") {
+        eprintln!("skipping: `d2` not on PATH (run inside the devShell)");
+        return;
+    }
+
+    let tree = Tree {
+        roots: vec![Area {
+            name: "Example".into(),
+            description: None,
+            children: vec![Area {
+                name: "Work".into(),
+                description: None,
+                children: vec![],
+            }],
+        }],
+    };
+    let source = diagram::tree_to_d2(&tree);
+    let svg = diagram::d2_to_svg(&source).expect("d2 must render the source");
+
+    let head = String::from_utf8_lossy(&svg);
+    assert!(head.contains("<svg"), "d2 output should be an SVG document");
+}
+
+#[test]
+fn load_reads_the_areas_fixture() {
+    if !available("cue") {
+        eprintln!("skipping: `cue` not on PATH (run inside the devShell)");
+        return;
+    }
+
+    let tree = Tree::load(Path::new("data")).expect("data package must export");
+    assert!(!tree.roots.is_empty(), "the fixture has at least one root");
+    assert!(
+        tree.roots.iter().any(|r| r.name == "Example"),
+        "the example fixture's root is named Example"
+    );
+}


### PR DESCRIPTION
`aof render` shells out to `cue export` to load the areas tree and to
`d2` to emit the diagram SVG. Declare both as runtimePathDeps so the
binary published to FlakeHub is self-contained, and add d2 to the
devShell for local development.

Add `src/diagram.rs`: a `Tree` model loaded from `cue export` over the
areas CUE package, `tree_to_d2` to turn it into a D2 source document
(synthetic node ids carry the area name as a quoted label, parent-child
links become edges), and a `d2 - -` shell-out that pipes the source to
SVG bytes for the renderer.

Synthetic ids sidestep D2 identifier escaping and keep duplicate area
names distinct across the tree.

`aof render` now loads the areas CUE package (`--data`, default `data`),
emits D2, shells out to `d2` for SVG, and displays it inline via the
existing renderer. `--from <svg>` is kept as a debug escape hatch that
renders a pre-built SVG directly, and conflicts with `--data`.

Closes #608