### PR TITLE
ci: fire consumer bump on kolohelios-nix publish

### DIFF
--- a/.github/workflows/bump-kolohelios-nix.yaml
+++ b/.github/workflows/bump-kolohelios-nix.yaml
@@ -19,9 +19,15 @@ name: Bump kolohelios-nix locks
 # re-triggers the PR's normal CI (which pushes via the default
 # `GITHUB_TOKEN` do not).
 on:
+  # Primary trigger: `build-nix-lib` dispatches `kolohelios-nix-published`
+  # right after publishing a fresh release, so consumers pick up a new
+  # `kolohelios-nix` (and the nixpkgs revision it carries) within minutes.
+  repository_dispatch:
+    types: [kolohelios-nix-published]
   schedule:
-    # 00:00 UTC daily. Picks up new `kolohelios-nix` releases ≤24h after
-    # publish.
+    # 00:00 UTC daily — backstop in case a dispatch is missed (e.g. a
+    # publish that didn't fire the notify step). Idempotent: a no-op when
+    # nothing changed.
     - cron: "0 0 * * *"
   # Manual trigger for ad-hoc bumps and verification after rotating the
   # bot's credentials.

--- a/.github/workflows/bump-nixpkgs.yaml
+++ b/.github/workflows/bump-nixpkgs.yaml
@@ -1,0 +1,84 @@
+name: Bump nixpkgs lock
+
+# Daily bump of `nix/kolohelios-nix`'s own `nixpkgs` flake input — the
+# single source of truth every consumer follows via
+# `nixpkgs.follows = "kolohelios-nix/nixpkgs"`. Nothing else moves this
+# lock; without this job it only advances on a manual
+# `nix flake update nixpkgs` (the staleness that caused #593).
+#
+# `shaka repo bump-locks --input nixpkgs` walks every project but only
+# re-locks the one that declares `nixpkgs.url` — `nix/kolohelios-nix` —
+# since consumers' `.follows` form is not a direct input. When the lock
+# changes it opens a single PR (`bot/bump-nixpkgs`); a force-push updates
+# any already-open PR rather than duplicating.
+#
+# Unlike the upstream-input case, the downstream propagation is NOT
+# time-based: merging this PR triggers `build-nix-lib` (paths-filtered to
+# `nix/kolohelios-nix/**`) to publish a fresh `kolohelios-nix` release and
+# dispatch `kolohelios-nix-published`, which fires `bump-kolohelios-nix`
+# immediately. This daily cron is the only clock-based poll in the chain
+# — upstream nixpkgs releases have no event we can subscribe to.
+#
+# `--auto-merge` queues GitHub auto-merge (rebase strategy); the `Gate`
+# required check gates it. Authenticates as the `kolohelios-bot` GitHub
+# App so the resulting push re-triggers the PR's normal CI (which pushes
+# via the default `GITHUB_TOKEN` do not).
+on:
+  schedule:
+    # 00:00 UTC daily. Picks up new upstream nixpkgs releases ≤24h later.
+    - cron: "0 0 * * *"
+  # Manual trigger for ad-hoc bumps and verification after rotating the
+  # bot's credentials.
+  workflow_dispatch:
+
+# A second invocation that lands while we're still bumping would race on
+# the bot branch. Cancel any in-flight run; the new one will see the
+# latest state.
+concurrency:
+  group: bump-nixpkgs
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # `id-token: write` lets DeterminateSystems/nix-installer-action mint
+    # an OIDC token for FlakeHub. `nix run ./tools/shaka` substitutes the
+    # wrapped shaka closure from FlakeHub Cache (published by the
+    # `build-shaka` job in `main.yaml`); `nix flake update nixpkgs` called
+    # by shaka itself also needs the token to fetch the private
+    # `kolohelios-nix` flake.
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: Configure git identity
+        # The numeric App ID (3591292) is part of GitHub's noreply email
+        # format `<app-id>+<bot-name>[bot]@users.noreply.github.com`,
+        # which is what makes commits attributable to the App. The Client
+        # ID (used above for token minting) doesn't fit this slot.
+        run: |
+          git config --global user.name 'kolohelios-bot[bot]'
+          git config --global user.email '3591292+kolohelios-bot[bot]@users.noreply.github.com'
+      - name: Bump nixpkgs and open or update PR
+        run: |
+          nix run ./tools/shaka -- repo bump-locks \
+            --input nixpkgs \
+            --pr-branch bot/bump-nixpkgs \
+            --auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -216,6 +216,21 @@ jobs:
         name: kolohelios/kolohelios-nix
         rolling: true
         visibility: public
+    - uses: actions/create-github-app-token@v3
+      id: bot-token
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      with:
+        client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
+        owner: kolohelios
+        private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
+        repositories: kolohelios
+    - name: Notify kolohelios of new kolohelios-nix publish
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      run: |
+        gh api -X POST repos/kolohelios/kolohelios/dispatches \
+          -f event_type=kolohelios-nix-published
+      env:
+        GH_TOKEN: ${{ steps.bot-token.outputs.token }}
   build-aof:
     name: Build aof
     needs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,8 +231,12 @@ up).
 
 ### Daily kolohelios-nix lock bump
 
-`.github/workflows/bump-kolohelios-nix.yaml` runs daily at 00:00 UTC
-(also `workflow_dispatch:` for manual triggers). It runs
+`.github/workflows/bump-kolohelios-nix.yaml` fires on a
+`repository_dispatch` (`kolohelios-nix-published`) that `build-nix-lib`
+emits right after publishing a fresh release — so a new `kolohelios-nix`
+(and the `nixpkgs` revision it carries) reaches consumers within minutes
+of its source landing on `main`, not on a clock. A daily 00:00 UTC
+`cron` and `workflow_dispatch:` remain as a backstop and manual trigger. It runs
 `shaka repo bump-locks --input kolohelios-nix --pr-branch
 bot/bump-kolohelios-nix`, which:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,25 @@ workflow run goes red.
 - See also #147 (`shaka repo rebase-wip`), the local-side companion
   for branches you're actively iterating on.
 
+### Daily `nixpkgs` lock bump
+
+`.github/workflows/bump-nixpkgs.yaml` runs daily at 00:00 UTC (also
+`workflow_dispatch:`). It runs `shaka repo bump-locks --input nixpkgs
+--pr-branch bot/bump-nixpkgs --auto-merge`, which re-locks the **one**
+project that declares `nixpkgs.url` directly — `nix/kolohelios-nix` — and
+opens (or updates) a single PR titled `chore(deps): bump nixpkgs flake
+input`. Consumers declare `nixpkgs.follows = "kolohelios-nix/nixpkgs"`
+rather than a direct `nixpkgs.url`, so the bumper's grep-based discovery
+skips them; this job moves only the shared source-of-truth lock.
+
+This is the **only** clock-based poll in the lock chain, and it has to be:
+upstream `NixOS/nixpkgs` releases have no event we can subscribe to.
+Downstream is event-driven — see the kolohelios-nix bump below. Without
+this job, `nix/kolohelios-nix/flake.lock` only advances on a manual
+`nix flake update nixpkgs`; that staleness caused #593 (the crates.io
+`importCargoLock` fix existed upstream for a month before our lock caught
+up).
+
 ### Daily kolohelios-nix lock bump
 
 `.github/workflows/bump-kolohelios-nix.yaml` runs daily at 00:00 UTC

--- a/nix/kolohelios-nix/project.cue
+++ b/nix/kolohelios-nix/project.cue
@@ -114,6 +114,17 @@ package project
 				visibility: "public"
 				rolling:    true
 			}
+			// Self-notify on a fresh publish so bump-kolohelios-nix runs
+			// immediately rather than waiting for its daily cron. This
+			// closes the propagation chain: the nixpkgs bump merges here,
+			// build-nix-lib republishes kolohelios-nix, and consumers pick
+			// up the new nixpkgs revision within minutes instead of ≤24h.
+			dispatch: [
+				{
+					repo:      "kolohelios/kolohelios"
+					eventType: "kolohelios-nix-published"
+				},
+			]
 		}
 	}
 }

--- a/tools/shaka/src/ci/audit_workflows.rs
+++ b/tools/shaka/src/ci/audit_workflows.rs
@@ -27,6 +27,7 @@ const HAND_AUTHORED: &[&str] = &[
     // Repo-event-driven
     "auto-rebase-prs.yaml",
     "bump-kolohelios-nix.yaml",
+    "bump-nixpkgs.yaml",
     "codeql.yml",
     // Repo-wide backstop: deletes any preview Worker whose PR has
     // closed. Runs on `push: main` + a daily cron + manual dispatch


### PR DESCRIPTION
Nothing moves nix/kolohelios-nix's own nixpkgs lock — the single source
of truth every consumer follows via nixpkgs.follows. It only advanced on
a manual nix flake update, the staleness that caused #593.

Add a daily scheduled workflow that runs shaka repo bump-locks --input
nixpkgs. The existing discovery re-locks only the project declaring
nixpkgs.url directly (nix/kolohelios-nix); consumers' .follows form is
skipped, so the shared lock moves in isolation.

The consumer bump (bump-kolohelios-nix) polled a daily cron for a
publish event the repo itself controls. Wire it to react instead:
build-nix-lib dispatches kolohelios-nix-published after flakehub-push,
and the workflow triggers on that repository_dispatch.

This closes the propagation chain end to end — the nixpkgs bump merges,
build-nix-lib republishes kolohelios-nix, and consumers re-lock within
minutes instead of waiting up to a day. The daily cron stays as an
idempotent backstop for a missed dispatch.

Closes #773