### PR TITLE
chore(infra/home): allowlist file-issue skill in global settings

### DIFF
--- a/infra/home/dotfiles/claude/settings.json
+++ b/infra/home/dotfiles/claude/settings.json
@@ -6,6 +6,11 @@
     "swift-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true
   },
+  "permissions": {
+    "allow": [
+      "Skill(file-issue)"
+    ]
+  },
   "agentPushNotifEnabled": true,
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
The file-issue skill is the one global, cross-repo skill home-manager
installs (infra/home/dotfiles/claude/commands/file-issue.md), but it had
no durable permission grant, so it re-prompted on every fresh checkout or
new devbox. Add a permissions.allow block to the managed
infra/home/dotfiles/claude/settings.json (which had none) granting
Skill(file-issue); it propagates to ~/.claude/settings.json on the next
home-manager switch, version-controlled and cross-machine.

Scoped to file-issue alone: it's the only skill that is both global and
always-safe. start/ship are repo-local (their allowlist belongs in the
repo's .claude/settings.json — out of scope here, and #778 revisits when
they go global), and update-config mutates settings/permissions, so a
prompt there stays the safer default.

Closes #752