### PR TITLE
feat(infra/home): put real shaka on PATH globally

### DIFF
--- a/infra/home/flake.lock
+++ b/infra/home/flake.lock
@@ -105,7 +105,8 @@
         "nixpkgs": [
           "kolohelios-nix",
           "nixpkgs"
-        ]
+        ],
+        "shaka": "shaka"
       }
     },
     "rust-overlay": {
@@ -127,6 +128,50 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "shaka",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777432579,
+        "narHash": "sha256-Ce11TStDsqCge2vAAfLKe2+4lDI5cSX5ZYZOuKJBKKQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3ecb5e6ab380ced3272ef7fcfe398bffbcc0f152",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "shaka": {
+      "inputs": {
+        "kolohelios-nix": [
+          "kolohelios-nix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1781375380,
+        "narHash": "sha256-ULmyOum/yVqsFFw6YiFDiODbtyQ/fHGldPzW8Bk3eJE=",
+        "rev": "506ef072b14701869d0e554f5cbc13588ba5d0af",
+        "revCount": 592,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/kolohelios/shaka/0.1.592%2Brev-506ef072b14701869d0e554f5cbc13588ba5d0af/019ec243-2208-7c82-8571-cc969a015737/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/kolohelios/shaka/%2A.tar.gz"
       }
     }
   },

--- a/infra/home/flake.nix
+++ b/infra/home/flake.nix
@@ -19,6 +19,11 @@
       url = "github:LnL7/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    shaka = {
+      url = "https://flakehub.com/f/kolohelios/shaka/*.tar.gz";
+      inputs.kolohelios-nix.follows = "kolohelios-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -29,6 +34,7 @@
       claude-hooks,
       home-manager,
       nix-darwin,
+      shaka,
       ...
     }:
     let
@@ -46,7 +52,7 @@
 
       darwinConfigurations.Jons-MacBook-Pro = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        specialArgs = { inherit claude-hooks kolohelios-nix; };
+        specialArgs = { inherit claude-hooks kolohelios-nix shaka; };
         modules = [
           home-manager.darwinModules.home-manager
           ./modules/darwin.nix
@@ -63,7 +69,7 @@
           home-manager.nixosModules.home-manager
           ./modules/linux.nix
         ];
-        _module.args = { inherit claude-hooks kolohelios-nix; };
+        _module.args = { inherit claude-hooks kolohelios-nix shaka; };
       };
 
       formatter = kolohelios-nix.formatter;

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -5,9 +5,35 @@
 {
   pkgs,
   claude-hooks,
-  kolohelios-nix,
+  shaka,
   ...
 }:
+
+let
+  # Global `shaka`. Prefers an in-checkout `tools/shaka/bin/shaka` when cwd
+  # is inside a kolohelios checkout (so hacking on shaka itself runs the
+  # local build), and otherwise execs the real FlakeHub `shaka`. This
+  # supersedes the bare `kolohelios-nix.lib.shakaShim`: the shim's only
+  # fallback was a PATH-scan for some *other* shaka, and nothing ever
+  # installed one globally — so outside a kolohelios checkout (e.g. the
+  # buzzingo repo) it exited non-zero and `/start` / `/ship` died with
+  # "no tools/shaka/bin/shaka found ... no other shaka on PATH". Pinning
+  # the FlakeHub package as the fallback makes `shaka` resolve everywhere.
+  shakaGlobal = pkgs.writeShellApplication {
+    name = "shaka";
+    text = ''
+      dir="$PWD"
+      while [[ "$dir" != "/" ]]; do
+        wrapper="$dir/tools/shaka/bin/shaka"
+        if [[ -x "$wrapper" ]]; then
+          exec "$wrapper" "$@"
+        fi
+        dir="$(dirname "$dir")"
+      done
+      exec ${shaka.packages.${pkgs.stdenv.hostPlatform.system}.default}/bin/shaka "$@"
+    '';
+  };
+in
 
 {
   home.stateVersion = "25.05";
@@ -35,14 +61,12 @@
     # globally lets the hook fire in any working directory, not just
     # inside the kolohelios checkout.
     claude-hooks.packages.${pkgs.stdenv.hostPlatform.system}.default
-    # `shaka` PATH shim from the shared lib. Same rationale as
-    # `claude-hooks` above: on PATH globally it resolves `shaka` in any
-    # bare shell (login shell, non-direnv terminal, agent harness)
-    # whenever `cwd` is inside the kolohelios checkout — not only inside
-    # a project devshell. The shim walks up from `cwd` to the canonical
-    # `tools/shaka/bin/shaka` wrapper; outside a checkout it's a no-op
-    # that exits non-zero, so installing it globally is safe (#755).
-    (kolohelios-nix.lib.shakaShim pkgs)
+    # `shaka` on PATH globally. Same rationale as `claude-hooks` above:
+    # available in any bare shell (login shell, non-direnv terminal, agent
+    # harness), not only inside a project devshell (#755). Inside a
+    # kolohelios checkout it runs the in-tree build; everywhere else it
+    # execs the FlakeHub package (see `shakaGlobal` above).
+    shakaGlobal
   ];
 
   programs.git = {

--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -1,6 +1,7 @@
 {
   claude-hooks,
   kolohelios-nix,
+  shaka,
   ...
 }:
 
@@ -32,7 +33,7 @@
 
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
-  home-manager.extraSpecialArgs = { inherit claude-hooks kolohelios-nix; };
+  home-manager.extraSpecialArgs = { inherit claude-hooks kolohelios-nix shaka; };
   home-manager.users.jedwards = import ./common.nix;
 
   # First-switch activation will encounter pre-existing dotfiles

--- a/infra/home/modules/linux.nix
+++ b/infra/home/modules/linux.nix
@@ -1,12 +1,13 @@
 {
   claude-hooks,
   kolohelios-nix,
+  shaka,
   ...
 }:
 
 {
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
-  home-manager.extraSpecialArgs = { inherit claude-hooks kolohelios-nix; };
+  home-manager.extraSpecialArgs = { inherit claude-hooks kolohelios-nix shaka; };
   home-manager.users.jon = import ./common.nix;
 }

--- a/infra/home/project.cue
+++ b/infra/home/project.cue
@@ -25,11 +25,22 @@ package project
 					"nixpkgs":        "nixpkgs"
 				}
 			}
+			// The real `shaka` CLI, consumed from FlakeHub so it can be
+			// put on PATH globally (modules/common.nix). Without it, the
+			// shim-only install resolved `shaka` only inside a kolohelios
+			// checkout; `/start` / `/ship` failed in external repos.
+			"shaka": {
+				url: "https://flakehub.com/f/kolohelios/shaka/*.tar.gz"
+				follows: {
+					"kolohelios-nix": "kolohelios-nix"
+					"nixpkgs":        "nixpkgs"
+				}
+			}
 		}
 		extra: """
       darwinConfigurations.Jons-MacBook-Pro = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        specialArgs = { inherit claude-hooks kolohelios-nix; };
+        specialArgs = { inherit claude-hooks kolohelios-nix shaka; };
         modules = [
           home-manager.darwinModules.home-manager
           ./modules/darwin.nix
@@ -46,7 +57,7 @@ package project
           home-manager.nixosModules.home-manager
           ./modules/linux.nix
         ];
-        _module.args = { inherit claude-hooks kolohelios-nix; };
+        _module.args = { inherit claude-hooks kolohelios-nix shaka; };
       };
 """
 	}


### PR DESCRIPTION
The global shaka install was only the kolohelios-nix shim, whose sole
fallback was a PATH scan for some other shaka that nothing ever
installed. Outside a kolohelios checkout it exited non-zero, so /start
and /ship died in external repos like buzzingo with "no
tools/shaka/bin/shaka found ... no other shaka on PATH".

Add the FlakeHub shaka input and wrap it: prefer an in-checkout
tools/shaka/bin/shaka when present, else exec the FlakeHub package.
shaka now resolves in any directory.