### PR TITLE
feat(shaka): pin worker-build and auto-sync worker wasm-bindgen

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -117,15 +117,10 @@ jobs:
         # in a `$PATH` we control. See `wrangler.toml`'s top-of-file
         # comment + #423.
         #
-        # Split into two `nix develop --command` invocations rather
-        # than one `bash -c`: each call applies the flake's
-        # `shellHook` (which puts `~/.cargo/bin` on `$PATH`), so the
-        # `worker-build` binary that `cargo install` drops there is
-        # visible to the second call. `--locked` pins `worker-build`
-        # to its published `Cargo.lock`; subsequent runs no-op when
-        # the binary is already cached.
+        # `worker-build` comes from the devshell (nixpkgs-pinned) rather
+        # than a floating `cargo install`, so its wasm-bindgen minimum
+        # can't drift by runner cache (#864).
         run: |
-          nix develop . --command cargo install -q worker-build --locked
           nix develop . --command worker-build --release
       - name: wrangler deploy${{ inputs.verify_only && ' (dry-run)' || '' }}
         id: wrangler

--- a/apps/cascadiajs2026-notes/flake.nix
+++ b/apps/cascadiajs2026-notes/flake.nix
@@ -56,6 +56,7 @@
             packages = [
               (rustToolchain pkgs)
               pkgs.wrangler
+              pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
               pkgs.tailwindcss

--- a/apps/cascadiajs2026-notes/justfile
+++ b/apps/cascadiajs2026-notes/justfile
@@ -13,7 +13,6 @@ wasm-check:
     cargo check --target wasm32-unknown-unknown
 
 worker-build-check:
-    cargo install -q worker-build --locked
     worker-build --release
 
 test:

--- a/apps/kolohelios-portfolio/flake.nix
+++ b/apps/kolohelios-portfolio/flake.nix
@@ -56,6 +56,7 @@
             packages = [
               (rustToolchain pkgs)
               pkgs.wrangler
+              pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
               pkgs.tailwindcss

--- a/apps/kolohelios-portfolio/justfile
+++ b/apps/kolohelios-portfolio/justfile
@@ -13,7 +13,6 @@ wasm-check:
     cargo check --target wasm32-unknown-unknown
 
 worker-build-check:
-    cargo install -q worker-build --locked
     worker-build --release
 
 test:

--- a/apps/notes-web/flake.nix
+++ b/apps/notes-web/flake.nix
@@ -56,6 +56,7 @@
             packages = [
               (rustToolchain pkgs)
               pkgs.wrangler
+              pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
             ]

--- a/apps/notes-web/justfile
+++ b/apps/notes-web/justfile
@@ -5,7 +5,6 @@ wasm-check:
     cargo check --target wasm32-unknown-unknown
 
 worker-build-check:
-    cargo install -q worker-build --locked
     worker-build --release
 
 test:

--- a/apps/pollen-alert/flake.nix
+++ b/apps/pollen-alert/flake.nix
@@ -56,6 +56,7 @@
             packages = [
               (rustToolchain pkgs)
               pkgs.wrangler
+              pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
             ]

--- a/apps/pollen-alert/justfile
+++ b/apps/pollen-alert/justfile
@@ -5,7 +5,6 @@ wasm-check:
     cargo check --target wasm32-unknown-unknown
 
 worker-build-check:
-    cargo install -q worker-build --locked
     worker-build --release
 
 test:

--- a/services/notes-sync/flake.nix
+++ b/services/notes-sync/flake.nix
@@ -56,6 +56,7 @@
             packages = [
               (rustToolchain pkgs)
               pkgs.wrangler
+              pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
             ]

--- a/services/notes-sync/justfile
+++ b/services/notes-sync/justfile
@@ -5,7 +5,6 @@ wasm-check:
     cargo check --target wasm32-unknown-unknown
 
 worker-build-check:
-    cargo install -q worker-build --locked
     worker-build --release
 
 test:

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -616,10 +616,10 @@ fn render_devshell(cli: &CliMeta) -> String {
 /// devShell-only: workers build to wasm via `worker-build`, not
 /// `buildRustPackage`, so there's no `packages`/`apps` and no
 /// `rustPlatform`. The toolchain adds the `wasm32-unknown-unknown`
-/// target; the devShell carries a fixed base (`wrangler` plus
-/// `pkg-config` and `openssl` for `worker-build`'s native
-/// `cargo install`), the `~/.cargo/bin` PATH `shellHook`, and any
-/// `extra_dev_shell_packages`.
+/// target; the devShell carries a fixed base (`wrangler`, a
+/// nixpkgs-pinned `worker-build`, plus `pkg-config` and `openssl` for
+/// the wasm-bindgen / wasm-opt downloads `worker-build` runs), the
+/// `~/.cargo/bin` PATH `shellHook`, and any `extra_dev_shell_packages`.
 fn render_worker_flake(name: &str, worker: &WorkerMeta) -> String {
     let description = worker.description.as_deref().unwrap_or(name);
     let mut out = String::with_capacity(2048);
@@ -676,10 +676,13 @@ const WORKER_OUTPUT_HEADER: &str = r#"    {
 "#;
 
 /// Devshell block for worker flakes. Fixed base — the worker toolchain,
-/// `wrangler`, `pkg-config`, `openssl` — then any `extra_dev_shell_packages`,
-/// then `workflowPackages` and the Linux-only `cargo-llvm-cov`, closing
-/// with the `~/.cargo/bin` PATH `shellHook` (appended, not prepended, so
-/// a runner's rustup `cargo` doesn't shadow nix's toolchain).
+/// `wrangler`, `worker-build`, `pkg-config`, `openssl` — then any
+/// `extra_dev_shell_packages`, then `workflowPackages` and the Linux-only
+/// `cargo-llvm-cov`, closing with the `~/.cargo/bin` PATH `shellHook`
+/// (appended, not prepended, so a runner's rustup `cargo` doesn't shadow
+/// nix's toolchain). `worker-build` is pinned via nixpkgs rather than
+/// `cargo install`ed at runtime so its wasm-bindgen minimum can't drift by
+/// runner cache (#864).
 fn render_worker_devshell(extra_dev_shell_packages: &[String]) -> String {
     let mut out = String::new();
     out.push_str("      devShells = forEachSupportedSystem (\n");
@@ -689,6 +692,7 @@ fn render_worker_devshell(extra_dev_shell_packages: &[String]) -> String {
     out.push_str("            packages = [\n");
     out.push_str("              (rustToolchain pkgs)\n");
     out.push_str("              pkgs.wrangler\n");
+    out.push_str("              pkgs.worker-build\n");
     out.push_str("              pkgs.pkg-config\n");
     out.push_str("              pkgs.openssl\n");
     for pkg in extra_dev_shell_packages {
@@ -1151,6 +1155,7 @@ mod tests {
     fn worker_devshell_carries_fixed_base_and_shell_hook() {
         let out = render_worker_flake("pollen-alert", &WorkerMeta::default());
         assert!(out.contains("pkgs.wrangler"));
+        assert!(out.contains("pkgs.worker-build"));
         assert!(out.contains("pkgs.pkg-config"));
         assert!(out.contains("pkgs.openssl"));
         assert!(out.contains(r#"export PATH="$PATH:$HOME/.cargo/bin""#));

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -238,21 +238,19 @@ validate: nix-fmt-check flake-check whitespace-check
 // composes the wasm check so wasm-incompat deps surface here, not
 // later when wrangler tries to compile.
 //
-// `worker-build-check` mirrors the exact `cargo install worker-build
-// --locked && worker-build --release` chain `cf-deploy.yml` runs in
-// CI (#424). `wasm-check` alone catches syntactic wasm-target
-// incompatibility but not the toolchain-resolution failure mode
-// that bit #403 — wasm-pack's `which("rustc")` probe is only
+// `worker-build-check` mirrors the `worker-build --release` chain
+// `cf-deploy.yml` runs in CI (#424). `wasm-check` alone catches
+// syntactic wasm-target incompatibility but not the toolchain-resolution
+// failure mode that bit #403 — wasm-pack's `which("rustc")` probe is only
 // exercised by `worker-build`. Validate runs it locally so a CI-only
-// failure of this class can no longer hide behind a green local
-// run. The `cargo install --locked` is idempotent (no-op on a
-// re-run with the same lockfile-pinned version); first-run cost is
-// the worker-build install.
+// failure of this class can no longer hide behind a green local run.
+// `worker-build` comes from the devshell (nixpkgs-pinned) rather than a
+// floating `cargo install`, so its wasm-bindgen minimum can't drift by
+// runner cache (#864).
 const RUST_WORKER_TEMPLATE: &str = r#"wasm-check:
     cargo check --target wasm32-unknown-unknown
 
 worker-build-check:
-    cargo install -q worker-build --locked
     worker-build --release
 
 test:

--- a/tools/shaka/src/project/schema_check.rs
+++ b/tools/shaka/src/project/schema_check.rs
@@ -115,6 +115,23 @@ pub fn cue_project(args: &[&str], project_file: &Path) -> io::Result<Output> {
         .output()
 }
 
+/// Read a project's declared `kind` from its `project.cue`. Returns
+/// `None` if the directory has no `project.cue`, `cue export` fails, or
+/// the output has no `kind` field — callers treat any of those as "not
+/// the kind I'm looking for" rather than an error.
+pub fn project_kind(project_dir: &Path) -> Option<String> {
+    let project_file = project_dir.join("project.cue");
+    if !project_file.exists() {
+        return None;
+    }
+    let output = cue_project(&["export"], &project_file).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    value.get("kind")?.as_str().map(str::to_owned)
+}
+
 enum ProjectResult {
     Pass,
     MissingFile,

--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -52,6 +52,10 @@ fn run_monorepo(input: String, pr_branch: Option<String>, auto_merge: bool) {
             BumpResult::Updated => {
                 println!("  {GREEN}{BOLD}updated{RESET}   {display}");
                 updated_paths.push(project.clone());
+                if let Err(e) = sync_worker_wasm_bindgen(project) {
+                    println!("  {RED}{BOLD}FAIL{RESET}      {display} ({DIM}{e}{RESET})");
+                    failed += 1;
+                }
             }
             BumpResult::Unchanged => {
                 println!("  {DIM}unchanged{RESET} {display}");
@@ -221,6 +225,45 @@ fn bump_one(project: &Path, input: &str) -> BumpResult {
     } else {
         BumpResult::Updated
     }
+}
+
+/// The wasm-bindgen crates a `rust-worker` pins in lockstep — their
+/// versions move together, so bumping one without the rest leaves an
+/// unsatisfiable lock. Every worker depends on the `worker` crate, which
+/// pulls all four transitively.
+const WASM_BINDGEN_FAMILY: [&str; 4] =
+    ["wasm-bindgen", "js-sys", "web-sys", "wasm-bindgen-futures"];
+
+/// Keep a `rust-worker`'s `wasm-bindgen` family at the latest release so
+/// it stays at/above `worker-build`'s minimum (#864). `worker-build` is
+/// nixpkgs-pinned, so its minimum only moves when the toolchain lock
+/// does — pairing this `cargo update` with the `flake.lock` bump keeps the
+/// two in lockstep inside a single PR. No-op for non-worker projects; the
+/// caller's `git add -A` folds the resulting `Cargo.lock` change into the
+/// bump commit.
+fn sync_worker_wasm_bindgen(project: &Path) -> Result<(), String> {
+    if schema_check::project_kind(project).as_deref() != Some("rust-worker") {
+        return Ok(());
+    }
+
+    let mut args = vec!["update"];
+    for pkg in WASM_BINDGEN_FAMILY {
+        args.push("-p");
+        args.push(pkg);
+    }
+    let output = Command::new("cargo")
+        .args(&args)
+        .current_dir(project)
+        .output()
+        .map_err(|e| format!("failed to spawn cargo: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "cargo update wasm-bindgen failed: {}",
+            stderr.lines().last().unwrap_or("(no output)")
+        ));
+    }
+    Ok(())
 }
 
 fn publish_pr(


### PR DESCRIPTION
Stops the `worker-build` minimum-wasm-bindgen mismatch (#856/#861/#862) from recurring, in two parts:

1. **Pin worker-build via nixpkgs.** The generated `worker-build-check` recipe and `cf-deploy.yml` no longer `cargo install -q worker-build --locked` (which pinned worker-build's deps but not its version, so each runner got a different cached release and a drifting wasm-bindgen minimum). worker-build now comes from the rust-worker devshell, flake-pinned and cached — killing the runner-cache non-determinism.
2. **Keep the crate current automatically.** `shaka repo bump-locks` now `cargo update`s the wasm-bindgen family in each `rust-worker` whose `flake.lock` it bumped, so the crate stays at/above worker-build's minimum inside the same daily lockstep PR.

`notes-editor` is untouched (it's a `wasm-app`, not a worker-build project; its CLI comes from nix). The worker-build-check runs on Linux CI — the worker devshell can't build on darwin (#812).

Closes #864