### PR TITLE
fix(shaka): writable HOME for jj-driven tests under nixpkgs 26.05

### DIFF
--- a/apps/blogctl/flake.nix
+++ b/apps/blogctl/flake.nix
@@ -64,6 +64,9 @@
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             nativeCheckInputs = [ pkgs.jujutsu ];
+            preCheck = ''
+              export HOME="$(mktemp -d)"
+            '';
             nativeBuildInputs = [ pkgs.installShellFiles ];
             postInstall = ''
               installShellCompletion --cmd blogctl \

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -69,6 +69,9 @@
               pkgs.git
               pkgs.opentofu
             ];
+            preCheck = ''
+              export HOME="$(mktemp -d)"
+            '';
             nativeBuildInputs = [
               pkgs.makeWrapper
               pkgs.installShellFiles

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -489,6 +489,18 @@ fn render_packages(cli: &CliMeta) -> String {
         out.push_str(&render_pkg_list("nativeCheckInputs", &cli.check_inputs, 12));
     }
 
+    // jj 0.30+ (nixpkgs 26.05) writes a per-repo "secure config" under
+    // `$HOME/.config/jj/repos/`, so `jj config set --repo` aborts when
+    // HOME is unwritable. The build sandbox sets HOME=/homeless-shelter,
+    // so any project whose tests drive jj needs a writable HOME for the
+    // check phase. Scoped to jj-using projects via the `jujutsu` check
+    // input rather than emitted unconditionally.
+    if cli.check_inputs.iter().any(|i| i == "jujutsu") {
+        out.push_str(
+            "            preCheck = ''\n              export HOME=\"$(mktemp -d)\"\n            '';\n",
+        );
+    }
+
     // `wrapProgram` (from makeWrapper) is needed for a PATH prefix and/or
     // the SHAKA_CUE_MODULE_DIR set, so either knob pulls it in.
     let needs_wrapper = !cli.runtime_path_deps.is_empty() || cli.cue_module.is_some();
@@ -1062,6 +1074,28 @@ mod tests {
         };
         let out = render_flake("demo", &cli);
         assert!(out.contains("nativeCheckInputs = [ pkgs.jujutsu ];"));
+    }
+
+    #[test]
+    fn jujutsu_check_input_adds_writable_home_precheck() {
+        let cli = CliMeta {
+            check_inputs: vec!["jujutsu".into()],
+            ..minimal_cli()
+        };
+        let out = render_flake("demo", &cli);
+        // jj 0.30+ aborts `config set --repo` without a writable HOME.
+        assert!(out.contains("preCheck = ''"));
+        assert!(out.contains(r#"export HOME="$(mktemp -d)""#));
+    }
+
+    #[test]
+    fn no_jujutsu_check_input_omits_precheck() {
+        let cli = CliMeta {
+            check_inputs: vec!["cue".into()],
+            ..minimal_cli()
+        };
+        let out = render_flake("demo", &cli);
+        assert!(!out.contains("preCheck"));
     }
 
     #[test]


### PR DESCRIPTION
nixpkgs 26.05 ships jj 0.30+, which writes a per-repo "secure config" under `$HOME/.config/jj/repos/` and aborts `jj config set --repo` when HOME is unwritable. The nix build sandbox sets `HOME=/homeless-shelter`, so shaka's jj-driven tests fail the check phase on 26.05. The flake generator now emits a `preCheck` that exports a writable HOME for rust projects whose tests drive jj (gated on the `jujutsu` check input — shaka and blogctl). Unblocks #786, whose shaka build hits this. Validated: `nix build ./tools/shaka` green with kolohelios-nix bumped to 26.05.