### PR TITLE
feat(shaka): make generated justfiles + shaka shim external-repo safe

### DIFF
--- a/apps/blogctl/justfile
+++ b/apps/blogctl/justfile
@@ -36,7 +36,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -51,6 +51,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/apps/cascadiajs2026-notes/justfile
+++ b/apps/cascadiajs2026-notes/justfile
@@ -46,7 +46,7 @@ coverage:
     #!/usr/bin/env bash
     # Line coverage only — see the rust-cli template for why.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on rust-worker); skipping"
         exit 0
@@ -65,7 +65,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 # `test` runs the native unit tests: coverage is optional on rust-worker
 # (cargo-llvm-cov can't see the wasm request paths), so unlike rust-cli

--- a/apps/kolohelios-portfolio/justfile
+++ b/apps/kolohelios-portfolio/justfile
@@ -46,7 +46,7 @@ coverage:
     #!/usr/bin/env bash
     # Line coverage only — see the rust-cli template for why.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on rust-worker); skipping"
         exit 0
@@ -65,7 +65,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 # `test` runs the native unit tests: coverage is optional on rust-worker
 # (cargo-llvm-cov can't see the wasm request paths), so unlike rust-cli

--- a/apps/notes-editor/justfile
+++ b/apps/notes-editor/justfile
@@ -54,7 +54,7 @@ coverage:
     # Optional on wasm-app (cargo-llvm-cov can't see the browser DOM and
     # socket paths); skip when not declared.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on wasm-app); skipping"
         exit 0
@@ -73,6 +73,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete wasm-build coverage nix-fmt-check flake-check whitespace-check

--- a/apps/notes-web/justfile
+++ b/apps/notes-web/justfile
@@ -38,7 +38,7 @@ coverage:
     #!/usr/bin/env bash
     # Line coverage only — see the rust-cli template for why.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on rust-worker); skipping"
         exit 0
@@ -57,7 +57,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 # `test` runs the native unit tests: coverage is optional on rust-worker
 # (cargo-llvm-cov can't see the wasm request paths), so unlike rust-cli

--- a/apps/pollen-alert/justfile
+++ b/apps/pollen-alert/justfile
@@ -38,7 +38,7 @@ coverage:
     #!/usr/bin/env bash
     # Line coverage only — see the rust-cli template for why.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on rust-worker); skipping"
         exit 0
@@ -57,7 +57,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 # `test` runs the native unit tests: coverage is optional on rust-worker
 # (cargo-llvm-cov can't see the wasm request paths), so unlike rust-cli

--- a/infra/cloudflare-deploy/justfile
+++ b/infra/cloudflare-deploy/justfile
@@ -11,7 +11,7 @@ nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: tofu-validate nix-fmt-check whitespace-check
 

--- a/infra/cloudflare-dns/justfile
+++ b/infra/cloudflare-dns/justfile
@@ -11,7 +11,7 @@ nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: tofu-validate nix-fmt-check whitespace-check
 

--- a/infra/cloudflare-tokens/justfile
+++ b/infra/cloudflare-tokens/justfile
@@ -11,7 +11,7 @@ nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: tofu-validate nix-fmt-check whitespace-check
 

--- a/infra/devbox/justfile
+++ b/infra/devbox/justfile
@@ -11,7 +11,7 @@ nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: tofu-validate nix-fmt-check whitespace-check
 

--- a/infra/home/justfile
+++ b/infra/home/justfile
@@ -11,6 +11,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: nix-fmt-check flake-check whitespace-check

--- a/nix/kolohelios-nix/flake.nix
+++ b/nix/kolohelios-nix/flake.nix
@@ -33,6 +33,12 @@
       # root — agents in a subdirectory or jj workspace hit `no such file
       # or directory`. Walking up (rather than asking git/jj) handles jj
       # workspaces uniformly, since those have no colocated `.git`.
+      #
+      # In an external repo with no kolohelios checkout above cwd, fall
+      # back to a real `shaka` elsewhere on PATH (a FlakeHub-installed
+      # binary) instead of erroring — otherwise this shim shadows it and
+      # `shaka` is unusable. The shim is itself named `shaka`, so the
+      # fallback skips its own store path to avoid exec'ing into itself.
       shakaShim =
         pkgs:
         pkgs.writeShellApplication {
@@ -46,8 +52,22 @@
               fi
               dir="$(dirname "$dir")"
             done
+            # No kolohelios checkout above cwd. Find the next `shaka` on
+            # PATH that isn't this shim and hand off to it. `self` is the
+            # absolute path of this script as invoked; resolve it so a
+            # symlinked PATH entry still matches the store realpath.
+            self="''${BASH_SOURCE[0]}"
+            self="$(readlink -f "$self" 2>/dev/null || echo "$self")"
+            IFS=':' read -ra path_dirs <<<"$PATH"
+            for d in "''${path_dirs[@]}"; do
+              cand="$d/shaka"
+              [[ -x "$cand" ]] || continue
+              real="$(readlink -f "$cand" 2>/dev/null || echo "$cand")"
+              [[ "$real" == "$self" ]] && continue
+              exec "$cand" "$@"
+            done
             echo "shaka: no tools/shaka/bin/shaka found above $PWD" >&2
-            echo "(this shim expects a kolohelios checkout)" >&2
+            echo "and no other shaka on PATH to fall back to" >&2
             exit 1
           '';
         };

--- a/nix/kolohelios-nix/justfile
+++ b/nix/kolohelios-nix/justfile
@@ -11,6 +11,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: nix-fmt-check flake-check whitespace-check

--- a/nix/kolohelios-nix/project.cue
+++ b/nix/kolohelios-nix/project.cue
@@ -32,6 +32,12 @@ package project
       # root — agents in a subdirectory or jj workspace hit `no such file
       # or directory`. Walking up (rather than asking git/jj) handles jj
       # workspaces uniformly, since those have no colocated `.git`.
+      #
+      # In an external repo with no kolohelios checkout above cwd, fall
+      # back to a real `shaka` elsewhere on PATH (a FlakeHub-installed
+      # binary) instead of erroring — otherwise this shim shadows it and
+      # `shaka` is unusable. The shim is itself named `shaka`, so the
+      # fallback skips its own store path to avoid exec'ing into itself.
       shakaShim =
         pkgs:
         pkgs.writeShellApplication {
@@ -45,8 +51,22 @@ package project
               fi
               dir="$(dirname "$dir")"
             done
+            # No kolohelios checkout above cwd. Find the next `shaka` on
+            # PATH that isn't this shim and hand off to it. `self` is the
+            # absolute path of this script as invoked; resolve it so a
+            # symlinked PATH entry still matches the store realpath.
+            self="''${BASH_SOURCE[0]}"
+            self="$(readlink -f "$self" 2>/dev/null || echo "$self")"
+            IFS=':' read -ra path_dirs <<<"$PATH"
+            for d in "''${path_dirs[@]}"; do
+              cand="$d/shaka"
+              [[ -x "$cand" ]] || continue
+              real="$(readlink -f "$cand" 2>/dev/null || echo "$cand")"
+              [[ "$real" == "$self" ]] && continue
+              exec "$cand" "$@"
+            done
             echo "shaka: no tools/shaka/bin/shaka found above $PWD" >&2
-            echo "(this shim expects a kolohelios checkout)" >&2
+            echo "and no other shaka on PATH to fall back to" >&2
             exit 1
           '';
         };

--- a/packages/notes-protocol/justfile
+++ b/packages/notes-protocol/justfile
@@ -41,7 +41,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -56,6 +56,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete wasm-check coverage nix-fmt-check flake-check whitespace-check

--- a/services/notes-sync/justfile
+++ b/services/notes-sync/justfile
@@ -38,7 +38,7 @@ coverage:
     #!/usr/bin/env bash
     # Line coverage only — see the rust-cli template for why.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on rust-worker); skipping"
         exit 0
@@ -57,7 +57,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 # `test` runs the native unit tests: coverage is optional on rust-worker
 # (cargo-llvm-cov can't see the wasm request paths), so unlike rust-cli

--- a/tools/aof/justfile
+++ b/tools/aof/justfile
@@ -43,7 +43,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -58,6 +58,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: cue-vet fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/tools/claude-hooks/justfile
+++ b/tools/claude-hooks/justfile
@@ -36,7 +36,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -51,6 +51,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/tools/resume/justfile
+++ b/tools/resume/justfile
@@ -76,6 +76,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: drift-check nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/justfile
+++ b/tools/shaka/justfile
@@ -36,7 +36,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -51,6 +51,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check

--- a/tools/shaka/src/project.rs
+++ b/tools/shaka/src/project.rs
@@ -1,4 +1,5 @@
 mod audit;
+mod coverage_thresholds;
 mod generate_flakes;
 mod generate_justfiles;
 mod new;
@@ -32,6 +33,10 @@ pub enum ProjectCommand {
         #[arg(long)]
         check: bool,
     },
+    /// Export the cwd project's `project.cue` as JSON (used by the
+    /// generated `coverage` recipe to read its gate without a
+    /// kolohelios source-tree path)
+    CoverageThresholds,
     /// Audit every discovered project for structural conformance
     Audit,
     /// Scaffold a new project (currently rust-only)
@@ -50,6 +55,7 @@ pub fn run(cmd: ProjectCommand) {
         ProjectCommand::SchemaCheck => schema_check::run(),
         ProjectCommand::GenerateJustfiles { check } => generate_justfiles::run(check),
         ProjectCommand::GenerateFlakes { check } => generate_flakes::run(check),
+        ProjectCommand::CoverageThresholds => coverage_thresholds::run(),
         ProjectCommand::Audit => audit::run(),
         ProjectCommand::New { name, slot } => new::run(name, slot),
     }

--- a/tools/shaka/src/project/coverage_thresholds.rs
+++ b/tools/shaka/src/project/coverage_thresholds.rs
@@ -1,0 +1,58 @@
+//! `shaka project coverage-thresholds` — emit the cwd project's
+//! `project.cue` as JSON so the generated `coverage` recipe can read its
+//! gate without referencing a kolohelios source-tree path.
+//!
+//! The generated justfile used to run
+//! `cue export ../../tools/shaka/schema/project-schema.cue project.cue`,
+//! which only resolves inside a kolohelios checkout. Routing through
+//! `shaka` lets the schema come from `$SHAKA_CUE_MODULE_DIR` (a packaged
+//! binary) or the in-tree copy (the dev wrapper) via the same resolution
+//! the rest of `shaka` uses, so the recipe works in any external repo
+//! that has `shaka` on PATH.
+//!
+//! Output is the full project JSON (identical to what `cue export`
+//! produced), so consumers keep reading `.coverage.line.fail` and
+//! `.coverage // "absent"` exactly as before.
+
+use std::path::Path;
+
+use crate::term::{BOLD, RED, RESET};
+
+use super::schema_check::cue_project;
+
+/// Export the `project.cue` in the current working directory to JSON and
+/// print it to stdout. Exits non-zero with a diagnostic on any failure
+/// so the calling recipe fails loudly rather than feeding empty input to
+/// `jq`.
+pub fn run() {
+    let project_file = Path::new("project.cue");
+    if !project_file.is_file() {
+        eprintln!(
+            "{RED}{BOLD}error:{RESET} no project.cue in {}",
+            std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| ".".into())
+        );
+        std::process::exit(1);
+    }
+
+    let output = match cue_project(&["export"], project_file) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} failed to run cue export: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("{RED}{BOLD}error:{RESET} cue export failed:\n{stderr}");
+        std::process::exit(1);
+    }
+
+    use std::io::Write;
+    let mut stdout = std::io::stdout();
+    if stdout.write_all(&output.stdout).is_err() {
+        std::process::exit(1);
+    }
+}

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -43,7 +43,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -58,7 +58,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check
 "#;
@@ -110,7 +110,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -125,7 +125,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete wasm-check coverage nix-fmt-check flake-check whitespace-check
 "#;
@@ -190,7 +190,7 @@ coverage:
     # Optional on wasm-app (cargo-llvm-cov can't see the browser DOM and
     # socket paths); skip when not declared.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on wasm-app); skipping"
         exit 0
@@ -209,7 +209,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete wasm-build coverage nix-fmt-check flake-check whitespace-check
 "#;
@@ -224,7 +224,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: nix-fmt-check flake-check whitespace-check
 "#;
@@ -285,7 +285,7 @@ coverage:
     #!/usr/bin/env bash
     # Line coverage only — see the rust-cli template for why.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     if [ "$(jq -r '.coverage // "absent"' <<<"$thresholds")" = "absent" ]; then
         echo "coverage: not declared (optional on rust-worker); skipping"
         exit 0
@@ -304,7 +304,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 # `test` runs the native unit tests: coverage is optional on rust-worker
 # (cargo-llvm-cov can't see the wasm request paths), so unlike rust-cli
@@ -331,7 +331,7 @@ nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: tofu-validate nix-fmt-check whitespace-check
 
@@ -368,7 +368,7 @@ nix-fmt-check:
     nix fmt -- --check $(find . -type f -name '*.nix' -not -path './.*')
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: tofu-validate nix-fmt-check whitespace-check
 
@@ -401,7 +401,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: nix-fmt-check flake-check whitespace-check
 "#;
@@ -487,7 +487,7 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: drift-check nix-fmt-check flake-check whitespace-check
 "#;
@@ -915,7 +915,7 @@ mod tests {
             DOCUMENT_TEMPLATE,
         ] {
             assert!(tpl.contains("whitespace-check:"));
-            assert!(tpl.contains("../../tools/shaka/bin/shaka whitespace check"));
+            assert!(tpl.contains("shaka whitespace check"));
             assert!(
                 tpl.contains("whitespace-check\n"),
                 "validate chain must include whitespace-check"
@@ -1044,7 +1044,7 @@ mod tests {
         // header may still mention `--branch` in an explanatory
         // comment, so we assert on the precise command line.
         assert!(RUST_TEMPLATE.contains("$(cargo llvm-cov --json --summary-only)"));
-        assert!(RUST_TEMPLATE.contains("cue export ../../tools/shaka/schema/project-schema.cue"));
+        assert!(RUST_TEMPLATE.contains("shaka project coverage-thresholds"));
         assert!(RUST_TEMPLATE.contains(".coverage.line.fail"));
     }
 

--- a/tools/shaka/tests/coverage_thresholds.rs
+++ b/tools/shaka/tests/coverage_thresholds.rs
@@ -1,0 +1,95 @@
+//! Integration test for `shaka project coverage-thresholds` (#832).
+//!
+//! The generated `coverage` recipe reads its gate from this subcommand
+//! instead of `cue export ../../tools/shaka/schema/project-schema.cue`,
+//! so the recipe works in an external repo with no kolohelios source
+//! tree. These tests prove the subcommand exports the cwd project's
+//! `project.cue` as JSON using the bundled CUE closure pointed at by
+//! `SHAKA_CUE_MODULE_DIR` — the same resolver `schema-check` uses for a
+//! nix-packaged binary run outside any CUE module.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+const MODULE_DIR_ENV: &str = "SHAKA_CUE_MODULE_DIR";
+
+fn copy_dir(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if from.is_dir() {
+            copy_dir(&from, &to);
+        } else {
+            fs::copy(&from, &to).unwrap();
+        }
+    }
+}
+
+/// Stage the bundled CUE module closure the packaged binary points at:
+/// a `cue.mod`, a stub domain registry, and the real schema files under
+/// the module-relative `tools/shaka/schema/` path.
+fn stage_module(dir: &Path) {
+    common::write_test_module(dir);
+    let real_schema = Path::new(env!("CARGO_MANIFEST_DIR")).join("schema");
+    copy_dir(&real_schema, &dir.join("tools/shaka/schema"));
+}
+
+fn coverage_thresholds(work: &Path, module: &Path) -> std::process::Output {
+    Command::new(SHAKA_BIN)
+        .args(["project", "coverage-thresholds"])
+        .current_dir(work)
+        .env(MODULE_DIR_ENV, module)
+        .output()
+        .expect("failed to spawn shaka")
+}
+
+#[test]
+fn emits_coverage_block_outside_a_cue_module() {
+    let module = tempfile::TempDir::new().unwrap();
+    stage_module(module.path());
+
+    // A consumer checkout that is NOT a CUE module and has no kolohelios
+    // source tree — exactly what a generated coverage recipe faces in an
+    // external repo. The project.cue carries a coverage gate.
+    let work = tempfile::TempDir::new().unwrap();
+    fs::write(
+        work.path().join("project.cue"),
+        "package project\n\
+         #Project & { name: \"foo\", kind: \"rust-cli\", \
+         cli: { binaryName: \"foo\" }, coverage: { line: { fail: 80 } } }\n",
+    )
+    .unwrap();
+
+    let out = coverage_thresholds(work.path(), module.path());
+    assert!(
+        out.status.success(),
+        "coverage-thresholds should succeed; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("output must be valid JSON");
+    // The recipe reads `.coverage.line.fail`; assert it survives the
+    // round-trip so the generated gate keeps working.
+    assert_eq!(json["coverage"]["line"]["fail"], 80);
+}
+
+#[test]
+fn fails_when_no_project_cue() {
+    let module = tempfile::TempDir::new().unwrap();
+    stage_module(module.path());
+
+    let work = tempfile::TempDir::new().unwrap();
+    let out = coverage_thresholds(work.path(), module.path());
+    assert!(
+        !out.status.success(),
+        "coverage-thresholds must fail loudly with no project.cue rather \
+         than feed empty input to jq",
+    );
+}

--- a/tools/todoist/justfile
+++ b/tools/todoist/justfile
@@ -36,7 +36,7 @@ coverage:
     # (`-Z coverage-options=branch`), incompatible with the pinned
     # stable toolchain.
     set -euo pipefail
-    thresholds=$(cue export ../../tools/shaka/schema/project-schema.cue project.cue)
+    thresholds=$(shaka project coverage-thresholds)
     fail_line=$(jq <<<"$thresholds" '.coverage.line.fail')
     measured=$(cargo llvm-cov --json --summary-only)
     line=$(jq <<<"$measured" '.data[0].totals.lines.percent')
@@ -51,6 +51,6 @@ flake-check:
     nix flake check
 
 whitespace-check:
-    ../../tools/shaka/bin/shaka whitespace check
+    shaka whitespace check
 
 validate: fmt-check lint doc-check deny machete coverage nix-fmt-check flake-check whitespace-check


### PR DESCRIPTION
Makes shaka's generated artifacts work outside a kolohelios checkout, so an external repo (buzzingo) can be shaka-managed:

- Generated justfiles no longer reference `../../tools/shaka/...`: `whitespace-check` calls `shaka` on PATH; `coverage` uses a new `shaka project coverage-thresholds` subcommand instead of `cue export ../../tools/shaka/schema/project-schema.cue`.
- The `workflowPackages` `shaka` shim (nix/kolohelios-nix) falls back to a real `shaka` found elsewhere on PATH instead of erroring when there's no `tools/shaka/bin/shaka`.
- Regenerates all per-project justfiles for the template change.

Verified: `generate-justfiles --check` + `generate-flakes --check` clean (no drift); shaka `just validate` green.

Closes #832