### PR TITLE
fix(shaka): parent new workspaces on main@origin

### DIFF
--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -450,17 +450,20 @@ fn parse_workspace_list(out: &str) -> Vec<WorkspaceInfo> {
     result
 }
 
-/// Register a new workspace at `path` with the given name.
-pub fn workspace_add(name: &str, path: &Path) -> Result<(), JjError> {
-    run_streaming(&[
-        "workspace",
-        "add",
-        "--name",
-        name,
-        path.to_str().context(WorkspacePathInvalidUtf8Snafu {
-            path: path.display().to_string(),
-        })?,
-    ])
+/// Register a new workspace at `path` with the given name. When `revision`
+/// is `Some`, the workspace's working copy is created on top of that revset;
+/// otherwise `jj` parents it on the invoking workspace's position (its
+/// default).
+pub fn workspace_add(name: &str, path: &Path, revision: Option<&str>) -> Result<(), JjError> {
+    let path = path.to_str().context(WorkspacePathInvalidUtf8Snafu {
+        path: path.display().to_string(),
+    })?;
+    let mut args = vec!["workspace", "add", "--name", name, path];
+    if let Some(revision) = revision {
+        args.push("--revision");
+        args.push(revision);
+    }
+    run_streaming(&args)
 }
 
 /// De-register a workspace from the repo. Does not remove the workspace

--- a/tools/shaka/src/workspace/new.rs
+++ b/tools/shaka/src/workspace/new.rs
@@ -34,7 +34,15 @@ pub fn run(name: Option<&str>, issue: Option<u64>) {
         die(&format!("workspace already registered: {derived_name}"));
     }
 
-    if let Err(e) = jj::workspace_add(&derived_name, &path) {
+    // Parent the new workspace on the freshly-fetched `main@origin` so it
+    // never inherits a stale base from wherever the invoking tree's `@`
+    // happens to sit (#805). Fall back to jj's default when `main@origin`
+    // doesn't resolve (fresh repo / no remote) rather than local `main`,
+    // which could itself lag behind the remote.
+    let revision = jj::commit_id_of("main@origin")
+        .is_ok()
+        .then_some("main@origin");
+    if let Err(e) = jj::workspace_add(&derived_name, &path, revision) {
         die(&e.to_string());
     }
 

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -41,6 +41,20 @@ fn assert_success(out: &std::process::Output, ctx: &str) {
     );
 }
 
+fn jj(repo: &Path, args: &[&str]) -> String {
+    let out = Command::new("jj")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("failed to spawn jj");
+    assert!(
+        out.status.success(),
+        "jj {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
 #[test]
 fn new_creates_workspace_and_directory() {
     let parent = TempDir::new().expect("tempdir");
@@ -275,5 +289,56 @@ fn cleanup_dry_run_does_not_remove_workspace() {
         workspace_path.is_dir(),
         "cleanup --dry-run must not remove the workspace directory: {}",
         workspace_path.display()
+    );
+}
+
+// Regression test for #805: a new workspace must be parented on the
+// fetched `main@origin`, not wherever the invoking tree's `@` sits.
+#[test]
+fn new_parents_workspace_on_main_origin_when_present() {
+    let parent = TempDir::new().expect("tempdir");
+
+    // An "origin" repo whose `main` carries a real commit.
+    let origin = parent.path().join("origin");
+    std::fs::create_dir(&origin).unwrap();
+    jj_init_colocated(&origin);
+    std::fs::write(origin.join("seed.txt"), "seed\n").unwrap();
+    jj(&origin, &["describe", "-m", "seed main"]);
+    jj(&origin, &["bookmark", "create", "main", "-r", "@"]);
+    // Export the bookmark to a git ref so the working repo can fetch it.
+    jj(&origin, &["git", "export"]);
+    let main_commit = jj(
+        &origin,
+        &["log", "-r", "main", "--no-graph", "-T", "commit_id"],
+    );
+
+    // The working repo fetches `main@origin`; its own `@` stays on the fresh
+    // root-based commit — i.e. NOT on main@origin (the stale-base scenario).
+    let repo = parent.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    jj_init_colocated(&repo);
+    let origin_git = origin.join(".git");
+    jj(
+        &repo,
+        &[
+            "git",
+            "remote",
+            "add",
+            "origin",
+            origin_git.to_str().unwrap(),
+        ],
+    );
+    jj(&repo, &["git", "fetch"]);
+
+    let out = shaka(&repo, &["workspace", "new", "feat-x"]);
+    assert_success(&out, "workspace new");
+
+    // The new workspace's working-copy commit must sit directly on top of
+    // main@origin, regardless of the invoking tree's `@`.
+    let ws = parent.path().join("repo-feat-x");
+    let ws_parent = jj(&ws, &["log", "-r", "@-", "--no-graph", "-T", "commit_id"]);
+    assert_eq!(
+        ws_parent, main_commit,
+        "workspace should be parented on main@origin ({main_commit}), got {ws_parent}"
     );
 }


### PR DESCRIPTION
`jj workspace add` without a revision parents the new workspace on the
invoking tree's working-copy position. When the primary tree's `@` sits
behind main — e.g. after it was rebased onto an older commit — every new
workspace inherited that stale base and had to be manually rebased onto
`main@origin` before work could start.

Probe `main@origin` with `commit_id_of` and, when it resolves, pass it as
the `--revision` for `jj workspace add` so fresh workspaces always start
on the freshly-fetched remote tip. Fall back to jj's default when
`main@origin` is absent (fresh repo / no remote) rather than local
`main`, which could itself lag the remote — this keeps the existing
no-remote workspace tests green.

Closes #805