### PR TITLE
docs(shaka): post-ship cleanup must not sync the primary tree

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -119,6 +119,11 @@ asked for `--then <N>` and needs to know it didn't happen.
   preflight` already gates correctness.
 - No Claude Code attribution in commit messages or PR bodies.
 - If the change closes a GitHub issue, include `Closes #<n>` in the PR body.
+- Post-merge cleanup forgets a merged workspace with `shaka workspace
+  cleanup` alone — **never** run `shaka repo sync` in the primary tree to
+  "freshen up" first. A primary-tree sync rebases unrelated in-flight WIP
+  onto the new `main@origin` and can resurface stale conflicts that have
+  nothing to do with the shipped change. Cleanup needs no sync.
 
 ## Stop conditions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,15 @@ Shape:
 5. `shaka workspace cleanup` forgets workspaces whose PRs have merged
    (uses the persisted issue link, so it works regardless of remote
    branch deletion). Workspaces created without `--issue` (ad-hoc
-   names) need `shaka workspace forget --force <name>`.
+   names) need `shaka workspace forget --force <name>`. **Cleanup needs
+   no preceding `shaka repo sync`** — it forgets a merged workspace from
+   the persisted link alone. Don't sync the primary tree as a cleanup
+   side effect: a primary-tree `shaka repo sync` rebases whatever
+   in-flight WIP sits on the primary `@` onto the new `main@origin`,
+   which can surface conflicts in unrelated work (and because `jj` conflict
+   markers read as ordinary modified content to `git`, a stale unresolved
+   conflict can resurface confusingly mid-cleanup). Sync the primary tree
+   only as a deliberate act, never to "freshen up" before cleanup.
 
 When briefing sub-agents to work in their own workspaces, the brief must
 restate two rules that `/start` and `/ship` would otherwise enforce:


### PR DESCRIPTION
Forgetting a merged workspace with `shaka workspace cleanup` needs no
preceding `shaka repo sync` — cleanup works from the persisted issue
link alone. Reflexively syncing the primary tree during cleanup rebases
unrelated in-flight WIP on the primary `@` onto the new `main@origin`,
which can resurface stale conflicts that have nothing to do with the
shipped change (jj conflict markers read as ordinary modified content to
git, so an old unresolved conflict reappears confusingly mid-cleanup).

Document the rule in the CLAUDE.md Workspaces cleanup step and add a
matching convention to the /ship skill so the primary-tree sync stays a
deliberate act, never a cleanup side effect.

Closes #789