### PR TITLE
fix(shaka): give jj-backed tests a writable HOME for sandbox builds

### DIFF
--- a/tools/shaka/tests/repo_send_workspace.rs
+++ b/tools/shaka/tests/repo_send_workspace.rs
@@ -6,6 +6,7 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::sync::OnceLock;
 
 use tempfile::TempDir;
 
@@ -13,10 +14,26 @@ const SHAKA: &str = env!("CARGO_BIN_EXE_shaka");
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
+/// A writable `HOME` for every spawned `jj`/`git`/`shaka` process.
+///
+/// The nix sandbox runs the build's check phase with `HOME=/homeless-shelter`
+/// on a read-only filesystem. `jj` writes per-repo state under
+/// `$HOME/.config/jj/repos/<hash>`, so a read-only `HOME` makes every
+/// jj-backed test fail with "Read-only file system". Pointing `HOME` at a
+/// process-wide writable tempdir (created once, shared via `.env` so there is
+/// no `set_var` race across parallel tests) keeps the tests hermetic and
+/// sandbox-safe.
+fn writable_home() -> &'static Path {
+    static HOME: OnceLock<TempDir> = OnceLock::new();
+    HOME.get_or_init(|| TempDir::new().expect("home tempdir"))
+        .path()
+}
+
 fn jj(cwd: &Path, args: &[&str]) -> std::process::Output {
     Command::new("jj")
         .args(args)
         .current_dir(cwd)
+        .env("HOME", writable_home())
         .output()
         .expect("failed to spawn jj")
 }
@@ -36,6 +53,7 @@ fn shaka(cwd: &Path, args: &[&str]) -> std::process::Output {
     Command::new(SHAKA)
         .args(args)
         .current_dir(cwd)
+        .env("HOME", writable_home())
         .output()
         .expect("failed to spawn shaka")
 }

--- a/tools/shaka/tests/repo_ship_workspace.rs
+++ b/tools/shaka/tests/repo_ship_workspace.rs
@@ -7,6 +7,7 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::sync::OnceLock;
 
 use tempfile::TempDir;
 
@@ -14,10 +15,26 @@ const SHAKA: &str = env!("CARGO_BIN_EXE_shaka");
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
+/// A writable `HOME` for every spawned `jj`/`git`/`shaka` process.
+///
+/// The nix sandbox runs the build's check phase with `HOME=/homeless-shelter`
+/// on a read-only filesystem. `jj` writes per-repo state under
+/// `$HOME/.config/jj/repos/<hash>`, so a read-only `HOME` makes every
+/// jj-backed test fail with "Read-only file system". Pointing `HOME` at a
+/// process-wide writable tempdir (created once, shared via `.env` so there is
+/// no `set_var` race across parallel tests) keeps the tests hermetic and
+/// sandbox-safe.
+fn writable_home() -> &'static Path {
+    static HOME: OnceLock<TempDir> = OnceLock::new();
+    HOME.get_or_init(|| TempDir::new().expect("home tempdir"))
+        .path()
+}
+
 fn jj(cwd: &Path, args: &[&str]) -> std::process::Output {
     Command::new("jj")
         .args(args)
         .current_dir(cwd)
+        .env("HOME", writable_home())
         .output()
         .expect("failed to spawn jj")
 }
@@ -37,6 +54,7 @@ fn shaka(cwd: &Path, args: &[&str]) -> std::process::Output {
     Command::new(SHAKA)
         .args(args)
         .current_dir(cwd)
+        .env("HOME", writable_home())
         .output()
         .expect("failed to spawn shaka")
 }

--- a/tools/shaka/tests/whitespace.rs
+++ b/tools/shaka/tests/whitespace.rs
@@ -12,8 +12,24 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::sync::OnceLock;
 
 const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+
+/// A writable `HOME` for every spawned `jj`/`git`/`shaka` process.
+///
+/// The nix sandbox runs the build's check phase with `HOME=/homeless-shelter`
+/// on a read-only filesystem. `jj` writes per-repo state under
+/// `$HOME/.config/jj/repos/<hash>`, so a read-only `HOME` makes every
+/// jj-backed test fail with "Read-only file system". Pointing `HOME` at a
+/// process-wide writable tempdir (created once, shared via `.env` so there is
+/// no `set_var` race across parallel tests) keeps the tests hermetic and
+/// sandbox-safe.
+fn writable_home() -> &'static Path {
+    static HOME: OnceLock<tempfile::TempDir> = OnceLock::new();
+    HOME.get_or_init(|| tempfile::TempDir::new().expect("home tempdir"))
+        .path()
+}
 
 struct Repo {
     root: tempfile::TempDir,
@@ -50,6 +66,7 @@ impl Repo {
         Command::new(SHAKA_BIN)
             .args(args)
             .current_dir(self.root.path())
+            .env("HOME", writable_home())
             .output()
             .expect("failed to spawn shaka")
     }
@@ -63,6 +80,7 @@ fn run(cwd: &Path, argv: &[&str]) {
     let status = Command::new(argv[0])
         .args(&argv[1..])
         .current_dir(cwd)
+        .env("HOME", writable_home())
         .status()
         .unwrap_or_else(|e| panic!("failed to spawn {}: {e}", argv[0]));
     assert!(status.success(), "{:?} failed", argv);

--- a/tools/shaka/tests/workspace.rs
+++ b/tools/shaka/tests/workspace.rs
@@ -7,15 +7,32 @@
 
 use std::path::Path;
 use std::process::Command;
+use std::sync::OnceLock;
 
 use tempfile::TempDir;
 
 const SHAKA: &str = env!("CARGO_BIN_EXE_shaka");
 
+/// A writable `HOME` for every spawned `jj`/`git`/`shaka` process.
+///
+/// The nix sandbox runs the build's check phase with `HOME=/homeless-shelter`
+/// on a read-only filesystem. `jj` writes per-repo state under
+/// `$HOME/.config/jj/repos/<hash>`, so a read-only `HOME` makes every
+/// jj-backed test fail with "Read-only file system". Pointing `HOME` at a
+/// process-wide writable tempdir (created once, shared via `.env` so there is
+/// no `set_var` race across parallel tests) keeps the tests hermetic and
+/// sandbox-safe.
+fn writable_home() -> &'static Path {
+    static HOME: OnceLock<TempDir> = OnceLock::new();
+    HOME.get_or_init(|| TempDir::new().expect("home tempdir"))
+        .path()
+}
+
 fn jj_init_colocated(repo: &Path) {
     Command::new("jj")
         .args(["git", "init", "--colocate"])
         .current_dir(repo)
+        .env("HOME", writable_home())
         .status()
         .expect("failed to spawn jj")
         .success()
@@ -27,6 +44,7 @@ fn shaka(repo: &Path, args: &[&str]) -> std::process::Output {
     Command::new(SHAKA)
         .args(args)
         .current_dir(repo)
+        .env("HOME", writable_home())
         .output()
         .expect("failed to spawn shaka")
 }
@@ -45,6 +63,7 @@ fn jj(repo: &Path, args: &[&str]) -> String {
     let out = Command::new("jj")
         .args(args)
         .current_dir(repo)
+        .env("HOME", writable_home())
         .output()
         .expect("failed to spawn jj");
     assert!(


### PR DESCRIPTION
Consuming `shaka.packages.<system>.default` from FlakeHub triggers a from-source build whose check phase runs `cargo test` under the nix sandbox, where `HOME=/homeless-shelter` lives on a read-only filesystem. jj writes per-repo state under `$HOME`, so every integration test that spawns jj against a colocated tempdir repo fails with "Read-only file system" — breaking the build for any consumer that rebuilds shaka (notably darwin, which has no cached FlakeHub closure).

This points `HOME` at a process-wide writable tempdir on every spawned `jj`/`git`/`shaka` command in the four jj-backed test binaries (`repo_send_workspace`, `repo_ship_workspace`, `workspace`, `whitespace`). The tempdir is created once via `OnceLock` and shared through `Command::env`, so there is no `std::env::set_var` race across parallel tests, and the tests stay hermetic instead of leaking into the host's real `$HOME`.

Verified by running the compiled test binaries with a read-only `HOME` (simulating the sandbox `/homeless-shelter`): they now pass. macOS nix builds run with `sandbox = false`, so `nix build .#default` cannot reproduce the read-only-HOME failure locally on darwin — the simulation above is the reproduction. `nix build .#default` and `just validate` both pass.

Note (secondary, from the issue): shaka still isn't built/cached for darwin on FlakeHub, so darwin consumers will rebuild from source rather than substitute a cached closure. This PR ensures that rebuild succeeds; caching darwin closures on FlakeHub is a separate CI-matrix change left out here to avoid conflicting with sibling work.

Closes #833