### PR TITLE
feat(shaka): thread ci.deploy.environment into generated deploy job

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -66,6 +66,11 @@ on:
         required: false
         type: string
         default: ""
+      environment:
+        description: "If non-empty, append `--env <environment>` to wrangler deploy so a named wrangler.toml environment (e.g. production) is used. Lets a prod-only custom_domain route live under `[env.production]` while route-free verifies/previews stay on *.workers.dev. Unset = top-level config, today's behavior."
+        required: false
+        type: string
+        default: ""
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         description: "1Password Service Account token used by `op run` to resolve `.env` references"
@@ -137,6 +142,14 @@ jobs:
         #
         # `--name <override>` (script_name_override mode) deploys to
         # an alternate Worker name without touching `wrangler.toml`.
+        #
+        # `--env <environment>` (environment mode) selects a named
+        # `[env.<name>]` section of `wrangler.toml`. Use it so a
+        # prod-only `custom_domain` route lives under `[env.production]`
+        # while the route-free top-level config serves verifies and PR
+        # previews — keeping the production domain off throwaway preview
+        # Workers. Unset selects the top-level config (today's behavior).
+        #
         # `tee` mirrors stdout to a file so the URL parser in the
         # next step can grep it without re-running wrangler.
         run: |
@@ -145,6 +158,7 @@ jobs:
             wrangler deploy \
             ${{ inputs.verify_only && '--dry-run' || '' }} \
             ${{ inputs.script_name_override && format('--name {0}', inputs.script_name_override) || '' }} \
+            ${{ inputs.environment && format('--env {0}', inputs.environment) || '' }} \
             2>&1 | tee /tmp/wrangler-output.log
           # `tee` masks the inner exit code; restore it explicitly.
           exit "${PIPESTATUS[0]}"

--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -217,6 +217,15 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	// as the `script_name_override` for the preview job and as the
 	// `--name` flag for the sibling cleanup workflow.
 	previewScriptPrefix: string & =~"^[a-z][a-z0-9-]*$"
+
+	// Optional wrangler environment for the production `deploy` job.
+	// When set, the generated `deploy` job passes `environment` to
+	// `cf-deploy.yml`, which appends `--env <environment>` so wrangler
+	// selects a named `[env.<name>]` section of `wrangler.toml`. The
+	// `verify`/`preview` jobs never set it: a prod-only `custom_domain`
+	// route lives under `[env.production]` while route-free previews
+	// stay on `*.workers.dev`. Omit to deploy with the top-level config.
+	environment?: string & =~"^[a-z][a-z0-9_-]*$"
 }
 
 // Where a project serves content. Decoupled from `#Deploy` (which is

--- a/tools/shaka/src/ci/worker_cleanup_workflow.rs
+++ b/tools/shaka/src/ci/worker_cleanup_workflow.rs
@@ -155,6 +155,7 @@ mod tests {
             deploy: CiDeploy {
                 reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
                 preview_script_prefix: "example-notes".to_string(),
+                environment: None,
             },
         }
     }

--- a/tools/shaka/src/ci/worker_deploy_workflow.rs
+++ b/tools/shaka/src/ci/worker_deploy_workflow.rs
@@ -45,6 +45,12 @@ pub struct WorkerDeploySpec {
 pub struct CiDeploy {
     pub reusable_workflow: String,
     pub preview_script_prefix: String,
+    /// Optional wrangler environment for the production `deploy` job
+    /// (`--env <environment>` in `cf-deploy.yml`). `verify`/`preview`
+    /// never set it, so a prod-only `custom_domain` route under
+    /// `[env.production]` stays off route-free previews.
+    #[serde(default)]
+    pub environment: Option<String>,
 }
 
 pub fn build(spec: &WorkerDeploySpec) -> Workflow {
@@ -231,6 +237,16 @@ fn deploy_call(spec: &WorkerDeploySpec) -> ReusableCall {
         Value::String(spec.project_dir.to_string_lossy().to_string()),
     );
     with.insert("verify_only".to_string(), Value::Bool(false));
+    // Only the production deploy selects a wrangler environment;
+    // `verify`/`preview` stay on the route-free top-level config so a
+    // prod-only `custom_domain` route under `[env.<environment>]` never
+    // lands on a `*.workers.dev` preview.
+    if let Some(environment) = &spec.deploy.environment {
+        with.insert(
+            "environment".to_string(),
+            Value::String(environment.clone()),
+        );
+    }
     // `workflow_dispatch` bypasses the changes filter so a manual
     // re-deploy isn't blocked by an unchanged push base. Real
     // `push: main` deploys still gate on the filter.
@@ -344,6 +360,7 @@ mod tests {
             deploy: CiDeploy {
                 reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
                 preview_script_prefix: "portfolio".to_string(),
+                environment: None,
             },
         }
     }
@@ -469,6 +486,7 @@ mod tests {
                 reusable_workflow: "kolohelios/kolohelios/.github/workflows/cf-deploy.yml@main"
                     .to_string(),
                 preview_script_prefix: "buzzingo".to_string(),
+                environment: None,
             },
         }
     }
@@ -508,5 +526,49 @@ mod tests {
         // ...but the cross-repo reusable workflow isn't a local file, so
         // there's nothing to watch.
         assert!(!filters.contains("cf-deploy.yml"), "{filters}");
+    }
+
+    // ── wrangler environment (prod-only custom_domain routes) ───────────
+
+    /// A consumer whose production `custom_domain` route lives under
+    /// `[env.production]` selects that environment on the real deploy.
+    fn env_spec() -> WorkerDeploySpec {
+        WorkerDeploySpec {
+            project_dir: PathBuf::from("apps/buzzingo"),
+            project_name: "buzzingo".to_string(),
+            deploy: CiDeploy {
+                reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
+                preview_script_prefix: "buzzingo".to_string(),
+                environment: Some("production".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn deploy_job_sets_environment_when_configured() {
+        let yaml = super::super::workflow::emit(&build(&env_spec()));
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid YAML");
+        assert_eq!(
+            parsed["jobs"]["deploy"]["with"]["environment"].as_str(),
+            Some("production")
+        );
+    }
+
+    #[test]
+    fn verify_and_preview_never_set_environment() {
+        let yaml = super::super::workflow::emit(&build(&env_spec()));
+        let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).expect("valid YAML");
+        // The route-free top-level config serves PR previews/verifies; a
+        // prod-only route under `[env.production]` must never reach them.
+        assert!(parsed["jobs"]["verify"]["with"]["environment"].is_null());
+        assert!(parsed["jobs"]["preview"]["with"]["environment"].is_null());
+    }
+
+    #[test]
+    fn environment_omitted_when_unset() {
+        // The portfolio fixture has `environment: None`; the deploy job's
+        // `with` map carries no `environment` key (today's behavior).
+        let parsed = emit_fixture();
+        assert!(parsed["jobs"]["deploy"]["with"]["environment"].is_null());
     }
 }

--- a/tools/shaka/tests/fixtures/schema/invalid/ci-deploy-bad-environment.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/ci-deploy-bad-environment.cue
@@ -1,0 +1,16 @@
+package project
+
+// `environment` must be a wrangler-style lowercase identifier; an
+// uppercase value is rejected.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	ci: {
+		deploy: {
+			reusableWorkflow:    "./.github/workflows/cf-deploy.yml"
+			previewScriptPrefix: "buzzingo"
+			environment:         "Production"
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-ci-deploy-environment.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-ci-deploy-environment.cue
@@ -1,0 +1,17 @@
+package project
+
+// A consumer whose production custom_domain is a wrangler route isolates
+// it under `[env.production]` and selects that environment on the real
+// deploy, keeping route-free previews on *.workers.dev.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	ci: {
+		deploy: {
+			reusableWorkflow:    "kolohelios/kolohelios/.github/workflows/cf-deploy.yml@main"
+			previewScriptPrefix: "buzzingo"
+			environment:         "production"
+		}
+	}
+}


### PR DESCRIPTION
A consumer whose production custom domain is declared as a wrangler
route (routes = [{ pattern, custom_domain = true }]) can't safely take
PR previews: a preview deploy would inherit that route and move the
production domain onto the throwaway Worker.

Add an optional `environment` input; when non-empty, append
`--env <environment>` to `wrangler deploy`. The consumer isolates the
production-only route under [env.production] (route-free top-level
config) and passes environment: production on the real deploy, while
verify/preview stay on the default config and *.workers.dev. Unset
preserves today's top-level-config behavior.

Refs #869

Add an optional `environment` field to #CiDeploy. When set, the
generated `deploy` job passes `environment` to cf-deploy.yml (which
appends `--env <environment>`); `verify` and `preview` never set it, so
a prod-only custom_domain route under [env.production] stays off the
route-free *.workers.dev previews.

This lets an external consumer (buzzingo) generate its deploy/cleanup
workflows from project.cue instead of hand-authoring them, even when its
production domain is a wrangler route rather than a Terraform attachment.

Closes #869