### PR TITLE
fix(ci): tolerate custom-domain-only deploys in cf-deploy URL parse

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -25,7 +25,8 @@
 # so each PR gets its own ephemeral Worker (cleanup is the
 # caller's responsibility, typically a `pull_request: closed`
 # job that runs `wrangler delete`). Output `worker_url` exposes
-# the `*.workers.dev` URL so the caller can post / update a PR
+# the deployed URL (the `*.workers.dev` URL, or the custom domain for
+# a custom-domain-only Worker) so the caller can post / update a PR
 # comment without re-parsing wrangler output itself.
 #
 # Threat-model assumptions (worth revisiting if any of these change):
@@ -77,7 +78,7 @@ on:
         required: true
     outputs:
       worker_url:
-        description: "The *.workers.dev URL the Worker was deployed to. Empty in verify_only mode."
+        description: "The URL the Worker was deployed to — its *.workers.dev URL, or the custom domain for a custom-domain-only Worker. Empty in verify_only mode."
         value: ${{ jobs.deploy.outputs.worker_url }}
 
 jobs:
@@ -164,15 +165,19 @@ jobs:
           exit "${PIPESTATUS[0]}"
       - name: parse worker URL
         id: parse-url
-        # Skipped in verify-only mode; nothing was deployed, no URL
-        # to extract. Grep the first `https://*.workers.dev` line
-        # from wrangler stdout — stable across recent wrangler
-        # versions; if the format ever shifts, this step fails the
-        # job rather than silently emitting an empty URL.
+        working-directory: ${{ inputs.project_dir }}
+        # Skipped in verify-only mode; nothing was deployed, no URL to
+        # extract. `shaka ci parse-deploy-url` prefers the
+        # `*.workers.dev` URL but falls back to a `<host> (custom domain)`
+        # trigger line — a Worker with a `custom_domain` route disables
+        # the workers.dev URL by default, so a clean custom-domain-only
+        # deploy prints no workers.dev line (#867). It exits non-zero only
+        # when neither shape is present (a genuine wrangler format change);
+        # that turns into the error annotation below rather than a silent
+        # empty URL.
         if: ${{ ! inputs.verify_only }}
         run: |
-          url=$(grep -oE 'https://[^[:space:]]+\.workers\.dev' /tmp/wrangler-output.log | head -1)
-          if [[ -z "$url" ]]; then
+          if ! url=$(nix develop . --command shaka ci parse-deploy-url /tmp/wrangler-output.log); then
             echo "::error::could not parse worker URL from wrangler output (format change?)"
             exit 1
           fi

--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -7,6 +7,7 @@ mod gate;
 mod generate;
 mod main_workflow;
 mod mask_and_run;
+mod parse_deploy_url;
 mod worker_cleanup_workflow;
 mod worker_deploy_workflow;
 mod workflow;
@@ -70,6 +71,20 @@ pub enum CiCommand {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
         args: Vec<String>,
     },
+    /// Extract a deployed Worker's public URL from captured
+    /// `wrangler deploy` output and print it to stdout.
+    ///
+    /// Prefers the `*.workers.dev` URL; falls back to a
+    /// `<host> (custom domain)` trigger line (emitting `https://<host>`)
+    /// for Workers that disable workers.dev. Exits non-zero only when
+    /// neither is present — a custom-domain-only deploy is valid, not a
+    /// failure (#867). Used by the `cf-deploy` reusable workflow's
+    /// post-deploy URL step.
+    #[command(name = "parse-deploy-url")]
+    ParseDeployUrl {
+        /// File holding captured `wrangler deploy` stdout.
+        log: PathBuf,
+    },
 }
 
 pub fn run(cmd: CiCommand) {
@@ -84,5 +99,6 @@ pub fn run(cmd: CiCommand) {
             retry_delay,
             args,
         } => mask_and_run::run(env_file, args, retry_on, max_retries, retry_delay),
+        CiCommand::ParseDeployUrl { log } => parse_deploy_url::run(log),
     }
 }

--- a/tools/shaka/src/ci/parse_deploy_url.rs
+++ b/tools/shaka/src/ci/parse_deploy_url.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+use std::process;
+
+use crate::term::{BOLD, RED, RESET};
+
+/// Extract a just-deployed Worker's public URL from captured
+/// `wrangler deploy` output.
+///
+/// Prefers the `*.workers.dev` URL wrangler prints for a route-free
+/// Worker. When the Worker declares an explicit `custom_domain` route
+/// wrangler disables the workers.dev URL (unless `workers_dev = true`)
+/// and prints only `<host> (custom domain)` trigger lines — fall back to
+/// the first of those, returning `https://<host>`. Returns `None` only
+/// when neither shape is present, which signals a genuine wrangler output
+/// format change rather than a valid custom-domain-only deploy (#867).
+pub fn parse(output: &str) -> Option<String> {
+    if let Some(url) = output
+        .split_whitespace()
+        .find(|t| t.starts_with("https://") && t.ends_with(".workers.dev"))
+    {
+        return Some(url.to_string());
+    }
+    output
+        .lines()
+        .find_map(custom_domain_host)
+        .map(|host| format!("https://{host}"))
+}
+
+/// A custom-domain trigger line looks like `  buzzingo.app (custom domain)`.
+/// Return the host (`buzzingo.app`) when the trimmed line ends with the
+/// `(custom domain)` marker; `None` otherwise.
+fn custom_domain_host(line: &str) -> Option<&str> {
+    let host = line.trim().strip_suffix("(custom domain)")?;
+    host.split_whitespace().next()
+}
+
+/// Read the captured wrangler output at `log` and print the deployed
+/// Worker's URL to stdout. Exits non-zero (with a message on stderr for
+/// the CI log) when the file can't be read or no URL of any kind is
+/// present; the workflow turns that exit into a GitHub error annotation.
+pub fn run(log: PathBuf) {
+    let output = match std::fs::read_to_string(&log) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} reading {}: {e}", log.display());
+            process::exit(1);
+        }
+    };
+    match parse(&output) {
+        Some(url) => println!("{url}"),
+        None => {
+            eprintln!(
+                "{RED}{BOLD}error:{RESET} no *.workers.dev or custom-domain \
+                 line in wrangler output (format change?)"
+            );
+            process::exit(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+    use std::fs;
+    use std::path::Path;
+
+    fn fixture(name: &str) -> String {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/parse-deploy-url")
+            .join(name);
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    }
+
+    #[test]
+    fn prefers_workers_dev_url() {
+        assert_eq!(
+            parse(&fixture("workers-dev.log")).as_deref(),
+            Some("https://my-worker.jedwards.workers.dev"),
+        );
+    }
+
+    #[test]
+    fn falls_back_to_custom_domain() {
+        assert_eq!(
+            parse(&fixture("custom-domain.log")).as_deref(),
+            Some("https://buzzingo.app"),
+        );
+    }
+
+    #[test]
+    fn prefers_workers_dev_when_both_present() {
+        assert_eq!(
+            parse(&fixture("both.log")).as_deref(),
+            Some("https://buzzingo.jedwards.workers.dev"),
+        );
+    }
+
+    #[test]
+    fn none_when_neither_present() {
+        assert_eq!(parse(&fixture("none.log")), None);
+    }
+}

--- a/tools/shaka/tests/fixtures/parse-deploy-url/both.log
+++ b/tools/shaka/tests/fixtures/parse-deploy-url/both.log
@@ -1,0 +1,6 @@
+Total Upload: 498.12 KiB / gzip: 128.04 KiB
+Uploaded buzzingo (3.10 sec)
+Deployed buzzingo triggers (0.95 sec)
+  https://buzzingo.jedwards.workers.dev
+  buzzingo.app (custom domain)
+Current Version ID: 0a1b2c3d-aaaa-bbbb-cccc-ddddeeeeffff

--- a/tools/shaka/tests/fixtures/parse-deploy-url/custom-domain.log
+++ b/tools/shaka/tests/fixtures/parse-deploy-url/custom-domain.log
@@ -1,0 +1,5 @@
+Total Upload: 498.12 KiB / gzip: 128.04 KiB
+Uploaded buzzingo (3.10 sec)
+Deployed buzzingo triggers (0.91 sec)
+  buzzingo.app (custom domain)
+Current Version ID: 9f8e7d6c-4321-8765-cba9-fed210987654

--- a/tools/shaka/tests/fixtures/parse-deploy-url/none.log
+++ b/tools/shaka/tests/fixtures/parse-deploy-url/none.log
@@ -1,0 +1,4 @@
+Total Upload: 498.12 KiB / gzip: 128.04 KiB
+Uploaded buzzingo (3.10 sec)
+No deploy targets for buzzingo (0.01 sec)
+Current Version ID: 0a1b2c3d-aaaa-bbbb-cccc-ddddeeeeffff

--- a/tools/shaka/tests/fixtures/parse-deploy-url/workers-dev.log
+++ b/tools/shaka/tests/fixtures/parse-deploy-url/workers-dev.log
@@ -1,0 +1,5 @@
+Total Upload: 512.34 KiB / gzip: 130.21 KiB
+Uploaded my-worker (3.45 sec)
+Deployed my-worker triggers (0.91 sec)
+  https://my-worker.jedwards.workers.dev
+Current Version ID: 1a2b3c4d-1234-5678-9abc-def012345678


### PR DESCRIPTION
The cf-deploy workflow extracts a deployed Worker's URL by grepping
wrangler output for a *.workers.dev URL. A Worker with a custom_domain
route disables that URL by default, so the only way to recover the URL
is to parse the custom-domain trigger line — logic that belongs in a
fixture-tested shaka subcommand, not inline workflow bash.

Add 'shaka ci parse-deploy-url <log>': prefer the *.workers.dev URL,
fall back to the first '<host> (custom domain)' line as 'https://<host>',
and exit non-zero only when neither is present (a genuine wrangler format
change). Covered by unit tests over real wrangler-output fixtures.

cf-deploy's 'parse worker URL' step grepped wrangler output for a
*.workers.dev URL and failed the job when none was found. A Worker that
declares a custom_domain route disables the workers.dev URL by default,
so a clean deploy prints only the custom domain — reddening an
otherwise-successful deploy (hit live in buzzingo).

Replace the inline grep with 'shaka ci parse-deploy-url', which prefers
the workers.dev URL and falls back to the custom-domain trigger line.
The step keeps only the GitHub error annotation for the genuine
no-URL-of-any-kind case. Update the worker_url output description, which
is no longer always a workers.dev URL.

Closes #867