### PR TITLE
feat(shaka): add rust-lib project kind for shared library crates

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -285,6 +285,36 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 		deploy?: #CiDeploy
 	}
 } | {
+	// Rust library crate shared across consumers — compiled natively
+	// for `cargo test` and to wasm32-unknown-unknown by the Worker and
+	// the WASM editor. No binary and no Cloudflare deploy; the wasm
+	// target is part of the contract, so the generated `validate`
+	// includes a `wasm-check`. `packages/notes-protocol` is the first.
+	//
+	// Coverage is required (like rust-cli): a shared lib is pure,
+	// natively testable logic, so cargo-llvm-cov measures the real
+	// surface — unlike rust-worker, whose wasm-only request paths it
+	// can't see.
+	kind: "rust-lib"
+	coverage: {
+		line: {
+			fail: number & >=0 & <=100
+		}
+	}
+	// Optional FlakeHub publication for a lib consumed by other repos.
+	// `notes-protocol` is consumed in-repo via a path dep and omits it.
+	ci?: {
+		build?: #CiBuild
+	}
+	rustLib?: {
+		// Top-level flake `description`. Defaults to the project name.
+		description?: string & !=""
+
+		// Extra nixpkgs attrs dropped into the devShell, on top of the
+		// rust toolchain and `workflowPackages`.
+		extraDevShellPackages?: [...string & =~"^[a-zA-Z_][a-zA-Z0-9_-]*$"]
+	}
+} | {
 	kind: "infra"
 	// CI/CD workflow configuration. Workflow files under
 	// `.github/workflows/` are generated from this block by

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -39,6 +39,7 @@ struct AuditConfig {
 pub enum ProjectKind {
     RustCli,
     RustWorker,
+    RustLib,
     Infra,
     NixLib,
     Document,
@@ -48,7 +49,10 @@ impl ProjectKind {
     /// Rust-flavored kinds share the cargo/clippy/license rules even
     /// when coverage requirements diverge.
     fn is_rust_flavored(self) -> bool {
-        matches!(self, ProjectKind::RustCli | ProjectKind::RustWorker)
+        matches!(
+            self,
+            ProjectKind::RustCli | ProjectKind::RustWorker | ProjectKind::RustLib
+        )
     }
 }
 
@@ -189,6 +193,9 @@ impl Rule for RustCoverageThresholdNonzero {
             return match meta.kind {
                 ProjectKind::RustCli => {
                     RuleResult::Fail("rust-cli project missing coverage block".into())
+                }
+                ProjectKind::RustLib => {
+                    RuleResult::Fail("rust-lib project missing coverage block".into())
                 }
                 ProjectKind::RustWorker => RuleResult::Pass,
                 _ => RuleResult::Pass,

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -24,6 +24,8 @@ struct ProjectMeta {
     infra: Option<InfraMeta>,
     #[serde(default)]
     nix_lib: Option<NixLibMeta>,
+    #[serde(default)]
+    rust_lib: Option<RustLibMeta>,
 }
 
 #[derive(Deserialize)]
@@ -93,6 +95,15 @@ struct NixLibMeta {
 }
 
 #[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RustLibMeta {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    extra_dev_shell_packages: Vec<String>,
+}
+
+#[derive(Default, Deserialize)]
 struct ExtraInput {
     url: String,
     #[serde(default)]
@@ -157,6 +168,17 @@ pub fn run(check: bool) {
                     render_infra_flake(&meta.name, infra),
                 ));
             }
+            "rust-lib" => {
+                // `rustLib:` is optional — fall back to a default block
+                // so a lib that doesn't override description or devShell
+                // packages still picks up the project name.
+                let default = RustLibMeta::default();
+                let rl = meta.rust_lib.as_ref().unwrap_or(&default);
+                items.push((
+                    project.join("flake.nix"),
+                    render_rust_lib_flake(&meta.name, rl),
+                ));
+            }
             "nix-lib" => {
                 // Same opt-in pattern as `infra`.
                 let Some(nl) = meta.nix_lib.as_ref() else {
@@ -200,6 +222,92 @@ fn render_flake(name: &str, cli: &CliMeta) -> String {
     out.push_str(&render_devshell(cli));
     out.push_str("\n      formatter = kolohelios-nix.formatter;\n    };\n");
     out.push_str("}\n");
+    out
+}
+
+/// Compose a rust-lib flake: a shared library crate consumed natively
+/// (for tests) and on wasm32-unknown-unknown (the Worker + the WASM
+/// editor). devShell-only — a lib produces no binary, so there's no
+/// `packages.default` / `apps.default`; the toolchain carries the wasm
+/// target so the generated `wasm-check` recipe finds the stdlib. Same
+/// kolohelios-nix + nixpkgs + rust-overlay inputs as the rust-cli flake.
+fn render_rust_lib_flake(name: &str, rl: &RustLibMeta) -> String {
+    let description = rl.description.as_deref().unwrap_or(name);
+    let mut out = String::with_capacity(2048);
+    out.push_str(HEADER);
+    out.push_str(&format!("{{\n  description = \"{description}\";\n\n"));
+    out.push_str(INPUTS);
+    out.push_str("\n  outputs =\n");
+    out.push_str(RUST_LIB_OUTPUT_HEADER);
+    out.push_str("    in\n    {\n");
+    out.push_str(&render_rust_lib_devshell(rl));
+    out.push_str("\n      formatter = kolohelios-nix.formatter;\n    };\n");
+    out.push_str("}\n");
+    out
+}
+
+/// `outputs` header for a rust-lib flake: identical to the rust-cli
+/// `OUTPUT_HEADER` except the toolchain adds the `wasm32-unknown-unknown`
+/// target (so `wasm-check` finds the stdlib) and there's no
+/// `rustPlatform` — a lib is never built via `buildRustPackage` here,
+/// it's consumed as a path dependency.
+const RUST_LIB_OUTPUT_HEADER: &str = r#"    {
+      self,
+      kolohelios-nix,
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      inherit (kolohelios-nix.lib) supportedSystems workflowPackages;
+
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+              overlays = [ rust-overlay.overlays.default ];
+            };
+          }
+        );
+
+      rustToolchain =
+        pkgs:
+        pkgs.rust-bin.stable."1.95.0".default.override {
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+            "llvm-tools-preview"
+          ];
+          targets = [ "wasm32-unknown-unknown" ];
+        };
+"#;
+
+/// devShell for a rust-lib flake: the wasm-targeted toolchain, any
+/// `extraDevShellPackages`, `workflowPackages`, and `cargo-llvm-cov` on
+/// Linux (for the `coverage` recipe). Mirrors the rust-cli devShell
+/// minus the shell-completion hook.
+fn render_rust_lib_devshell(rl: &RustLibMeta) -> String {
+    let mut out = String::new();
+    out.push_str("      devShells = forEachSupportedSystem (\n");
+    out.push_str("        { pkgs, ... }:\n");
+    out.push_str("        {\n");
+    out.push_str("          default = pkgs.mkShell {\n");
+    out.push_str("            packages = [\n");
+    out.push_str("              (rustToolchain pkgs)\n");
+    for pkg in &rl.extra_dev_shell_packages {
+        out.push_str(&format!("              pkgs.{pkg}\n"));
+    }
+    out.push_str("            ]\n");
+    out.push_str("            ++ (workflowPackages pkgs)\n");
+    out.push_str(
+        "            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;\n",
+    );
+    out.push_str("          };\n        }\n      );\n");
     out
 }
 
@@ -907,5 +1015,62 @@ mod tests {
     fn no_shell_hook_without_shell_completions() {
         let out = render_flake("demo", &minimal_cli());
         assert!(!out.contains("shellHook"));
+    }
+
+    #[test]
+    fn rust_lib_flake_starts_with_generated_header() {
+        let out = render_rust_lib_flake("notes-protocol", &RustLibMeta::default());
+        assert!(out.starts_with("# Generated by shaka. Do not edit by hand."));
+    }
+
+    #[test]
+    fn rust_lib_description_defaults_to_project_name() {
+        let out = render_rust_lib_flake("notes-protocol", &RustLibMeta::default());
+        assert!(out.contains(r#"description = "notes-protocol""#));
+    }
+
+    #[test]
+    fn rust_lib_description_override_takes_precedence() {
+        let rl = RustLibMeta {
+            description: Some("notes-protocol — wire types".into()),
+            ..RustLibMeta::default()
+        };
+        let out = render_rust_lib_flake("notes-protocol", &rl);
+        assert!(out.contains(r#"description = "notes-protocol — wire types""#));
+    }
+
+    #[test]
+    fn rust_lib_flake_carries_wasm_target() {
+        // The lib is consumed on wasm32-unknown-unknown, so the toolchain
+        // must add the target for the `wasm-check` recipe to find the stdlib.
+        let out = render_rust_lib_flake("notes-protocol", &RustLibMeta::default());
+        assert!(out.contains(r#"targets = [ "wasm32-unknown-unknown" ];"#));
+    }
+
+    #[test]
+    fn rust_lib_flake_is_devshell_only() {
+        // A lib produces no binary — no packages/apps, no buildRustPackage.
+        let out = render_rust_lib_flake("notes-protocol", &RustLibMeta::default());
+        assert!(!out.contains("packages = forEachSupportedSystem"));
+        assert!(!out.contains("apps = forEachSupportedSystem"));
+        assert!(!out.contains("buildRustPackage"));
+        assert!(out.contains("devShells = forEachSupportedSystem"));
+    }
+
+    #[test]
+    fn rust_lib_extra_dev_shell_packages_render_into_dev_shell() {
+        let rl = RustLibMeta {
+            extra_dev_shell_packages: vec!["wabt".into(), "wasm-tools".into()],
+            ..RustLibMeta::default()
+        };
+        let out = render_rust_lib_flake("notes-protocol", &rl);
+        assert!(out.contains("pkgs.wabt"));
+        assert!(out.contains("pkgs.wasm-tools"));
+    }
+
+    #[test]
+    fn rust_lib_flake_carries_formatter() {
+        let out = render_rust_lib_flake("notes-protocol", &RustLibMeta::default());
+        assert!(out.contains("formatter = kolohelios-nix.formatter;"));
     }
 }

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -66,6 +66,73 @@ whitespace-check:
 validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check
 "#;
 
+// Shared library crate (`packages/`). Same native gates as the
+// rust-cli template, plus a `wasm-check`: a shared lib is consumed on
+// both native (for tests) and `wasm32-unknown-unknown` (by the Worker
+// and the WASM editor), so wasm-compat is part of the contract and is
+// checked here for localized feedback rather than only transitively
+// through consumers. No worker-build — a lib produces no artifact of
+// its own.
+const RUST_LIB_TEMPLATE: &str = r#"build:
+    cargo build --release
+
+test:
+    cargo test
+
+fmt:
+    cargo fmt
+
+fmt-check:
+    cargo fmt --check
+
+fmt-toml:
+    taplo fmt
+
+lint:
+    cargo clippy --all-targets -- -D warnings
+
+doc-check:
+    RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --document-private-items
+
+deny:
+    cargo deny check
+
+# Macro-only deps can register as false positives — allowlist via
+# `package.metadata.cargo-machete.ignored` in the offending Cargo.toml.
+machete:
+    cargo machete
+
+# Shared libs are consumed on wasm32-unknown-unknown by the Worker and
+# the WASM editor, so the wasm target is part of the contract.
+wasm-check:
+    cargo check --target wasm32-unknown-unknown
+
+coverage:
+    #!/usr/bin/env bash
+    # Line coverage only — `cargo llvm-cov --branch` requires nightly
+    # (`-Z coverage-options=branch`), incompatible with the pinned
+    # stable toolchain.
+    set -euo pipefail
+    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
+    measured=$(cargo llvm-cov --json --summary-only)
+    line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
+    printf 'coverage: line=%.1f%% (gate: line>=%s%%)\n' "$line" "$fail_line"
+    awk -v l="$line" -v fl="$fail_line" \
+        'BEGIN { exit (l < fl) ? 1 : 0 }'
+
+nix-fmt-check:
+    nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
+
+flake-check:
+    nix flake check
+
+whitespace-check:
+    ../../tools/shaka/bin/shaka whitespace check
+
+validate: fmt-check lint doc-check deny machete wasm-check coverage nix-fmt-check flake-check whitespace-check
+"#;
+
 const NIX_LIB_TEMPLATE: &str = r#"fmt-toml:
     taplo fmt
 
@@ -431,6 +498,7 @@ fn template_for(kind: &str, project_dir: &Path) -> Option<String> {
             }
             .to_string(),
         ),
+        "rust-lib" => Some(RUST_LIB_TEMPLATE.to_string()),
         "nix-lib" => Some(NIX_LIB_TEMPLATE.to_string()),
         "document" => Some(DOCUMENT_TEMPLATE.to_string()),
         _ => None,
@@ -666,6 +734,31 @@ mod tests {
             template_for("rust-worker", dir.path()).as_deref(),
             Some(RUST_WORKER_TEMPLATE)
         );
+    }
+
+    #[test]
+    fn template_for_rust_lib_returns_rust_lib_template() {
+        let dir = tmp_project("rust-lib");
+        assert_eq!(
+            template_for("rust-lib", dir.path()).as_deref(),
+            Some(RUST_LIB_TEMPLATE)
+        );
+    }
+
+    #[test]
+    fn rust_lib_template_gates_validate_on_wasm_check() {
+        // A shared lib is consumed on wasm32-unknown-unknown, so the
+        // generated `validate` must include `wasm-check`.
+        assert!(RUST_LIB_TEMPLATE.contains("wasm-check:\n"));
+        assert!(RUST_LIB_TEMPLATE
+            .lines()
+            .any(|l| l.starts_with("validate:") && l.contains("wasm-check")));
+    }
+
+    #[test]
+    fn rust_lib_template_has_no_worker_build() {
+        // A lib produces no artifact of its own — no worker-build step.
+        assert!(!RUST_LIB_TEMPLATE.contains("worker-build"));
     }
 
     #[test]

--- a/tools/shaka/tests/fixtures/schema/invalid/rust-lib-bad-devshell-package.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/rust-lib-bad-devshell-package.cue
@@ -1,0 +1,16 @@
+package project
+
+// extraDevShellPackages entries are nixpkgs attr names; a value with a
+// space can't be one and must fail cue vet.
+#Project & {
+	name: "bad-devshell-lib"
+	kind: "rust-lib"
+	coverage: {
+		line: {
+			fail: 30
+		}
+	}
+	rustLib: {
+		extraDevShellPackages: ["has space"]
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/rust-lib-without-coverage.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/rust-lib-without-coverage.cue
@@ -1,0 +1,8 @@
+package project
+
+// rust-lib requires a coverage block (a shared lib is pure, natively
+// testable logic). Omitting it must fail cue vet.
+#Project & {
+	name: "missing-coverage-lib"
+	kind: "rust-lib"
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-lib-minimal.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-lib-minimal.cue
@@ -1,0 +1,11 @@
+package project
+
+#Project & {
+	name: "notes-protocol"
+	kind: "rust-lib"
+	coverage: {
+		line: {
+			fail: 30
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-lib-with-ci-build-flakehub.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-lib-with-ci-build-flakehub.cue
@@ -1,0 +1,24 @@
+package project
+
+#Project & {
+	name: "notes-protocol"
+	kind: "rust-lib"
+	coverage: {
+		line: {
+			fail: 30
+		}
+	}
+	ci: {
+		build: {
+			filterKey:   "notes-protocol"
+			jobId:       "notes-protocol"
+			displayName: "notes-protocol"
+			publish: {
+				kind:       "flakehub"
+				name:       "kolohelios/notes-protocol"
+				visibility: "public"
+				rolling:    true
+			}
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-lib-with-rustlib-block.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-lib-with-rustlib-block.cue
@@ -1,0 +1,15 @@
+package project
+
+#Project & {
+	name: "notes-protocol"
+	kind: "rust-lib"
+	coverage: {
+		line: {
+			fail: 30
+		}
+	}
+	rustLib: {
+		description: "notes-protocol — shared wire types"
+		extraDevShellPackages: ["wabt"]
+	}
+}


### PR DESCRIPTION
packages/ had no project kind: the schema only modeled rust-cli,
rust-worker, infra, nix-lib, and document. The shared notes-protocol
wire-types crate (#763) is a plain library compiled natively for tests
and to wasm32-unknown-unknown by the Worker and the WASM editor, with no
home in the schema. Rather than carve an unmanaged crate outside the
generators' drift-checked envelope, add a first-class kind.

The schema branch requires a coverage block (a shared lib is pure,
natively testable logic — unlike rust-worker, whose wasm-only paths
cargo-llvm-cov can't see) and carries an optional rustLib block for the
flake description and extra devShell packages. The generated justfile
mirrors the rust-cli gates plus a wasm-check, since wasm-compat is part
of a shared lib's contract. The generated flake is devShell-only (a lib
produces no binary) with the wasm target on the toolchain — verified
nixfmt-clean against a throwaway probe project.

Schema fixtures (3 valid, 2 invalid) and generator unit tests cover the
new paths.

Closes #762
Part of #757