### PR TITLE
feat(services/notes-sync): lazy git commit with two-alarm cadence

### DIFF
--- a/services/notes-sync/Cargo.lock
+++ b/services/notes-sync/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,9 +310,11 @@ dependencies = [
 name = "notes-sync"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "notes-protocol",
  "serde",
  "serde_json",
+ "tokio",
  "worker",
 ]
 
@@ -540,6 +548,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/services/notes-sync/Cargo.toml
+++ b/services/notes-sync/Cargo.toml
@@ -10,15 +10,24 @@ version      = "0.1.0"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+# Base64-encode the note body for the GitHub contents API (cold-tier
+# commit). Pure-rust, builds on wasm32-unknown-unknown.
+base64 = "0.22"
 # Shared wire-protocol types (ClientMsg / ServerMsg / Delta), used by
 # both the Durable Object here and the WASM editor.
 notes-protocol = { path = "../../packages/notes-protocol" }
 # Per-connection hibernation attachment is (de)serialized through serde.
 serde = { version = "1", features = ["derive"] }
-# Wire frames are JSON-encoded ClientMsg / ServerMsg over the WebSocket.
+# Wire frames are JSON-encoded ClientMsg / ServerMsg over the WebSocket;
+# also used to (de)serialize GitHub contents-API request/response bodies.
 serde_json = "1"
 # workers-rs runtime: Durable Objects + the WebSocket Hibernation API.
 worker = "0.8"
+
+[dev-dependencies]
+# Drives the async `commit_with_retry` tests on the host. The Worker
+# runtime has its own executor; this is native-test-only.
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [profile.release]
 codegen-units = 1

--- a/services/notes-sync/README.md
+++ b/services/notes-sync/README.md
@@ -45,13 +45,22 @@ Phased build tracked in issue #757.
   per-connection state in the socket attachment, never in struct fields.
   See [`docs/hibernation.md`](docs/hibernation.md) for the verification
   procedure.
-- **Phase 2 — edit log (this).** The editor speaks the `notes-protocol`
-  wire types over the socket. On `Open` the object replies with a `Sync`
-  of the current `seq` and `text`; an `Edit` whose `base_seq` matches is
-  applied, appended to the append-only log in DO storage, and `Ack`ed,
-  while a stale edit (or one that can't apply) is rejected with a fresh
-  `Sync`. The body is rebuilt by replaying the log, so an evicted object
+- **Phase 2 — edit log.** The editor speaks the `notes-protocol` wire
+  types over the socket. On `Open` the object replies with a `Sync` of the
+  current `seq` and `text`; an `Edit` whose `base_seq` matches is applied,
+  appended to the append-only log in DO storage, and `Ack`ed, while a
+  stale edit (or one that can't apply) is rejected with a fresh `Sync`.
+  The body is rebuilt by replaying the log, so an evicted object
   reconstructs without loss.
+- **Phase 3 — git cold tier (this).** Edits keep persisting to DO storage
+  synchronously; the body is committed to GitHub lazily — a `debounce`
+  (commit a few seconds after the last edit, coalescing a burst) and a
+  `backstop` (commit at least once a minute under continuous editing)
+  multiplexed onto the DO's single alarm, plus a commit when the last
+  socket disconnects. Each commit is a single-file write to the contents
+  API with an optimistic retry when the ref moves; a `BackedUp` is then
+  broadcast to connected editors. The repo/branch live in `wrangler.toml`;
+  the commit token is a `wrangler secret` (`GITHUB_TOKEN`).
 
 ## Local development
 

--- a/services/notes-sync/src/git.rs
+++ b/services/notes-sync/src/git.rs
@@ -1,0 +1,314 @@
+//! GitHub as the cold storage tier: committing a note's current body to a
+//! repo as a single file, with an optimistic retry when the ref moves
+//! under us. The fast cadence never reaches here — git commits are lazy
+//! (debounce + backstop alarms, and on last-socket-disconnect).
+//!
+//! The retry loop (`commit_with_retry`) is generic over a [`GitHubClient`]
+//! so it's native-testable with a fake; the real client (wasm-only) talks
+//! to the GitHub contents API via `worker::Fetch`.
+
+/// Where a note's markdown lives in the backing GitHub repo.
+#[derive(Debug, Clone)]
+pub struct GitTarget {
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+    /// Repo-relative path, e.g. `notes/<id>.md`.
+    pub path: String,
+}
+
+/// Result of a single write attempt.
+pub enum PutOutcome {
+    /// Committed; carries the new commit sha.
+    Committed(String),
+    /// The base sha was stale — the ref moved under us. Re-read and retry.
+    StaleRef,
+}
+
+/// Why a commit could not be landed.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CommitError {
+    /// Transport or API error (status + message).
+    Transport(String),
+    /// The ref kept moving past `max_retries` attempts.
+    RetriesExhausted,
+}
+
+impl std::fmt::Display for CommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommitError::Transport(m) => write!(f, "github transport error: {m}"),
+            CommitError::RetriesExhausted => {
+                write!(f, "ref kept moving; commit retries exhausted")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CommitError {}
+
+/// The GitHub operations the retry loop needs. Implemented for real by a
+/// `worker::Fetch`-backed client on wasm, and by fakes in tests.
+//
+// `async fn` in a trait is fine here: the only consumer is the generic
+// `commit_with_retry` (static dispatch), and we deliberately want no
+// `Send` bound — the wasm `worker::Fetch` futures are `!Send`.
+#[allow(async_fn_in_trait)]
+pub trait GitHubClient {
+    /// Current blob sha of the file at `target.path`, or `None` if the
+    /// file doesn't exist yet (a fresh note).
+    async fn current_sha(&self, target: &GitTarget) -> Result<Option<String>, CommitError>;
+
+    /// Write `content` to `target.path` on top of `base_sha` (`None` to
+    /// create a new file). Returns `Committed(sha)` or `StaleRef`.
+    async fn put_file(
+        &self,
+        target: &GitTarget,
+        content: &str,
+        base_sha: Option<&str>,
+        message: &str,
+    ) -> Result<PutOutcome, CommitError>;
+}
+
+/// Commit `text` to `target`, re-reading the sha and retrying when the ref
+/// moves under us. Returns the new commit sha. No commit coordinator is
+/// needed at single-user scale — the optimistic retry absorbs the rare
+/// concurrent write.
+pub async fn commit_with_retry<C: GitHubClient>(
+    client: &C,
+    target: &GitTarget,
+    text: &str,
+    message: &str,
+    max_retries: u32,
+) -> Result<String, CommitError> {
+    for _ in 0..=max_retries {
+        let base_sha = client.current_sha(target).await?;
+        match client
+            .put_file(target, text, base_sha.as_deref(), message)
+            .await?
+        {
+            PutOutcome::Committed(sha) => return Ok(sha),
+            // Ref moved between the read and the write — loop to re-read.
+            PutOutcome::StaleRef => continue,
+        }
+    }
+    Err(CommitError::RetriesExhausted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// Fake that returns `stale_first` StaleRef outcomes before
+    /// succeeding, counting how many times each method was called.
+    struct FakeClient {
+        stale_first: Cell<u32>,
+        reads: Cell<u32>,
+        puts: Cell<u32>,
+    }
+
+    impl FakeClient {
+        fn new(stale_first: u32) -> Self {
+            Self {
+                stale_first: Cell::new(stale_first),
+                reads: Cell::new(0),
+                puts: Cell::new(0),
+            }
+        }
+    }
+
+    impl GitHubClient for FakeClient {
+        async fn current_sha(&self, _target: &GitTarget) -> Result<Option<String>, CommitError> {
+            self.reads.set(self.reads.get() + 1);
+            Ok(Some("base-sha".into()))
+        }
+
+        async fn put_file(
+            &self,
+            _target: &GitTarget,
+            _content: &str,
+            _base_sha: Option<&str>,
+            _message: &str,
+        ) -> Result<PutOutcome, CommitError> {
+            self.puts.set(self.puts.get() + 1);
+            if self.stale_first.get() > 0 {
+                self.stale_first.set(self.stale_first.get() - 1);
+                Ok(PutOutcome::StaleRef)
+            } else {
+                Ok(PutOutcome::Committed("new-commit-sha".into()))
+            }
+        }
+    }
+
+    fn target() -> GitTarget {
+        GitTarget {
+            owner: "kolohelios".into(),
+            repo: "notes".into(),
+            branch: "main".into(),
+            path: "notes/demo.md".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn commits_on_the_first_try_when_ref_is_fresh() {
+        let c = FakeClient::new(0);
+        let sha = commit_with_retry(&c, &target(), "body", "msg", 3)
+            .await
+            .unwrap();
+        assert_eq!(sha, "new-commit-sha");
+        assert_eq!(c.reads.get(), 1);
+        assert_eq!(c.puts.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_then_succeeds_after_stale_ref_conflicts() {
+        let c = FakeClient::new(2);
+        let sha = commit_with_retry(&c, &target(), "body", "msg", 3)
+            .await
+            .unwrap();
+        assert_eq!(sha, "new-commit-sha");
+        // Re-read the sha before each of the 3 attempts.
+        assert_eq!(c.reads.get(), 3);
+        assert_eq!(c.puts.get(), 3);
+    }
+
+    #[tokio::test]
+    async fn exhausts_retries_when_ref_keeps_moving() {
+        let c = FakeClient::new(99);
+        let err = commit_with_retry(&c, &target(), "body", "msg", 3)
+            .await
+            .unwrap_err();
+        assert_eq!(err, CommitError::RetriesExhausted);
+        // max_retries=3 → 4 attempts (the initial try plus 3 retries).
+        assert_eq!(c.puts.get(), 4);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use worker_client::WorkerGitHubClient;
+
+/// Real GitHub contents-API client, wasm-only because it depends on
+/// `worker::Fetch`. The `commit_with_retry` loop above drives it.
+#[cfg(target_arch = "wasm32")]
+mod worker_client {
+    use super::{CommitError, GitHubClient, GitTarget, PutOutcome};
+    use base64::Engine;
+    use worker::{Fetch, Headers, Method, Request, RequestInit};
+
+    /// A GitHub contents-API client authenticated with a static token (a
+    /// GitHub App installation token or a PAT) held as a Wrangler secret.
+    pub struct WorkerGitHubClient {
+        token: String,
+    }
+
+    impl WorkerGitHubClient {
+        pub fn new(token: String) -> Self {
+            Self { token }
+        }
+
+        fn contents_url(target: &GitTarget) -> String {
+            format!(
+                "https://api.github.com/repos/{}/{}/contents/{}",
+                target.owner, target.repo, target.path
+            )
+        }
+
+        fn headers(&self) -> Result<Headers, CommitError> {
+            let headers = Headers::new();
+            let set = |h: &Headers, k: &str, v: &str| {
+                h.set(k, v)
+                    .map_err(|e| CommitError::Transport(e.to_string()))
+            };
+            set(&headers, "Authorization", &format!("Bearer {}", self.token))?;
+            set(&headers, "Accept", "application/vnd.github+json")?;
+            set(&headers, "X-GitHub-Api-Version", "2022-11-28")?;
+            // GitHub rejects requests without a User-Agent.
+            set(&headers, "User-Agent", "kolohelios-notes-sync")?;
+            Ok(headers)
+        }
+
+        async fn send(&self, req: Request) -> Result<worker::Response, CommitError> {
+            Fetch::Request(req)
+                .send()
+                .await
+                .map_err(|e| CommitError::Transport(e.to_string()))
+        }
+    }
+
+    impl GitHubClient for WorkerGitHubClient {
+        async fn current_sha(&self, target: &GitTarget) -> Result<Option<String>, CommitError> {
+            let url = format!("{}?ref={}", Self::contents_url(target), target.branch);
+            let mut init = RequestInit::new();
+            init.with_method(Method::Get).with_headers(self.headers()?);
+            let req = Request::new_with_init(&url, &init)
+                .map_err(|e| CommitError::Transport(e.to_string()))?;
+            let mut resp = self.send(req).await?;
+
+            match resp.status_code() {
+                200 => {
+                    let body = resp
+                        .text()
+                        .await
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    let v: serde_json::Value = serde_json::from_str(&body)
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    Ok(v.get("sha").and_then(|s| s.as_str()).map(str::to_owned))
+                }
+                404 => Ok(None),
+                other => Err(CommitError::Transport(format!(
+                    "GET contents returned {other}"
+                ))),
+            }
+        }
+
+        async fn put_file(
+            &self,
+            target: &GitTarget,
+            content: &str,
+            base_sha: Option<&str>,
+            message: &str,
+        ) -> Result<PutOutcome, CommitError> {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(content);
+            let mut body = serde_json::json!({
+                "message": message,
+                "content": encoded,
+                "branch": target.branch,
+            });
+            if let Some(sha) = base_sha {
+                body["sha"] = serde_json::Value::String(sha.to_owned());
+            }
+
+            let mut init = RequestInit::new();
+            init.with_method(Method::Put)
+                .with_headers(self.headers()?)
+                .with_body(Some(body.to_string().into()));
+            let req = Request::new_with_init(&Self::contents_url(target), &init)
+                .map_err(|e| CommitError::Transport(e.to_string()))?;
+            let mut resp = self.send(req).await?;
+
+            match resp.status_code() {
+                200 | 201 => {
+                    let text = resp
+                        .text()
+                        .await
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    let v: serde_json::Value = serde_json::from_str(&text)
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    let sha = v
+                        .get("commit")
+                        .and_then(|c| c.get("sha"))
+                        .and_then(|s| s.as_str())
+                        .unwrap_or_default()
+                        .to_owned();
+                    Ok(PutOutcome::Committed(sha))
+                }
+                // The supplied sha didn't match the current ref.
+                409 => Ok(PutOutcome::StaleRef),
+                other => Err(CommitError::Transport(format!(
+                    "PUT contents returned {other}"
+                ))),
+            }
+        }
+    }
+}

--- a/services/notes-sync/src/lib.rs
+++ b/services/notes-sync/src/lib.rs
@@ -13,9 +13,15 @@
 //! Phase 2 (issue #763) adds the append-only edit log: the editor speaks
 //! the `notes-protocol` wire types over the socket, accepted edits are
 //! appended to DO storage, and the body rehydrates by replaying the log
-//! (see [`state`]). Two-alarm persistence, the lazy GitHub commit, and
-//! auth land in later phases.
+//! (see [`state`]).
+//!
+//! Phase 3 (issue #764) adds the cold tier: edits keep persisting to DO
+//! storage synchronously, while the note body is committed to git lazily
+//! — a debounce + backstop pair multiplexed onto the DO's single alarm,
+//! plus a commit on last-socket-disconnect, landing through the
+//! optimistic-retry [`git`] client. Auth lands next.
 
+pub mod git;
 pub mod route;
 pub mod state;
 

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -3,7 +3,9 @@
 //! `NoteDurableObject` itself. Cfg-gated to `wasm32` because everything
 //! here depends on `worker` runtime types that only exist on the
 //! Cloudflare Worker target; native `cargo test` exercises the pure
-//! `route` and `state` modules instead (mirrors the `pollen-alert` split).
+//! `route`, `state`, and `git` modules instead.
+
+use std::time::Duration;
 
 use notes_protocol::{ClientMsg, Delta, Seq, ServerMsg};
 use serde::{Deserialize, Serialize};
@@ -11,12 +13,25 @@ use serde::{Deserialize, Serialize};
 // `#[durable_object]` macro expands to JS-glue code that references it by
 // bare name (see the workers-rs `counter.rs` example).
 use worker::{
-    console_log, durable_object, event, wasm_bindgen, Context, DurableObject, Env, Error, Request,
-    Response, ResponseBuilder, Result, State, WebSocket, WebSocketIncomingMessage, WebSocketPair,
+    console_log, durable_object, event, wasm_bindgen, Context, Date, DurableObject, Env, Error,
+    Request, Response, ResponseBuilder, Result, State, WebSocket, WebSocketIncomingMessage,
+    WebSocketPair,
 };
 
+use crate::git::{commit_with_retry, CommitError, GitTarget, WorkerGitHubClient};
 use crate::route::parse_ws_note_id;
-use crate::state::is_stale;
+use crate::state::{is_stale, next_alarm};
+
+/// Commit the note this long after the last edit — coalesces a burst of
+/// keystrokes into a single git commit once the typing settles.
+const COMMIT_DEBOUNCE: Duration = Duration::from_secs(5);
+/// Commit at least this often under continuous editing, so a never-idle
+/// session still backs up.
+const COMMIT_BACKSTOP: Duration = Duration::from_secs(60);
+/// After a failed commit, retry no sooner than this.
+const COMMIT_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+/// Optimistic stale-ref retries within a single commit attempt.
+const MAX_COMMIT_RETRIES: u32 = 3;
 
 /// Top-level Worker entrypoint. A websocket upgrade for `/note/<id>/ws`
 /// is forwarded to that note's Durable Object (`idFromName(id)`), which
@@ -65,8 +80,6 @@ fn send(ws: &WebSocket, msg: &ServerMsg) -> Result<()> {
 #[durable_object]
 pub struct NoteDurableObject {
     state: State,
-    // Unused until phase 3 (alarms read GitHub-commit config off the env).
-    #[allow(dead_code)]
     env: Env,
 }
 
@@ -90,6 +103,86 @@ impl NoteDurableObject {
         self.state.storage().put("text", text).await?;
         Ok(())
     }
+
+    /// Schedule the lazy git commit after an accepted edit: push the
+    /// debounce deadline out to now + `COMMIT_DEBOUNCE`, arm the backstop
+    /// once if it isn't already, and set the DO's single alarm to the
+    /// earlier of the two.
+    async fn schedule_commit(&self) -> Result<()> {
+        let now = Date::now().as_millis() as i64;
+        let debounce = now + COMMIT_DEBOUNCE.as_millis() as i64;
+        self.state
+            .storage()
+            .put("commit_debounce_due", debounce)
+            .await?;
+
+        let backstop = match self.state.storage().get("commit_backstop_due").await? {
+            Some(existing) => existing,
+            None => {
+                let b = now + COMMIT_BACKSTOP.as_millis() as i64;
+                self.state.storage().put("commit_backstop_due", b).await?;
+                b
+            }
+        };
+
+        if let Some(at) = next_alarm(Some(debounce), Some(backstop)) {
+            let delay = (at - now).max(0) as u64;
+            self.state
+                .storage()
+                .set_alarm(Duration::from_millis(delay))
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Clear the commit deadlines (after a commit lands, or before a
+    /// reschedule).
+    async fn clear_commit_deadlines(&self) {
+        let _ = self.state.storage().delete("commit_debounce_due").await;
+        let _ = self.state.storage().delete("commit_backstop_due").await;
+    }
+
+    /// Resolve the GitHub target for this note from env config plus the
+    /// stored note id. The body lives at `notes/<note_id>.md`.
+    async fn git_target(&self) -> Result<GitTarget> {
+        let note_id: String = self
+            .state
+            .storage()
+            .get("note_id")
+            .await?
+            .unwrap_or_default();
+        Ok(GitTarget {
+            owner: self.env.var("GITHUB_OWNER")?.to_string(),
+            repo: self.env.var("GITHUB_REPO")?.to_string(),
+            branch: self.env.var("GITHUB_BRANCH")?.to_string(),
+            path: format!("notes/{note_id}.md"),
+        })
+    }
+
+    /// Commit the current body to git with optimistic stale-ref retry.
+    /// Returns the new commit sha.
+    async fn commit_now(&self, seq: Seq, text: &str) -> std::result::Result<String, CommitError> {
+        let target = self
+            .git_target()
+            .await
+            .map_err(|e| CommitError::Transport(e.to_string()))?;
+        let token = self
+            .env
+            .secret("GITHUB_TOKEN")
+            .map_err(|e| CommitError::Transport(e.to_string()))?
+            .to_string();
+        let client = WorkerGitHubClient::new(token);
+        let message = format!("note: update {} (seq {seq})", target.path);
+        commit_with_retry(&client, &target, text, &message, MAX_COMMIT_RETRIES).await
+    }
+
+    /// Send `msg` to every connected editor (e.g. a `BackedUp` after a
+    /// commit lands).
+    fn broadcast(&self, msg: &ServerMsg) {
+        for ws in self.state.get_websockets() {
+            let _ = send(&ws, msg);
+        }
+    }
 }
 
 impl DurableObject for NoteDurableObject {
@@ -105,6 +198,9 @@ impl DurableObject for NoteDurableObject {
         let note_id = parse_ws_note_id(&req.path())
             .map(str::to_owned)
             .unwrap_or_default();
+        // Persist the note id so the alarm handler (which has no socket)
+        // can resolve the git path on wake.
+        self.state.storage().put("note_id", &note_id).await?;
 
         let pair = WebSocketPair::new()?;
         let server = pair.server;
@@ -171,6 +267,9 @@ impl DurableObject for NoteDurableObject {
                     Ok(new_text) => {
                         let new_seq = seq + 1;
                         self.commit_edit(new_seq, &delta, &new_text).await?;
+                        // Persist is done; schedule the lazy git commit.
+                        // The fast cadence never touches git.
+                        self.schedule_commit().await?;
                         send(&ws, &ServerMsg::Ack { seq: new_seq })
                     }
                     Err(e) => {
@@ -189,6 +288,43 @@ impl DurableObject for NoteDurableObject {
         }
     }
 
+    async fn alarm(&self) -> Result<Response> {
+        let (seq, text) = self.load_state().await?;
+        let committed: Seq = self
+            .state
+            .storage()
+            .get("committed_seq")
+            .await?
+            .unwrap_or(0);
+        // Clear deadlines up front; a failed commit re-arms a backstop.
+        self.clear_commit_deadlines().await;
+
+        if seq <= committed {
+            return Response::ok("nothing to commit");
+        }
+
+        match self.commit_now(seq, &text).await {
+            Ok(commit_sha) => {
+                self.state.storage().put("committed_seq", seq).await?;
+                self.broadcast(&ServerMsg::BackedUp {
+                    commit_sha: Some(commit_sha),
+                });
+                Response::ok("committed")
+            }
+            Err(e) => {
+                console_log!("git commit failed: {e}; backing off");
+                let backstop =
+                    Date::now().as_millis() as i64 + COMMIT_RETRY_BACKOFF.as_millis() as i64;
+                self.state
+                    .storage()
+                    .put("commit_backstop_due", backstop)
+                    .await?;
+                self.state.storage().set_alarm(COMMIT_RETRY_BACKOFF).await?;
+                Response::error("commit failed; retry scheduled", 500)
+            }
+        }
+    }
+
     async fn websocket_close(
         &self,
         _ws: WebSocket,
@@ -196,6 +332,30 @@ impl DurableObject for NoteDurableObject {
         _reason: String,
         _was_clean: bool,
     ) -> Result<()> {
+        // On the last socket leaving, flush to git immediately rather than
+        // waiting for the alarm. `get_websockets()` still includes the
+        // socket being closed, so `<= 1` means "this was the last one".
+        if self.state.get_websockets().len() <= 1 {
+            let (seq, text) = self.load_state().await?;
+            let committed: Seq = self
+                .state
+                .storage()
+                .get("committed_seq")
+                .await?
+                .unwrap_or(0);
+            if seq > committed {
+                match self.commit_now(seq, &text).await {
+                    Ok(_) => {
+                        self.state.storage().put("committed_seq", seq).await?;
+                        self.clear_commit_deadlines().await;
+                    }
+                    Err(e) => {
+                        // Leave the deadlines armed so the alarm retries.
+                        console_log!("commit on disconnect failed: {e}");
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/services/notes-sync/src/state.rs
+++ b/services/notes-sync/src/state.rs
@@ -27,6 +27,19 @@ pub fn is_stale(base_seq: Seq, current_seq: Seq) -> bool {
     base_seq != current_seq
 }
 
+/// The time the single DO alarm should fire next: the earliest of the
+/// (optional) commit deadlines. A Durable Object has one alarm primitive,
+/// so the lazy git commit multiplexes its `debounce` deadline (commit
+/// shortly after the last edit, coalescing a burst) and its `backstop`
+/// deadline (commit at least every N seconds under continuous editing)
+/// onto it. `None` when neither is pending — nothing to commit.
+pub fn next_alarm(debounce_due: Option<i64>, backstop_due: Option<i64>) -> Option<i64> {
+    match (debounce_due, backstop_due) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (a, b) => a.or(b),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,5 +84,22 @@ mod tests {
         assert!(is_stale(2, 3)); // behind
         assert!(is_stale(4, 3)); // ahead (also a mismatch)
         assert!(!is_stale(3, 3)); // exact match is fresh
+    }
+
+    #[test]
+    fn next_alarm_is_the_earlier_deadline() {
+        assert_eq!(next_alarm(Some(100), Some(250)), Some(100));
+        assert_eq!(next_alarm(Some(300), Some(250)), Some(250));
+    }
+
+    #[test]
+    fn next_alarm_uses_whichever_deadline_is_set() {
+        assert_eq!(next_alarm(Some(100), None), Some(100));
+        assert_eq!(next_alarm(None, Some(250)), Some(250));
+    }
+
+    #[test]
+    fn next_alarm_is_none_when_nothing_pending() {
+        assert_eq!(next_alarm(None, None), None);
     }
 }

--- a/services/notes-sync/wrangler.toml
+++ b/services/notes-sync/wrangler.toml
@@ -22,3 +22,16 @@ bindings = [{ name = "NOTE", class_name = "NoteDurableObject" }]
 [[migrations]]
 new_sqlite_classes = ["NoteDurableObject"]
 tag                = "v1"
+
+# Cold-tier git target (phase 3). The Durable Object commits each note's
+# body to `notes/<note_id>.md` in this repo on the lazy debounce/backstop
+# cadence. Non-secret, so it lives here.
+#
+# The commit credential is a static server-side secret (a GitHub App
+# installation token or a PAT) — unrelated to user login. Set it out of
+# band, never in this file:
+#   wrangler secret put GITHUB_TOKEN
+[vars]
+GITHUB_BRANCH = "main"
+GITHUB_OWNER  = "kolohelios"
+GITHUB_REPO   = "notes-store"


### PR DESCRIPTION
Adds the cold storage tier. Edits still persist to DO storage
synchronously (the lossless-on-eviction guarantee is unchanged); the note
body is committed to GitHub lazily. A Durable Object has one alarm
primitive, so the commit timing multiplexes two deadlines onto it: a
debounce (commit a few seconds after the last edit, coalescing a burst
into one commit) and a backstop (commit at least once a minute under
continuous editing). The last socket to disconnect also flushes
immediately. The fast cadence never touches git.

The commit itself is a single-file write to the GitHub contents API with
an optimistic retry when the ref moves under us — no commit coordinator at
single-user scale. The retry loop is generic over a GitHubClient trait, so
it is native-tested (fresh ref, retry-then-succeed, retries-exhausted)
with a fake; the real worker::Fetch client is wasm-only. On a successful
commit the object broadcasts BackedUp to connected editors.

The repo and branch are wrangler vars; the commit token is a static
server-side secret (GITHUB_TOKEN), unrelated to user login.

Closes #764
Part of #757