### PR TITLE
feat(shaka): stub absent domain registry so domain-free repos validate

### DIFF
--- a/tools/shaka/src/project/schema_check.rs
+++ b/tools/shaka/src/project/schema_check.rs
@@ -95,23 +95,100 @@ fn cue_module_root(project_file: &Path) -> io::Result<PathBuf> {
     ))
 }
 
+/// The CUE module a `cue` invocation runs in, plus an optional temp dir
+/// whose lifetime must span that invocation.
+///
+/// When the project's enclosing module supplies the real domain registry
+/// (`cwd` points straight at it), `_stub` is `None`. When it doesn't, we
+/// assemble a permissive stub module and `cwd` points there; `_stub`
+/// holds the `TempDir` so it isn't cleaned up until the `cue` process has
+/// exited. Drop order in `cue_project` keeps it alive across `.output()`.
+struct CueModule {
+    cwd: PathBuf,
+    _stub: Option<tempfile::TempDir>,
+}
+
+/// Resolve the cwd `cue` should run in so the project schema's
+/// `import "kolohelios.com/infra/cloudflare-dns/domains:domain"` resolves.
+///
+/// Prefer the project's enclosing module when it ships the registry — the
+/// live monorepo (real hostname constraint) or the bundled closure. When
+/// the enclosing module has no registry (a domain-free external repo with
+/// no `serving`/`deploy` and no `cloudflare-dns` project), assemble a
+/// permissive stub so it still validates instead of failing on a
+/// `cannot find package` import error (#863). A repo that *does* declare
+/// hostnames keeps its own registry and so still gets the real constraint.
+fn cue_module(project_file: &Path) -> io::Result<CueModule> {
+    let root = cue_module_root(project_file)?;
+    if has_domain_registry(&root) {
+        return Ok(CueModule {
+            cwd: root,
+            _stub: None,
+        });
+    }
+    let stub = write_stub_module()?;
+    Ok(CueModule {
+        cwd: stub.path().to_path_buf(),
+        _stub: Some(stub),
+    })
+}
+
+/// Whether `module_root` ships the domain registry package — a
+/// `infra/cloudflare-dns/domains/` directory holding at least one `.cue`
+/// file. An empty directory counts as absent (cue can't import an empty
+/// package), so it routes to the stub like a missing one.
+fn has_domain_registry(module_root: &Path) -> bool {
+    let domains = module_root.join("infra/cloudflare-dns/domains");
+    let Ok(entries) = std::fs::read_dir(&domains) else {
+        return false;
+    };
+    entries.flatten().any(|e| {
+        e.path()
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("cue"))
+    })
+}
+
+/// Assemble a throwaway CUE module that satisfies the schema's domain
+/// import with a permissive stub registry (`#KnownHostnames: _`, so any
+/// hostname passes — structural validation still runs). Mirrors the
+/// closure bundled into the packaged `shaka` at `tools/shaka/cue-bundle/`;
+/// assembled at runtime here so the dev wrapper (no `$SHAKA_CUE_MODULE_DIR`)
+/// validates a registry-less external repo too.
+fn write_stub_module() -> io::Result<tempfile::TempDir> {
+    let dir = tempfile::TempDir::new()?;
+    std::fs::create_dir_all(dir.path().join("cue.mod"))?;
+    std::fs::write(
+        dir.path().join("cue.mod/module.cue"),
+        "module: \"kolohelios.com\"\nlanguage: version: \"v0.15.1\"\n",
+    )?;
+    let registry = dir.path().join("infra/cloudflare-dns/domains");
+    std::fs::create_dir_all(&registry)?;
+    std::fs::write(
+        registry.join("registry.cue"),
+        "package domain\n\n#KnownHostnames: _\n",
+    )?;
+    Ok(dir)
+}
+
 /// Run `cue <args> <project-schema> <project-file>` with cwd anchored at
-/// the CUE module root so the schema's import closure resolves no matter
-/// where the project file lives — including a nix-packaged `shaka` run in
-/// a repo with no `cue.mod` of its own. The project file is passed by
-/// absolute path because cue's cwd is the module root, not the caller's.
+/// a CUE module that resolves the schema's import closure no matter where
+/// the project file lives — the enclosing module when it ships the
+/// registry, otherwise a permissive stub (see `cue_module`). The project
+/// file is passed by absolute path because cue's cwd is the module root,
+/// not the caller's.
 ///
 /// `args` carries the verb and its flags, e.g. `["vet", "-c"]` or
 /// `["export", "--out", "json"]`.
 pub fn cue_project(args: &[&str], project_file: &Path) -> io::Result<Output> {
     let schema = project_schema_path()?;
-    let module_root = cue_module_root(project_file)?;
+    let module = cue_module(project_file)?;
     let project_abs = std::fs::canonicalize(project_file)?;
     Command::new("cue")
         .args(args)
         .arg(&schema)
         .arg(&project_abs)
-        .current_dir(&module_root)
+        .current_dir(&module.cwd)
         .output()
 }
 
@@ -488,5 +565,50 @@ mod tests {
         let strays = find_stray_project_cues(tmp.path());
 
         assert!(strays.is_empty(), "got strays: {strays:?}");
+    }
+
+    // ── domain-registry detection & stub assembly (#863) ────────────────
+
+    #[test]
+    fn has_domain_registry_true_when_package_present() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "infra/cloudflare-dns/domains/registry.cue");
+        assert!(has_domain_registry(tmp.path()));
+    }
+
+    #[test]
+    fn has_domain_registry_false_when_dir_absent() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!has_domain_registry(tmp.path()));
+    }
+
+    #[test]
+    fn has_domain_registry_false_when_dir_empty() {
+        // An empty package dir can't be imported, so it routes to the
+        // stub like a missing one.
+        let tmp = TempDir::new().unwrap();
+        mkdir(tmp.path(), "infra/cloudflare-dns/domains");
+        assert!(!has_domain_registry(tmp.path()));
+    }
+
+    #[test]
+    fn has_domain_registry_ignores_non_cue_files() {
+        let tmp = TempDir::new().unwrap();
+        touch(tmp.path(), "infra/cloudflare-dns/domains/README.md");
+        assert!(!has_domain_registry(tmp.path()));
+    }
+
+    #[test]
+    fn stub_module_provides_an_importable_domain_package() {
+        // The assembled stub is a self-contained CUE module: a `cue.mod`
+        // plus the `domain` package the schema imports.
+        let stub = write_stub_module().unwrap();
+        assert!(stub.path().join("cue.mod/module.cue").is_file());
+        let registry = stub
+            .path()
+            .join("infra/cloudflare-dns/domains/registry.cue");
+        let body = fs::read_to_string(registry).unwrap();
+        assert!(body.contains("package domain"), "{body}");
+        assert!(body.contains("#KnownHostnames"), "{body}");
     }
 }

--- a/tools/shaka/tests/external_repo.rs
+++ b/tools/shaka/tests/external_repo.rs
@@ -1,0 +1,97 @@
+//! Integration test for a domain-free external repo (#863).
+//!
+//! An external consumer (buzzingo) that ships no custom domains has no
+//! `infra/cloudflare-dns/domains` registry — yet the project schema
+//! hard-imports that package. We stage a temp repo with its own
+//! `cue.mod` (module `kolohelios.com`) and a single domain-free
+//! `rust-worker` project, but *no* registry, then drive the binary
+//! against it: `schema_check` must assemble a permissive stub instead of
+//! failing on a `cannot find package` import, and `ci generate-workflows`
+//! must round-trip with no drift. Both route through
+//! `schema_check::cue_project`, the shared chokepoint every `project.cue`
+//! consumer (`schema-check`, `generate-justfiles`, `generate-workflows`,
+//! `audit`) funnels through, so a green pass here covers them all.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+
+fn fixtures_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/external-repo")
+}
+
+/// Stage a domain-free external repo: a `cue.mod` declaring module
+/// `kolohelios.com` (so the schema's absolute import has a module to
+/// resolve against), a root LICENSE, and one `rust-worker` project — but
+/// deliberately *no* `infra/cloudflare-dns` registry. This is the shape
+/// the registry stub has to make validate.
+fn staged_repo() -> tempfile::TempDir {
+    let root = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(root.path().join("cue.mod")).unwrap();
+    std::fs::write(
+        root.path().join("cue.mod/module.cue"),
+        "module: \"kolohelios.com\"\nlanguage: version: \"v0.15.1\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.path().join("LICENSE"), "MIT OR Apache-2.0\n").unwrap();
+
+    let dst = root.path().join("apps/buzzingo");
+    std::fs::create_dir_all(&dst).unwrap();
+    std::fs::copy(
+        fixtures_root().join("buzzingo/project.cue.fixture"),
+        dst.join("project.cue"),
+    )
+    .unwrap();
+
+    root
+}
+
+fn run(root: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(SHAKA_BIN)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("spawn shaka")
+}
+
+#[test]
+fn schema_check_passes_without_a_domain_registry() {
+    let repo = staged_repo();
+    let out = run(repo.path(), &["project", "schema-check"]);
+    assert!(
+        out.status.success(),
+        "schema-check failed for a domain-free repo: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // The buzzingo project validated against the stub registry.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("apps/buzzingo"), "{stdout}");
+}
+
+#[test]
+fn generate_workflows_round_trips_without_a_domain_registry() {
+    let repo = staged_repo();
+    // First emit the deploy/cleanup workflows from the ci.deploy block...
+    let gen = run(repo.path(), &["ci", "generate-workflows"]);
+    assert!(
+        gen.status.success(),
+        "generate-workflows failed for a domain-free repo: {}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    // ...the cross-repo deploy workflow is emitted (proves #868 + #863
+    // compose: a domain-free external repo generates its deploy wrapper).
+    let deploy = repo.path().join(".github/workflows/buzzingo-deploy.yml");
+    let body = std::fs::read_to_string(&deploy).expect("buzzingo-deploy.yml written");
+    assert!(
+        body.contains("kolohelios/kolohelios/.github/workflows/cf-deploy.yml@main"),
+        "{body}"
+    );
+    // ...and `--check` agrees byte-for-byte right after generating.
+    let check = run(repo.path(), &["ci", "generate-workflows", "--check"]);
+    assert!(
+        check.status.success(),
+        "--check drifted right after generate: {}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+}

--- a/tools/shaka/tests/fixtures/external-repo/buzzingo/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/external-repo/buzzingo/project.cue.fixture
@@ -1,0 +1,20 @@
+package project
+
+// A domain-free external-repo project: a workers.dev-only rust-worker
+// with no `serving`/`deploy` block and no custom domains, so the repo
+// ships no `infra/cloudflare-dns/domains` registry. It reuses this
+// repo's `cf-deploy.yml` cross-repo (#868) with a wrangler environment
+// for its prod-only route (#869). Validating it must not require a
+// vendored domain registry (#863).
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	ci: {
+		deploy: {
+			reusableWorkflow:    "kolohelios/kolohelios/.github/workflows/cf-deploy.yml@main"
+			previewScriptPrefix: "buzzingo"
+			environment:         "production"
+		}
+	}
+}


### PR DESCRIPTION
The embedded project schema hard-imports
kolohelios.com/infra/cloudflare-dns/domains, and cue_module_root walks
up to an external repo's own cue.mod before reaching the bundled stub.
So a domain-free repo (no serving/deploy, no custom domains) with no
registry package failed every shaka command on a `cannot find package`
import error, forcing it to vendor a fake cloudflare-dns project.

Resolve the cue cwd through the registry: use the enclosing module when
it ships infra/cloudflare-dns/domains (the live monorepo or the bundled
closure keep the real hostname constraint), otherwise assemble a
permissive temp stub module (#KnownHostnames: _) so the import resolves.
Every project.cue consumer funnels through schema_check::cue_project, so
this covers schema-check, generate-justfiles, generate-workflows, and
audit at once. Repos that declare hostnames still supply their own
registry and get the real constraint; kolohelios is unchanged.

Unblocks graduating buzzingo to fully shaka-managed CI.

Closes #863