### PR TITLE
feat(shaka): let rust-worker flakes declare extra Rust targets

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -404,6 +404,16 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 		// needs none.
 		extraDevShellPackages?: [...string & =~"^[a-zA-Z_][a-zA-Z0-9_-]*$"]
 
+		// Extra Rust target triples appended to the toolchain's
+		// `targets`, on top of the fixed `wasm32-unknown-unknown` the
+		// Worker is built for. rust-overlay supplies each target's std
+		// components, so this is the only knob a `rust-worker` needs to
+		// cross-compile the same crate elsewhere (for example a `uniffi`
+		// FFI crate to `aarch64-apple-ios` / `aarch64-linux-android`).
+		// Platform cross-linkers/SDKs are out of scope here — the
+		// Android NDK and friends go through `extraDevShellPackages`.
+		extraRustTargets?: [...string & =~"^[a-z0-9_]+(-[a-z0-9_]+)+$"]
+
 		// Pull a FlakeHub-built `shaka` into the devShell and
 		// PATH-prepend it ahead of the `workflowPackages` shim. Only
 		// external consumers (repos with no kolohelios checkout) need

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -144,6 +144,12 @@ struct WorkerMeta {
     description: Option<String>,
     #[serde(default)]
     extra_dev_shell_packages: Vec<String>,
+    /// Extra Rust target triples unioned into the toolchain's `targets`
+    /// on top of the fixed `wasm32-unknown-unknown`. Lets a `rust-worker`
+    /// cross-compile the same crate elsewhere (e.g. a `uniffi` FFI crate
+    /// to iOS/Android targets) without a hand-authored flake holdout.
+    #[serde(default)]
+    extra_rust_targets: Vec<String>,
     /// External consumers (no kolohelios checkout) need a real `shaka`
     /// on PATH ahead of the `workflowPackages` shim, which can't resolve
     /// `tools/shaka/bin/shaka` outside the monorepo. When set, the flake
@@ -644,7 +650,10 @@ fn render_worker_flake(name: &str, worker: &WorkerMeta) -> String {
     out.push_str(&format!("{{\n  description = \"{description}\";\n\n"));
     out.push_str(&render_worker_inputs(worker.consumes_shaka));
     out.push_str("\n  outputs =\n");
-    out.push_str(&render_worker_output_header(worker.consumes_shaka));
+    out.push_str(&render_worker_output_header(
+        worker.consumes_shaka,
+        &worker.extra_rust_targets,
+    ));
     out.push_str("    in\n    {\n");
     out.push_str(&render_worker_devshell(
         &worker.extra_dev_shell_packages,
@@ -674,21 +683,51 @@ fn render_worker_inputs(consumes_shaka: bool) -> String {
 
 /// `outputs` header for a worker flake. With `consumes_shaka`, add
 /// `shaka` to the destructured inputs so the devShell `shellHook` can
-/// reference `shaka.packages.${system}.default`.
-fn render_worker_output_header(consumes_shaka: bool) -> String {
-    if !consumes_shaka {
-        return WORKER_OUTPUT_HEADER.to_string();
+/// reference `shaka.packages.${system}.default`. `extra_rust_targets`
+/// are unioned into the toolchain `targets` on top of the fixed
+/// `wasm32-unknown-unknown`.
+fn render_worker_output_header(consumes_shaka: bool, extra_rust_targets: &[String]) -> String {
+    let mut header = WORKER_OUTPUT_HEADER.replace(
+        "          targets = [ \"wasm32-unknown-unknown\" ];\n",
+        &render_worker_targets(extra_rust_targets),
+    );
+    if consumes_shaka {
+        header = header.replace(
+            "      rust-overlay,\n",
+            "      rust-overlay,\n      shaka,\n",
+        );
     }
-    WORKER_OUTPUT_HEADER.replace(
-        "      rust-overlay,\n",
-        "      rust-overlay,\n      shaka,\n",
-    )
+    header
+}
+
+/// Render the toolchain `targets` list. `wasm32-unknown-unknown` is the
+/// fixed Worker target and always leads; `extra_rust_targets` are unioned
+/// in after it (deduped, order preserved). With no extras the list stays
+/// on one line; with extras it renders one-per-line to match nixfmt.
+fn render_worker_targets(extra_rust_targets: &[String]) -> String {
+    let mut targets = vec!["wasm32-unknown-unknown".to_string()];
+    for t in extra_rust_targets {
+        if !targets.contains(t) {
+            targets.push(t.clone());
+        }
+    }
+    if targets.len() == 1 {
+        return "          targets = [ \"wasm32-unknown-unknown\" ];\n".to_string();
+    }
+    let mut out = String::from("          targets = [\n");
+    for t in &targets {
+        out.push_str(&format!("            \"{t}\"\n"));
+    }
+    out.push_str("          ];\n");
+    out
 }
 
 /// Like `OUTPUT_HEADER` but tailored for workers: the toolchain gains
 /// the `wasm32-unknown-unknown` target (so `cargo check --target
 /// wasm32-unknown-unknown` and `worker-build` find the stdlib), and
 /// `rustPlatform` is omitted since workers never call `buildRustPackage`.
+/// The `targets` line is a placeholder rewritten by
+/// `render_worker_targets` when `worker.extraRustTargets` adds more.
 const WORKER_OUTPUT_HEADER: &str = r#"    {
       self,
       kolohelios-nix,
@@ -1218,6 +1257,42 @@ mod tests {
     fn worker_toolchain_targets_wasm() {
         let out = render_worker_flake("pollen-alert", &WorkerMeta::default());
         assert!(out.contains(r#"targets = [ "wasm32-unknown-unknown" ];"#));
+    }
+
+    #[test]
+    fn worker_extra_rust_targets_render_multiline_after_wasm() {
+        let worker = WorkerMeta {
+            extra_rust_targets: vec!["aarch64-apple-ios".into(), "aarch64-linux-android".into()],
+            ..WorkerMeta::default()
+        };
+        let out = render_worker_flake("buzzingo", &worker);
+        // Extras union into the list one-per-line, wasm32 still leading.
+        assert!(out.contains(
+            "          targets = [\n            \"wasm32-unknown-unknown\"\n            \"aarch64-apple-ios\"\n            \"aarch64-linux-android\"\n          ];\n"
+        ));
+        // The single-line form is gone once extras are present.
+        assert!(!out.contains(r#"targets = [ "wasm32-unknown-unknown" ];"#));
+    }
+
+    #[test]
+    fn worker_extra_rust_targets_dedup_wasm() {
+        // Redundantly listing wasm32 doesn't duplicate it in the output.
+        let worker = WorkerMeta {
+            extra_rust_targets: vec!["wasm32-unknown-unknown".into(), "aarch64-apple-ios".into()],
+            ..WorkerMeta::default()
+        };
+        let out = render_worker_flake("buzzingo", &worker);
+        assert!(out.contains(
+            "          targets = [\n            \"wasm32-unknown-unknown\"\n            \"aarch64-apple-ios\"\n          ];\n"
+        ));
+        assert_eq!(out.matches("wasm32-unknown-unknown").count(), 1);
+    }
+
+    #[test]
+    fn worker_no_extra_rust_targets_stays_single_line() {
+        let out = render_worker_flake("pollen-alert", &WorkerMeta::default());
+        assert!(out.contains(r#"          targets = [ "wasm32-unknown-unknown" ];"#));
+        assert!(!out.contains("          targets = [\n"));
     }
 
     #[test]

--- a/tools/shaka/tests/fixtures/schema/invalid/rust-worker-bad-rust-target.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/rust-worker-bad-rust-target.cue
@@ -1,0 +1,13 @@
+package project
+
+// `extraRustTargets` entries are Rust target triples matching
+// `^[a-z0-9_]+(-[a-z0-9_]+)+$` — at least two hyphen-joined segments,
+// lowercase. An uppercase / single-segment entry would not be a real
+// target the toolchain could fetch std for, so the schema rejects it.
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {
+		extraRustTargets: ["AArch64-Apple-iOS"]
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-extra-rust-targets.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/rust-worker-with-extra-rust-targets.cue
@@ -1,0 +1,16 @@
+package project
+
+// Worker that cross-compiles the same crate to non-wasm targets via
+// `extraRustTargets` — the toolchain unions these onto the fixed
+// `wasm32-unknown-unknown` (the buzzingo `uniffi` FFI shape).
+#Project & {
+	name: "buzzingo"
+	kind: "rust-worker"
+	worker: {
+		extraRustTargets: [
+			"aarch64-apple-ios",
+			"aarch64-apple-ios-sim",
+			"aarch64-linux-android",
+		]
+	}
+}


### PR DESCRIPTION
The generated rust-worker flake hardcoded the toolchain to
wasm32-unknown-unknown, and the schema offered no knob to add more.
Because rust-worker forbids hand-authored flake holdouts, a worker that
needs to cross-compile the same crate elsewhere had no way to express it
without tripping generate-flakes --check.

Add a worker.extraRustTargets knob that unions onto the fixed wasm32
target so a rust-worker can build a uniffi FFI crate for iOS/Android
targets from its own toolchain. rust-overlay already supplies each
target's std components, so this is a schema field plus a template
change with no new inputs.

Closes #932