### PR TITLE
feat(shaka): generate.skip waiver for generate-justfiles --check

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -14,6 +14,23 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	justification: string & !=""
 }
 
+// Waive a generator step for this project. shaka can't yet produce a
+// workspace-aware justfile for a rust-worker Cargo workspace (#922), so such a
+// project hand-maintains its justfile and would otherwise fail
+// `generate-justfiles --check`. Listing the step here excludes the project from
+// BOTH the write pass and the `--check` drift pass. `reason` (non-empty,
+// mirroring #AuditOverride.justification) is mandatory so the waiver is
+// auditable in git history and self-documents the interim. `step` is an enum so
+// future generator artifacts extend it without a schema migration.
+#GenerateSkip: {
+	step:   "justfile"
+	reason: string & !=""
+}
+
+#GenerateConfig: {
+	skip?: [...#GenerateSkip]
+}
+
 // Cache rules for the deploy's zone. When set, `shaka deploy
 // generate-tf` emits a `cloudflare_ruleset` (phase
 // `http_request_cache_settings`) alongside the custom-domain
@@ -261,6 +278,7 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	audit?: {
 		overrides: [...#AuditOverride]
 	}
+	generate?: #GenerateConfig
 	serving?: [#Serving, ...#Serving]
 } & ({
 	// Rust binary crate that ships a CLI. `cli:` carries the

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -531,6 +531,34 @@ struct ProjectMeta {
     #[allow(dead_code)]
     name: String,
     kind: String,
+    #[serde(default)]
+    generate: Option<GenerateConfig>,
+}
+
+#[derive(Deserialize)]
+struct GenerateConfig {
+    #[serde(default)]
+    skip: Vec<GenerateSkip>,
+}
+
+#[derive(Deserialize)]
+struct GenerateSkip {
+    step: String,
+    reason: String,
+}
+
+/// The justification if this project waives `justfile` generation via
+/// `generate.skip`, else `None`. A waived project is excluded from both the
+/// write pass and the `--check` drift pass — the interim escape hatch (#924)
+/// for a hand-maintained rust-worker workspace justfile until #922 lands
+/// workspace-aware generation.
+fn waived_justfile(meta: &ProjectMeta) -> Option<&str> {
+    meta.generate
+        .as_ref()?
+        .skip
+        .iter()
+        .find(|s| s.step == "justfile")
+        .map(|s| s.reason.as_str())
 }
 
 pub fn run(check: bool) {
@@ -544,17 +572,26 @@ pub fn run(check: bool) {
     let projects = discover_projects(Path::new("."));
     for project in &projects {
         match read_meta(project) {
-            Ok(meta) => match template_for(&meta.kind, project) {
-                Some(body) => items.push((project.join("justfile"), render(&body))),
-                None => {
-                    eprintln!(
-                        "{RED}{BOLD}error:{RESET} {} has unknown kind {:?}",
-                        project.display(),
-                        meta.kind
+            Ok(meta) => {
+                if let Some(reason) = waived_justfile(&meta) {
+                    println!(
+                        "  {YELLOW}{BOLD}WAIVED{RESET}   {} {DIM}({reason}){RESET}",
+                        project.join("justfile").display()
                     );
-                    std::process::exit(1);
+                    continue;
                 }
-            },
+                match template_for(&meta.kind, project) {
+                    Some(body) => items.push((project.join("justfile"), render(&body))),
+                    None => {
+                        eprintln!(
+                            "{RED}{BOLD}error:{RESET} {} has unknown kind {:?}",
+                            project.display(),
+                            meta.kind
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            }
             Err(e) => {
                 eprintln!(
                     "{RED}{BOLD}error:{RESET} could not read {}: {e}",
@@ -1203,5 +1240,61 @@ mod tests {
         // and shouldn't render as a deliverable. Without the skip, every
         // document project would produce stray README.pdf/.docx outputs.
         assert!(DOCUMENT_TEMPLATE.contains(r#"[ "$md" = "README.md" ] && continue"#));
+    }
+
+    fn meta_with_skip(steps: &[&str]) -> ProjectMeta {
+        ProjectMeta {
+            name: "p".into(),
+            kind: "rust-worker".into(),
+            generate: Some(GenerateConfig {
+                skip: steps
+                    .iter()
+                    .map(|s| GenerateSkip {
+                        step: (*s).into(),
+                        reason: "because".into(),
+                    })
+                    .collect(),
+            }),
+        }
+    }
+
+    #[test]
+    fn waived_justfile_returns_reason_when_step_listed() {
+        assert_eq!(
+            waived_justfile(&meta_with_skip(&["justfile"])),
+            Some("because")
+        );
+    }
+
+    #[test]
+    fn waived_justfile_is_none_without_a_generate_block() {
+        let meta = ProjectMeta {
+            name: "p".into(),
+            kind: "rust-worker".into(),
+            generate: None,
+        };
+        assert_eq!(waived_justfile(&meta), None);
+    }
+
+    #[test]
+    fn waived_justfile_ignores_other_steps() {
+        // A future step (not yet honored) must not waive the justfile.
+        assert_eq!(waived_justfile(&meta_with_skip(&["flakes"])), None);
+    }
+
+    #[test]
+    fn project_meta_deserializes_generate_skip() {
+        // Shape of `cue export` output for a project carrying generate.skip.
+        let json = r#"{"name":"buzzingo","kind":"rust-worker","generate":{"skip":[{"step":"justfile","reason":"hand-maintained"}]}}"#;
+        let meta: ProjectMeta = serde_json::from_str(json).expect("parse");
+        assert_eq!(waived_justfile(&meta), Some("hand-maintained"));
+    }
+
+    #[test]
+    fn project_meta_without_generate_defaults_to_none() {
+        let meta: ProjectMeta =
+            serde_json::from_str(r#"{"name":"x","kind":"rust-cli"}"#).expect("parse");
+        assert!(meta.generate.is_none());
+        assert_eq!(waived_justfile(&meta), None);
     }
 }

--- a/tools/shaka/tests/fixtures/schema/invalid/generate-skip-empty-reason.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/generate-skip-empty-reason.cue
@@ -1,0 +1,17 @@
+package project
+
+// A generate.skip entry must carry a non-empty justification (mirrors
+// #AuditOverride.justification) — an empty reason is rejected.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	generate: {
+		skip: [
+			{
+				step:   "justfile"
+				reason: ""
+			},
+		]
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/generate-skip-unknown-step.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/generate-skip-unknown-step.cue
@@ -1,0 +1,17 @@
+package project
+
+// `step` is a closed enum (`justfile` today); an unknown step is rejected so a
+// typo or an un-implemented step can't silently waive nothing.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	generate: {
+		skip: [
+			{
+				step:   "bogus"
+				reason: "not a real generator step"
+			},
+		]
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-generate-skip.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-generate-skip.cue
@@ -1,0 +1,18 @@
+package project
+
+// rust-worker Cargo workspace that hand-maintains its justfile until shaka
+// grows workspace-aware generation (#922): `generate.skip` waives the project
+// from `generate-justfiles` (#924).
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	generate: {
+		skip: [
+			{
+				step:   "justfile"
+				reason: "hand-maintained justfile for the rust-worker workspace until #922"
+			},
+		]
+	}
+}

--- a/tools/shaka/tests/generate_justfiles_skip.rs
+++ b/tools/shaka/tests/generate_justfiles_skip.rs
@@ -1,0 +1,118 @@
+//! Integration: `generate.skip` waives a project from generate-justfiles (#924).
+//!
+//! A rust-worker Cargo workspace hand-maintains its justfile until shaka grows
+//! workspace-aware generation (#922). `generate.skip [{step: "justfile"}]` must
+//! exclude it from BOTH the write pass (the hand-maintained file is never
+//! overwritten) and the `--check` drift pass (it never counts as drift), while a
+//! non-waived project still drifts. The drift check runs once at the repo level,
+//! so this exercises the real end-to-end path the way preflight/CI does.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+const SHAKA_BIN: &str = env!("CARGO_BIN_EXE_shaka");
+const JUNK: &str = "# hand-maintained — not the generated template\ndefault:\n    @echo waived\n";
+
+fn run(root: &Path, args: &[&str]) -> Output {
+    Command::new(SHAKA_BIN)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("spawn shaka")
+}
+
+/// Stage a domain-free repo (cue.mod + LICENSE so the schema's domain import
+/// resolves via shaka's stub) with two rust-worker projects: `apps/waived`
+/// carries `generate.skip` + a hand-maintained justfile; `apps/plain` does not.
+fn stage() -> tempfile::TempDir {
+    let root = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(root.path().join("cue.mod")).unwrap();
+    std::fs::write(
+        root.path().join("cue.mod/module.cue"),
+        "module: \"kolohelios.com\"\nlanguage: version: \"v0.15.1\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.path().join("LICENSE"), "MIT OR Apache-2.0\n").unwrap();
+
+    let waived = root.path().join("apps/waived");
+    std::fs::create_dir_all(&waived).unwrap();
+    std::fs::write(
+        waived.join("project.cue"),
+        "package project\n\n#Project & {\n\tname: \"waived\"\n\tkind: \"rust-worker\"\n\tworker: {}\n\tgenerate: {\n\t\tskip: [{step: \"justfile\", reason: \"hand-maintained until #922\"}]\n\t}\n}\n",
+    )
+    .unwrap();
+    std::fs::write(waived.join("justfile"), JUNK).unwrap();
+
+    let plain = root.path().join("apps/plain");
+    std::fs::create_dir_all(&plain).unwrap();
+    std::fs::write(
+        plain.join("project.cue"),
+        "package project\n\n#Project & {\n\tname: \"plain\"\n\tkind: \"rust-worker\"\n\tworker: {}\n}\n",
+    )
+    .unwrap();
+
+    root
+}
+
+#[test]
+fn waiver_protects_justfile_from_write_and_check() {
+    let repo = stage();
+
+    // Write pass: the waived project's hand-maintained justfile is untouched,
+    // and the run reports it as WAIVED rather than writing over it.
+    let gen = run(repo.path(), &["project", "generate-justfiles"]);
+    assert!(
+        gen.status.success(),
+        "generate-justfiles failed: {}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    let waived_jf = std::fs::read_to_string(repo.path().join("apps/waived/justfile")).unwrap();
+    assert_eq!(
+        waived_jf, JUNK,
+        "the waiver must not overwrite the hand-maintained justfile"
+    );
+    assert!(
+        String::from_utf8_lossy(&gen.stdout).contains("WAIVED"),
+        "expected a WAIVED line: {}",
+        String::from_utf8_lossy(&gen.stdout)
+    );
+
+    // --check now passes: every generated item was just written, and the
+    // waived project is excluded despite its drifting hand-maintained justfile.
+    let check = run(repo.path(), &["project", "generate-justfiles", "--check"]);
+    assert!(
+        check.status.success(),
+        "--check should pass when the only drift is waived:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&check.stdout),
+        String::from_utf8_lossy(&check.stderr),
+    );
+    assert!(String::from_utf8_lossy(&check.stdout).contains("WAIVED"));
+}
+
+#[test]
+fn unwaived_drift_still_fails() {
+    let repo = stage();
+    // Generate everything correctly first (waiving apps/waived).
+    assert!(run(repo.path(), &["project", "generate-justfiles"])
+        .status
+        .success());
+
+    // Drift the NON-waived project; --check must fail on it (the waiver is
+    // surgical, not a global mute).
+    std::fs::write(repo.path().join("apps/plain/justfile"), "drifted\n").unwrap();
+    let check = run(repo.path(), &["project", "generate-justfiles", "--check"]);
+    assert!(
+        !check.status.success(),
+        "unwaived drift must fail the check: {}",
+        String::from_utf8_lossy(&check.stdout)
+    );
+    let out = String::from_utf8_lossy(&check.stdout);
+    assert!(
+        out.contains("DRIFT"),
+        "expected DRIFT for apps/plain: {out}"
+    );
+    assert!(
+        out.contains("WAIVED"),
+        "apps/waived should still be waived: {out}"
+    );
+}


### PR DESCRIPTION
`shaka project generate-justfiles --check` runs once at the repo level over all
projects, so a rust-worker Cargo workspace that hand-maintains its justfile
(until #922 lands workspace-aware generation) is a standing drift that trips
preflight on any `project.cue` edit — making such PRs unshippable
(kolohelios/buzzingo#70, kolohelios/buzzingo#16).

Adds an interim per-project waiver mirroring the `audit.overrides` pattern: a
`generate.skip` list in `project.cue`, each entry a `{ step, reason }` with a
mandatory non-empty justification. Honored inside `generate_justfiles.rs` (not
preflight — the drift check is repo-level): a waived project is excluded from
both the write pass and the `--check` drift pass, printing a loud `WAIVED` line.
`step` is a closed enum (`justfile` today) so future generator artifacts extend
it without a schema migration.

Interim until #922 lands full workspace-aware generation.

Closes #924.
