### PR TITLE
perf(ci): trim devshell closure — drop awscli2 and rust-docs

### DIFF
--- a/apps/blogctl/flake.nix
+++ b/apps/blogctl/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/apps/cascadiajs2026-notes/flake.nix
+++ b/apps/cascadiajs2026-notes/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/apps/kolohelios-portfolio/flake.nix
+++ b/apps/kolohelios-portfolio/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/apps/notes-editor/flake.nix
+++ b/apps/notes-editor/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/apps/notes-web/flake.nix
+++ b/apps/notes-web/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/apps/pollen-alert/flake.nix
+++ b/apps/pollen-alert/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/packages/notes-protocol/flake.nix
+++ b/packages/notes-protocol/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/services/notes-sync/flake.nix
+++ b/services/notes-sync/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/tools/aof/flake.nix
+++ b/tools/aof/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/tools/claude-hooks/flake.nix
+++ b/tools/claude-hooks/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/tools/shaka/flake.nix
+++ b/tools/shaka/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"
@@ -128,7 +130,6 @@
               (rustToolchain pkgs)
               pkgs.actionlint
               pkgs.shellcheck
-              pkgs.awscli2
               pkgs.opentofu
               pkgs.taplo
               pkgs.whois

--- a/tools/shaka/project.cue
+++ b/tools/shaka/project.cue
@@ -39,8 +39,6 @@ package project
 			// for linting embedded `run:` scripts.
 			"actionlint",
 			"shellcheck",
-			// awscli2 powers `shaka object-store ns audit`.
-			"awscli2",
 			// opentofu is needed by `shaka terraform emit` and the
 			// integration tests under `tests/terraform_emit.rs`.
 			"opentofu",

--- a/tools/shaka/src/object_store/ns.rs
+++ b/tools/shaka/src/object_store/ns.rs
@@ -97,7 +97,8 @@ enum AuditBucketResult {
 fn audit_bucket(entries: &[registry::Entry], bucket: &str, cluster: &str) -> AuditBucketResult {
     if !s3::aws_available() {
         return AuditBucketResult::Skipped(
-            "aws CLI not on PATH (enter shaka's devshell to run the bucket-side audit)".into(),
+            "aws CLI not on PATH (run `nix shell nixpkgs#awscli2` for the bucket-side audit)"
+                .into(),
         );
     }
     if !s3::creds_present() {

--- a/tools/shaka/src/object_store/status.rs
+++ b/tools/shaka/src/object_store/status.rs
@@ -76,7 +76,7 @@ fn registry_section(bucket: &str, cluster: &str) {
     println!("{BOLD}drift{RESET}");
     if !s3::aws_available() {
         println!(
-            "  {YELLOW}skipped{RESET}  {DIM}aws CLI not on PATH (enter shaka's devshell){RESET}"
+            "  {YELLOW}skipped{RESET}  {DIM}aws CLI not on PATH (run `nix shell nixpkgs#awscli2`){RESET}"
         );
         return;
     }

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -340,8 +340,10 @@ const RUST_LIB_OUTPUT_HEADER: &str = r#"    {
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"
@@ -457,8 +459,10 @@ const OUTPUT_HEADER: &str = r#"    {
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"
@@ -665,8 +669,10 @@ const WORKER_OUTPUT_HEADER: &str = r#"    {
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"

--- a/tools/todoist/flake.nix
+++ b/tools/todoist/flake.nix
@@ -39,8 +39,10 @@
 
       rustToolchain =
         pkgs:
-        pkgs.rust-bin.stable."1.95.0".default.override {
+        pkgs.rust-bin.stable."1.95.0".minimal.override {
           extensions = [
+            "clippy"
+            "rustfmt"
             "rust-src"
             "rust-analyzer"
             "llvm-tools-preview"


### PR DESCRIPTION
CI's preflight enters `nix develop ./tools/shaka` and fetches the whole
devshell closure from cache.flakehub.com on every run; the Nix store is
not persisted to the runner, so weight that preflight never touches is
re-downloaded each time.

Drop awscli2 (~157M) from shaka's devshell — the object-store audit
already no-ops when aws is absent; its hint now points at
`nix shell nixpkgs#awscli2`. Switch the rust toolchain generator from
the `.default` profile to `.minimal` plus explicit clippy/rustfmt,
dropping the unused offline rust-docs across all 12 rust flakes.
rust-analyzer stays for local ergonomics.

Closes #871