### PR TITLE
chore(meta): set GH_REPO so gh resolves the repo from any cwd

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,8 @@
       "Bash(shaka *)",
       "Bash(tools/shaka/bin/shaka *)"
     ]
+  },
+  "env": {
+    "GH_REPO": "kolohelios/kolohelios"
   }
 }


### PR DESCRIPTION
gh commands run from a shaka workspace fail with "not a git repository"
because secondary jj workspaces have no reachable .git for gh to infer
the repo. Setting GH_REPO makes every gh invocation resolve the repo
regardless of cwd, dropping the failure class for query commands (pr
view, pr checks, issue list/view/comment) without an explicit -R.

Partial mitigation surfaced by /audit-workflow (11 sessions in the last
7 days). The shaka pr wrapper and repo send --auto-merge work tracked in
the issue remains the durable fix for create/merge paths.

Refs #687