### PR TITLE
fix(blogctl): extract URN from LinkedIn share-URL post links

### DIFF
--- a/apps/blogctl/src/linkedin.rs
+++ b/apps/blogctl/src/linkedin.rs
@@ -232,16 +232,28 @@ fn cell_u64(cell: &Data) -> Option<u64> {
     }
 }
 
-/// Extract the canonical `urn:li:activity:<id>` from a post URL such as
-/// `https://www.linkedin.com/feed/update/urn:li:activity:7463470632568008704`.
-/// Any trailing path or query after the id is ignored.
+/// Extract the canonical `urn:li:activity:<id>` from a post URL in either
+/// form LinkedIn's exports use:
+///
+/// - the `urn:li:activity:<id>` of `Content_*` exports
+///   (`…/feed/update/urn:li:activity:7463470632568008704`), and
+/// - the share form of `AggregateAnalytics_*` exports
+///   (`…/posts/<slug>-<id>-<code>`), which carries no `urn:` substring.
+///
+/// Any trailing path or query after the id is ignored. The share form
+/// falls back to [`activity_id`] and reconstructs the canonical URN, so
+/// both layouts key to the same `urn:li:activity:<id>`.
 fn extract_urn(url: &str) -> Option<String> {
-    let start = url.find(URN_PREFIX)?;
-    let digits: String = url[start + URN_PREFIX.len()..]
-        .chars()
-        .take_while(char::is_ascii_digit)
-        .collect();
-    (!digits.is_empty()).then(|| format!("{URN_PREFIX}{digits}"))
+    if let Some(start) = url.find(URN_PREFIX) {
+        let digits: String = url[start + URN_PREFIX.len()..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if !digits.is_empty() {
+            return Some(format!("{URN_PREFIX}{digits}"));
+        }
+    }
+    activity_id(url).map(|id| format!("{URN_PREFIX}{id}"))
 }
 
 /// Extract the bare LinkedIn activity id (the digit run) from any post
@@ -543,6 +555,17 @@ mod tests {
         assert_eq!(
             extract_urn("https://www.linkedin.com/feed/update/urn:li:activity:123/?utm=x"),
             Some("urn:li:activity:123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_urn_from_share_url() {
+        // AggregateAnalytics_* exports use the share form, with no `urn:`
+        // substring; the id is the long digit run before the share code.
+        let url = "https://www.linkedin.com/posts/kolohelios_the-beaver-community-share-7456442827909005312-8FKm/?utm_source=share";
+        assert_eq!(
+            extract_urn(url),
+            Some("urn:li:activity:7456442827909005312".to_string())
         );
     }
 

--- a/apps/blogctl/src/linkedin.rs
+++ b/apps/blogctl/src/linkedin.rs
@@ -119,7 +119,7 @@ pub fn parse_export(path: &Path) -> Result<Vec<PostSnapshot>> {
     let rows: Vec<&[Data]> = range.rows().collect();
     let header_idx = rows
         .iter()
-        .position(|row| row.iter().any(|cell| cell_str(cell) == Some(URL_HEADER)))
+        .position(|row| row.iter().any(|cell| header_is(cell, URL_HEADER)))
         .ok_or_else(|| Error::LinkedinHeaderMissing {
             path: path.to_path_buf(),
         })?;
@@ -176,18 +176,24 @@ pub fn parse_export(path: &Path) -> Result<Vec<PostSnapshot>> {
 fn locate_tables(header: &[Data]) -> Vec<Table> {
     let mut tables = Vec::new();
     for (col, cell) in header.iter().enumerate() {
-        if cell_str(cell) != Some(URL_HEADER) {
+        if !header_is(cell, URL_HEADER) {
             continue;
         }
         let date_col = col + 1;
         let metric_col = col + 2;
-        if header.get(date_col).and_then(cell_str) != Some(DATE_HEADER) {
+        if !header
+            .get(date_col)
+            .is_some_and(|c| header_is(c, DATE_HEADER))
+        {
             continue;
         }
-        let metric = match header.get(metric_col).and_then(cell_str) {
-            Some(ENGAGEMENTS_HEADER) => Metric::Engagements,
-            Some(IMPRESSIONS_HEADER) => Metric::Impressions,
-            _ => continue,
+        let metric_cell = header.get(metric_col);
+        let metric = if metric_cell.is_some_and(|c| header_is(c, ENGAGEMENTS_HEADER)) {
+            Metric::Engagements
+        } else if metric_cell.is_some_and(|c| header_is(c, IMPRESSIONS_HEADER)) {
+            Metric::Impressions
+        } else {
+            continue;
         };
         tables.push(Table {
             url_col: col,
@@ -204,6 +210,14 @@ fn cell_str(cell: &Data) -> Option<&str> {
         Data::String(s) => Some(s.as_str()),
         _ => None,
     }
+}
+
+/// Compare a header cell to an expected label, ignoring ASCII case. The
+/// older `Content_*` exports used sentence case (`Post publish date`);
+/// the newer `AggregateAnalytics_*` exports title-case the same headers
+/// (`Post Publish Date`). Matching case-insensitively reads both layouts.
+fn header_is(cell: &Data, header: &str) -> bool {
+    cell_str(cell).is_some_and(|s| s.eq_ignore_ascii_case(header))
 }
 
 /// Coerce a metric cell to a count. LinkedIn stores these as numbers,
@@ -591,6 +605,27 @@ mod tests {
                 "expected a filename error for {bad}"
             );
         }
+    }
+
+    #[test]
+    fn header_is_ignores_ascii_case() {
+        // Title-case (`AggregateAnalytics_*`) and sentence-case
+        // (`Content_*`) headers both match their constant.
+        assert!(header_is(
+            &Data::String("Post Publish Date".into()),
+            DATE_HEADER
+        ));
+        assert!(header_is(&Data::String("post url".into()), URL_HEADER));
+        assert!(header_is(
+            &Data::String("ENGAGEMENTS".into()),
+            ENGAGEMENTS_HEADER
+        ));
+        // Unrelated labels and non-string cells don't match.
+        assert!(!header_is(
+            &Data::String("Reactions".into()),
+            ENGAGEMENTS_HEADER
+        ));
+        assert!(!header_is(&Data::Empty, URL_HEADER));
     }
 
     #[test]

--- a/apps/blogctl/tests/linkedin.rs
+++ b/apps/blogctl/tests/linkedin.rs
@@ -226,6 +226,35 @@ fn same_post_across_days_is_one_urn_with_per_day_snapshots() {
 }
 
 #[test]
+fn title_case_headers_are_parsed() {
+    // The newer `AggregateAnalytics_*` exports title-case the `TOP POSTS`
+    // headers (`Post Publish Date`) where `Content_*` used sentence case.
+    // The parser matches headers case-insensitively, so both yield posts.
+    let dir = TempDir::new().unwrap();
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("TOP POSTS").unwrap();
+    sheet.write_string(2, 0, "Post URL").unwrap();
+    sheet.write_string(2, 1, "Post Publish Date").unwrap();
+    sheet.write_string(2, 2, "Engagements").unwrap();
+    sheet.write_string(2, 4, "Post URL").unwrap();
+    sheet.write_string(2, 5, "Post Publish Date").unwrap();
+    sheet.write_string(2, 6, "Impressions").unwrap();
+    write_table(sheet, 0, &rows(1..=3));
+    write_table(sheet, 4, &rows(1..=3));
+    let path = dir
+        .path()
+        .join("AggregateAnalytics_Synthetic_2026-02-01_2026-02-01.xlsx");
+    workbook.save(&path).unwrap();
+
+    let snaps = linkedin::parse_export(&path).unwrap();
+    assert_eq!(snaps.len(), 3, "title-case headers must still yield posts");
+    let s = find(&snaps, BASE + 1, date!(2026 - 02 - 01));
+    assert_eq!(s.engagements, Some(11));
+    assert_eq!(s.impressions, Some(11));
+}
+
+#[test]
 fn missing_top_posts_sheet_is_an_error() {
     let dir = TempDir::new().unwrap();
     let mut workbook = Workbook::new();

--- a/apps/blogctl/tests/linkedin.rs
+++ b/apps/blogctl/tests/linkedin.rs
@@ -45,6 +45,12 @@ fn url(id: u64) -> String {
     format!("https://www.linkedin.com/feed/update/urn:li:activity:{id}")
 }
 
+/// The share-URL form `AggregateAnalytics_*` exports use for `Post URL`:
+/// `…/posts/<slug>-<id>-<code>`, carrying no `urn:` substring.
+fn share_url(id: u64) -> String {
+    format!("https://www.linkedin.com/posts/kolohelios_synthetic-post-{id}-aB3d/?utm_source=share")
+}
+
 /// Build the post rows for activity ids `BASE + n` over `ns`. The
 /// publish date uses a single-digit month and a day that spans one and
 /// two digits, exercising the unpadded `M/D/YYYY` parse.
@@ -252,6 +258,34 @@ fn title_case_headers_are_parsed() {
     let s = find(&snaps, BASE + 1, date!(2026 - 02 - 01));
     assert_eq!(s.engagements, Some(11));
     assert_eq!(s.impressions, Some(11));
+}
+
+#[test]
+fn share_form_post_urls_resolve_to_the_same_urn() {
+    // AggregateAnalytics_* exports carry Post URL in the share form
+    // (.../posts/<slug>-<id>-<code>) with no urn: substring. It must
+    // resolve to the same canonical URN as the Content_* feed form.
+    let dir = TempDir::new().unwrap();
+    let mut workbook = Workbook::new();
+    let sheet = workbook.add_worksheet();
+    sheet.set_name("TOP POSTS").unwrap();
+    sheet.write_string(2, 0, "Post URL").unwrap();
+    sheet.write_string(2, 1, "Post publish date").unwrap();
+    sheet.write_string(2, 2, "Engagements").unwrap();
+    let id = BASE + 1;
+    sheet.write_string(3, 0, share_url(id)).unwrap();
+    sheet.write_string(3, 1, "3/1/2026").unwrap();
+    sheet.write_number(3, 2, 42.0).unwrap();
+    let path = dir
+        .path()
+        .join("AggregateAnalytics_Synthetic_2026-02-01_2026-02-01.xlsx");
+    workbook.save(&path).unwrap();
+
+    let snaps = linkedin::parse_export(&path).unwrap();
+    assert_eq!(snaps.len(), 1);
+    // Same canonical URN as the feed-form URL for the same id.
+    assert_eq!(snaps[0].urn, format!("urn:li:activity:{id}"));
+    assert_eq!(snaps[0].engagements, Some(42));
 }
 
 #[test]


### PR DESCRIPTION
LinkedIn's newer AggregateAnalytics_* exports title-case the TOP POSTS
headers (Post Publish Date) where the older Content_* exports used
sentence case (Post publish date). The case-sensitive comparison in
locate_tables skipped the renamed date column, so every new file yielded
zero snapshots. Match all four headers with eq_ignore_ascii_case so both
layouts parse.

The AggregateAnalytics_* exports carry Post URL in the share form
(.../posts/<slug>-<id>-<code>), which has no urn:li:activity: substring,
so extract_urn returned None and the row errored. Fall back to the
existing activity_id() (longest digit run) and reconstruct the canonical
urn:li:activity:<id>, so both the feed form and the share form key to
the same URN.

Closes #907