### PR TITLE
feat(shaka): add consumesShaka knob to rust-worker flake template

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -356,6 +356,18 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 		// `tailwindcss` + `cue` for its build path; `pollen-alert`
 		// needs none.
 		extraDevShellPackages?: [...string & =~"^[a-zA-Z_][a-zA-Z0-9_-]*$"]
+
+		// Pull a FlakeHub-built `shaka` into the devShell and
+		// PATH-prepend it ahead of the `workflowPackages` shim. Only
+		// external consumers (repos with no kolohelios checkout) need
+		// this: the shim resolves `shaka` by walking up to
+		// `tools/shaka/bin/shaka`, which doesn't exist outside the
+		// monorepo, so it dies at runtime (`shaka ci mask-and-run`,
+		// any local `shaka <cmd>`). When true, `generate-flakes` adds
+		// the `shaka` FlakeHub input and a shellHook that puts the real
+		// binary on PATH first. Leave default-false for in-repo workers,
+		// where the shim finds the monorepo binary.
+		consumesShaka: *false | bool
 	}
 } | {
 	// Rust library crate shared across consumers — compiled natively

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -144,6 +144,14 @@ struct WorkerMeta {
     description: Option<String>,
     #[serde(default)]
     extra_dev_shell_packages: Vec<String>,
+    /// External consumers (no kolohelios checkout) need a real `shaka`
+    /// on PATH ahead of the `workflowPackages` shim, which can't resolve
+    /// `tools/shaka/bin/shaka` outside the monorepo. When set, the flake
+    /// gains the `shaka` FlakeHub input and a PATH-prepend in the
+    /// `shellHook`. Default-false: in-repo workers let the shim find the
+    /// monorepo binary.
+    #[serde(default)]
+    consumes_shaka: bool,
 }
 
 #[derive(Default, Deserialize)]
@@ -624,19 +632,57 @@ fn render_devshell(cli: &CliMeta) -> String {
 /// nixpkgs-pinned `worker-build`, plus `pkg-config` and `openssl` for
 /// the wasm-bindgen / wasm-opt downloads `worker-build` runs), the
 /// `~/.cargo/bin` PATH `shellHook`, and any `extra_dev_shell_packages`.
+///
+/// When `consumes_shaka` is set the flake also pulls a FlakeHub-built
+/// `shaka` into the devShell and PATH-prepends it ahead of the
+/// `workflowPackages` shim — see `render_worker_inputs` /
+/// `render_worker_devshell` for why external consumers need it.
 fn render_worker_flake(name: &str, worker: &WorkerMeta) -> String {
     let description = worker.description.as_deref().unwrap_or(name);
     let mut out = String::with_capacity(2048);
     out.push_str(HEADER);
     out.push_str(&format!("{{\n  description = \"{description}\";\n\n"));
-    out.push_str(INPUTS);
+    out.push_str(&render_worker_inputs(worker.consumes_shaka));
     out.push_str("\n  outputs =\n");
-    out.push_str(WORKER_OUTPUT_HEADER);
+    out.push_str(&render_worker_output_header(worker.consumes_shaka));
     out.push_str("    in\n    {\n");
-    out.push_str(&render_worker_devshell(&worker.extra_dev_shell_packages));
+    out.push_str(&render_worker_devshell(
+        &worker.extra_dev_shell_packages,
+        worker.consumes_shaka,
+    ));
     out.push_str("\n      formatter = kolohelios-nix.formatter;\n    };\n");
     out.push_str("}\n");
     out
+}
+
+/// Inputs for a worker flake. Default is the shared rust `INPUTS`
+/// (kolohelios-nix + nixpkgs + rust-overlay). With `consumes_shaka`,
+/// splice a `shaka` FlakeHub input in before the closing brace, pinned
+/// to follow this flake's `kolohelios-nix` so its nixpkgs/rust-overlay
+/// closure dedups against ours in `flake.lock`.
+fn render_worker_inputs(consumes_shaka: bool) -> String {
+    if !consumes_shaka {
+        return INPUTS.to_string();
+    }
+    let base = INPUTS
+        .strip_suffix("  };\n")
+        .expect("INPUTS ends with a closing brace line");
+    format!(
+        "{base}    shaka = {{\n      url = \"https://flakehub.com/f/kolohelios/shaka/*.tar.gz\";\n      inputs.kolohelios-nix.follows = \"kolohelios-nix\";\n    }};\n  }};\n"
+    )
+}
+
+/// `outputs` header for a worker flake. With `consumes_shaka`, add
+/// `shaka` to the destructured inputs so the devShell `shellHook` can
+/// reference `shaka.packages.${system}.default`.
+fn render_worker_output_header(consumes_shaka: bool) -> String {
+    if !consumes_shaka {
+        return WORKER_OUTPUT_HEADER.to_string();
+    }
+    WORKER_OUTPUT_HEADER.replace(
+        "      rust-overlay,\n",
+        "      rust-overlay,\n      shaka,\n",
+    )
 }
 
 /// Like `OUTPUT_HEADER` but tailored for workers: the toolchain gains
@@ -689,10 +735,21 @@ const WORKER_OUTPUT_HEADER: &str = r#"    {
 /// nix's toolchain). `worker-build` is pinned via nixpkgs rather than
 /// `cargo install`ed at runtime so its wasm-bindgen minimum can't drift by
 /// runner cache (#864).
-fn render_worker_devshell(extra_dev_shell_packages: &[String]) -> String {
+///
+/// With `consumes_shaka`, the devShell function destructures `system`
+/// (needed to index `shaka.packages.${system}`) and the `shellHook`
+/// PATH-prepends the FlakeHub `shaka` binary ahead of the
+/// `workflowPackages` shim, which can't resolve a `shaka` outside the
+/// monorepo. The prepend lands before the `~/.cargo/bin` append so the
+/// real binary wins.
+fn render_worker_devshell(extra_dev_shell_packages: &[String], consumes_shaka: bool) -> String {
     let mut out = String::new();
     out.push_str("      devShells = forEachSupportedSystem (\n");
-    out.push_str("        { pkgs, ... }:\n");
+    if consumes_shaka {
+        out.push_str("        { pkgs, system, ... }:\n");
+    } else {
+        out.push_str("        { pkgs, ... }:\n");
+    }
     out.push_str("        {\n");
     out.push_str("          default = pkgs.mkShell {\n");
     out.push_str("            packages = [\n");
@@ -710,6 +767,11 @@ fn render_worker_devshell(extra_dev_shell_packages: &[String]) -> String {
         "            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;\n",
     );
     out.push_str("\n            shellHook = ''\n");
+    if consumes_shaka {
+        out.push_str(
+            "              export PATH=\"${shaka.packages.${system}.default}/bin:$PATH\"\n",
+        );
+    }
     out.push_str("              export PATH=\"$PATH:$HOME/.cargo/bin\"\n");
     out.push_str("            '';\n");
     out.push_str("          };\n        }\n      );\n");
@@ -1182,6 +1244,59 @@ mod tests {
     fn worker_flake_carries_formatter() {
         let out = render_worker_flake("pollen-alert", &WorkerMeta::default());
         assert!(out.contains("formatter = kolohelios-nix.formatter;"));
+    }
+
+    #[test]
+    fn worker_without_consumes_shaka_omits_shaka_input_and_path() {
+        // Default-false: in-repo workers rely on the workflowPackages
+        // shim to resolve the monorepo binary, so nothing shaka-specific
+        // is emitted.
+        let out = render_worker_flake("pollen-alert", &WorkerMeta::default());
+        assert!(!out.contains("flakehub.com/f/kolohelios/shaka"));
+        assert!(!out.contains("shaka.packages"));
+        assert!(!out.contains("system, ... }:"));
+    }
+
+    #[test]
+    fn worker_consumes_shaka_adds_flakehub_input() {
+        let worker = WorkerMeta {
+            consumes_shaka: true,
+            ..WorkerMeta::default()
+        };
+        let out = render_worker_flake("buzzingo", &worker);
+        assert!(out.contains(r#"url = "https://flakehub.com/f/kolohelios/shaka/*.tar.gz";"#));
+        // Follows our kolohelios-nix so the closure dedups in flake.lock.
+        assert!(out.contains(r#"inputs.kolohelios-nix.follows = "kolohelios-nix";"#));
+        // The standard base inputs survive the splice.
+        assert!(out.contains(r#"nixpkgs.follows = "kolohelios-nix/nixpkgs";"#));
+    }
+
+    #[test]
+    fn worker_consumes_shaka_adds_input_to_outputs_destructure() {
+        let worker = WorkerMeta {
+            consumes_shaka: true,
+            ..WorkerMeta::default()
+        };
+        let out = render_worker_flake("buzzingo", &worker);
+        // `shaka` must be destructured for the shellHook to reference it,
+        // and `system` for the per-system package index.
+        assert!(out.contains("      shaka,\n"));
+        assert!(out.contains("{ pkgs, system, ... }:"));
+    }
+
+    #[test]
+    fn worker_consumes_shaka_prepends_shaka_ahead_of_cargo_bin() {
+        let worker = WorkerMeta {
+            consumes_shaka: true,
+            ..WorkerMeta::default()
+        };
+        let out = render_worker_flake("buzzingo", &worker);
+        let shaka_path = out.find(r#"export PATH="${shaka.packages.${system}.default}/bin:$PATH""#);
+        let cargo_path = out.find(r#"export PATH="$PATH:$HOME/.cargo/bin""#);
+        let shaka_pos = shaka_path.expect("shaka PATH prepend present");
+        let cargo_pos = cargo_path.expect("cargo bin PATH append present");
+        // The real shaka must win over the shim, so it lands first.
+        assert!(shaka_pos < cargo_pos);
     }
 
     #[test]

--- a/tools/shaka/tests/external_repo.rs
+++ b/tools/shaka/tests/external_repo.rs
@@ -70,6 +70,38 @@ fn schema_check_passes_without_a_domain_registry() {
 }
 
 #[test]
+fn generate_flakes_emits_shaka_consumer_knobs_for_external_repo() {
+    // The buzzingo fixture sets `consumesShaka`, so the generated flake
+    // must pull the FlakeHub `shaka` and PATH-prepend it ahead of the
+    // `workflowPackages` shim — without that, `shaka <cmd>` dies in a
+    // repo with no `tools/shaka/bin/shaka` to walk up to (#831).
+    let repo = staged_repo();
+    let gen = run(repo.path(), &["project", "generate-flakes"]);
+    assert!(
+        gen.status.success(),
+        "generate-flakes failed for a domain-free repo: {}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    let flake = repo.path().join("apps/buzzingo/flake.nix");
+    let body = std::fs::read_to_string(&flake).expect("apps/buzzingo/flake.nix written");
+    assert!(
+        body.contains("https://flakehub.com/f/kolohelios/shaka/*.tar.gz"),
+        "{body}"
+    );
+    assert!(
+        body.contains(r#"export PATH="${shaka.packages.${system}.default}/bin:$PATH""#),
+        "{body}"
+    );
+    // ...and `--check` agrees byte-for-byte right after generating.
+    let check = run(repo.path(), &["project", "generate-flakes", "--check"]);
+    assert!(
+        check.status.success(),
+        "--check drifted right after generate: {}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+}
+
+#[test]
 fn generate_workflows_round_trips_without_a_domain_registry() {
     let repo = staged_repo();
     // First emit the deploy/cleanup workflows from the ci.deploy block...

--- a/tools/shaka/tests/fixtures/external-repo/buzzingo/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/external-repo/buzzingo/project.cue.fixture
@@ -5,11 +5,15 @@ package project
 // ships no `infra/cloudflare-dns/domains` registry. It reuses this
 // repo's `cf-deploy.yml` cross-repo (#868) with a wrangler environment
 // for its prod-only route (#869). Validating it must not require a
-// vendored domain registry (#863).
+// vendored domain registry (#863). As an external consumer it sets
+// `consumesShaka` so the generated flake PATH-prepends a FlakeHub
+// `shaka` ahead of the `workflowPackages` shim (#831).
 #Project & {
 	name: "buzzingo"
 	kind: "rust-worker"
-	worker: {}
+	worker: {
+		consumesShaka: true
+	}
 	ci: {
 		deploy: {
 			reusableWorkflow:    "kolohelios/kolohelios/.github/workflows/cf-deploy.yml@main"

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-consumes-shaka.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-consumes-shaka.cue
@@ -1,0 +1,13 @@
+package project
+
+// Worker carrying the `consumesShaka` knob: an external consumer (no
+// kolohelios checkout) that needs a FlakeHub-built `shaka` PATH-prepended
+// ahead of the `workflowPackages` shim, which can't resolve a `shaka`
+// outside the monorepo. The buzzingo shape.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {
+		consumesShaka: true
+	}
+}


### PR DESCRIPTION
External consumers (repos with no kolohelios checkout) only get the
workflowPackages shaka shim, which resolves shaka by walking up to
tools/shaka/bin/shaka. That path doesn't exist outside the monorepo and
there's no other shaka on PATH to fall back to, so the shim dies at
runtime — breaking cf-deploy's mask-and-run and any local shaka command.

Add a consumesShaka knob to the worker: block. When set, generate-flakes
emits a FlakeHub shaka input (following our kolohelios-nix so its closure
dedups in flake.lock) and a shellHook that PATH-prepends the real binary
ahead of the shim. In-repo workers leave it default-false, where the shim
finds the monorepo binary — their generated flakes are unchanged.

Closes #831