### PR TITLE
feat(services/notes-sync): hand-rolled ATProto OAuth flow (authn-only)

### DIFF
--- a/services/notes-sync/Cargo.lock
+++ b/services/notes-sync/Cargo.lock
@@ -20,10 +20,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "block-buffer"
@@ -64,12 +76,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -83,12 +113,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -102,6 +144,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -181,6 +267,31 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -375,10 +486,14 @@ name = "notes-sync"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "getrandom",
  "hmac",
  "notes-protocol",
+ "p256",
+ "rand_core",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha2",
  "tokio",
  "worker",
@@ -398,6 +513,27 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -432,12 +568,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -459,6 +614,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +643,20 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "serde"
@@ -548,6 +736,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +756,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -680,6 +888,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -868,6 +1082,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/services/notes-sync/Cargo.toml
+++ b/services/notes-sync/Cargo.toml
@@ -13,8 +13,17 @@ crate-type = ["cdylib", "rlib"]
 # Base64-encode the note body for the GitHub contents API (cold-tier
 # commit). Pure-rust, builds on wasm32-unknown-unknown.
 base64 = "0.22"
+# The `js` feature routes wasm32 randomness to workerd's
+# crypto.getRandomValues, so the DPoP P-256 keygen below works on the
+# Worker target.
+getrandom = { version = "0.2", features = ["js"] }
 # HMAC-SHA256 for the signed session cookie.
 hmac = "0.12"
+# ES256 (P-256 ECDSA) for the DPoP proofs — the portable crypto part of
+# the ATProto OAuth flow (RustCrypto, compiles to wasm).
+p256 = { version = "0.13", features = ["ecdsa"] }
+# OS RNG (backed by getrandom above) for the ephemeral DPoP keypair.
+rand_core = { version = "0.6", features = ["getrandom"] }
 # Shared wire-protocol types (ClientMsg / ServerMsg / Delta), used by
 # both the Durable Object here and the WASM editor.
 notes-protocol = { path = "../../packages/notes-protocol" }
@@ -24,6 +33,9 @@ serde = { version = "1", features = ["derive"] }
 # also used to (de)serialize GitHub contents-API and OAuth bodies, plus
 # the session-cookie claims.
 serde_json = "1"
+# Form-encode the PAR and token-exchange request bodies. Pure-rust,
+# builds on wasm32-unknown-unknown.
+serde_urlencoded = "0.7"
 # SHA-256 for the PKCE S256 challenge and the session-cookie HMAC.
 sha2 = "0.10"
 # workers-rs runtime: Durable Objects + the WebSocket Hibernation API.

--- a/services/notes-sync/src/dpop.rs
+++ b/services/notes-sync/src/dpop.rs
@@ -1,0 +1,174 @@
+//! DPoP (RFC 9449) proof JWTs for the ATProto OAuth flow: an ephemeral
+//! ES256 (P-256) key per flow, binding the PAR and token requests to this
+//! client instance. Pure RustCrypto, so it compiles to wasm and is
+//! native-tested; the HTTP/nonce-retry glue that drives it is wasm-only.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use p256::ecdsa::{signature::Signer, Signature, SigningKey};
+use sha2::{Digest, Sha256};
+
+/// An ephemeral DPoP key. The private key signs proofs; the public JWK
+/// rides each proof header, and its thumbprint (`jkt`) is what the access
+/// token is bound to.
+pub struct DpopKey {
+    signing: SigningKey,
+}
+
+impl Default for DpopKey {
+    fn default() -> Self {
+        Self::generate()
+    }
+}
+
+impl DpopKey {
+    /// Generate a fresh P-256 key. The OS RNG is workerd's
+    /// crypto.getRandomValues on wasm (via getrandom's `js` backend).
+    pub fn generate() -> Self {
+        Self {
+            signing: SigningKey::random(&mut rand_core::OsRng),
+        }
+    }
+
+    /// Reconstruct from the 32-byte private scalar persisted in the
+    /// AuthFlow Durable Object across the redirect.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        SigningKey::from_slice(bytes)
+            .ok()
+            .map(|signing| Self { signing })
+    }
+
+    /// The 32-byte private scalar, to persist across the redirect.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.signing.to_bytes().to_vec()
+    }
+
+    /// The public key as a JWK (`{crv, kty, x, y}`) for the proof header.
+    pub fn public_jwk(&self) -> (String, String) {
+        let point = self.signing.verifying_key().to_encoded_point(false);
+        let x = URL_SAFE_NO_PAD.encode(point.x().expect("affine x"));
+        let y = URL_SAFE_NO_PAD.encode(point.y().expect("affine y"));
+        (x, y)
+    }
+
+    fn jwk_json(&self) -> serde_json::Value {
+        let (x, y) = self.public_jwk();
+        serde_json::json!({ "crv": "P-256", "kty": "EC", "x": x, "y": y })
+    }
+
+    /// The JWK SHA-256 thumbprint (RFC 7638), base64url — the `jkt` the
+    /// token binds to. Members are the canonical lexicographic set with no
+    /// whitespace.
+    pub fn thumbprint(&self) -> String {
+        let (x, y) = self.public_jwk();
+        let canonical = format!(r#"{{"crv":"P-256","kty":"EC","x":"{x}","y":"{y}"}}"#);
+        URL_SAFE_NO_PAD.encode(Sha256::digest(canonical.as_bytes()))
+    }
+
+    /// Build and sign a DPoP proof JWT for the `htm` method against the
+    /// `htu` URL, with an optional server-issued `nonce`. `jti` is a
+    /// unique id and `iat` the issued-at second — both supplied by the
+    /// caller so this stays pure.
+    pub fn proof(&self, htm: &str, htu: &str, nonce: Option<&str>, jti: &str, iat: i64) -> String {
+        let header = serde_json::json!({
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": self.jwk_json(),
+        });
+        let mut claims = serde_json::json!({
+            "htm": htm,
+            "htu": htu,
+            "jti": jti,
+            "iat": iat,
+        });
+        if let Some(n) = nonce {
+            claims["nonce"] = serde_json::Value::String(n.to_owned());
+        }
+
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(header.to_string()),
+            URL_SAFE_NO_PAD.encode(claims.to_string()),
+        );
+        let sig: Signature = self.signing.sign(signing_input.as_bytes());
+        format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(sig.to_bytes()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdsa::signature::Verifier;
+
+    #[test]
+    fn private_scalar_round_trips_to_the_same_key() {
+        let key = DpopKey::generate();
+        let restored = DpopKey::from_bytes(&key.to_bytes()).unwrap();
+        assert_eq!(key.thumbprint(), restored.thumbprint());
+        assert_eq!(key.public_jwk(), restored.public_jwk());
+    }
+
+    #[test]
+    fn thumbprint_is_stable_for_a_key() {
+        let key = DpopKey::generate();
+        assert_eq!(key.thumbprint(), key.thumbprint());
+        // base64url SHA-256 is 43 chars (no padding).
+        assert_eq!(key.thumbprint().len(), 43);
+    }
+
+    #[test]
+    fn distinct_keys_have_distinct_thumbprints() {
+        assert_ne!(
+            DpopKey::generate().thumbprint(),
+            DpopKey::generate().thumbprint()
+        );
+    }
+
+    #[test]
+    fn proof_is_a_three_part_jwt_that_verifies() {
+        let key = DpopKey::generate();
+        let proof = key.proof(
+            "POST",
+            "https://pds/par",
+            Some("srv-nonce"),
+            "jti-1",
+            1_700_000_000,
+        );
+
+        let parts: Vec<&str> = proof.split('.').collect();
+        assert_eq!(parts.len(), 3);
+
+        // The header and claims decode and carry the expected fields.
+        let header: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[0]).unwrap()).unwrap();
+        assert_eq!(header["typ"], "dpop+jwt");
+        assert_eq!(header["alg"], "ES256");
+        assert_eq!(header["jwk"]["crv"], "P-256");
+        let claims: serde_json::Value =
+            serde_json::from_slice(&URL_SAFE_NO_PAD.decode(parts[1]).unwrap()).unwrap();
+        assert_eq!(claims["htm"], "POST");
+        assert_eq!(claims["htu"], "https://pds/par");
+        assert_eq!(claims["nonce"], "srv-nonce");
+
+        // The ES256 signature verifies over `header.claims`.
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig = Signature::from_slice(&URL_SAFE_NO_PAD.decode(parts[2]).unwrap()).unwrap();
+        key.signing
+            .verifying_key()
+            .verify(signing_input.as_bytes(), &sig)
+            .expect("DPoP proof signature verifies");
+    }
+
+    #[test]
+    fn proof_omits_nonce_when_absent() {
+        let key = DpopKey::generate();
+        let proof = key.proof("GET", "https://pds/x", None, "jti-2", 1);
+        let claims: serde_json::Value = serde_json::from_slice(
+            &URL_SAFE_NO_PAD
+                .decode(proof.split('.').nth(1).unwrap())
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(claims.get("nonce").is_none());
+    }
+}

--- a/services/notes-sync/src/lib.rs
+++ b/services/notes-sync/src/lib.rs
@@ -21,14 +21,18 @@
 //! plus a commit on last-socket-disconnect, landing through the
 //! optimistic-retry [`git`] client.
 //!
-//! Phase 4 (issue #765) adds sign-in: ATProto OAuth, authentication only.
-//! The security-critical, native-tested core lives in [`auth`] (the
-//! `sub`-vs-DID check, PKCE, and the signed session cookie that gates the
-//! WS); the wasm-only OAuth HTTP flow (resolution, PAR, DPoP, token
-//! exchange) lives in the runtime.
+//! Phase 4 adds sign-in: ATProto OAuth, authentication only. The
+//! native-tested security core lives in [`auth`] (the `sub`-vs-DID check,
+//! PKCE, the signed session cookie that gates the WS) and [`dpop`] (the
+//! ES256 DPoP proofs); the [`oauth`] module is the hand-rolled HTTP flow —
+//! the client-metadata document, resolution, PAR, the token exchange with
+//! DPoP nonce-retry, and the per-flow `AuthFlow` Durable Object — which
+//! verifies the DID, discards the ATProto tokens, and mints the cookie.
 
 pub mod auth;
+pub mod dpop;
 pub mod git;
+pub mod oauth;
 pub mod route;
 pub mod state;
 

--- a/services/notes-sync/src/oauth.rs
+++ b/services/notes-sync/src/oauth.rs
@@ -1,0 +1,463 @@
+//! Hand-rolled ATProto OAuth, authentication only. The Worker is the
+//! OAuth client: it serves the client-metadata JSON (its public URL is
+//! the `client_id`), runs PAR and the token exchange with DPoP, verifies
+//! the account DID against the one resolved up front, then discards the
+//! ATProto tokens and mints its own signed session cookie.
+//!
+//! Per-flow state (PKCE verifier, DPoP key, resolved DID/issuer/token
+//! endpoint) lives in the `AuthFlow` Durable Object keyed by the
+//! `state` value, so nothing sensitive round-trips through the browser.
+//! The HTTP/DPoP-nonce glue is wasm-only and deploy-verified; the
+//! client-metadata builder is pure and native-tested, and the security
+//! checks it leans on (`verify_identity`, `pkce_challenge`, the cookie,
+//! the DPoP proof) are tested in their own modules.
+
+use serde_json::{json, Value};
+
+/// The client-metadata document. Its own public URL is the `client_id`.
+/// Authentication-only: minimal `atproto` scope, a public client
+/// (`token_endpoint_auth_method: none`), DPoP-bound.
+pub fn client_metadata(base_url: &str) -> Value {
+    let base = base_url.trim_end_matches('/');
+    json!({
+        "client_id": format!("{base}/client-metadata.json"),
+        "client_name": "kolohelios notes",
+        "client_uri": base,
+        "application_type": "web",
+        "grant_types": ["authorization_code"],
+        "response_types": ["code"],
+        "redirect_uris": [format!("{base}/oauth/callback")],
+        "scope": "atproto",
+        "token_endpoint_auth_method": "none",
+        "dpop_bound_access_tokens": true,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use flow::{handle_callback, handle_login, AuthFlow};
+
+#[cfg(target_arch = "wasm32")]
+mod flow {
+    use crate::auth::{mint_session, pkce_challenge, verify_identity};
+    use crate::dpop::DpopKey;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+    // `wasm_bindgen` must be in scope by name: the `#[durable_object]`
+    // macro expands to glue that references it (see runtime.rs).
+    use worker::{
+        console_log, durable_object, wasm_bindgen, Date, DurableObject, Env, Fetch, Headers,
+        Method, Request, RequestInit, Response, ResponseBuilder, Result, State,
+    };
+
+    /// Session cookie lifetime.
+    const SESSION_TTL_SECS: i64 = 7 * 24 * 3600;
+    /// Flow state expires if the user doesn't return from the authz server.
+    const FLOW_TTL_SECS: i64 = 10 * 60;
+
+    fn now_secs() -> i64 {
+        (Date::now().as_millis() / 1000) as i64
+    }
+
+    /// A fresh random token (base64url, 32 bytes) for the PKCE verifier,
+    /// the `state`, and DPoP `jti`s.
+    fn random_token() -> String {
+        let mut bytes = [0u8; 32];
+        getrandom::getrandom(&mut bytes).expect("rng");
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    fn err(msg: impl std::fmt::Display) -> worker::Error {
+        worker::Error::RustError(msg.to_string())
+    }
+
+    /// Per-flow state, persisted in the AuthFlow DO between `/oauth/login`
+    /// and `/oauth/callback`.
+    #[derive(Serialize, Deserialize)]
+    struct FlowState {
+        verifier: String,
+        dpop_key: Vec<u8>,
+        did: String,
+        issuer: String,
+        token_endpoint: String,
+    }
+
+    /// One Durable Object per in-flight OAuth flow (`idFromName(state)`).
+    /// Strongly consistent so the callback reliably reads what login
+    /// wrote; a short alarm cleans it up if the user never returns.
+    #[durable_object]
+    pub struct AuthFlow {
+        state: State,
+        #[allow(dead_code)]
+        env: Env,
+    }
+
+    impl DurableObject for AuthFlow {
+        fn new(state: State, env: Env) -> Self {
+            Self { state, env }
+        }
+
+        async fn fetch(&self, mut req: Request) -> Result<Response> {
+            match req.path().as_str() {
+                "/put" => {
+                    let flow: FlowState = req.json().await?;
+                    self.state.storage().put("flow", &flow).await?;
+                    self.state
+                        .storage()
+                        .set_alarm(std::time::Duration::from_secs(FLOW_TTL_SECS as u64))
+                        .await?;
+                    Response::ok("stored")
+                }
+                "/take" => {
+                    let flow: Option<FlowState> = self.state.storage().get("flow").await?;
+                    // One-shot: consume it so a code can't be replayed.
+                    let _ = self.state.storage().delete("flow").await;
+                    match flow {
+                        Some(f) => Response::from_json(&f),
+                        None => Response::error("no such flow", 404),
+                    }
+                }
+                _ => Response::error("not found", 404),
+            }
+        }
+
+        async fn alarm(&self) -> Result<Response> {
+            // Expired without a callback — drop the state.
+            let _ = self.state.storage().delete("flow").await;
+            Response::ok("expired")
+        }
+    }
+
+    async fn auth_flow_stub(env: &Env, state: &str) -> Result<worker::Stub> {
+        env.durable_object("AUTH_FLOW")?
+            .id_from_name(state)?
+            .get_stub()
+    }
+
+    // ---- HTTP helpers --------------------------------------------------
+
+    async fn get_json(url: &str) -> Result<Value> {
+        let mut resp = Fetch::Url(url.parse().map_err(err)?).send().await?;
+        if resp.status_code() != 200 {
+            return Err(err(format!("GET {url} -> {}", resp.status_code())));
+        }
+        resp.json().await
+    }
+
+    /// POST a form body with a DPoP proof, retrying once with the
+    /// server-issued nonce (the documented PAR/token first-response is a
+    /// `use_dpop_nonce` error carrying a `DPoP-Nonce` header).
+    async fn dpop_post_form(url: &str, params: &[(&str, &str)], key: &DpopKey) -> Result<Response> {
+        let body = serde_urlencoded::to_string(params).map_err(err)?;
+        let mut nonce: Option<String> = None;
+        let mut last: Option<Response> = None;
+        for _ in 0..2 {
+            let proof = key.proof("POST", url, nonce.as_deref(), &random_token(), now_secs());
+            let headers = Headers::new();
+            headers.set("Content-Type", "application/x-www-form-urlencoded")?;
+            headers.set("DPoP", &proof)?;
+            let mut init = RequestInit::new();
+            init.with_method(Method::Post)
+                .with_headers(headers)
+                .with_body(Some(body.clone().into()));
+            let req = Request::new_with_init(url, &init)?;
+            let resp = Fetch::Request(req).send().await?;
+            let code = resp.status_code();
+            if (code == 400 || code == 401) && nonce.is_none() {
+                if let Ok(Some(n)) = resp.headers().get("DPoP-Nonce") {
+                    nonce = Some(n);
+                    last = Some(resp);
+                    continue;
+                }
+            }
+            return Ok(resp);
+        }
+        last.ok_or_else(|| err("dpop_post_form produced no response"))
+    }
+
+    // ---- Identity & metadata resolution --------------------------------
+
+    /// Resolve a handle (or pass a DID through) to a DID, then to the PDS,
+    /// then to the authorization server's metadata.
+    async fn resolve(identifier: &str, env: &Env) -> Result<(String, AuthzMeta)> {
+        let did = if identifier.starts_with("did:") {
+            identifier.to_owned()
+        } else {
+            let resolver = env
+                .var("OAUTH_HANDLE_RESOLVER")
+                .map(|v| v.to_string())
+                .unwrap_or_else(|_| "https://bsky.social".to_owned());
+            let url = format!(
+                "{}/xrpc/com.atproto.identity.resolveHandle?handle={}",
+                resolver.trim_end_matches('/'),
+                identifier
+            );
+            get_json(&url).await?["did"]
+                .as_str()
+                .ok_or_else(|| err("resolveHandle: no did"))?
+                .to_owned()
+        };
+
+        let pds = did_to_pds(&did).await?;
+        let meta = pds_to_authz(&pds).await?;
+        Ok((did, meta))
+    }
+
+    async fn did_to_pds(did: &str) -> Result<String> {
+        // did:plc via plc.directory; did:web by fetching its document.
+        let doc_url = if let Some(rest) = did.strip_prefix("did:web:") {
+            format!("https://{rest}/.well-known/did.json")
+        } else {
+            format!("https://plc.directory/{did}")
+        };
+        let doc = get_json(&doc_url).await?;
+        doc["service"]
+            .as_array()
+            .and_then(|services| {
+                services
+                    .iter()
+                    .find(|s| s["type"].as_str() == Some("AtprotoPersonalDataServer"))
+            })
+            .and_then(|s| s["serviceEndpoint"].as_str())
+            .map(str::to_owned)
+            .ok_or_else(|| err("DID doc has no PDS service endpoint"))
+    }
+
+    struct AuthzMeta {
+        issuer: String,
+        par_endpoint: String,
+        authorization_endpoint: String,
+        token_endpoint: String,
+    }
+
+    async fn pds_to_authz(pds: &str) -> Result<AuthzMeta> {
+        let prot = get_json(&format!(
+            "{}/.well-known/oauth-protected-resource",
+            pds.trim_end_matches('/')
+        ))
+        .await?;
+        let authz = prot["authorization_servers"][0]
+            .as_str()
+            .ok_or_else(|| err("no authorization_servers"))?
+            .to_owned();
+        let meta = get_json(&format!(
+            "{}/.well-known/oauth-authorization-server",
+            authz.trim_end_matches('/')
+        ))
+        .await?;
+        let s = |k: &str| {
+            meta[k]
+                .as_str()
+                .map(str::to_owned)
+                .ok_or_else(|| err(format!("authz metadata missing {k}")))
+        };
+        Ok(AuthzMeta {
+            issuer: authz,
+            par_endpoint: s("pushed_authorization_request_endpoint")?,
+            authorization_endpoint: s("authorization_endpoint")?,
+            token_endpoint: s("token_endpoint")?,
+        })
+    }
+
+    fn base_url(env: &Env) -> Result<String> {
+        Ok(env
+            .var("OAUTH_BASE_URL")
+            .map_err(|_| err("OAUTH_BASE_URL not set"))?
+            .to_string()
+            .trim_end_matches('/')
+            .to_owned())
+    }
+
+    // ---- Endpoints -----------------------------------------------------
+
+    /// `GET /oauth/login?handle=…` — resolve, PAR, persist flow state, and
+    /// redirect the user to the authorization server.
+    pub async fn handle_login(req: Request, env: Env) -> Result<Response> {
+        let url = req.url()?;
+        let handle = url
+            .query_pairs()
+            .find(|(k, _)| k == "handle")
+            .map(|(_, v)| v.into_owned())
+            .ok_or_else(|| err("missing ?handle"))?;
+
+        let base = base_url(&env)?;
+        let client_id = format!("{base}/client-metadata.json");
+        let redirect_uri = format!("{base}/oauth/callback");
+
+        let (did, meta) = resolve(&handle, &env).await?;
+
+        let verifier = random_token();
+        let challenge = pkce_challenge(&verifier);
+        let state = random_token();
+        let key = DpopKey::generate();
+
+        // Pushed Authorization Request.
+        let par_params = [
+            ("client_id", client_id.as_str()),
+            ("response_type", "code"),
+            ("scope", "atproto"),
+            ("redirect_uri", redirect_uri.as_str()),
+            ("state", state.as_str()),
+            ("code_challenge", challenge.as_str()),
+            ("code_challenge_method", "S256"),
+            ("login_hint", handle.as_str()),
+        ];
+        let mut par_resp = dpop_post_form(&meta.par_endpoint, &par_params, &key).await?;
+        if par_resp.status_code() / 100 != 2 {
+            return Err(err(format!("PAR -> {}", par_resp.status_code())));
+        }
+        let request_uri = par_resp.json::<Value>().await?["request_uri"]
+            .as_str()
+            .ok_or_else(|| err("PAR: no request_uri"))?
+            .to_owned();
+
+        // Persist the flow state keyed by `state`.
+        let flow = FlowState {
+            verifier,
+            dpop_key: key.to_bytes(),
+            did,
+            issuer: meta.issuer.clone(),
+            token_endpoint: meta.token_endpoint,
+        };
+        let stub = auth_flow_stub(&env, &state).await?;
+        let put = {
+            let headers = Headers::new();
+            headers.set("Content-Type", "application/json")?;
+            let mut init = RequestInit::new();
+            init.with_method(Method::Post)
+                .with_headers(headers)
+                .with_body(Some(serde_json::to_string(&flow).map_err(err)?.into()));
+            Request::new_with_init("https://auth-flow/put", &init)?
+        };
+        let _ = stub.fetch_with_request(put).await?;
+
+        // Redirect to the authorization endpoint (PAR-style: client_id +
+        // request_uri).
+        let location = format!(
+            "{}?client_id={}&request_uri={}",
+            meta.authorization_endpoint,
+            urlencode(&client_id),
+            urlencode(&request_uri),
+        );
+        Response::redirect(location.parse().map_err(err)?)
+    }
+
+    /// `GET /oauth/callback?code=…&state=…&iss=…` — exchange the code,
+    /// verify the identity, mint the session cookie, discard the tokens.
+    pub async fn handle_callback(req: Request, env: Env) -> Result<Response> {
+        let url = req.url()?;
+        let q = |name: &str| {
+            url.query_pairs()
+                .find(|(k, _)| k == name)
+                .map(|(_, v)| v.into_owned())
+        };
+        let code = q("code").ok_or_else(|| err("missing ?code"))?;
+        let state = q("state").ok_or_else(|| err("missing ?state"))?;
+        let iss = q("iss").ok_or_else(|| err("missing ?iss"))?;
+
+        // Take the one-shot flow state.
+        let stub = auth_flow_stub(&env, &state).await?;
+        let take = Request::new("https://auth-flow/take", Method::Get)?;
+        let mut take_resp = stub.fetch_with_request(take).await?;
+        if take_resp.status_code() != 200 {
+            return Err(err("unknown or expired flow state"));
+        }
+        let flow: FlowState = take_resp.json().await?;
+        let key = DpopKey::from_bytes(&flow.dpop_key).ok_or_else(|| err("bad dpop key"))?;
+
+        let base = base_url(&env)?;
+        let client_id = format!("{base}/client-metadata.json");
+        let redirect_uri = format!("{base}/oauth/callback");
+
+        // Token exchange.
+        let token_params = [
+            ("grant_type", "authorization_code"),
+            ("code", code.as_str()),
+            ("redirect_uri", redirect_uri.as_str()),
+            ("client_id", client_id.as_str()),
+            ("code_verifier", flow.verifier.as_str()),
+        ];
+        let mut token_resp = dpop_post_form(&flow.token_endpoint, &token_params, &key).await?;
+        if token_resp.status_code() / 100 != 2 {
+            return Err(err(format!("token -> {}", token_resp.status_code())));
+        }
+        let body = token_resp.json::<Value>().await?;
+        let sub = body["sub"].as_str().ok_or_else(|| err("token: no sub"))?;
+
+        // The mandatory check: sub is the DID we resolved, iss is the
+        // authorization server we used.
+        verify_identity(sub, &iss, &flow.did, &flow.issuer).map_err(err)?;
+
+        // Authn-only: the ATProto tokens are discarded here (we never store
+        // `body["access_token"]`/`refresh_token`). Mint our own cookie.
+        let cookie = mint_session(
+            &flow.did,
+            now_secs() + SESSION_TTL_SECS,
+            session_secret(&env)?.as_bytes(),
+        );
+        console_log!("authenticated {} via {}", flow.did, flow.issuer);
+
+        let headers = Headers::new();
+        headers.set("Location", "/")?;
+        headers.set(
+            "Set-Cookie",
+            &format!("session={cookie}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age={SESSION_TTL_SECS}"),
+        )?;
+        Ok(ResponseBuilder::new()
+            .with_status(302)
+            .with_headers(headers)
+            .empty())
+    }
+
+    fn session_secret(env: &Env) -> Result<String> {
+        Ok(env
+            .secret("SESSION_SECRET")
+            .map_err(|_| err("SESSION_SECRET not set"))?
+            .to_string())
+    }
+
+    /// Minimal percent-encoding for the two query values we put in the
+    /// authorize redirect (the rest of the flow uses form bodies).
+    fn urlencode(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for b in s.bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    out.push(b as char)
+                }
+                _ => out.push_str(&format!("%{b:02X}")),
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_metadata_is_authn_only_and_self_describing() {
+        let m = client_metadata("https://notes.example.com/");
+        assert_eq!(
+            m["client_id"],
+            "https://notes.example.com/client-metadata.json"
+        );
+        assert_eq!(m["scope"], "atproto");
+        assert_eq!(m["token_endpoint_auth_method"], "none");
+        assert_eq!(m["dpop_bound_access_tokens"], true);
+        assert_eq!(m["grant_types"][0], "authorization_code");
+        assert_eq!(
+            m["redirect_uris"][0],
+            "https://notes.example.com/oauth/callback"
+        );
+    }
+
+    #[test]
+    fn client_metadata_trims_a_trailing_slash() {
+        let a = client_metadata("https://x.example");
+        let b = client_metadata("https://x.example/");
+        assert_eq!(a["client_id"], b["client_id"]);
+    }
+}

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -40,7 +40,25 @@ const MAX_COMMIT_RETRIES: u32 = 3;
 /// hello response.
 #[event(fetch)]
 pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
-    if let Some(note_id) = parse_ws_note_id(&req.path()) {
+    let path = req.path();
+
+    // ATProto OAuth, authentication only. The metadata document's URL is
+    // the client_id; login resolves + redirects; the callback verifies the
+    // DID and mints the session cookie.
+    match path.as_str() {
+        "/client-metadata.json" => {
+            let base = env
+                .var("OAUTH_BASE_URL")
+                .map(|v| v.to_string())
+                .unwrap_or_default();
+            return Response::from_json(&crate::oauth::client_metadata(&base));
+        }
+        "/oauth/login" => return crate::oauth::handle_login(req, env).await,
+        "/oauth/callback" => return crate::oauth::handle_callback(req, env).await,
+        _ => {}
+    }
+
+    if let Some(note_id) = parse_ws_note_id(&path) {
         // The session cookie gates the upgrade. The `sub`-vs-DID check at
         // login is where identity is established; this only re-checks the
         // signed cookie that login minted.

--- a/services/notes-sync/wrangler.toml
+++ b/services/notes-sync/wrangler.toml
@@ -10,18 +10,26 @@ name               = "notes-sync"
 [build]
 command = "cargo install -q worker-build --locked && worker-build --release"
 
-# Per-note Durable Object binding. The Worker resolves a note id to its
-# object with `env.durable_object("NOTE").id_from_name(noteId)`; while a
-# note is open that object is the single writer and source of truth.
+# Durable Object bindings: one per-note object (`NOTE`, the single writer
+# and source of truth), and one per-OAuth-flow object (`AUTH_FLOW`, keyed
+# by the `state` value, holding the PKCE verifier + DPoP key between login
+# and callback).
 [durable_objects]
-bindings = [{ name = "NOTE", class_name = "NoteDurableObject" }]
+bindings = [
+  { name = "NOTE", class_name = "NoteDurableObject" },
+  { name = "AUTH_FLOW", class_name = "AuthFlow" },
+]
 
-# SQLite-backed storage for the Durable Object class. The SQLite backend
-# is what the append-only edit log (phase 2) is built on; a fresh class
-# opts in here at creation time.
+# SQLite-backed storage for the Durable Object classes. The SQLite backend
+# is what the append-only edit log (phase 2) is built on; classes opt in
+# at creation time. Migrations are append-only by tag.
 [[migrations]]
 new_sqlite_classes = ["NoteDurableObject"]
 tag                = "v1"
+
+[[migrations]]
+new_sqlite_classes = ["AuthFlow"]
+tag                = "v2"
 
 # Cold-tier git target (phase 3). The Durable Object commits each note's
 # body to `notes/<note_id>.md` in this repo on the lazy debounce/backstop
@@ -31,7 +39,16 @@ tag                = "v1"
 # installation token or a PAT) — unrelated to user login. Set it out of
 # band, never in this file:
 #   wrangler secret put GITHUB_TOKEN
+#
+# Auth (phase 4): `OAUTH_BASE_URL` is this Worker's public origin — the
+# client_id is `<OAUTH_BASE_URL>/client-metadata.json` and the redirect is
+# `<OAUTH_BASE_URL>/oauth/callback`, so it must match the deployed
+# hostname. `OAUTH_HANDLE_RESOLVER` (optional) is the appview used to
+# resolve a handle to a DID. The cookie-signing key is a secret:
+#   wrangler secret put SESSION_SECRET
 [vars]
-GITHUB_BRANCH = "main"
-GITHUB_OWNER  = "kolohelios"
-GITHUB_REPO   = "notes-store"
+GITHUB_BRANCH        = "main"
+GITHUB_OWNER         = "kolohelios"
+GITHUB_REPO          = "notes-store"
+OAUTH_BASE_URL       = "https://notes-sync.example.workers.dev"
+OAUTH_HANDLE_RESOLVER = "https://bsky.social"


### PR DESCRIPTION
feat(services/notes-sync): hand-rolled ATProto OAuth flow (authn-only)

Completes #765 on top of the auth core. The Worker is the OAuth client:
it serves the client-metadata document (whose URL is the client_id),
resolves handle -> DID -> PDS -> authorization server, runs PAR with PKCE
and a fresh ES256 DPoP key, and on the callback exchanges the code (DPoP
with a one-shot nonce retry), verifies the token's sub against the
resolved DID and the iss against the authorization server, discards the
ATProto tokens, and mints the signed session cookie that gates the WS.

Per-flow state (PKCE verifier, DPoP key, DID/issuer/token endpoint) lives
in a per-flow AuthFlow Durable Object keyed by state — strongly
consistent, one-shot, self-cleaning via a short alarm — so no secret
round-trips through the browser.

The DPoP proofs are RustCrypto p256 (ES256), native-tested (sign/verify
round-trip, jkt thumbprint, key persistence) and confirmed to compile to
wasm; the client-metadata builder is native-tested too. The HTTP and
DPoP-nonce glue is wasm-only and deploy-verified — it needs a real
Bluesky account and a deploy to exercise end to end.

OAUTH_BASE_URL and OAUTH_HANDLE_RESOLVER are wrangler vars; SESSION_SECRET
is a wrangler secret.

Closes #765
Part of #757
