### PR TITLE
ci(cf-deploy): push Worker runtime secrets from 1Password at deploy

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -45,9 +45,12 @@
 #     execing the consumer, so any value op resolves shows as `***` in
 #     the log even if a consumer prints it.
 #
-# `wrangler secret put` for declared Worker runtime secrets is not
-# implemented in v1 — portfolio has none today, and the idempotence
-# story belongs in a separate issue when there's a real consumer.
+# Declared Worker runtime secrets (each project's `wrangler.secrets`)
+# are pushed after the deploy by `shaka ci push-worker-secrets`, run
+# under the same `mask-and-run` + SA-token mechanism as the deploy: it
+# reads each secret's value from the resolved `.env` and pipes it to
+# the idempotent `wrangler secret put`. Skipped in `verify_only` mode.
+# See the `push Worker runtime secrets` step below (#794).
 name: cf-deploy
 
 on:
@@ -179,6 +182,27 @@ jobs:
             2>&1 | tee /tmp/wrangler-output.log
           # `tee` masks the inner exit code; restore it explicitly.
           exit "${PIPESTATUS[0]}"
+      - name: push Worker runtime secrets
+        working-directory: ${{ inputs.project_dir }}
+        # Now that the Worker exists, push every secret declared in the
+        # project's `wrangler.secrets` from its `op://` reference. The
+        # `.env` written by the deploy step above still holds the refs.
+        # Run under `mask-and-run` so each resolved value lands a
+        # `::add-mask::` before `wrangler secret put` touches it, and so
+        # the same SA token resolves the refs. `wrangler secret put` is
+        # idempotent, so an unchanged re-deploy is a no-op.
+        #
+        # Skipped in verify_only mode — a dry-run uploads nothing, so
+        # there's no Worker to attach secrets to. `--name`/`--environment`
+        # mirror the deploy's targeting so the secret lands on the same
+        # Worker: preview scripts (`--name`) get the key too, so their
+        # submit paths work, not just the production Worker.
+        if: ${{ ! inputs.verify_only }}
+        run: |
+          nix develop . --command shaka ci mask-and-run --env-file=.env -- \
+            shaka ci push-worker-secrets \
+            ${{ inputs.script_name_override && format('--name {0}', inputs.script_name_override) || '' }} \
+            ${{ inputs.environment && format('--environment {0}', inputs.environment) || '' }}
       - name: parse worker URL
         id: parse-url
         working-directory: ${{ inputs.project_dir }}

--- a/apps/kolohelios-portfolio/.env.example
+++ b/apps/kolohelios-portfolio/.env.example
@@ -16,3 +16,8 @@ CLOUDFLARE_API_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/Cloudflare Deploy Token/pa
 # looked up because the deploy-scoped token can't list accounts via
 # /accounts (same pattern as `infra/cloudflare-deploy/.env.example`).
 CLOUDFLARE_ACCOUNT_ID="cc625b188f1219ec7ff2e9d19d1a1a7e"
+
+# Kit API key. A declared Worker runtime secret (`wrangler.secrets` in
+# project.cue); the deploy resolves this ref and pushes it to the
+# Worker via `shaka ci push-worker-secrets` (`wrangler secret put`).
+KIT_API_KEY="op://vedq2v6cmtkglnonkenrjneepa/Kit API Secret/password"

--- a/apps/kolohelios-portfolio/README.md
+++ b/apps/kolohelios-portfolio/README.md
@@ -111,14 +111,11 @@ browser. Provisioning is a one-time manual step:
 2. Copy each form's numeric id into `project.cue`'s `wrangler.vars`
    (`KIT_FORM_ID_CONTACT`, `KIT_FORM_ID_NEWSLETTER`), then run
    `shaka deploy generate-wrangler`. Form ids are not secret.
-3. Set the API key as a Worker secret (not committed):
-
-   ```
-   wrangler secret put KIT_API_KEY
-   ```
-
-   The deploy workflow does not push Worker secrets yet (#794), so set
-   it once against the production worker.
+3. Store the Kit API key in 1Password and put its `op://` reference in
+   `.env.example` as `KIT_API_KEY` (already wired). The deploy resolves
+   it via `op run` and pushes it to the Worker with `wrangler secret put`
+   on every `push: main` (and to PR-preview Workers) — no manual
+   `wrangler secret put` step.
 4. Enable double opt-in on both Kit forms so Kit owns confirmation and
    unsubscribe/compliance.
 

--- a/tools/shaka/src/ci.rs
+++ b/tools/shaka/src/ci.rs
@@ -8,6 +8,7 @@ mod generate;
 mod main_workflow;
 mod mask_and_run;
 mod parse_deploy_url;
+mod push_worker_secrets;
 mod worker_cleanup_workflow;
 mod worker_deploy_workflow;
 mod workflow;
@@ -85,6 +86,33 @@ pub enum CiCommand {
         /// File holding captured `wrangler deploy` stdout.
         log: PathBuf,
     },
+    /// Push a project's declared Worker runtime secrets to Cloudflare.
+    ///
+    /// Reads the secret *names* from the project's `wrangler.secrets`
+    /// (in `project.cue`) and the *values* from the ambient environment,
+    /// then runs `wrangler secret put <NAME>` for each. Designed to run
+    /// under `shaka ci mask-and-run --env-file=.env --`, which resolves
+    /// each declared secret's `op://` reference into an env var (and
+    /// registers it for log masking) first. `wrangler secret put` is
+    /// idempotent, so re-running an unchanged deploy is a no-op. A
+    /// project with no declared secrets is a clean no-op (#794).
+    ///
+    /// `--name` / `--env` mirror `wrangler deploy`'s flags so the secret
+    /// targets the same Worker the deploy did — `--name` for a PR-preview
+    /// script, `--env` for a named production environment.
+    #[command(name = "push-worker-secrets")]
+    PushWorkerSecrets {
+        /// Directory holding the project's `project.cue`. Defaults to the
+        /// current directory (the `cf-deploy` step's `working-directory`).
+        #[arg(long, default_value = ".")]
+        project_dir: PathBuf,
+        /// Override the target Worker script name (PR-preview deploys).
+        #[arg(long)]
+        name: Option<String>,
+        /// Select a named `[env.<name>]` Worker (production environment).
+        #[arg(long)]
+        environment: Option<String>,
+    },
 }
 
 pub fn run(cmd: CiCommand) {
@@ -100,5 +128,10 @@ pub fn run(cmd: CiCommand) {
             args,
         } => mask_and_run::run(env_file, args, retry_on, max_retries, retry_delay),
         CiCommand::ParseDeployUrl { log } => parse_deploy_url::run(log),
+        CiCommand::PushWorkerSecrets {
+            project_dir,
+            name,
+            environment,
+        } => push_worker_secrets::run(project_dir, name, environment),
     }
 }

--- a/tools/shaka/src/ci/push_worker_secrets.rs
+++ b/tools/shaka/src/ci/push_worker_secrets.rs
@@ -1,0 +1,231 @@
+//! Push a Worker's declared runtime secrets to Cloudflare from the
+//! ambient environment.
+//!
+//! The reusable `cf-deploy` workflow runs this under
+//! `shaka ci mask-and-run --env-file=.env --`, so each declared secret's
+//! `op://` reference is already resolved into an env var (and masked)
+//! by the time this runs. For every name in the project's
+//! `wrangler.secrets`, we read the matching env var and pipe it to
+//! `wrangler secret put <NAME>`, which is idempotent — re-uploading the
+//! same value is a no-op from the consumer's perspective.
+//!
+//! Secret *names* live in `project.cue`'s `wrangler:` block (the same
+//! source `generate-wrangler` reads); secret *values* never touch the
+//! repo — they arrive only through the resolved environment. A project
+//! with no declared secrets is a clean no-op.
+//!
+//! `--name` / `--env` mirror `wrangler deploy`'s flags so the secret
+//! lands on the same Worker the deploy targeted: `--name` for a
+//! PR-preview script (`<project>-pr-<n>`), `--env` for a named
+//! `[env.<name>]` production deploy.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+
+use crate::project::schema_check::cue_project;
+use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
+
+/// Subset of a project's CUE export — just the declared secret names.
+#[derive(Deserialize)]
+struct ProjectExport {
+    #[serde(default)]
+    wrangler: Option<Wrangler>,
+}
+
+#[derive(Deserialize)]
+struct Wrangler {
+    #[serde(default)]
+    secrets: Option<Vec<String>>,
+}
+
+pub fn run(project_dir: PathBuf, name: Option<String>, environment: Option<String>) {
+    match run_inner(&project_dir, name.as_deref(), environment.as_deref()) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("{RED}{BOLD}error:{RESET} {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run_inner(
+    project_dir: &Path,
+    script_name: Option<&str>,
+    environment: Option<&str>,
+) -> Result<(), String> {
+    let project_file = project_dir.join("project.cue");
+    if !project_file.exists() {
+        return Err(format!("no project.cue at {}", project_dir.display()));
+    }
+
+    let secrets = declared_secrets(&project_file)?;
+    if secrets.is_empty() {
+        println!(
+            "{YELLOW}{BOLD}push-worker-secrets:{RESET} no runtime secrets declared; nothing to push"
+        );
+        return Ok(());
+    }
+
+    for name in &secrets {
+        let value = std::env::var(name).map_err(|_| {
+            format!(
+                "secret {name} is declared in {} but unset in the environment; \
+                 add its `op://` reference to the project `.env.example`",
+                project_file.display()
+            )
+        })?;
+        if value.is_empty() {
+            return Err(format!(
+                "secret {name} resolved to an empty value; check its `op://` reference"
+            ));
+        }
+        put_secret(name, &value, script_name, environment)?;
+        // Print only the name — never the value (already masked, but
+        // belt-and-suspenders).
+        println!("  {GREEN}{BOLD}put{RESET}      {name}");
+    }
+
+    println!(
+        "\n{GREEN}{BOLD}push-worker-secrets:{RESET} pushed {} secret(s)",
+        secrets.len()
+    );
+    Ok(())
+}
+
+/// Read the project's CUE export and return its declared
+/// `wrangler.secrets` names (empty when the project has no `wrangler:`
+/// block or no `secrets`).
+fn declared_secrets(project_file: &Path) -> Result<Vec<String>, String> {
+    let output =
+        cue_project(&["export"], project_file).map_err(|e| format!("failed to spawn cue: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!(
+            "cue export failed for {}: {stderr}",
+            project_file.display()
+        ));
+    }
+    secrets_from_export(&output.stdout).map_err(|e| {
+        format!(
+            "could not parse cue export of {}: {e}",
+            project_file.display()
+        )
+    })
+}
+
+/// Parse declared secret names out of a project's `cue export` JSON.
+fn secrets_from_export(json: &[u8]) -> Result<Vec<String>, serde_json::Error> {
+    let export: ProjectExport = serde_json::from_slice(json)?;
+    Ok(export.wrangler.and_then(|w| w.secrets).unwrap_or_default())
+}
+
+/// Run `wrangler secret put <name>`, piping `value` on stdin so the
+/// command runs non-interactively.
+fn put_secret(
+    name: &str,
+    value: &str,
+    script_name: Option<&str>,
+    environment: Option<&str>,
+) -> Result<(), String> {
+    let args = secret_put_args(name, script_name, environment);
+    let mut child = Command::new("wrangler")
+        .args(&args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("could not spawn `wrangler {}`: {e}", args.join(" ")))?;
+
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| "wrangler stdin not captured".to_string())?
+        .write_all(value.as_bytes())
+        .map_err(|e| format!("writing secret {name} to wrangler stdin: {e}"))?;
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("waiting on `wrangler {}`: {e}", args.join(" ")))?;
+    if !status.success() {
+        return Err(format!(
+            "`wrangler {}` exited with status {status}",
+            args.join(" ")
+        ));
+    }
+    Ok(())
+}
+
+/// Build the `wrangler secret put` argument vector, appending `--name`
+/// and `--env` to mirror the targeting flags `wrangler deploy` used.
+fn secret_put_args(
+    name: &str,
+    script_name: Option<&str>,
+    environment: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec!["secret".to_string(), "put".to_string(), name.to_string()];
+    if let Some(script) = script_name {
+        args.push("--name".to_string());
+        args.push(script.to_string());
+    }
+    if let Some(env) = environment {
+        args.push("--env".to_string());
+        args.push(env.to_string());
+    }
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secrets_from_export_reads_declared_names() {
+        let json = br#"{"name":"x","wrangler":{"secrets":["KIT_API_KEY","OTHER"]}}"#;
+        assert_eq!(
+            secrets_from_export(json).unwrap(),
+            vec!["KIT_API_KEY".to_string(), "OTHER".to_string()]
+        );
+    }
+
+    #[test]
+    fn secrets_from_export_is_empty_without_wrangler_block() {
+        assert!(secrets_from_export(br#"{"name":"x"}"#).unwrap().is_empty());
+    }
+
+    #[test]
+    fn secrets_from_export_is_empty_without_secrets_field() {
+        let json = br#"{"name":"x","wrangler":{"main":"shim.mjs"}}"#;
+        assert!(secrets_from_export(json).unwrap().is_empty());
+    }
+
+    #[test]
+    fn secret_put_args_bare() {
+        assert_eq!(
+            secret_put_args("KIT_API_KEY", None, None),
+            vec!["secret", "put", "KIT_API_KEY"]
+        );
+    }
+
+    #[test]
+    fn secret_put_args_with_script_name() {
+        assert_eq!(
+            secret_put_args("KIT_API_KEY", Some("kolohelios-portfolio-pr-7"), None),
+            vec![
+                "secret",
+                "put",
+                "KIT_API_KEY",
+                "--name",
+                "kolohelios-portfolio-pr-7"
+            ]
+        );
+    }
+
+    #[test]
+    fn secret_put_args_with_environment() {
+        assert_eq!(
+            secret_put_args("KIT_API_KEY", None, Some("production")),
+            vec!["secret", "put", "KIT_API_KEY", "--env", "production"]
+        );
+    }
+}


### PR DESCRIPTION
Push a Worker's declared runtime secrets to Cloudflare from the ambient
environment. Reads secret names from the project's wrangler.secrets and
values from env vars (resolved upstream by mask-and-run's op run), then
runs idempotent wrangler secret put per name. --name/--env mirror
wrangler deploy's targeting flags. A project with no declared secrets is
a clean no-op.

Part of #794.

Add the Kit API key's op:// reference to .env.example so the deploy
resolves and pushes it as a Worker runtime secret, and drop the manual
wrangler secret put step from the README.

Part of #794.

After the Worker exists, push every secret declared in the project's
wrangler.secrets from its op:// reference via shaka ci
push-worker-secrets, run under the same mask-and-run + SA-token
mechanism as the deploy. wrangler secret put is idempotent, so an
unchanged re-deploy is a no-op; resolved values are masked.
--name/--environment mirror the deploy's targeting so preview scripts
receive the key too, not just the production Worker.

Closes #794.