### PR TITLE
style(build): align drifted TOML formatting across projects

### DIFF
--- a/apps/cascadiajs2026-notes/Cargo.toml
+++ b/apps/cascadiajs2026-notes/Cargo.toml
@@ -19,8 +19,14 @@ path              = "src/bin/build-site.rs"
 required-features = ["build-site"]
 
 [features]
-build-site = ["dep:askama", "dep:pulldown-cmark", "dep:serde", "dep:serde_json", "dep:tempfile"]
-default    = []
+build-site = [
+  "dep:askama",
+  "dep:pulldown-cmark",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:tempfile",
+]
+default = []
 
 [dependencies]
 worker = "0.8"

--- a/services/notes-sync/wrangler.toml
+++ b/services/notes-sync/wrangler.toml
@@ -14,9 +14,7 @@ command = "cargo install -q worker-build --locked && worker-build --release"
 # object with `env.durable_object("NOTE").id_from_name(noteId)`; while a
 # note is open that object is the single writer and source of truth.
 [durable_objects]
-bindings = [
-  { name = "NOTE", class_name = "NoteDurableObject" },
-]
+bindings = [{ name = "NOTE", class_name = "NoteDurableObject" }]
 
 # SQLite-backed storage for the Durable Object class. The SQLite backend
 # is what the append-only edit log (phase 2) is built on; a fresh class

--- a/tools/claude-hooks/Cargo.toml
+++ b/tools/claude-hooks/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/main.rs"
 [dependencies]
 clap          = { version = "4", features = ["derive"] }
 clap_complete = "4"
-serde      = { version = "1", features = ["derive"] }
-serde_json = "1"
-shlex      = "1"
+serde         = { version = "1", features = ["derive"] }
+serde_json    = "1"
+shlex         = "1"
 
 [lints.clippy]
 mod_module_files = "deny"

--- a/tools/todoist/Cargo.toml
+++ b/tools/todoist/Cargo.toml
@@ -13,11 +13,11 @@ path = "src/main.rs"
 [dependencies]
 clap          = { version = "4", features = ["derive"] }
 clap_complete = "4"
-serde      = { version = "1", features = ["derive"] }
-serde_json = "1"
-snafu      = "0.9"
-toml       = "0.8"
-ureq       = { version = "2", features = ["json"] }
+serde         = { version = "1", features = ["derive"] }
+serde_json    = "1"
+snafu         = "0.9"
+toml          = "0.8"
+ureq          = { version = "2", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Four committed TOML files had drifted out of `taplo`'s alignment format, surfaced by a full `shaka preflight` (CI's `--since` scoping never re-checked them since their projects weren't in recent change sets). Reformatted with `taplo fmt`: `apps/cascadiajs2026-notes/Cargo.toml`, `services/notes-sync/wrangler.toml`, `tools/claude-hooks/Cargo.toml`, `tools/todoist/Cargo.toml`.