### PR TITLE
chore(shaka): exclude vendored vale styles from whitespace scan

### DIFF
--- a/tools/shaka/src/whitespace.rs
+++ b/tools/shaka/src/whitespace.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
@@ -310,13 +311,33 @@ fn list_tracked_files(paths: &[String]) -> Result<Vec<PathBuf>, String> {
     } else {
         paths
     };
-    if jj::in_repo() {
+    let files = if jj::in_repo() {
         jj::file_list("@", arg_slice)
-            .map(|files| files.into_iter().map(PathBuf::from).collect())
-            .map_err(|e| e.to_string())
+            .map(|files| files.into_iter().map(PathBuf::from).collect::<Vec<_>>())
+            .map_err(|e| e.to_string())?
     } else {
-        git_list_tracked_files(arg_slice)
-    }
+        git_list_tracked_files(arg_slice)?
+    };
+    Ok(files.into_iter().filter(|p| !is_vendored(p)).collect())
+}
+
+// Vendored, third-party content we don't author, so the repo's whitespace
+// conventions don't apply to it. `vale sync` installs style packages under
+// `.vale/styles/<Package>/` (e.g. the `Google` package in `.vale.ini`'s
+// `Packages =`); those files belong to upstream. Scanning them is harmless,
+// but a full-tree `shaka whitespace fix` would *rewrite* a pre-existing
+// upstream offender (a missing trailing newline in `Google/EmDash.yml` during
+// #154) and drag that unrelated churn into whatever change happened to run it
+// — invisible to `preflight --since` because the file isn't in the diff.
+// Excluding the vendored packages keeps `fix` off them for good, even after a
+// future `vale sync` reintroduces an offender; our own vale content lives in
+// the reserved `.vale/styles/config/` subtree (vocabularies, ignore lists)
+// and stays in scope (#895).
+fn is_vendored(path: &Path) -> bool {
+    let comps: Vec<&OsStr> = path.components().map(|c| c.as_os_str()).collect();
+    comps.windows(3).any(|w| {
+        w[0] == OsStr::new(".vale") && w[1] == OsStr::new("styles") && w[2] != OsStr::new("config")
+    })
 }
 
 // `git ls-files` fallback for git-only checkouts. Mirrors `jj file list`'s
@@ -351,6 +372,28 @@ mod tests {
 
     fn issues(bytes: &[u8]) -> Vec<Issue> {
         scan_bytes(bytes)
+    }
+
+    #[test]
+    fn vendored_excludes_vale_style_packages() {
+        // Files inside a vendored vale package are vendored, at any depth.
+        assert!(is_vendored(Path::new(".vale/styles/Google/EmDash.yml")));
+        assert!(is_vendored(Path::new(".vale/styles/Google/vocab.txt")));
+        // Any package name, not just Google.
+        assert!(is_vendored(Path::new(".vale/styles/Microsoft/Foo.yml")));
+    }
+
+    #[test]
+    fn vendored_keeps_our_vale_config_and_sources() {
+        // The reserved config/ subtree (our vocabularies) is not vendored.
+        assert!(!is_vendored(Path::new(
+            ".vale/styles/config/vocabularies/Base/accept.txt"
+        )));
+        // The vale config file itself and ordinary sources are ours.
+        assert!(!is_vendored(Path::new(".vale.ini")));
+        assert!(!is_vendored(Path::new("tools/shaka/src/whitespace.rs")));
+        // `.vale/styles` with no package component is not a file to exclude.
+        assert!(!is_vendored(Path::new(".vale/styles")));
     }
 
     #[test]

--- a/tools/shaka/tests/whitespace.rs
+++ b/tools/shaka/tests/whitespace.rs
@@ -299,6 +299,53 @@ fn check_finds_files_added_only_in_sibling() {
 }
 
 #[test]
+fn check_skips_vendored_vale_packages_but_not_our_config() {
+    // A whitespace offender inside a vendored vale package
+    // (.vale/styles/<Package>/) is excluded from scanning; our own vocab
+    // under the reserved .vale/styles/config/ subtree is not (#895).
+    let repo = Repo::new(&[
+        ("clean.txt", b"hello\n"),
+        (".vale/styles/Google/EmDash.yml", b"extends: existence\n \n"),
+        (
+            ".vale/styles/config/vocabularies/Base/accept.txt",
+            b"kolohelios \n",
+        ),
+    ]);
+    let out = repo.shaka(&["whitespace", "check"]);
+    assert!(
+        !out.status.success(),
+        "our vocab offender should still fail the check\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+    let combined = format!("{}{}", stdout_of(&out), stderr_of(&out));
+    assert!(
+        combined.contains("accept.txt"),
+        "our vocab file must be flagged: {combined}"
+    );
+    assert!(
+        !combined.contains("EmDash.yml"),
+        "vendored package file must be excluded: {combined}"
+    );
+}
+
+#[test]
+fn fix_leaves_vendored_vale_packages_untouched() {
+    // Even a non-conformant vendored file keeps its original bytes — `fix`
+    // never rewrites it, so it can't drag unrelated churn into a change.
+    let bad: &[u8] = b"extends: existence\ntrailing \n";
+    let repo = Repo::new(&[(".vale/styles/Google/EmDash.yml", bad)]);
+    let out = repo.shaka(&["whitespace", "fix"]);
+    assert!(
+        out.status.success(),
+        "fix exited non-zero\nstdout: {}\nstderr: {}",
+        stdout_of(&out),
+        stderr_of(&out)
+    );
+    assert_eq!(repo.read(".vale/styles/Google/EmDash.yml"), bad);
+}
+
+#[test]
 fn check_default_path_scans_cwd_subtree() {
     let repo = Repo::new(&[
         ("project/a.txt", b"hello\n"),


### PR DESCRIPTION
`shaka whitespace fix` walked the whole tree, so a full-tree run would
rewrite vendored vale style packages under .vale/styles/<Package>/ (it
repaired Google/EmDash.yml's missing trailing newline during #154) and
drag that upstream churn into an unrelated change — invisible to
`preflight --since` because the file isn't in the diff.

Exclude vendored vale packages from both check and fix at the
list_tracked_files chokepoint, keying off the path shape rather than
fixing offenders once: exclusion holds even after a future `vale sync`
reintroduces an offender. Our own vale content under the reserved
.vale/styles/config/ subtree (vocabularies) stays in scope.

Closes #895