### PR TITLE
feat(services/notes-sync): auth core + session-cookie WS gate

### DIFF
--- a/services/notes-sync/Cargo.lock
+++ b/services/notes-sync/Cargo.lock
@@ -26,6 +26,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +61,36 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -135,10 +174,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -282,6 +340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,9 +375,11 @@ name = "notes-sync"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "hmac",
  "notes-protocol",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "worker",
 ]
@@ -471,6 +537,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +585,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -563,6 +646,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +674,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/services/notes-sync/Cargo.toml
+++ b/services/notes-sync/Cargo.toml
@@ -13,14 +13,19 @@ crate-type = ["cdylib", "rlib"]
 # Base64-encode the note body for the GitHub contents API (cold-tier
 # commit). Pure-rust, builds on wasm32-unknown-unknown.
 base64 = "0.22"
+# HMAC-SHA256 for the signed session cookie.
+hmac = "0.12"
 # Shared wire-protocol types (ClientMsg / ServerMsg / Delta), used by
 # both the Durable Object here and the WASM editor.
 notes-protocol = { path = "../../packages/notes-protocol" }
 # Per-connection hibernation attachment is (de)serialized through serde.
 serde = { version = "1", features = ["derive"] }
 # Wire frames are JSON-encoded ClientMsg / ServerMsg over the WebSocket;
-# also used to (de)serialize GitHub contents-API request/response bodies.
+# also used to (de)serialize GitHub contents-API and OAuth bodies, plus
+# the session-cookie claims.
 serde_json = "1"
+# SHA-256 for the PKCE S256 challenge and the session-cookie HMAC.
+sha2 = "0.10"
 # workers-rs runtime: Durable Objects + the WebSocket Hibernation API.
 worker = "0.8"
 

--- a/services/notes-sync/src/auth.rs
+++ b/services/notes-sync/src/auth.rs
@@ -1,0 +1,270 @@
+//! Authentication core — the parts that admit the wrong user when wrong,
+//! kept pure and native-tested off the wasm-only OAuth flow:
+//!
+//! - [`verify_identity`] — the mandatory post-token-exchange check that
+//!   the account DID (`sub`) matches the DID resolved when the flow began
+//!   and the issuer matches the authorization server. This is where authn
+//!   security actually lives, not the cookie.
+//! - [`pkce_challenge`] — the S256 PKCE challenge.
+//! - [`mint_session`] / [`verify_session`] — the app's own signed session
+//!   cookie (HMAC-SHA256). That cookie, not any ATProto token, is what
+//!   gates the WebSocket upgrade.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Ways authentication can be refused.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AuthError {
+    /// The token's `sub` DID is not the DID resolved at flow start.
+    DidMismatch { expected: String, got: String },
+    /// The token's `iss` is not the authorization server we used.
+    IssuerMismatch { expected: String, got: String },
+    /// The session cookie isn't `<payload>.<sig>`.
+    MalformedCookie,
+    /// The cookie signature didn't verify — tampered or wrong secret.
+    BadSignature,
+    /// The cookie is past its expiry.
+    Expired,
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::DidMismatch { expected, got } => {
+                write!(f, "token sub {got} does not match resolved DID {expected}")
+            }
+            AuthError::IssuerMismatch { expected, got } => {
+                write!(f, "token iss {got} does not match authz server {expected}")
+            }
+            AuthError::MalformedCookie => write!(f, "malformed session cookie"),
+            AuthError::BadSignature => write!(f, "session cookie signature mismatch"),
+            AuthError::Expired => write!(f, "session cookie expired"),
+        }
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// The mandatory identity check after the token exchange. The token
+/// response's `sub` is the account DID; it must equal the DID resolved
+/// when the flow began, and `iss` must be the authorization server the
+/// user was sent to. A mismatch means a swapped or forged identity —
+/// reject hard.
+pub fn verify_identity(
+    token_sub: &str,
+    token_iss: &str,
+    expected_did: &str,
+    expected_issuer: &str,
+) -> Result<(), AuthError> {
+    if token_sub != expected_did {
+        return Err(AuthError::DidMismatch {
+            expected: expected_did.to_owned(),
+            got: token_sub.to_owned(),
+        });
+    }
+    if token_iss != expected_issuer {
+        return Err(AuthError::IssuerMismatch {
+            expected: expected_issuer.to_owned(),
+            got: token_iss.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+/// The S256 PKCE challenge for a verifier: `base64url(sha256(verifier))`,
+/// no padding.
+pub fn pkce_challenge(verifier: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()))
+}
+
+/// Claims carried by the session cookie — only the verified DID and an
+/// absolute expiry. No ATProto material survives login.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct SessionClaims {
+    did: String,
+    exp: i64,
+}
+
+fn sign(payload: &str, secret: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(payload.as_bytes());
+    URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+}
+
+/// Constant-time byte comparison so cookie verification doesn't leak the
+/// signature through timing.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Mint a signed session cookie value: `<payload>.<sig>`, where `payload`
+/// is base64url(JSON `{did, exp}`) and `sig` is
+/// base64url(HMAC-SHA256(secret, payload)). The payload is base64 (no
+/// `.`) so the split is unambiguous even for `did:web:` DIDs that contain
+/// dots.
+pub fn mint_session(did: &str, exp_unix: i64, secret: &[u8]) -> String {
+    let claims = SessionClaims {
+        did: did.to_owned(),
+        exp: exp_unix,
+    };
+    let json = serde_json::to_string(&claims).expect("session claims serialize");
+    let payload = URL_SAFE_NO_PAD.encode(json);
+    let sig = sign(&payload, secret);
+    format!("{payload}.{sig}")
+}
+
+/// Verify a session cookie and return the DID it carries. Rejects a
+/// malformed value, a bad signature (tamper or wrong secret), or an
+/// expired cookie.
+pub fn verify_session(cookie: &str, secret: &[u8], now_unix: i64) -> Result<String, AuthError> {
+    let (payload, sig) = cookie.split_once('.').ok_or(AuthError::MalformedCookie)?;
+    if !constant_time_eq(sig.as_bytes(), sign(payload, secret).as_bytes()) {
+        return Err(AuthError::BadSignature);
+    }
+    let json = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| AuthError::MalformedCookie)?;
+    let claims: SessionClaims =
+        serde_json::from_slice(&json).map_err(|_| AuthError::MalformedCookie)?;
+    if now_unix >= claims.exp {
+        return Err(AuthError::Expired);
+    }
+    Ok(claims.did)
+}
+
+/// Find the value of cookie `name` in a `Cookie:` header of the form
+/// `a=1; session=xyz; b=2`. Avoids prefix collisions (`sessionx`).
+pub fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    cookie_header
+        .split(';')
+        .map(str::trim)
+        .find_map(|kv| kv.strip_prefix(name)?.strip_prefix('='))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"test-session-secret-please-change";
+
+    #[test]
+    fn identity_check_accepts_matching_sub_and_iss() {
+        assert!(verify_identity(
+            "did:plc:abc",
+            "https://bsky.social",
+            "did:plc:abc",
+            "https://bsky.social",
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn identity_check_rejects_a_sub_that_is_not_the_resolved_did() {
+        // The brief's load-bearing case: a token whose sub doesn't match
+        // the DID resolved up front must be refused.
+        let err = verify_identity(
+            "did:plc:attacker",
+            "https://bsky.social",
+            "did:plc:victim",
+            "https://bsky.social",
+        )
+        .unwrap_err();
+        assert!(matches!(err, AuthError::DidMismatch { .. }));
+    }
+
+    #[test]
+    fn identity_check_rejects_a_mismatched_issuer() {
+        let err = verify_identity(
+            "did:plc:abc",
+            "https://evil.example",
+            "did:plc:abc",
+            "https://bsky.social",
+        )
+        .unwrap_err();
+        assert!(matches!(err, AuthError::IssuerMismatch { .. }));
+    }
+
+    #[test]
+    fn pkce_challenge_matches_the_rfc7636_vector() {
+        // RFC 7636 appendix B.
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(
+            pkce_challenge(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn session_round_trips_and_returns_the_did() {
+        let cookie = mint_session("did:web:example.com", 2_000, SECRET);
+        assert_eq!(
+            verify_session(&cookie, SECRET, 1_000).unwrap(),
+            "did:web:example.com"
+        );
+    }
+
+    #[test]
+    fn session_with_a_tampered_payload_is_rejected() {
+        let cookie = mint_session("did:plc:abc", 2_000, SECRET);
+        // Swap the payload for one minting a different DID, keep the sig.
+        let other = mint_session("did:plc:evil", 2_000, SECRET);
+        let forged = format!(
+            "{}.{}",
+            other.split_once('.').unwrap().0,
+            cookie.split_once('.').unwrap().1
+        );
+        assert_eq!(
+            verify_session(&forged, SECRET, 1_000).unwrap_err(),
+            AuthError::BadSignature
+        );
+    }
+
+    #[test]
+    fn session_signed_with_a_different_secret_is_rejected() {
+        let cookie = mint_session("did:plc:abc", 2_000, SECRET);
+        assert_eq!(
+            verify_session(&cookie, b"a-different-secret", 1_000).unwrap_err(),
+            AuthError::BadSignature
+        );
+    }
+
+    #[test]
+    fn expired_session_is_rejected() {
+        let cookie = mint_session("did:plc:abc", 1_000, SECRET);
+        assert_eq!(
+            verify_session(&cookie, SECRET, 1_000).unwrap_err(),
+            AuthError::Expired
+        );
+    }
+
+    #[test]
+    fn malformed_session_is_rejected() {
+        assert_eq!(
+            verify_session("not-a-cookie", SECRET, 1_000).unwrap_err(),
+            AuthError::MalformedCookie
+        );
+    }
+
+    #[test]
+    fn cookie_value_extracts_the_named_cookie() {
+        assert_eq!(
+            cookie_value("a=1; session=xyz; b=2", "session"),
+            Some("xyz")
+        );
+        assert_eq!(cookie_value("session=abc", "session"), Some("abc"));
+        assert_eq!(cookie_value("other=1", "session"), None);
+        // No false match on a longer name sharing the prefix.
+        assert_eq!(cookie_value("sessionx=1", "session"), None);
+    }
+}

--- a/services/notes-sync/src/lib.rs
+++ b/services/notes-sync/src/lib.rs
@@ -19,8 +19,15 @@
 //! storage synchronously, while the note body is committed to git lazily
 //! — a debounce + backstop pair multiplexed onto the DO's single alarm,
 //! plus a commit on last-socket-disconnect, landing through the
-//! optimistic-retry [`git`] client. Auth lands next.
+//! optimistic-retry [`git`] client.
+//!
+//! Phase 4 (issue #765) adds sign-in: ATProto OAuth, authentication only.
+//! The security-critical, native-tested core lives in [`auth`] (the
+//! `sub`-vs-DID check, PKCE, and the signed session cookie that gates the
+//! WS); the wasm-only OAuth HTTP flow (resolution, PAR, DPoP, token
+//! exchange) lives in the runtime.
 
+pub mod auth;
 pub mod git;
 pub mod route;
 pub mod state;

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -18,6 +18,7 @@ use worker::{
     WebSocketPair,
 };
 
+use crate::auth::{cookie_value, verify_session};
 use crate::git::{commit_with_retry, CommitError, GitTarget, WorkerGitHubClient};
 use crate::route::parse_ws_note_id;
 use crate::state::{is_stale, next_alarm};
@@ -40,6 +41,12 @@ const MAX_COMMIT_RETRIES: u32 = 3;
 #[event(fetch)]
 pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     if let Some(note_id) = parse_ws_note_id(&req.path()) {
+        // The session cookie gates the upgrade. The `sub`-vs-DID check at
+        // login is where identity is established; this only re-checks the
+        // signed cookie that login minted.
+        if !session_authorized(&req, &env) {
+            return Response::error("unauthorized", 401);
+        }
         let stub = env
             .durable_object("NOTE")?
             .id_from_name(note_id)?
@@ -48,6 +55,27 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     }
 
     Response::ok("notes-sync: ok")
+}
+
+/// Whether the request carries a valid session cookie. When
+/// `SESSION_SECRET` isn't configured yet, the gate is open — the OAuth
+/// login flow that issues cookies (and the secret) lands with auth; until
+/// then the WS stays reachable for the earlier phases' runtime checks.
+fn session_authorized(req: &Request, env: &Env) -> bool {
+    let secret = match env.secret("SESSION_SECRET") {
+        Ok(s) => s.to_string(),
+        Err(_) => return true,
+    };
+    let header = req
+        .headers()
+        .get("Cookie")
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let now = Date::now().as_millis() as i64 / 1000;
+    cookie_value(&header, "session")
+        .and_then(|v| verify_session(v, secret.as_bytes(), now).ok())
+        .is_some()
 }
 
 /// Per-connection state persisted across hibernation via the socket


### PR DESCRIPTION
feat(services/notes-sync): auth core + session-cookie WS gate

The security-critical, native-tested core of sign-in, ahead of the
wasm-only OAuth HTTP flow (resolution / PAR / DPoP / token exchange) that
lands next and closes #765.

- verify_identity: the mandatory post-token-exchange check that the
  account DID (sub) matches the DID resolved at flow start and that the
  iss matches the authorization server. This is where authn security
  lives, not the cookie — it rejects a sub that isn't the resolved DID.
- pkce_challenge: the S256 PKCE challenge, checked against the RFC 7636
  vector.
- mint_session / verify_session: the app's own HMAC-SHA256 session cookie
  (DID plus expiry, no ATProto material), rejecting a tampered payload, a
  wrong secret, and expiry, with a constant-time signature compare.
- The WebSocket upgrade is gated on a valid session cookie. The gate
  stays open until SESSION_SECRET is configured, so it doesn't lock out
  the earlier phases' runtime checks before the login flow exists.

Part of #765
Part of #757
