### PR TITLE
feat(blogctl): refresh post metrics from LinkedIn exports by URN

### DIFF
--- a/apps/blogctl/src/analytics/compare.rs
+++ b/apps/blogctl/src/analytics/compare.rs
@@ -253,6 +253,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![TargetEntry {
+                    samples: Vec::new(),
                     name: Target::Linkedin,
                     status: TargetStatus::Published,
                     url: Some("https://example.invalid".into()),

--- a/apps/blogctl/src/analytics/derived.rs
+++ b/apps/blogctl/src/analytics/derived.rs
@@ -98,6 +98,7 @@ mod tests {
         reposts: u64,
     ) -> TargetEntry {
         TargetEntry {
+            samples: Vec::new(),
             name: Target::Linkedin,
             status: TargetStatus::Published,
             url: Some("https://example.invalid".into()),
@@ -135,6 +136,7 @@ mod tests {
     #[test]
     fn missing_metrics_yields_none_engagement_rate_and_zero_interactions() {
         let t = TargetEntry {
+            samples: Vec::new(),
             name: Target::Linkedin,
             status: TargetStatus::Planned,
             url: None,

--- a/apps/blogctl/src/analytics/recommendations.rs
+++ b/apps/blogctl/src/analytics/recommendations.rs
@@ -395,6 +395,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![TargetEntry {
+                    samples: Vec::new(),
                     name: Target::Linkedin,
                     status: TargetStatus::Published,
                     url: Some("https://example.invalid".into()),

--- a/apps/blogctl/src/analytics/summary.rs
+++ b/apps/blogctl/src/analytics/summary.rs
@@ -238,6 +238,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![TargetEntry {
+                    samples: Vec::new(),
                     name: target,
                     status: TargetStatus::Published,
                     url: Some("https://example.invalid".into()),
@@ -275,6 +276,7 @@ mod tests {
                 todoist_task_id: None,
                 history_checked: false,
                 targets: vec![TargetEntry {
+                    samples: Vec::new(),
                     name: Target::Linkedin,
                     status: TargetStatus::Published,
                     url: None,

--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -333,6 +333,11 @@ pub enum Command {
         #[command(subcommand)]
         action: MetricsAction,
     },
+    /// LinkedIn analytics-export workflows.
+    Linkedin {
+        #[command(subcommand)]
+        action: LinkedinAction,
+    },
     /// Walk every published post and fill in missing classifications
     /// + metrics interactively, or batch-import from a JSON file.
     Backfill {
@@ -439,6 +444,28 @@ pub enum MetricsAction {
         /// eligible in one sitting.
         #[arg(long, default_value_t = 10)]
         batch_size: usize,
+        /// Skip the post-write `jj` commit + push for this invocation.
+        #[arg(long)]
+        no_sync: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LinkedinAction {
+    /// Refresh post metrics from parsed exports, matching posts by
+    /// activity URN. Records a per-day data point per matched post;
+    /// reports unmatched URNs for later import (#860).
+    Import {
+        /// Workdir path. Defaults to the current working directory.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// Directory of `Content_*.xlsx` exports. Defaults to
+        /// `linkedin-exports/` under the workdir.
+        #[arg(long, value_name = "PATH")]
+        xlsx_dir: Option<PathBuf>,
+        /// Preview matches and counts without writing or syncing.
+        #[arg(long)]
+        dry_run: bool,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -759,6 +786,23 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
                     &mut output,
                 )
             }
+        },
+        Command::Linkedin { action } => match action {
+            LinkedinAction::Import {
+                workdir,
+                xlsx_dir,
+                dry_run,
+                no_sync,
+            } => commands::linkedin::run(
+                jj,
+                commands::linkedin::ImportArgs {
+                    workdir: workdir_or_pwd(workdir)?,
+                    xlsx_dir,
+                    dry_run,
+                    no_sync,
+                },
+            )
+            .map(|_| ()),
         },
         Command::Backfill {
             workdir,

--- a/apps/blogctl/src/commands.rs
+++ b/apps/blogctl/src/commands.rs
@@ -10,6 +10,7 @@ pub mod final_edit;
 pub mod fix;
 pub mod import;
 pub mod init;
+pub mod linkedin;
 pub mod list;
 pub mod metrics;
 pub mod new;

--- a/apps/blogctl/src/commands/add_target.rs
+++ b/apps/blogctl/src/commands/add_target.rs
@@ -47,6 +47,7 @@ pub fn run(jj: &dyn Jj, args: AddTargetArgs) -> Result<()> {
     }
 
     post.metadata.targets.push(TargetEntry {
+        samples: Vec::new(),
         name: args.target,
         status: TargetStatus::Planned,
         url: None,

--- a/apps/blogctl/src/commands/backfill.rs
+++ b/apps/blogctl/src/commands/backfill.rs
@@ -720,6 +720,7 @@ mod tests {
             url: Some("https://example.invalid".into()),
             published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
             metrics: None,
+            samples: Vec::new(),
         }];
         let outcome = merge_metrics(&mut targets, Target::Linkedin, &sample_metrics());
         assert_eq!(outcome, MergeMetricsOutcome::Applied);
@@ -741,6 +742,7 @@ mod tests {
             url: Some("https://example.invalid".into()),
             published_at: Some(datetime!(2026-05-08 14:32:00 UTC)),
             metrics: Some(sample_metrics()),
+            samples: Vec::new(),
         }];
         let outcome = merge_metrics(&mut targets, Target::Linkedin, &sample_metrics());
         assert_eq!(outcome, MergeMetricsOutcome::Unchanged);

--- a/apps/blogctl/src/commands/import.rs
+++ b/apps/blogctl/src/commands/import.rs
@@ -85,6 +85,7 @@ pub fn run(jj: &dyn Jj, args: ImportArgs) -> Result<()> {
             todoist_task_id: None,
             history_checked: false,
             targets: vec![TargetEntry {
+                samples: Vec::new(),
                 name: target_name,
                 status: TargetStatus::Published,
                 url: Some(args.url),

--- a/apps/blogctl/src/commands/linkedin.rs
+++ b/apps/blogctl/src/commands/linkedin.rs
@@ -1,0 +1,256 @@
+//! `blogctl linkedin import` — refresh post metrics from LinkedIn's
+//! daily `Content_*.xlsx` analytics exports.
+//!
+//! Parses every export in `--xlsx-dir`, matches each post by the
+//! activity id embedded in its `targets[].url`, and records a per-day
+//! `(impressions, engagements)` sample on the matching LinkedIn target.
+//! Idempotent on `(urn, snapshot_date)`: re-running overlapping exports
+//! adds no duplicate data points. URNs with no matching post are
+//! reported, not created — post creation is #860's job.
+//!
+//! This is the metrics half of the `linkedin import` surface (#707); the
+//! HTML-fetch / published-stub step lands in #860.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::PathBuf;
+
+use time::OffsetDateTime;
+
+use crate::error::{Error, Result};
+use crate::linkedin::{self, activity_id, PostSnapshot};
+use crate::storage::{PostHandle, Repository, Workdir};
+use crate::sync::{self, Jj, SyncOptions};
+use crate::target::{MetricSample, Target};
+
+/// Export directory relative to the workdir when `--xlsx-dir` is unset.
+const DEFAULT_XLSX_DIR: &str = "linkedin-exports";
+
+#[derive(Debug)]
+pub struct ImportArgs {
+    pub workdir: PathBuf,
+    /// Directory of `Content_*.xlsx` exports. Defaults to
+    /// `linkedin-exports/` under the workdir.
+    pub xlsx_dir: Option<PathBuf>,
+    pub dry_run: bool,
+    pub no_sync: bool,
+}
+
+/// What an import run did: how many daily samples were newly recorded,
+/// how many were already present (idempotent skips), and which export
+/// URNs matched no post in the workdir.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImportSummary {
+    pub added: usize,
+    pub skipped: usize,
+    pub unmatched: Vec<String>,
+}
+
+pub fn run(jj: &dyn Jj, args: ImportArgs) -> Result<ImportSummary> {
+    let xlsx_dir = args
+        .xlsx_dir
+        .unwrap_or_else(|| args.workdir.join(DEFAULT_XLSX_DIR));
+    let snapshots = linkedin::parse_dir(&xlsx_dir)?;
+
+    let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let handles = repo.list()?;
+    let (matched, unmatched) = match_snapshots(&handles, &snapshots);
+
+    let mut added = 0usize;
+    let mut skipped = 0usize;
+    let mut writes: Vec<(PathBuf, String)> = Vec::new();
+    for (slug, samples) in &matched {
+        let (handle, mut post) = repo.load_raw(slug)?;
+        let Some(idx) = post
+            .metadata
+            .targets
+            .iter()
+            .position(|t| t.name == Target::Linkedin)
+        else {
+            continue;
+        };
+        let mut changed = false;
+        for sample in samples {
+            if post.metadata.targets[idx].record_sample(sample.clone()) {
+                added += 1;
+                changed = true;
+            } else {
+                skipped += 1;
+            }
+        }
+        if changed && !args.dry_run {
+            post.metadata.updated_at = OffsetDateTime::now_utc();
+            let rendered = post.render()?;
+            writes.push((handle.path.clone(), rendered));
+        }
+    }
+
+    let summary = ImportSummary {
+        added,
+        skipped,
+        unmatched: unmatched.into_iter().collect(),
+    };
+    print_summary(&summary, args.dry_run);
+
+    if !args.dry_run && !writes.is_empty() {
+        let config = repo.read_config()?;
+        let opts = SyncOptions::from_config(&config.sync, args.no_sync);
+        let post_count = writes.len();
+        let message =
+            format!("chore: linkedin metrics — {added} sample(s) across {post_count} post(s)");
+        sync::commit_and_push(jj, &args.workdir, &opts, &message, || {
+            for (path, rendered) in &writes {
+                fs::write(path, rendered).map_err(|e| Error::io(path, e))?;
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(summary)
+}
+
+/// Match parsed snapshots to posts by activity id. Returns the daily
+/// samples to record per matched post slug, plus the export URNs that
+/// matched no post. Pure: no IO, so the matching logic is unit-tested
+/// without a workdir on disk.
+fn match_snapshots(
+    handles: &[PostHandle],
+    snapshots: &[PostSnapshot],
+) -> (BTreeMap<String, Vec<MetricSample>>, BTreeSet<String>) {
+    // Index every LinkedIn target URL by its activity id → post slug.
+    let mut id_to_slug: HashMap<String, String> = HashMap::new();
+    for handle in handles {
+        for target in &handle.metadata.targets {
+            if target.name != Target::Linkedin {
+                continue;
+            }
+            if let Some(id) = target.url.as_deref().and_then(activity_id) {
+                id_to_slug
+                    .entry(id.to_string())
+                    .or_insert_with(|| handle.metadata.slug.clone());
+            }
+        }
+    }
+
+    let mut matched: BTreeMap<String, Vec<MetricSample>> = BTreeMap::new();
+    let mut unmatched: BTreeSet<String> = BTreeSet::new();
+    for snap in snapshots {
+        match activity_id(&snap.urn).and_then(|id| id_to_slug.get(id)) {
+            Some(slug) => matched.entry(slug.clone()).or_default().push(MetricSample {
+                date: snap.snapshot_date,
+                impressions: snap.impressions,
+                engagements: snap.engagements,
+            }),
+            None => {
+                unmatched.insert(snap.urn.clone());
+            }
+        }
+    }
+    (matched, unmatched)
+}
+
+fn print_summary(summary: &ImportSummary, dry_run: bool) {
+    let tag = if dry_run { " [dry-run]" } else { "" };
+    println!(
+        "linkedin import: {} sample(s) added, {} already present, {} unmatched URN(s){tag}",
+        summary.added,
+        summary.skipped,
+        summary.unmatched.len(),
+    );
+    if !summary.unmatched.is_empty() {
+        println!("  unmatched URNs (no post in the workdir):");
+        for urn in &summary.unmatched {
+            println!("    {urn}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kind::Kind;
+    use crate::post::PostMetadata;
+    use crate::stage::Stage;
+    use crate::target::{TargetEntry, TargetStatus};
+    use time::macros::{date, datetime};
+
+    fn linkedin_post(slug: &str, url: &str) -> PostHandle {
+        PostHandle {
+            stage: Stage::Published,
+            path: format!("/x/{slug}.md").into(),
+            metadata: PostMetadata {
+                title: slug.into(),
+                slug: slug.into(),
+                kind: Kind::Post,
+                theme: "standard".into(),
+                status: Stage::Published,
+                created_at: datetime!(2026-05-01 00:00:00 UTC),
+                updated_at: datetime!(2026-05-01 00:00:00 UTC),
+                tags: vec![],
+                todoist_task_id: None,
+                history_checked: false,
+                targets: vec![TargetEntry {
+                    name: Target::Linkedin,
+                    status: TargetStatus::Published,
+                    url: Some(url.into()),
+                    published_at: None,
+                    metrics: None,
+                    samples: Vec::new(),
+                }],
+                classifications: Default::default(),
+                ai: None,
+            },
+        }
+    }
+
+    fn snap(id: &str, day: time::Date, imp: Option<u64>, eng: Option<u64>) -> PostSnapshot {
+        PostSnapshot {
+            urn: format!("urn:li:activity:{id}"),
+            url: format!("https://www.linkedin.com/feed/update/urn:li:activity:{id}"),
+            publish_date: date!(2026 - 01 - 01),
+            impressions: imp,
+            engagements: eng,
+            snapshot_date: day,
+        }
+    }
+
+    #[test]
+    fn matches_export_urn_to_share_url_by_activity_id() {
+        // The post stores the `/posts/...-<id>-<code>` share URL; the
+        // export carries `urn:li:activity:<id>`. Both must resolve to
+        // the same id.
+        let handles = vec![linkedin_post(
+            "beaver",
+            "https://www.linkedin.com/posts/x_the-beaver-share-7456442827909005312-8FKm/?utm=1",
+        )];
+        let snaps = vec![snap(
+            "7456442827909005312",
+            date!(2026 - 05 - 30),
+            Some(74),
+            Some(3),
+        )];
+        let (matched, unmatched) = match_snapshots(&handles, &snaps);
+        assert!(unmatched.is_empty());
+        assert_eq!(matched.get("beaver").map(Vec::len), Some(1));
+        assert_eq!(matched["beaver"][0].impressions, Some(74));
+        assert_eq!(matched["beaver"][0].engagements, Some(3));
+    }
+
+    #[test]
+    fn reports_unmatched_urns() {
+        let handles = vec![linkedin_post(
+            "known",
+            "https://www.linkedin.com/posts/x-7400000000000000001-Aa/",
+        )];
+        let snaps = vec![
+            snap("7400000000000000001", date!(2026 - 05 - 01), Some(1), None),
+            snap("7400000000000000999", date!(2026 - 05 - 01), Some(2), None),
+        ];
+        let (matched, unmatched) = match_snapshots(&handles, &snaps);
+        assert!(matched.contains_key("known"));
+        assert_eq!(
+            unmatched.into_iter().collect::<Vec<_>>(),
+            vec!["urn:li:activity:7400000000000000999".to_string()],
+        );
+    }
+}

--- a/apps/blogctl/src/lib.rs
+++ b/apps/blogctl/src/lib.rs
@@ -24,5 +24,5 @@ pub use linkedin::PostSnapshot;
 pub use post::{Post, PostMetadata};
 pub use stage::Stage;
 pub use storage::{Repository, Workdir};
-pub use target::{Target, TargetEntry, TargetStatus};
+pub use target::{MetricSample, Target, TargetEntry, TargetStatus};
 pub use taxonomy::{Dimension, Taxonomy};

--- a/apps/blogctl/src/linkedin.rs
+++ b/apps/blogctl/src/linkedin.rs
@@ -33,6 +33,10 @@ const DATE_HEADER: &str = "Post publish date";
 const ENGAGEMENTS_HEADER: &str = "Engagements";
 const IMPRESSIONS_HEADER: &str = "Impressions";
 const URN_PREFIX: &str = "urn:li:activity:";
+/// Minimum digit-run length to treat as a LinkedIn activity id. Real ids
+/// are 19 digits; the threshold rejects shorter numbers (utm ids,
+/// timestamps) that appear elsewhere in a URL.
+const MIN_ACTIVITY_ID_LEN: usize = 17;
 
 /// One post's metrics as captured by one daily export.
 ///
@@ -222,6 +226,37 @@ fn extract_urn(url: &str) -> Option<String> {
     (!digits.is_empty()).then(|| format!("{URN_PREFIX}{digits}"))
 }
 
+/// Extract the bare LinkedIn activity id (the digit run) from any post
+/// URL form: the `urn:li:activity:<id>` of analytics exports, or the
+/// `/posts/<slug>-<id>-<code>/?…` of a shared post URL. Returns the
+/// longest digit run when it is at least 17 digits (real ids are 19).
+///
+/// Used to match an export's [`PostSnapshot::urn`] to a post's
+/// `targets[].url`, which usually carries the id in the share-URL form
+/// rather than the `urn:` form.
+pub fn activity_id(url: &str) -> Option<&str> {
+    let bytes = url.as_bytes();
+    // Track the longest digit run; the activity id is the only long one.
+    let mut best: Option<(usize, usize)> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        if !bytes[i].is_ascii_digit() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        let len = i - start;
+        if best.is_none_or(|(_, best_len)| len > best_len) {
+            best = Some((start, len));
+        }
+    }
+    best.filter(|&(_, len)| len >= MIN_ACTIVITY_ID_LEN)
+        .map(|(start, len)| &url[start..start + len])
+}
+
 /// Parse LinkedIn's `M/D/YYYY` publish dates (month and day unpadded).
 fn parse_us_date(value: &str) -> std::result::Result<Date, time::error::Parse> {
     Date::parse(
@@ -271,6 +306,26 @@ fn is_export(path: &Path) -> bool {
 mod tests {
     use super::*;
     use time::macros::date;
+
+    #[test]
+    fn activity_id_from_export_urn() {
+        assert_eq!(
+            activity_id("urn:li:activity:7440067024082604032"),
+            Some("7440067024082604032")
+        );
+    }
+
+    #[test]
+    fn activity_id_from_shared_post_url() {
+        let url = "https://www.linkedin.com/posts/kolohelios_the-beaver-community-share-7456442827909005312-8FKm/?utm_source=share";
+        assert_eq!(activity_id(url), Some("7456442827909005312"));
+    }
+
+    #[test]
+    fn activity_id_rejects_urls_without_a_long_id() {
+        assert_eq!(activity_id("https://example.com/posts/123"), None);
+        assert_eq!(activity_id("https://www.linkedin.com/in/someone"), None);
+    }
 
     #[test]
     fn extract_urn_from_feed_url() {

--- a/apps/blogctl/src/post.rs
+++ b/apps/blogctl/src/post.rs
@@ -549,6 +549,7 @@ Body.
         let mut metadata = fixture_metadata();
         metadata.targets = vec![
             TargetEntry {
+                samples: Vec::new(),
                 name: Target::Linkedin,
                 status: TargetStatus::Published,
                 url: Some("https://www.linkedin.com/posts/example".into()),
@@ -556,6 +557,7 @@ Body.
                 metrics: None,
             },
             TargetEntry {
+                samples: Vec::new(),
                 name: Target::Blog,
                 status: TargetStatus::Planned,
                 url: None,
@@ -642,6 +644,7 @@ body
         use crate::target::{Target, TargetEntry, TargetMetrics, TargetStatus};
         let mut metadata = fixture_metadata();
         metadata.targets = vec![TargetEntry {
+            samples: Vec::new(),
             name: Target::Linkedin,
             status: TargetStatus::Published,
             url: Some("https://www.linkedin.com/posts/example".into()),

--- a/apps/blogctl/src/target.rs
+++ b/apps/blogctl/src/target.rs
@@ -7,9 +7,14 @@ use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
+use time::{Date, OffsetDateTime};
 
 use crate::error::{Error, Result};
+
+// Serialize `MetricSample::date` as a bare `YYYY-MM-DD` ISO date rather
+// than `time`'s default integer encoding, keeping the frontmatter
+// human-readable.
+time::serde::format_description!(iso_date, Date, "[year]-[month]-[day]");
 
 /// A venue a post can be distributed to. Closed enum — adding a new
 /// venue is a deliberate code change, not a frontmatter typo away.
@@ -118,6 +123,22 @@ pub struct TargetMetrics {
     pub sampled_at: OffsetDateTime,
 }
 
+/// One day's observed performance for a target, sourced from a daily
+/// analytics export (`blogctl linkedin import`). Coarser than
+/// [`TargetMetrics`] — engagements is a single aggregate, not split into
+/// reactions/comments/reposts — and keyed by `date` so a target accrues
+/// a time-series. Either metric may be absent when an export populated
+/// only one of its two ranked tables.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetricSample {
+    #[serde(with = "iso_date")]
+    pub date: Date,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub impressions: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engagements: Option<u64>,
+}
+
 /// One entry in a post's `targets:` list. `url` and `published_at` are
 /// required when `status == Published` and optional otherwise; the
 /// invariant is enforced at parse time, not by the type.
@@ -138,6 +159,32 @@ pub struct TargetEntry {
     /// and for posts on a venue without analytics surfaced yet).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metrics: Option<TargetMetrics>,
+    /// Per-day metric samples imported from LinkedIn analytics exports,
+    /// kept sorted by date and idempotent on date (see
+    /// [`TargetEntry::record_sample`]). Distinct from `metrics`, which
+    /// holds the latest single manual sample.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub samples: Vec<MetricSample>,
+}
+
+impl TargetEntry {
+    /// Record a daily metric sample, keeping `samples` sorted by date.
+    /// Idempotent on date: a sample whose date is already present is a
+    /// no-op (returns `false`); a new date is inserted in order
+    /// (returns `true`). Idempotency on `(urn, date)` is what lets
+    /// re-running overlapping exports add no duplicate data points.
+    pub fn record_sample(&mut self, sample: MetricSample) -> bool {
+        match self
+            .samples
+            .binary_search_by(|existing| existing.date.cmp(&sample.date))
+        {
+            Ok(_) => false,
+            Err(idx) => {
+                self.samples.insert(idx, sample);
+                true
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -268,5 +315,62 @@ mod tests {
         let raw = "name: blog\nstatus: planned\n";
         let parsed: TargetEntry = serde_yaml_ng::from_str(raw).unwrap();
         assert!(parsed.metrics.is_none());
+        // And no `samples:` key either — pre-#859 frontmatter.
+        assert!(parsed.samples.is_empty());
+    }
+
+    #[test]
+    fn metric_sample_serializes_date_as_iso_and_round_trips() {
+        let sample = MetricSample {
+            date: time::macros::date!(2026 - 05 - 22),
+            impressions: Some(1234),
+            engagements: Some(56),
+        };
+        let yaml = serde_yaml_ng::to_string(&sample).unwrap();
+        assert!(yaml.contains("date: 2026-05-22"), "got: {yaml}");
+        let reparsed: MetricSample = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(reparsed, sample);
+    }
+
+    #[test]
+    fn metric_sample_omits_absent_metric() {
+        let sample = MetricSample {
+            date: time::macros::date!(2026 - 05 - 22),
+            impressions: Some(10),
+            engagements: None,
+        };
+        let yaml = serde_yaml_ng::to_string(&sample).unwrap();
+        assert!(!yaml.contains("engagements"), "got: {yaml}");
+    }
+
+    #[test]
+    fn record_sample_is_idempotent_on_date_and_keeps_sorted() {
+        let mut entry = TargetEntry {
+            name: Target::Linkedin,
+            status: TargetStatus::Published,
+            url: Some("https://www.linkedin.com/posts/x-7400000000000000001-Ab/".into()),
+            published_at: None,
+            metrics: None,
+            samples: Vec::new(),
+        };
+        let sample = |day, imp| MetricSample {
+            date: day,
+            impressions: Some(imp),
+            engagements: None,
+        };
+        assert!(entry.record_sample(sample(time::macros::date!(2026 - 05 - 02), 2)));
+        assert!(entry.record_sample(sample(time::macros::date!(2026 - 05 - 01), 1)));
+        // Re-recording an existing date is a no-op that keeps the first value.
+        assert!(!entry.record_sample(sample(time::macros::date!(2026 - 05 - 01), 999)));
+
+        let dates: Vec<_> = entry.samples.iter().map(|s| s.date).collect();
+        assert_eq!(
+            dates,
+            vec![
+                time::macros::date!(2026 - 05 - 01),
+                time::macros::date!(2026 - 05 - 02),
+            ],
+        );
+        assert_eq!(entry.samples[0].impressions, Some(1));
     }
 }

--- a/apps/blogctl/tests/analytics_render.rs
+++ b/apps/blogctl/tests/analytics_render.rs
@@ -51,6 +51,7 @@ fn post(
             todoist_task_id: None,
             history_checked: false,
             targets: vec![TargetEntry {
+                samples: Vec::new(),
                 name: Target::Linkedin,
                 status: TargetStatus::Published,
                 url: Some("https://www.linkedin.com/posts/example".into()),

--- a/apps/blogctl/tests/linkedin_import.rs
+++ b/apps/blogctl/tests/linkedin_import.rs
@@ -1,0 +1,225 @@
+//! Integration tests for `blogctl linkedin import`.
+//!
+//! Seeds a workdir with published posts whose LinkedIn target URLs carry
+//! activity ids in the `/posts/…-<id>-<code>` share form, writes
+//! synthetic `Content_*.xlsx` exports (carrying the `urn:li:activity:<id>`
+//! form), and drives the import end-to-end against a `FakeJj` so the
+//! sync path runs without a real `jj` binary.
+
+use std::path::Path;
+
+use rust_xlsxwriter::Workbook;
+use tempfile::TempDir;
+use time::macros::{date, datetime};
+
+use blogctl::commands;
+use blogctl::kind::Kind;
+use blogctl::post::{Post, PostMetadata};
+use blogctl::stage::Stage;
+use blogctl::storage::{Repository, Workdir};
+use blogctl::sync::FakeJj;
+use blogctl::target::{MetricSample, Target, TargetEntry, TargetStatus};
+
+fn workdir() -> (TempDir, Repository) {
+    let tmp = TempDir::new().unwrap();
+    let repo = Repository::unchecked(Workdir::new(tmp.path()));
+    repo.init().unwrap();
+    (tmp, repo)
+}
+
+/// Seed a published post whose LinkedIn target stores the share-form URL
+/// (the activity id sits between the slug and a short code).
+fn seed_post(repo: &Repository, slug: &str, activity_id: &str) {
+    let url = format!("https://www.linkedin.com/posts/kolohelios_{slug}-share-{activity_id}-AbCd/");
+    let post = Post::new(
+        PostMetadata {
+            title: slug.into(),
+            slug: slug.into(),
+            kind: Kind::Post,
+            theme: "standard".into(),
+            status: Stage::Published,
+            created_at: datetime!(2026-05-01 00:00:00 UTC),
+            updated_at: datetime!(2026-05-01 00:00:00 UTC),
+            tags: vec![],
+            todoist_task_id: None,
+            history_checked: false,
+            targets: vec![TargetEntry {
+                name: Target::Linkedin,
+                status: TargetStatus::Published,
+                url: Some(url),
+                published_at: Some(datetime!(2026-05-01 00:00:00 UTC)),
+                metrics: None,
+                samples: Vec::new(),
+            }],
+            classifications: Default::default(),
+            ai: None,
+        },
+        "body\n",
+    );
+    repo.create_post(&post).unwrap();
+}
+
+/// Write one `Content_<date>_<date>_Synthetic.xlsx` export. Each row is
+/// `(activity_id, impressions, engagements)` and is written to both the
+/// engagements-ranked (A:C) and impressions-ranked (E:G) tables.
+fn write_export(dir: &Path, date: &str, rows: &[(&str, u64, u64)]) {
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("TOP POSTS").unwrap();
+    sheet.write_string(2, 0, "Post URL").unwrap();
+    sheet.write_string(2, 1, "Post publish date").unwrap();
+    sheet.write_string(2, 2, "Engagements").unwrap();
+    sheet.write_string(2, 4, "Post URL").unwrap();
+    sheet.write_string(2, 5, "Post publish date").unwrap();
+    sheet.write_string(2, 6, "Impressions").unwrap();
+    for (i, (id, impressions, engagements)) in rows.iter().enumerate() {
+        let r = 3 + i as u32;
+        let url = format!("https://www.linkedin.com/feed/update/urn:li:activity:{id}");
+        sheet.write_string(r, 0, url.as_str()).unwrap();
+        sheet.write_string(r, 1, "5/1/2026").unwrap();
+        sheet.write_number(r, 2, *engagements as f64).unwrap();
+        sheet.write_string(r, 4, url.as_str()).unwrap();
+        sheet.write_string(r, 5, "5/1/2026").unwrap();
+        sheet.write_number(r, 6, *impressions as f64).unwrap();
+    }
+    let path = dir.join(format!("Content_{date}_{date}_Synthetic.xlsx"));
+    workbook.save(&path).unwrap();
+}
+
+fn samples_of(repo: &Repository, slug: &str) -> Vec<MetricSample> {
+    let (_handle, post) = repo.load_raw(slug).unwrap();
+    post.metadata
+        .targets
+        .iter()
+        .find(|t| t.name == Target::Linkedin)
+        .expect("linkedin target")
+        .samples
+        .clone()
+}
+
+fn import_args(workdir: &Path, xlsx: &Path, dry_run: bool) -> commands::linkedin::ImportArgs {
+    commands::linkedin::ImportArgs {
+        workdir: workdir.to_path_buf(),
+        xlsx_dir: Some(xlsx.to_path_buf()),
+        dry_run,
+        no_sync: false,
+    }
+}
+
+#[test]
+fn records_per_day_samples_for_matched_posts() {
+    let (tmp, repo) = workdir();
+    seed_post(&repo, "alpha", "7400000000000000001");
+    seed_post(&repo, "beta", "7400000000000000002");
+    let exports = TempDir::new().unwrap();
+    write_export(
+        exports.path(),
+        "2026-05-22",
+        &[
+            ("7400000000000000001", 100, 10),
+            ("7400000000000000002", 200, 20),
+        ],
+    );
+    write_export(
+        exports.path(),
+        "2026-05-23",
+        &[("7400000000000000001", 150, 12)],
+    );
+
+    let summary = commands::linkedin::run(
+        &FakeJj::new(),
+        import_args(tmp.path(), exports.path(), false),
+    )
+    .unwrap();
+    assert_eq!(summary.added, 3);
+    assert_eq!(summary.skipped, 0);
+    assert!(summary.unmatched.is_empty());
+
+    let alpha = samples_of(&repo, "alpha");
+    assert_eq!(alpha.len(), 2);
+    assert_eq!(alpha[0].date, date!(2026 - 05 - 22));
+    assert_eq!(alpha[0].impressions, Some(100));
+    assert_eq!(alpha[0].engagements, Some(10));
+    assert_eq!(alpha[1].date, date!(2026 - 05 - 23));
+    assert_eq!(alpha[1].impressions, Some(150));
+
+    assert_eq!(samples_of(&repo, "beta").len(), 1);
+}
+
+#[test]
+fn re_running_overlapping_exports_is_idempotent() {
+    let (tmp, repo) = workdir();
+    seed_post(&repo, "alpha", "7400000000000000001");
+    let exports = TempDir::new().unwrap();
+    write_export(
+        exports.path(),
+        "2026-05-22",
+        &[("7400000000000000001", 100, 10)],
+    );
+
+    let first = commands::linkedin::run(
+        &FakeJj::new(),
+        import_args(tmp.path(), exports.path(), false),
+    )
+    .unwrap();
+    assert_eq!(first.added, 1);
+
+    let second = commands::linkedin::run(
+        &FakeJj::new(),
+        import_args(tmp.path(), exports.path(), false),
+    )
+    .unwrap();
+    assert_eq!(second.added, 0);
+    assert_eq!(second.skipped, 1);
+    // No duplicate data point for the same (urn, date).
+    assert_eq!(samples_of(&repo, "alpha").len(), 1);
+}
+
+#[test]
+fn unmatched_urns_are_reported_not_created() {
+    let (tmp, repo) = workdir();
+    seed_post(&repo, "alpha", "7400000000000000001");
+    let exports = TempDir::new().unwrap();
+    write_export(
+        exports.path(),
+        "2026-05-22",
+        &[
+            ("7400000000000000001", 100, 10),
+            ("7400000000000000999", 50, 5),
+        ],
+    );
+
+    let summary = commands::linkedin::run(
+        &FakeJj::new(),
+        import_args(tmp.path(), exports.path(), false),
+    )
+    .unwrap();
+    assert_eq!(
+        summary.unmatched,
+        vec!["urn:li:activity:7400000000000000999".to_string()],
+    );
+    // The unmatched URN did not create a post.
+    assert_eq!(repo.list().unwrap().len(), 1);
+}
+
+#[test]
+fn dry_run_previews_without_writing() {
+    let (tmp, repo) = workdir();
+    seed_post(&repo, "alpha", "7400000000000000001");
+    let exports = TempDir::new().unwrap();
+    write_export(
+        exports.path(),
+        "2026-05-22",
+        &[("7400000000000000001", 100, 10)],
+    );
+
+    let summary = commands::linkedin::run(
+        &FakeJj::new(),
+        import_args(tmp.path(), exports.path(), true),
+    )
+    .unwrap();
+    // The preview reports what would be added...
+    assert_eq!(summary.added, 1);
+    // ...but nothing is persisted.
+    assert!(samples_of(&repo, "alpha").is_empty());
+}


### PR DESCRIPTION
#858 landed the export parser; this consumes it. `blogctl linkedin
import` parses Content_*.xlsx, matches each post by the activity id in
its targets[].url (resolving both the `urn:li:activity:` export form and
the `/posts/...-<id>-` share form posts actually store), and records a
per-day (impressions, engagements) sample on the matching LinkedIn
target. Idempotent on (urn, snapshot_date): re-running overlapping
exports adds no duplicate points. Unmatched URNs are reported for the
#860 import path, not created; --dry-run previews the counts.

Metrics history lives in a new targets[].samples time-series alongside
the existing single-snapshot metrics field, which is why every
TargetEntry construction site gained the field.

Closes #859