### PR TITLE
docs(infra/home): note Bash uses BSD coreutils on darwin

### DIFF
--- a/infra/home/dotfiles/claude/CLAUDE.md
+++ b/infra/home/dotfiles/claude/CLAUDE.md
@@ -24,3 +24,6 @@
   - Project runbooks, snippets, architecture notes, inventories: a `docs/` folder in the relevant project, or a GitHub issue
 - **Memory is only appropriate for** ephemeral within-session/within-project state that genuinely doesn't need to be surfaced to me — and even then, prefer surfacing.
 - When you catch yourself reaching for memory to "make something durable," that's the signal to instead propose an edit to one of the files above and let me approve it.
+
+## Shell commands
+- **The Bash tool runs on macOS with BSD coreutils, not GNU.** GNU-only flags fail — no `grep -P`/`grep -oP` (Perl regex), no `cat -A`, no GNU-only `sed`/`head`/`date` options. Reach for `rg`, `grep -E`, or `perl` for regex; verify with `man` when unsure. Devshells may ship GNU tools, but the Bash tool doesn't activate `direnv`, so commands run against the base BSD userland.


### PR DESCRIPTION
Agents assume GNU coreutils in raw Bash, but the Bash tool runs on
macOS/BSD, so GNU-only flags (grep -P, cat -A, GNU sed/head/date) fail
and cost a retry. Surfaced by /audit-workflow across 5 sessions in 7
days (and twice in the session that filed this).

Adds a "Shell commands" section to the global Claude directives
(deployed to ~/.claude/CLAUDE.md via home-manager). Run
`home-manager switch` after merge to pick it up.

Closes #825