### PR TITLE
feat(shaka): ci.deploy.secrets for hand-authored-wrangler workers

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -261,6 +261,17 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	// run in the member crate holding the cdylib (e.g. `crates/<name>-server`).
 	// Omit for a single-crate Worker (worker-build runs in `project_dir`).
 	workerBuildDir?: string & =~"^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$"
+
+	// Worker runtime secret names to push at deploy via
+	// `shaka ci push-worker-secrets` (the reusable `cf-deploy.yml` runs
+	// it). Names only — values arrive from the resolved `op://`
+	// environment at deploy, never the repo. Unlike `wrangler.secrets`,
+	// this lives outside `#Wrangler`, so a project with a hand-authored
+	// `wrangler.toml` (Durable Objects, migrations, `[env.production]` —
+	// none modelled by `#Wrangler`) can declare push-able secrets without
+	// enrolling in `generate-wrangler` drift. `push-worker-secrets`
+	// pushes the union of these and `wrangler.secrets`.
+	secrets?: [...string & =~"^[A-Z][A-Z0-9_]*$"]
 }
 
 // Where a project serves content. Decoupled from `#Deploy` (which is

--- a/tools/shaka/src/ci/push_worker_secrets.rs
+++ b/tools/shaka/src/ci/push_worker_secrets.rs
@@ -4,15 +4,18 @@
 //! The reusable `cf-deploy` workflow runs this under
 //! `shaka ci mask-and-run --env-file=.env --`, so each declared secret's
 //! `op://` reference is already resolved into an env var (and masked)
-//! by the time this runs. For every name in the project's
-//! `wrangler.secrets`, we read the matching env var and pipe it to
-//! `wrangler secret put <NAME>`, which is idempotent — re-uploading the
-//! same value is a no-op from the consumer's perspective.
+//! by the time this runs. For every declared name we read the matching
+//! env var and pipe it to `wrangler secret put <NAME>`, which is
+//! idempotent — re-uploading the same value is a no-op from the
+//! consumer's perspective.
 //!
-//! Secret *names* live in `project.cue`'s `wrangler:` block (the same
-//! source `generate-wrangler` reads); secret *values* never touch the
-//! repo — they arrive only through the resolved environment. A project
-//! with no declared secrets is a clean no-op.
+//! Secret *names* come from two sources, unioned: `wrangler.secrets`
+//! (for a shaka-managed `wrangler.toml`, the same source
+//! `generate-wrangler` reads) and `ci.deploy.secrets` (for a
+//! hand-authored `wrangler.toml`, which can't carry a `wrangler:` block
+//! without tripping `generate-wrangler` drift). Secret *values* never
+//! touch the repo — they arrive only through the resolved environment. A
+//! project with no declared secrets is a clean no-op.
 //!
 //! `--name` / `--env` mirror `wrangler deploy`'s flags so the secret
 //! lands on the same Worker the deploy targeted: `--name` for a
@@ -28,15 +31,31 @@ use serde::Deserialize;
 use crate::project::schema_check::cue_project;
 use crate::term::{BOLD, GREEN, RED, RESET, YELLOW};
 
-/// Subset of a project's CUE export — just the declared secret names.
+/// Subset of a project's CUE export — just the declared secret names,
+/// from either `wrangler.secrets` or `ci.deploy.secrets` (see
+/// `secrets_from_export`).
 #[derive(Deserialize)]
 struct ProjectExport {
     #[serde(default)]
     wrangler: Option<Wrangler>,
+    #[serde(default)]
+    ci: Option<Ci>,
 }
 
 #[derive(Deserialize)]
 struct Wrangler {
+    #[serde(default)]
+    secrets: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct Ci {
+    #[serde(default)]
+    deploy: Option<CiDeploy>,
+}
+
+#[derive(Deserialize)]
+struct CiDeploy {
     #[serde(default)]
     secrets: Option<Vec<String>>,
 }
@@ -95,9 +114,9 @@ fn run_inner(
     Ok(())
 }
 
-/// Read the project's CUE export and return its declared
-/// `wrangler.secrets` names (empty when the project has no `wrangler:`
-/// block or no `secrets`).
+/// Read the project's CUE export and return its declared secret names —
+/// the union of `wrangler.secrets` and `ci.deploy.secrets` (empty when
+/// the project declares neither).
 fn declared_secrets(project_file: &Path) -> Result<Vec<String>, String> {
     let output =
         cue_project(&["export"], project_file).map_err(|e| format!("failed to spawn cue: {e}"))?;
@@ -116,10 +135,24 @@ fn declared_secrets(project_file: &Path) -> Result<Vec<String>, String> {
     })
 }
 
-/// Parse declared secret names out of a project's `cue export` JSON.
+/// Parse declared secret names out of a project's `cue export` JSON —
+/// the union of `wrangler.secrets` and `ci.deploy.secrets`, order-stable
+/// (wrangler names first) and de-duplicated so a name declared in both
+/// is pushed once.
 fn secrets_from_export(json: &[u8]) -> Result<Vec<String>, serde_json::Error> {
     let export: ProjectExport = serde_json::from_slice(json)?;
-    Ok(export.wrangler.and_then(|w| w.secrets).unwrap_or_default())
+    let mut names = export.wrangler.and_then(|w| w.secrets).unwrap_or_default();
+    let ci = export
+        .ci
+        .and_then(|c| c.deploy)
+        .and_then(|d| d.secrets)
+        .unwrap_or_default();
+    for name in ci {
+        if !names.contains(&name) {
+            names.push(name);
+        }
+    }
+    Ok(names)
 }
 
 /// Run `wrangler secret put <name>`, piping `value` on stdin so the
@@ -197,6 +230,32 @@ mod tests {
     fn secrets_from_export_is_empty_without_secrets_field() {
         let json = br#"{"name":"x","wrangler":{"main":"shim.mjs"}}"#;
         assert!(secrets_from_export(json).unwrap().is_empty());
+    }
+
+    #[test]
+    fn secrets_from_export_reads_ci_deploy_secrets() {
+        // A hand-authored-wrangler project declares secrets under
+        // `ci.deploy.secrets` (no `wrangler:` block at all).
+        let json = br#"{"name":"x","ci":{"deploy":{"secrets":["OPENROUTER_API_KEY"]}}}"#;
+        assert_eq!(
+            secrets_from_export(json).unwrap(),
+            vec!["OPENROUTER_API_KEY".to_string()]
+        );
+    }
+
+    #[test]
+    fn secrets_from_export_unions_wrangler_and_ci_deploy_dedup() {
+        // Both sources contribute; `SHARED` appears in both and is pushed
+        // once, with wrangler names ordered first.
+        let json = br#"{"name":"x","wrangler":{"secrets":["KIT_API_KEY","SHARED"]},"ci":{"deploy":{"secrets":["SHARED","OPENROUTER_API_KEY"]}}}"#;
+        assert_eq!(
+            secrets_from_export(json).unwrap(),
+            vec![
+                "KIT_API_KEY".to_string(),
+                "SHARED".to_string(),
+                "OPENROUTER_API_KEY".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/tools/shaka/src/ci/worker_cleanup_workflow.rs
+++ b/tools/shaka/src/ci/worker_cleanup_workflow.rs
@@ -157,6 +157,7 @@ mod tests {
                 preview_script_prefix: "example-notes".to_string(),
                 environment: None,
                 worker_build_dir: None,
+                secrets: None,
             },
         }
     }

--- a/tools/shaka/src/ci/worker_deploy_workflow.rs
+++ b/tools/shaka/src/ci/worker_deploy_workflow.rs
@@ -59,6 +59,15 @@ pub struct CiDeploy {
     /// `project_dir` (the single-crate default).
     #[serde(default)]
     pub worker_build_dir: Option<String>,
+    /// Worker runtime secret names pushed at deploy by
+    /// `push-worker-secrets`. Modelled here only so this
+    /// `deny_unknown_fields` struct (which `generate-workflows`
+    /// deserializes `ci.deploy` through) tolerates the field; workflow
+    /// generation never reads it (hence `allow(dead_code)`), so the
+    /// emitted deploy workflow is unchanged.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub secrets: Option<Vec<String>>,
 }
 
 pub fn build(spec: &WorkerDeploySpec) -> Workflow {
@@ -433,6 +442,7 @@ mod tests {
                 preview_script_prefix: "portfolio".to_string(),
                 environment: None,
                 worker_build_dir: None,
+                secrets: None,
             },
         }
     }
@@ -603,6 +613,7 @@ mod tests {
                 preview_script_prefix: "buzzingo".to_string(),
                 environment: None,
                 worker_build_dir: Some("crates/buzzingo-server".to_string()),
+                secrets: None,
             },
         }
     }
@@ -657,6 +668,7 @@ mod tests {
                 preview_script_prefix: "buzzingo".to_string(),
                 environment: Some("production".to_string()),
                 worker_build_dir: None,
+                secrets: None,
             },
         }
     }

--- a/tools/shaka/tests/fixtures/schema/invalid/ci-deploy-secrets-bad-name.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/ci-deploy-secrets-bad-name.cue
@@ -1,0 +1,17 @@
+package project
+
+// `ci.deploy.secrets` entries must be SCREAMING_SNAKE_CASE
+// (`^[A-Z][A-Z0-9_]*$`) to match a real env var / `wrangler secret`
+// name; a lowercase name is rejected.
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust-worker"
+	worker: {}
+	ci: {
+		deploy: {
+			reusableWorkflow:    "./.github/workflows/cf-deploy.yml"
+			previewScriptPrefix: "kolohelios-portfolio"
+			secrets: ["openrouter_api_key"]
+		}
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-ci-deploy-secrets.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-ci-deploy-secrets.cue
@@ -1,0 +1,18 @@
+package project
+
+// A rust-worker with a hand-authored wrangler.toml declares the Worker
+// runtime secrets to push at deploy via `ci.deploy.secrets` (names only),
+// without a `wrangler:` block that would enroll it in generate-wrangler
+// drift. `push-worker-secrets` reads these alongside `wrangler.secrets`.
+#Project & {
+	name: "kolohelios-portfolio"
+	kind: "rust-worker"
+	worker: {}
+	ci: {
+		deploy: {
+			reusableWorkflow:    "./.github/workflows/cf-deploy.yml"
+			previewScriptPrefix: "kolohelios-portfolio"
+			secrets: ["OPENROUTER_API_KEY", "KIT_API_KEY"]
+		}
+	}
+}


### PR DESCRIPTION
push-worker-secrets read secret names only from wrangler.secrets, which
lives inside #Wrangler, so declaring one forced a wrangler: block that
enrolls the project in generate-wrangler drift. A worker with a
hand-authored wrangler.toml (Durable Objects, migrations, [env.production]
— none modelled by #Wrangler) could not declare a push-able secret
without failing generate-wrangler --check.

Add an optional ci.deploy.secrets list, read by push-worker-secrets as the
union (dedup, order-stable) with wrangler.secrets. The deny_unknown_fields
CiDeploy struct that generate-workflows deserializes through gains the
field for tolerance only; generation never reads it, so emitted workflows
are unchanged.

Closes #933