### PR TITLE
fix(notes): add missing .env.example for cf-deploy

### DIFF
--- a/apps/notes-web/.env.example
+++ b/apps/notes-web/.env.example
@@ -1,0 +1,18 @@
+# Copy to `.env` (gitignored) and run commands via:
+#   op run --env-file=.env -- wrangler deploy
+#
+# All secrets live in 1Password; `op run` resolves references at
+# runtime. CI uses the same `.env.example` via the SA token —
+# see `.github/workflows/cf-deploy.yml`.
+
+# Cloudflare API token. Needs Workers Scripts:Edit (account-scoped)
+# + Zone:DNS:Edit + Zone:Cache Settings:Edit (all zones the Worker
+# attaches to). Provisioned by `infra/cloudflare-tokens` —
+# `tokens/deploy.cue` is the source of truth for the permission set.
+CLOUDFLARE_API_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/Cloudflare Deploy Token/password"
+
+# CF account ID. Stable and not secret; copy from the dashboard URL
+# (`dash.cloudflare.com/<id>/...`). Passed literally rather than
+# looked up because the deploy-scoped token can't list accounts via
+# /accounts (same pattern as `infra/cloudflare-deploy/.env.example`).
+CLOUDFLARE_ACCOUNT_ID="cc625b188f1219ec7ff2e9d19d1a1a7e"

--- a/services/notes-sync/.env.example
+++ b/services/notes-sync/.env.example
@@ -1,0 +1,18 @@
+# Copy to `.env` (gitignored) and run commands via:
+#   op run --env-file=.env -- wrangler deploy
+#
+# All secrets live in 1Password; `op run` resolves references at
+# runtime. CI uses the same `.env.example` via the SA token —
+# see `.github/workflows/cf-deploy.yml`.
+
+# Cloudflare API token. Needs Workers Scripts:Edit (account-scoped)
+# + Zone:DNS:Edit + Zone:Cache Settings:Edit (all zones the Worker
+# attaches to). Provisioned by `infra/cloudflare-tokens` —
+# `tokens/deploy.cue` is the source of truth for the permission set.
+CLOUDFLARE_API_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/Cloudflare Deploy Token/password"
+
+# CF account ID. Stable and not secret; copy from the dashboard URL
+# (`dash.cloudflare.com/<id>/...`). Passed literally rather than
+# looked up because the deploy-scoped token can't list accounts via
+# /accounts (same pattern as `infra/cloudflare-deploy/.env.example`).
+CLOUDFLARE_ACCOUNT_ID="cc625b188f1219ec7ff2e9d19d1a1a7e"


### PR DESCRIPTION
PR #827 added the `notes-sync` and `notes-web` deploy workflows but omitted the `.env.example` each `cf-deploy.yml` run copies to `.env`. Without it the verify and deploy jobs fail at `cp .env.example .env`, breaking CI on every PR that touches either project (and on `main` push). The file holds the `op://` Cloudflare token ref and account ID, mirroring the other Cloudflare-deployed projects.