### PR TITLE
fix(infra/home): build under nixpkgs 26.05

### DIFF
--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -1,4 +1,8 @@
-{ claude-hooks, ... }:
+{
+  claude-hooks,
+  kolohelios-nix,
+  ...
+}:
 
 {
   system.stateVersion = 5;
@@ -28,7 +32,7 @@
 
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
-  home-manager.extraSpecialArgs = { inherit claude-hooks; };
+  home-manager.extraSpecialArgs = { inherit claude-hooks kolohelios-nix; };
   home-manager.users.jedwards = import ./common.nix;
 
   # First-switch activation will encounter pre-existing dotfiles

--- a/infra/home/modules/linux.nix
+++ b/infra/home/modules/linux.nix
@@ -1,8 +1,12 @@
-{ claude-hooks, ... }:
+{
+  claude-hooks,
+  kolohelios-nix,
+  ...
+}:
 
 {
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
-  home-manager.extraSpecialArgs = { inherit claude-hooks; };
+  home-manager.extraSpecialArgs = { inherit claude-hooks kolohelios-nix; };
   home-manager.users.jon = import ./common.nix;
 }


### PR DESCRIPTION
Unbreaks the darwin build after the kolohelios-nix bump to nixpkgs 26.05: bumps nix-darwin/home-manager to release-26.05 (nix-darwin asserts its release matches nixpkgs) and threads kolohelios-nix through specialArgs/extraSpecialArgs so common.nix's shakaShim resolves (a latent miss that nix-darwin 26.05's deeper flake-check eval surfaces).

Carries the nixpkgs 26.05 lock bump (the same one in #786) because the release pins mismatch on 25.11, so the two must land together. Supersedes #786 — once this merges, #786 is redundant. Automation gap tracked in #804.