### PR TITLE
docs(meta): mark services/ slot as populated in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ project. Project-local docs and configuration live alongside the project.
 | `apps/`      | End-user applications                                |
 | `packages/`  | Shared libraries                                     |
 | `projects/`  | Standalone projects that don't fit another slot      |
-| `services/`  | Long-running services (reserved; not yet populated)  |
+| `services/`  | Long-running services (for example, `services/notes-sync`) |
 | `tools/`     | Developer tooling (for example, `tools/shaka`)       |
 | `infra/`     | Infrastructure as code (for example, `infra/devbox`) |
 | `nix/`       | Shared nix infrastructure (for example, `nix/kolohelios-nix`) |


### PR DESCRIPTION
The layout table still called services/ "reserved; not yet populated",
but services/notes-sync is a live rust-worker project. The stale doc led
an ad-hoc file-glob during #154 to skip services/ entirely. Cite
services/notes-sync as the example, mirroring the other slot rows.

Closes #894