### PR TITLE
feat(shaka): emit worker_build_dir from ci.deploy.workerBuildDir

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -253,6 +253,14 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	// route lives under `[env.production]` while route-free previews
 	// stay on `*.workers.dev`. Omit to deploy with the top-level config.
 	environment?: string & =~"^[a-z][a-z0-9_-]*$"
+
+	// The Cargo-workspace member crate (a subdir of `project_dir`) that
+	// `cf-deploy.yml` runs `worker-build` in, threaded to its `worker_build_dir`
+	// input in all three (verify/preview/deploy) `with:` blocks. A workspace
+	// Worker's virtual root manifest has no `[package]`, so worker-build must
+	// run in the member crate holding the cdylib (e.g. `crates/<name>-server`).
+	// Omit for a single-crate Worker (worker-build runs in `project_dir`).
+	workerBuildDir?: string & =~"^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$"
 }
 
 // Where a project serves content. Decoupled from `#Deploy` (which is

--- a/tools/shaka/src/ci/worker_cleanup_workflow.rs
+++ b/tools/shaka/src/ci/worker_cleanup_workflow.rs
@@ -156,6 +156,7 @@ mod tests {
                 reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
                 preview_script_prefix: "example-notes".to_string(),
                 environment: None,
+                worker_build_dir: None,
             },
         }
     }

--- a/tools/shaka/src/ci/worker_deploy_workflow.rs
+++ b/tools/shaka/src/ci/worker_deploy_workflow.rs
@@ -51,6 +51,14 @@ pub struct CiDeploy {
     /// `[env.production]` stays off route-free previews.
     #[serde(default)]
     pub environment: Option<String>,
+    /// The Cargo-workspace member crate (a subdir of `project_dir`) that
+    /// `cf-deploy.yml` runs `worker-build` in, via its `worker_build_dir`
+    /// input. Threaded into all three calls (verify/preview/deploy) so the
+    /// Worker builds from the member crate rather than the virtual workspace
+    /// root (which has no `[package]`). Unset → omitted, so worker-build runs in
+    /// `project_dir` (the single-crate default).
+    #[serde(default)]
+    pub worker_build_dir: Option<String>,
 }
 
 pub fn build(spec: &WorkerDeploySpec) -> Workflow {
@@ -193,6 +201,16 @@ echo "ref=$BASE" >> "$GITHUB_OUTPUT"
 
 // ── verify / preview / deploy: cf-deploy.yml callers ─────────────────────
 
+/// Add `worker_build_dir` to a reusable-call `with:` block when the project set
+/// it — the Cargo-workspace member crate cf-deploy runs `worker-build` in. Used
+/// by all three calls (verify/preview/deploy) so the Worker always builds from
+/// the member crate, not the virtual workspace root (which has no `[package]`).
+fn insert_worker_build_dir(with: &mut BTreeMap<String, Value>, spec: &WorkerDeploySpec) {
+    if let Some(dir) = &spec.deploy.worker_build_dir {
+        with.insert("worker_build_dir".to_string(), Value::String(dir.clone()));
+    }
+}
+
 fn verify_call(spec: &WorkerDeploySpec) -> ReusableCall {
     let mut with: BTreeMap<String, Value> = BTreeMap::new();
     with.insert(
@@ -200,6 +218,7 @@ fn verify_call(spec: &WorkerDeploySpec) -> ReusableCall {
         Value::String(spec.project_dir.to_string_lossy().to_string()),
     );
     with.insert("verify_only".to_string(), Value::Bool(true));
+    insert_worker_build_dir(&mut with, spec);
     ReusableCall {
         needs: Needs::Single("changes".to_string()),
         if_: Some(pr_gate()),
@@ -222,6 +241,7 @@ fn preview_call(spec: &WorkerDeploySpec) -> ReusableCall {
             spec.deploy.preview_script_prefix,
         )),
     );
+    insert_worker_build_dir(&mut with, spec);
     ReusableCall {
         needs: Needs::Multiple(vec!["changes".to_string(), "verify".to_string()]),
         if_: Some(pr_gate()),
@@ -248,6 +268,7 @@ fn deploy_call(spec: &WorkerDeploySpec) -> ReusableCall {
             Value::String(environment.clone()),
         );
     }
+    insert_worker_build_dir(&mut with, spec);
     // `workflow_dispatch` bypasses the changes filter so a manual
     // re-deploy isn't blocked by an unchanged push base. Real
     // `push: main` deploys still gate on the filter.
@@ -411,6 +432,7 @@ mod tests {
                 reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
                 preview_script_prefix: "portfolio".to_string(),
                 environment: None,
+                worker_build_dir: None,
             },
         }
     }
@@ -580,6 +602,7 @@ mod tests {
                     .to_string(),
                 preview_script_prefix: "buzzingo".to_string(),
                 environment: None,
+                worker_build_dir: Some("crates/buzzingo-server".to_string()),
             },
         }
     }
@@ -633,6 +656,7 @@ mod tests {
                 reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
                 preview_script_prefix: "buzzingo".to_string(),
                 environment: Some("production".to_string()),
+                worker_build_dir: None,
             },
         }
     }
@@ -663,5 +687,32 @@ mod tests {
         // `with` map carries no `environment` key (today's behavior).
         let parsed = emit_fixture();
         assert!(parsed["jobs"]["deploy"]["with"]["environment"].is_null());
+    }
+
+    #[test]
+    fn worker_build_dir_emitted_in_all_three_calls() {
+        // cross_repo_spec sets `worker_build_dir`; unlike `environment` (deploy
+        // only), it must thread into every cf-deploy call so the Worker always
+        // builds from the member crate, not the virtual workspace root.
+        let parsed = emit_cross_repo();
+        for job in ["verify", "preview", "deploy"] {
+            assert_eq!(
+                parsed["jobs"][job]["with"]["worker_build_dir"].as_str(),
+                Some("crates/buzzingo-server"),
+                "{job} should pass worker_build_dir"
+            );
+        }
+    }
+
+    #[test]
+    fn worker_build_dir_omitted_when_unset() {
+        // The portfolio fixture has `worker_build_dir: None`; no call carries it.
+        let parsed = emit_fixture();
+        for job in ["verify", "preview", "deploy"] {
+            assert!(
+                parsed["jobs"][job]["with"]["worker_build_dir"].is_null(),
+                "{job} should omit worker_build_dir"
+            );
+        }
     }
 }

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-ci-deploy-worker-build-dir.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-ci-deploy-worker-build-dir.cue
@@ -1,0 +1,17 @@
+package project
+
+// A workspace Worker builds from a member crate, so it declares
+// `workerBuildDir` — threaded to cf-deploy.yml's `worker_build_dir` input.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {}
+	ci: {
+		deploy: {
+			reusableWorkflow:    "kolohelios/kolohelios/.github/workflows/cf-deploy.yml@main"
+			previewScriptPrefix: "buzzingo"
+			environment:         "production"
+			workerBuildDir:      "crates/buzzingo-server"
+		}
+	}
+}


### PR DESCRIPTION
The deploy-workflow generator stopped emitting `worker_build_dir` (the 0.1.604
derivation was lost in the worker_deploy_workflow.rs rewrite), so a Cargo-
workspace Worker — whose virtual root manifest has no [package] — can't tell
cf-deploy.yml which member crate to run worker-build in. Deriving it is also
ambiguous now that a workspace can hold several cdylib members (buzzingo has
server + wasm + ffi).

Add an explicit `ci.deploy.workerBuildDir` field (the original #898 proposal),
threaded into all three cf-deploy calls (verify/preview/deploy) — unlike
`environment`, which only the production deploy sets. Unset → omitted, so
single-crate Workers generate unchanged.

Closes #898.