### PR TITLE
feat(blogctl): configurable LinkedIn export filename prefixes

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -459,7 +459,8 @@ pub enum LinkedinAction {
         /// Workdir path. Defaults to the current working directory.
         #[arg(long, value_name = "PATH")]
         workdir: Option<PathBuf>,
-        /// Directory of `Content_*.xlsx` exports. Defaults to
+        /// Directory of `xlsx` exports (filenames matched against the
+        /// configured `[linkedin] export_filename_prefixes`). Defaults to
         /// `linkedin-exports/` under the workdir.
         #[arg(long, value_name = "PATH")]
         xlsx_dir: Option<PathBuf>,

--- a/apps/blogctl/src/commands/linkedin.rs
+++ b/apps/blogctl/src/commands/linkedin.rs
@@ -1,5 +1,6 @@
 //! `blogctl linkedin import` — refresh post metrics from LinkedIn's
-//! daily `Content_*.xlsx` analytics exports.
+//! daily `xlsx` analytics exports (filenames matched against the
+//! configured `[linkedin] export_filename_prefixes`).
 //!
 //! Parses every export in `--xlsx-dir`, matches each post by the
 //! activity id embedded in its `targets[].url`, and records a per-day
@@ -34,8 +35,8 @@ const DEFAULT_XLSX_DIR: &str = "linkedin-exports";
 #[derive(Debug)]
 pub struct ImportArgs {
     pub workdir: PathBuf,
-    /// Directory of `Content_*.xlsx` exports. Defaults to
-    /// `linkedin-exports/` under the workdir.
+    /// Directory of `xlsx` exports. Defaults to `linkedin-exports/`
+    /// under the workdir.
     pub xlsx_dir: Option<PathBuf>,
     /// Skip the HTML fetch + post-creation step; only refresh metrics on
     /// posts already in the workdir (the #859 behavior).
@@ -62,9 +63,11 @@ pub fn run(jj: &dyn Jj, fetcher: &dyn Fetcher, args: ImportArgs) -> Result<Impor
     let xlsx_dir = args
         .xlsx_dir
         .unwrap_or_else(|| args.workdir.join(DEFAULT_XLSX_DIR));
-    let snapshots = linkedin::parse_dir(&xlsx_dir)?;
 
     let repo = Repository::open(Workdir::new(&args.workdir))?;
+    let config = repo.read_config()?;
+    let snapshots = linkedin::parse_dir(&xlsx_dir, &config.linkedin.export_filename_prefixes)?;
+
     let handles = repo.list()?;
     let (matched, unmatched) = match_snapshots(&handles, &snapshots);
 
@@ -100,7 +103,7 @@ pub fn run(jj: &dyn Jj, fetcher: &dyn Fetcher, args: ImportArgs) -> Result<Impor
     // Phase 2: for unmatched URNs, fetch the public HTML and build a
     // `published/` stub — unless `--no-fetch`.
     let by_urn = group_snapshots_by_urn(&snapshots);
-    let theme = repo.read_config()?.defaults.theme;
+    let theme = config.defaults.theme;
     let mut taken_slugs: BTreeSet<String> =
         handles.iter().map(|h| h.metadata.slug.clone()).collect();
     let mut new_posts: Vec<Post> = Vec::new();

--- a/apps/blogctl/src/linkedin.rs
+++ b/apps/blogctl/src/linkedin.rs
@@ -1,5 +1,6 @@
-//! Parser for LinkedIn's daily `Content_<start>_<end>_*.xlsx` analytics
-//! exports.
+//! Parser for LinkedIn's daily analytics exports — `xlsx` files whose
+//! names start with a configured prefix (`Content_`, `AggregateAnalytics_`,
+//! …; see `[linkedin] export_filename_prefixes`).
 //!
 //! Each export's `TOP POSTS` sheet holds two side-by-side tables — one
 //! ranked by engagements, one by impressions — that share the columns
@@ -9,9 +10,10 @@
 //! distinct post per file. The two tables rank the same posts
 //! differently, so the merge is by URN, never by row position.
 //!
-//! The snapshot date comes from the filename's `<start>_<end>` window,
-//! not the sheet, so re-parsing overlapping exports yields stable
-//! per-day data points keyed by `(urn, snapshot_date)`.
+//! The snapshot date comes from the filename's `<start>_<end>` window
+//! (the last date token, regardless of field order), not the sheet, so
+//! re-parsing overlapping exports yields stable per-day data points keyed
+//! by `(urn, snapshot_date)`.
 //!
 //! Pure parse: no writes, no network. The batch import (#707) and the
 //! metrics refresh (#859) consume these snapshots.
@@ -75,15 +77,15 @@ struct Table {
     metric: Metric,
 }
 
-/// Parse every `Content_*.xlsx` export in `dir`, in filename order,
-/// concatenating their per-post snapshots. A post recurs once per day
-/// it appears in; de-duplicate by [`PostSnapshot::urn`] to count
-/// distinct posts.
-pub fn parse_dir(dir: &Path) -> Result<Vec<PostSnapshot>> {
+/// Parse every export in `dir` whose filename starts with one of
+/// `prefixes`, in filename order, concatenating their per-post snapshots.
+/// A post recurs once per day it appears in; de-duplicate by
+/// [`PostSnapshot::urn`] to count distinct posts.
+pub fn parse_dir(dir: &Path, prefixes: &[String]) -> Result<Vec<PostSnapshot>> {
     let mut paths: Vec<PathBuf> = std::fs::read_dir(dir)
         .map_err(|source| Error::io(dir, source))?
         .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .filter(|path| is_export(path))
+        .filter(|path| is_export(path, prefixes))
         .collect();
     paths.sort();
 
@@ -267,41 +269,39 @@ fn parse_us_date(value: &str) -> std::result::Result<Date, time::error::Parse> {
     )
 }
 
-/// Derive the snapshot date from a `Content_<start>_<end>_*.xlsx`
-/// filename, using the window end. Dailies have `start == end`; the end
-/// is the "as of" date the metrics represent.
+/// Derive the snapshot date from an export filename, using the window
+/// end. Dailies carry a `<start>_<end>` window with `start == end`; the
+/// end is the "as of" date the metrics represent. The prefix and field
+/// order differ across export formats (`Content_<date>_<date>_<name>` vs
+/// `AggregateAnalytics_<name>_<date>_<date>`), so we don't depend on field
+/// position — we take the last parseable `YYYY-MM-DD` token, which is the
+/// window end in both layouts.
 fn snapshot_date_from_filename(path: &Path) -> Result<Date> {
-    let name = path
-        .file_name()
+    let stem = path
+        .file_stem()
         .and_then(OsStr::to_str)
         .ok_or_else(|| Error::LinkedinFilename {
             name: path.display().to_string(),
         })?;
-    let window = name
-        .strip_prefix("Content_")
+    let date = format_description!("[year]-[month]-[day]");
+    stem.split('_')
+        .filter_map(|field| Date::parse(field, &date).ok())
+        .next_back()
         .ok_or_else(|| Error::LinkedinFilename {
-            name: name.to_string(),
-        })?;
-    // window == "<start>_<end>_<rest>.xlsx"; the end date is the 2nd field.
-    let end = window
-        .split('_')
-        .nth(1)
-        .ok_or_else(|| Error::LinkedinFilename {
-            name: name.to_string(),
-        })?;
-    Date::parse(end, &format_description!("[year]-[month]-[day]")).map_err(|_| {
-        Error::LinkedinFilename {
-            name: name.to_string(),
-        }
-    })
+            name: stem.to_string(),
+        })
 }
 
-fn is_export(path: &Path) -> bool {
+fn is_export(path: &Path, prefixes: &[String]) -> bool {
     path.extension().and_then(OsStr::to_str) == Some("xlsx")
         && path
             .file_name()
             .and_then(OsStr::to_str)
-            .is_some_and(|name| name.starts_with("Content_"))
+            .is_some_and(|name| {
+                prefixes
+                    .iter()
+                    .any(|prefix| name.starts_with(prefix.as_str()))
+            })
 }
 
 // ---- Public-HTML post extraction (`blogctl linkedin import`, #860) ----
@@ -552,20 +552,36 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_date_uses_window_end() {
-        let path = Path::new("/x/Content_2026-04-30_2026-05-01_JonathanEdwards.xlsx");
+    fn snapshot_date_uses_window_end_regardless_of_field_order() {
+        // Old format: dates first, name last.
         assert_eq!(
-            snapshot_date_from_filename(path).unwrap(),
+            snapshot_date_from_filename(Path::new(
+                "/x/Content_2026-04-30_2026-05-01_JonathanEdwards.xlsx"
+            ))
+            .unwrap(),
+            date!(2026 - 05 - 01)
+        );
+        // New format: name first, dates last.
+        assert_eq!(
+            snapshot_date_from_filename(Path::new(
+                "/x/AggregateAnalytics_JonathanEdwards_2026-04-30_2026-05-01.xlsx"
+            ))
+            .unwrap(),
+            date!(2026 - 05 - 01)
+        );
+        // Daily window collapses to a single date.
+        assert_eq!(
+            snapshot_date_from_filename(Path::new("/x/Content_2026-05-01.xlsx")).unwrap(),
             date!(2026 - 05 - 01)
         );
     }
 
     #[test]
-    fn snapshot_date_rejects_unexpected_filenames() {
+    fn snapshot_date_rejects_filenames_without_a_date() {
         for bad in [
-            "/x/Shares_2026-04-30_2026-04-30.xlsx", // wrong prefix
-            "/x/Content_2026-04-30.xlsx",           // only one date field
-            "/x/Content_nope_alsonope_x.xlsx",      // fields aren't dates
+            "/x/Content_nope_alsonope_x.xlsx", // fields aren't dates
+            "/x/AggregateAnalytics_JonathanEdwards.xlsx",
+            "/x/README.xlsx",
         ] {
             assert!(
                 matches!(
@@ -588,12 +604,31 @@ mod tests {
     }
 
     #[test]
-    fn is_export_matches_only_content_xlsx() {
-        assert!(is_export(Path::new(
-            "/x/Content_2026-04-30_2026-04-30_X.xlsx"
-        )));
-        assert!(!is_export(Path::new("/x/Shares_2026-04-30.csv")));
-        assert!(!is_export(Path::new("/x/Content_2026-04-30.txt")));
-        assert!(!is_export(Path::new("/x/README.md")));
+    fn is_export_matches_any_configured_prefix() {
+        let prefixes = vec!["Content_".to_string(), "AggregateAnalytics_".to_string()];
+        assert!(is_export(
+            Path::new("/x/Content_2026-04-30_2026-04-30_X.xlsx"),
+            &prefixes
+        ));
+        assert!(is_export(
+            Path::new("/x/AggregateAnalytics_X_2026-04-30_2026-04-30.xlsx"),
+            &prefixes
+        ));
+        // Right prefix, wrong extension.
+        assert!(!is_export(
+            Path::new("/x/Content_2026-04-30.txt"),
+            &prefixes
+        ));
+        // Right extension, unconfigured prefix.
+        assert!(!is_export(
+            Path::new("/x/Shares_2026-04-30.xlsx"),
+            &prefixes
+        ));
+        assert!(!is_export(Path::new("/x/README.md"), &prefixes));
+        // A prefix absent from the config no longer matches.
+        assert!(!is_export(
+            Path::new("/x/Content_2026-04-30.xlsx"),
+            &["AggregateAnalytics_".to_string()]
+        ));
     }
 }

--- a/apps/blogctl/src/storage.rs
+++ b/apps/blogctl/src/storage.rs
@@ -59,6 +59,11 @@ pub struct Config {
     /// unlimited; workdirs opt in by declaring `[tags] max = N`.
     #[serde(default, skip_serializing_if = "TagsConfig::is_default")]
     pub tags: TagsConfig,
+    /// LinkedIn analytics-export import settings — currently the set of
+    /// accepted export filename prefixes. Absent table falls back to both
+    /// known prefixes, so existing workdirs import with no config change.
+    #[serde(default, skip_serializing_if = "LinkedinConfig::is_default")]
+    pub linkedin: LinkedinConfig,
 }
 
 /// Workdir-wide defaults. The theme `blogctl new` selects when `--theme`
@@ -114,6 +119,41 @@ impl TagsConfig {
     fn is_default(&self) -> bool {
         self.max.is_none()
     }
+}
+
+/// LinkedIn analytics-export import settings. LinkedIn renamed the
+/// default download of the same export — `Content_<date>_<date>_<name>`
+/// became `AggregateAnalytics_<name>_<date>_<date>` — and may rename it
+/// again. The importer accepts a file whose name starts with any listed
+/// prefix, so historical and current exports import side by side. Read as
+/// `[linkedin] export_filename_prefixes = [...]`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LinkedinConfig {
+    /// Filename prefixes the importer accepts under `linkedin-exports/`.
+    /// Defaults to both known LinkedIn export prefixes.
+    #[serde(default = "default_export_filename_prefixes")]
+    pub export_filename_prefixes: Vec<String>,
+}
+
+impl Default for LinkedinConfig {
+    fn default() -> Self {
+        Self {
+            export_filename_prefixes: default_export_filename_prefixes(),
+        }
+    }
+}
+
+impl LinkedinConfig {
+    /// True when the prefixes match the built-in default — used by
+    /// `skip_serializing_if` to keep `[linkedin]` out of `.blog-os.toml`
+    /// for workdirs that haven't customized it.
+    fn is_default(&self) -> bool {
+        self.export_filename_prefixes == default_export_filename_prefixes()
+    }
+}
+
+fn default_export_filename_prefixes() -> Vec<String> {
+    vec!["Content_".to_string(), "AggregateAnalytics_".to_string()]
 }
 
 /// Per-kind stage configuration. Keyed by `Stage::as_str()` so the TOML
@@ -193,6 +233,7 @@ impl Config {
             classifications: Taxonomy::current_v1().to_btreemap(),
             kinds: BTreeMap::new(),
             tags: TagsConfig::default(),
+            linkedin: LinkedinConfig::default(),
         }
     }
 
@@ -822,6 +863,52 @@ mod tests {
         assert!(cfg.sync.enabled);
         assert_eq!(cfg.sync.remote, "upstream");
         assert_eq!(cfg.sync.bookmark, "trunk");
+    }
+
+    #[test]
+    fn config_without_linkedin_table_back_fills_both_known_prefixes() {
+        // Pre-`[linkedin]` workdir: parse must succeed and yield both
+        // known export prefixes so existing workdirs import current and
+        // historical exports with no config change.
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        fs::write(repo.workdir().config_path(), "version = 1\n").unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(
+            cfg.linkedin.export_filename_prefixes,
+            vec!["Content_".to_string(), "AggregateAnalytics_".to_string()]
+        );
+    }
+
+    #[test]
+    fn config_with_custom_linkedin_prefixes_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let repo = Repository::unchecked(Workdir::new(tmp.path()));
+        for dir in repo.workdir().directories() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let raw = concat!(
+            "version = 1\n",
+            "[linkedin]\n",
+            "export_filename_prefixes = [\"Content_\", \"Exports_\"]\n",
+        );
+        fs::write(repo.workdir().config_path(), raw).unwrap();
+        let cfg = repo.read_config().unwrap();
+        assert_eq!(
+            cfg.linkedin.export_filename_prefixes,
+            vec!["Content_".to_string(), "Exports_".to_string()]
+        );
+    }
+
+    #[test]
+    fn default_config_omits_linkedin_table_from_serialized_toml() {
+        // The default prefixes are implicit, so a freshly-written config
+        // keeps `[linkedin]` out of the file (skip_serializing_if).
+        let serialized = toml::to_string(&Config::current()).unwrap();
+        assert!(!serialized.contains("[linkedin]"));
     }
 
     #[test]

--- a/apps/blogctl/tests/linkedin.rs
+++ b/apps/blogctl/tests/linkedin.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the LinkedIn `Content_*.xlsx` export parser.
+//! Integration tests for the LinkedIn `xlsx` export parser.
 //!
 //! LinkedIn's exports are binary (zipped XML), and the real ones carry
 //! the author's private per-post impression/engagement counts. Rather
@@ -28,6 +28,12 @@ use blogctl::Error;
 /// Synthetic activity ids are offset from this base; clearly distinct
 /// from real LinkedIn URNs while staying within `u64`.
 const BASE: u64 = 7_400_000_000_000_000_000;
+
+/// The accepted export filename prefixes for these tests — the synthetic
+/// corpus uses the `Content_` form.
+fn prefixes() -> Vec<String> {
+    vec!["Content_".to_string()]
+}
 
 struct Row {
     id: u64,
@@ -136,7 +142,7 @@ fn corpus() -> Vec<PostSnapshot> {
     write_export(d, "2026-02-04", &rows(31..=45), &[]);
     // Unequal-length sides: engagements 46..=58, impressions 50..=58.
     write_export(d, "2026-02-05", &rows(46..=58), &rows(50..=58));
-    linkedin::parse_dir(d).unwrap()
+    linkedin::parse_dir(d, &prefixes()).unwrap()
 }
 
 fn find(snaps: &[PostSnapshot], id: u64, snapshot: Date) -> &PostSnapshot {
@@ -285,12 +291,12 @@ fn corrupt_file_is_an_open_error() {
 }
 
 #[test]
-fn unparsable_filename_window_is_an_error() {
+fn filename_without_a_date_is_an_error() {
     let dir = TempDir::new().unwrap();
     let mut workbook = Workbook::new();
     workbook.add_worksheet().set_name("TOP POSTS").unwrap();
-    // Only one date field — the window parser rejects it.
-    let path = dir.path().join("Content_2026-02-01.xlsx");
+    // No parseable date token anywhere in the filename.
+    let path = dir.path().join("Content_nope_alsonope.xlsx");
     workbook.save(&path).unwrap();
     assert!(matches!(
         linkedin::parse_export(&path),
@@ -304,6 +310,6 @@ fn parse_dir_ignores_non_export_files() {
     std::fs::write(dir.path().join("README.md"), b"hi").unwrap();
     std::fs::write(dir.path().join("Shares_2026-01-01.csv"), b"x,y").unwrap();
     write_export(dir.path(), "2026-02-01", &rows(1..=3), &[]);
-    let snaps = linkedin::parse_dir(dir.path()).unwrap();
+    let snaps = linkedin::parse_dir(dir.path(), &prefixes()).unwrap();
     assert_eq!(snaps.len(), 3);
 }

--- a/apps/blogctl/tests/linkedin_import.rs
+++ b/apps/blogctl/tests/linkedin_import.rs
@@ -2,9 +2,10 @@
 //!
 //! Seeds a workdir with published posts whose LinkedIn target URLs carry
 //! activity ids in the `/posts/…-<id>-<code>` share form, writes
-//! synthetic `Content_*.xlsx` exports (carrying the `urn:li:activity:<id>`
-//! form), and drives the import end-to-end against a `FakeJj` so the
-//! sync path runs without a real `jj` binary.
+//! synthetic exports (both the old `Content_` and new
+//! `AggregateAnalytics_` filename formats, carrying the
+//! `urn:li:activity:<id>` form), and drives the import end-to-end against
+//! a `FakeJj` so the sync path runs without a real `jj` binary.
 
 use std::path::Path;
 
@@ -60,10 +61,29 @@ fn seed_post(repo: &Repository, slug: &str, activity_id: &str) {
     repo.create_post(&post).unwrap();
 }
 
-/// Write one `Content_<date>_<date>_Synthetic.xlsx` export. Each row is
+/// Write one old-format `Content_<date>_<date>_Synthetic.xlsx` export
+/// (dates first, name last).
+fn write_export(dir: &Path, date: &str, rows: &[(&str, u64, u64)]) {
+    write_workbook(
+        &dir.join(format!("Content_{date}_{date}_Synthetic.xlsx")),
+        rows,
+    );
+}
+
+/// Write one new-format `AggregateAnalytics_<name>_<date>_<date>.xlsx`
+/// export (name first, dates last). The sheet contents are identical to
+/// the old format — only the filename differs.
+fn write_aggregate_export(dir: &Path, date: &str, rows: &[(&str, u64, u64)]) {
+    write_workbook(
+        &dir.join(format!("AggregateAnalytics_Synthetic_{date}_{date}.xlsx")),
+        rows,
+    );
+}
+
+/// Write the `TOP POSTS` sheet to `path`. Each row is
 /// `(activity_id, impressions, engagements)` and is written to both the
 /// engagements-ranked (A:C) and impressions-ranked (E:G) tables.
-fn write_export(dir: &Path, date: &str, rows: &[(&str, u64, u64)]) {
+fn write_workbook(path: &Path, rows: &[(&str, u64, u64)]) {
     let mut workbook = Workbook::new();
     let sheet = workbook.add_worksheet();
     sheet.set_name("TOP POSTS").unwrap();
@@ -83,8 +103,7 @@ fn write_export(dir: &Path, date: &str, rows: &[(&str, u64, u64)]) {
         sheet.write_string(r, 5, "5/1/2026").unwrap();
         sheet.write_number(r, 6, *impressions as f64).unwrap();
     }
-    let path = dir.join(format!("Content_{date}_{date}_Synthetic.xlsx"));
-    workbook.save(&path).unwrap();
+    workbook.save(path).unwrap();
 }
 
 fn samples_of(repo: &Repository, slug: &str) -> Vec<MetricSample> {
@@ -152,6 +171,52 @@ fn records_per_day_samples_for_matched_posts() {
     assert_eq!(alpha[1].impressions, Some(150));
 
     assert_eq!(samples_of(&repo, "beta").len(), 1);
+}
+
+#[test]
+fn imports_mixed_prefix_exports_without_duplicates() {
+    // A `linkedin-exports/` dir holding both the old `Content_` format
+    // and the new `AggregateAnalytics_` format must import every file —
+    // the default `[linkedin] export_filename_prefixes` covers both —
+    // and re-running adds no duplicate data points.
+    let (tmp, repo) = workdir();
+    seed_post(&repo, "alpha", "7400000000000000001");
+    let exports = TempDir::new().unwrap();
+    write_export(
+        exports.path(),
+        "2026-05-22",
+        &[("7400000000000000001", 100, 10)],
+    );
+    write_aggregate_export(
+        exports.path(),
+        "2026-05-23",
+        &[("7400000000000000001", 150, 12)],
+    );
+
+    let summary = commands::linkedin::run(
+        &FakeJj::new(),
+        &FakeFetcher::new(),
+        import_args(tmp.path(), exports.path(), true, false),
+    )
+    .unwrap();
+    assert_eq!(summary.added, 2);
+    assert!(summary.unmatched.is_empty());
+
+    let alpha = samples_of(&repo, "alpha");
+    assert_eq!(alpha.len(), 2);
+    assert_eq!(alpha[0].date, date!(2026 - 05 - 22));
+    assert_eq!(alpha[1].date, date!(2026 - 05 - 23));
+
+    // Re-running the same mixed dir is idempotent on `(urn, date)`.
+    let second = commands::linkedin::run(
+        &FakeJj::new(),
+        &FakeFetcher::new(),
+        import_args(tmp.path(), exports.path(), true, false),
+    )
+    .unwrap();
+    assert_eq!(second.added, 0);
+    assert_eq!(second.skipped, 2);
+    assert_eq!(samples_of(&repo, "alpha").len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
LinkedIn renamed the default download of its daily analytics export from
`Content_<date>_<date>_<name>.xlsx` to
`AggregateAnalytics_<name>_<date>_<date>.xlsx` — same five sheets, only
the filename differs. The importer's hardcoded `Content_` prefix silently
skipped every new export, so daily metrics stopped flowing.

Add `[linkedin] export_filename_prefixes` to `.blog-os.toml` as an array,
defaulting to both known prefixes so existing workdirs keep working with
no config change and historical files import alongside new ones. The
array shape anticipates the next rename.

The two formats also reorder the date fields (name moved from last to
second), so position-based window parsing would mis-read the new layout.
Snapshot-date extraction now scans for the last parseable `YYYY-MM-DD`
token instead — position-independent, and for daily exports start == end
anyway.

Closes #901