### PR TITLE
chore(apps/kolohelios-portfolio): set Kit form ids in wrangler vars

### DIFF
--- a/apps/kolohelios-portfolio/wrangler.toml
+++ b/apps/kolohelios-portfolio/wrangler.toml
@@ -34,12 +34,12 @@ directory = "./dist"
 
 # Non-secret runtime config the worker reads via `env.var(...)`. These
 # are Kit form ids (safe to commit — they're embedded in public Kit
-# forms), one per submission `kind`. Replace the placeholders with the
-# real form ids; see README "Kit setup". KIT_API_KEY is a *secret*, set
-# out-of-band via `wrangler secret put KIT_API_KEY` (not committed here).
+# forms), one per submission `kind`; see README "Kit setup". KIT_API_KEY
+# is a *secret*, set out-of-band via `wrangler secret put KIT_API_KEY`
+# (not committed here).
 [vars]
-KIT_FORM_ID_CONTACT    = "REPLACE_WITH_CONTACT_FORM_ID"
-KIT_FORM_ID_NEWSLETTER = "REPLACE_WITH_NEWSLETTER_FORM_ID"
+KIT_FORM_ID_CONTACT    = "9525720"
+KIT_FORM_ID_NEWSLETTER = "9525721"
 
 # Cloudflare native rate limiting. The worker calls this binding
 # (`SUBSCRIBE_RATE_LIMITER`) per client IP in `handle_subscribe`; over


### PR DESCRIPTION
The contact and newsletter Kit forms now exist (ids 9525720 / 9525721),
so replace the placeholder vars from #780 with the real ids. The worker's
/api/subscribe routes to the matching form by submission kind.

The endpoint still needs the KIT_API_KEY worker secret before it serves
live traffic (see README; automation tracked in #794).