### PR TITLE
fix(shaka): gate rust-worker wrangler to linux in devshell template

### DIFF
--- a/apps/cascadiajs2026-notes/flake.nix
+++ b/apps/cascadiajs2026-notes/flake.nix
@@ -57,7 +57,6 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
-              pkgs.wrangler
               pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
@@ -65,6 +64,7 @@
               pkgs.cue
             ]
             ++ (workflowPackages pkgs)
+            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
 
             shellHook = ''

--- a/apps/kolohelios-portfolio/flake.nix
+++ b/apps/kolohelios-portfolio/flake.nix
@@ -57,7 +57,6 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
-              pkgs.wrangler
               pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
@@ -65,6 +64,7 @@
               pkgs.cue
             ]
             ++ (workflowPackages pkgs)
+            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
 
             shellHook = ''

--- a/apps/notes-web/flake.nix
+++ b/apps/notes-web/flake.nix
@@ -57,12 +57,12 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
-              pkgs.wrangler
               pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
             ]
             ++ (workflowPackages pkgs)
+            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
 
             shellHook = ''

--- a/apps/pollen-alert/flake.nix
+++ b/apps/pollen-alert/flake.nix
@@ -57,12 +57,12 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
-              pkgs.wrangler
               pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
             ]
             ++ (workflowPackages pkgs)
+            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
 
             shellHook = ''

--- a/services/notes-sync/flake.nix
+++ b/services/notes-sync/flake.nix
@@ -57,12 +57,12 @@
           default = pkgs.mkShell {
             packages = [
               (rustToolchain pkgs)
-              pkgs.wrangler
               pkgs.worker-build
               pkgs.pkg-config
               pkgs.openssl
             ]
             ++ (workflowPackages pkgs)
+            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler
             ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;
 
             shellHook = ''

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -728,13 +728,22 @@ const WORKER_OUTPUT_HEADER: &str = r#"    {
 "#;
 
 /// Devshell block for worker flakes. Fixed base — the worker toolchain,
-/// `wrangler`, `worker-build`, `pkg-config`, `openssl` — then any
+/// `worker-build`, `pkg-config`, `openssl` — then any
 /// `extra_dev_shell_packages`, then `workflowPackages` and the Linux-only
-/// `cargo-llvm-cov`, closing with the `~/.cargo/bin` PATH `shellHook`
-/// (appended, not prepended, so a runner's rustup `cargo` doesn't shadow
-/// nix's toolchain). `worker-build` is pinned via nixpkgs rather than
-/// `cargo install`ed at runtime so its wasm-bindgen minimum can't drift by
-/// runner cache (#864).
+/// `wrangler` and `cargo-llvm-cov`, closing with the `~/.cargo/bin` PATH
+/// `shellHook` (appended, not prepended, so a runner's rustup `cargo`
+/// doesn't shadow nix's toolchain). `worker-build` is pinned via nixpkgs
+/// rather than `cargo install`ed at runtime so its wasm-bindgen minimum
+/// can't drift by runner cache (#864).
+///
+/// `wrangler` is gated to Linux (`lib.optional isLinux`) because its
+/// nixpkgs derivation has no darwin binary substitute and source-builds
+/// deterministically fail on darwin (EBADF in tsup's DTS step), which
+/// would gate the whole shell — `shaka`/`cargo`/`worker-build` never reach
+/// PATH. It's only needed at deploy time, and `cf-deploy.yml` runs on
+/// `ubuntu-latest` via `nix develop . --command`, so it must stay in the
+/// **default** shell on Linux (a separate deploy shell breaks CI verify).
+/// See #877.
 ///
 /// With `consumes_shaka`, the devShell function destructures `system`
 /// (needed to index `shaka.packages.${system}`) and the `shellHook`
@@ -754,7 +763,6 @@ fn render_worker_devshell(extra_dev_shell_packages: &[String], consumes_shaka: b
     out.push_str("          default = pkgs.mkShell {\n");
     out.push_str("            packages = [\n");
     out.push_str("              (rustToolchain pkgs)\n");
-    out.push_str("              pkgs.wrangler\n");
     out.push_str("              pkgs.worker-build\n");
     out.push_str("              pkgs.pkg-config\n");
     out.push_str("              pkgs.openssl\n");
@@ -763,6 +771,9 @@ fn render_worker_devshell(extra_dev_shell_packages: &[String], consumes_shaka: b
     }
     out.push_str("            ]\n");
     out.push_str("            ++ (workflowPackages pkgs)\n");
+    out.push_str(
+        "            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler\n",
+    );
     out.push_str(
         "            ++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.cargo-llvm-cov;\n",
     );
@@ -1227,6 +1238,18 @@ mod tests {
         assert!(out.contains("pkgs.pkg-config"));
         assert!(out.contains("pkgs.openssl"));
         assert!(out.contains(r#"export PATH="$PATH:$HOME/.cargo/bin""#));
+    }
+
+    #[test]
+    fn worker_wrangler_is_linux_gated() {
+        // wrangler source-builds (and deterministically fails) on darwin,
+        // which would gate the whole shell. It's gated to Linux so darwin
+        // shells enter, while cf-deploy.yml (ubuntu) still gets it from the
+        // default shell. See #877.
+        let out = render_worker_flake("pollen-alert", &WorkerMeta::default());
+        assert!(out.contains("++ pkgs.lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wrangler"));
+        // Not in the unconditional package list.
+        assert!(!out.contains("              pkgs.wrangler\n"));
     }
 
     #[test]


### PR DESCRIPTION
pkgs.wrangler has no darwin binary substitute, so the rust-worker
devshell source-builds it on aarch64-darwin — and that build
deterministically fails (EBADF in tsup's DTS step). Because wrangler sat
in the devshell's unconditional package list, the failure gated the
whole shell: shaka, cargo, rustc, and worker-build never reached PATH,
making every rust-worker project unenterable on darwin.

Gate wrangler behind lib.optional isLinux, mirroring the existing
cargo-llvm-cov line. It stays in the default shell on linux, so
cf-deploy.yml's verify (nix develop . --command ... wrangler deploy
--dry-run on ubuntu) keeps working; darwin shells simply omit it.
wrangler is only needed at deploy time, which runs in CI.

A separate deploy shell or npm-only wrangler was ruled out: cf-deploy
resolves wrangler from the default shell and doesn't run npm ci.

Closes #877