### PR TITLE
fix(shaka): fall back to git ls-files for whitespace check without jj

### DIFF
--- a/tools/shaka/src/jj.rs
+++ b/tools/shaka/src/jj.rs
@@ -378,6 +378,21 @@ pub fn repo_root() -> Result<PathBuf, JjError> {
     Ok(PathBuf::from(out.trim()))
 }
 
+/// Whether the current directory is inside a jj repo, detected by walking
+/// up for a `.jj` entry. Deliberately filesystem-only (no `jj` subprocess)
+/// so it returns a correct `false` in a plain git checkout where the `jj`
+/// binary may not even be installed — e.g. a GitHub Actions
+/// `actions/checkout`. Callers use this to choose jj-vs-git behavior. See
+/// #902.
+pub fn in_repo() -> bool {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    in_repo_from(&cwd)
+}
+
+fn in_repo_from(start: &Path) -> bool {
+    start.ancestors().any(|p| p.join(".jj").exists())
+}
+
 /// Absolute path of the *default* (primary) workspace's working copy,
 /// regardless of which workspace this process is running inside.
 ///
@@ -743,5 +758,23 @@ mod tests {
         let out = format!("feat: x\n\npara 1\n\npara 2\n{TERM}\n");
         let got = parse_commits_between(&out, TERM);
         assert_eq!(got[0].body, "para 1\n\npara 2");
+    }
+
+    #[test]
+    fn in_repo_from_true_when_dot_jj_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".jj")).unwrap();
+        let nested = tmp.path().join("tools/shaka/src");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(in_repo_from(&nested), "should find .jj in an ancestor");
+        assert!(in_repo_from(tmp.path()), "should find .jj at the start dir");
+    }
+
+    #[test]
+    fn in_repo_from_false_without_dot_jj() {
+        // A git-only checkout (`.git`, no `.jj`) must read as "not jj".
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        assert!(!in_repo_from(tmp.path()));
     }
 }

--- a/tools/shaka/src/whitespace.rs
+++ b/tools/shaka/src/whitespace.rs
@@ -295,10 +295,13 @@ fn is_binary(bytes: &[u8]) -> bool {
     bytes.iter().take(BINARY_PROBE).any(|&b| b == 0)
 }
 
-// Enumerate via jj rather than git so the listing reflects the calling
-// jj workspace's `@`. `git ls-files` reads the colocated index, which is
-// pinned to the primary workspace and never sees files added in a
-// sibling workspace's `@`. See issue #210.
+// Enumerate via jj when in a jj repo so the listing reflects the calling
+// workspace's `@`: `git ls-files` reads the colocated index, which is
+// pinned to the primary workspace and never sees files added in a sibling
+// workspace's `@` (issue #210). In a plain git checkout (no jj repo —
+// e.g. a GitHub Actions `actions/checkout`) there's no `@` to honor, so
+// fall back to `git ls-files`; it's equivalent there because the index
+// matches the checked-out tree (issue #902).
 fn list_tracked_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
     let owned: Vec<String>;
     let arg_slice: &[String] = if paths.is_empty() {
@@ -307,9 +310,39 @@ fn list_tracked_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
     } else {
         paths
     };
-    jj::file_list("@", arg_slice)
-        .map(|files| files.into_iter().map(PathBuf::from).collect())
-        .map_err(|e| e.to_string())
+    if jj::in_repo() {
+        jj::file_list("@", arg_slice)
+            .map(|files| files.into_iter().map(PathBuf::from).collect())
+            .map_err(|e| e.to_string())
+    } else {
+        git_list_tracked_files(arg_slice)
+    }
+}
+
+// `git ls-files` fallback for git-only checkouts. Mirrors `jj file list`'s
+// output: tracked paths under the given pathspecs, relative to `cwd`.
+fn git_list_tracked_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
+    let mut args: Vec<&str> = vec!["ls-files", "--"];
+    for p in paths {
+        args.push(p.as_str());
+    }
+    let output = std::process::Command::new("git")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("git ls-files: {}", stderr.trim()));
+    }
+    Ok(parse_git_ls_files(&String::from_utf8_lossy(&output.stdout)))
+}
+
+fn parse_git_ls_files(stdout: &str) -> Vec<PathBuf> {
+    stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(PathBuf::from)
+        .collect()
 }
 
 #[cfg(test)]
@@ -318,6 +351,24 @@ mod tests {
 
     fn issues(bytes: &[u8]) -> Vec<Issue> {
         scan_bytes(bytes)
+    }
+
+    #[test]
+    fn parse_git_ls_files_drops_blank_lines() {
+        let out = "src/main.rs\nCargo.toml\n\nbin/shaka\n";
+        assert_eq!(
+            parse_git_ls_files(out),
+            vec![
+                PathBuf::from("src/main.rs"),
+                PathBuf::from("Cargo.toml"),
+                PathBuf::from("bin/shaka"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_git_ls_files_empty_is_empty() {
+        assert!(parse_git_ls_files("").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
`shaka whitespace check` enumerated tracked files via `jj file list`,
hard-failing in a plain git checkout (no .jj) with "There is no jj repo".
That blocked running the `just validate` gate in a GitHub Actions
`actions/checkout`, where there's no jj repo.

Detect the jj repo by walking up for a `.jj` entry (filesystem-only, so
it's correct even where the jj binary isn't installed) and fall back to
`git ls-files` when absent. jj stays preferred when present, preserving
the sibling-workspace `@` correctness from #210; the git index matches
the checked-out tree in a fresh CI checkout, so the listing is
equivalent there.

Closes #902