### PR TITLE
fix(shaka): correct stale generate-flakes help text

### DIFF
--- a/tools/shaka/src/project.rs
+++ b/tools/shaka/src/project.rs
@@ -26,8 +26,10 @@ pub enum ProjectCommand {
         #[arg(long)]
         check: bool,
     },
-    /// Generate per-project flake.nix from each project.cue's `cli:` block
-    /// (rust-cli kind only; other kinds keep their hand-authored flake)
+    /// Generate per-project flake.nix from each project.cue's kind block
+    /// (rust-cli, rust-lib, rust-worker, wasm-app, document, and opt-in
+    /// infra/nix-lib; kinds without a flake template keep their
+    /// hand-authored flake)
     GenerateFlakes {
         /// Compare generated content to disk and fail on any drift instead of writing
         #[arg(long)]

--- a/tools/shaka/tests/external_repo.rs
+++ b/tools/shaka/tests/external_repo.rs
@@ -102,6 +102,42 @@ fn generate_flakes_emits_shaka_consumer_knobs_for_external_repo() {
 }
 
 #[test]
+fn generate_flakes_renders_extra_rust_targets_and_drift_checks_the_worker_flake() {
+    // Regression guard for #937: a rust-worker flake is generated and
+    // drift-gated like any other kind — `extraRustTargets` from
+    // `project.cue` must land in the toolchain, and `--check` must catch a
+    // hand-edit. (The bug report's "wrote 0 files / --check passes after
+    // editing" was a stale-FlakeHub-pin artifact; this locks the live
+    // behavior so it can't silently regress.)
+    let repo = staged_repo();
+    let gen = run(repo.path(), &["project", "generate-flakes"]);
+    assert!(
+        gen.status.success(),
+        "generate-flakes failed for a domain-free repo: {}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+
+    let flake = repo.path().join("apps/buzzingo/flake.nix");
+    let body = std::fs::read_to_string(&flake).expect("apps/buzzingo/flake.nix written");
+    // The declared targets union onto the fixed wasm32 target, one-per-line.
+    assert!(
+        body.contains(
+            "          targets = [\n            \"wasm32-unknown-unknown\"\n            \"aarch64-apple-ios\"\n            \"aarch64-linux-android\"\n          ];\n"
+        ),
+        "extraRustTargets did not render into the toolchain targets:\n{body}"
+    );
+
+    // Hand-edit the generated flake; `--check` must flag the drift rather
+    // than treating a rust-worker flake as hand-authored.
+    std::fs::write(&flake, format!("{body}\n# stray hand edit\n")).unwrap();
+    let check = run(repo.path(), &["project", "generate-flakes", "--check"]);
+    assert!(
+        !check.status.success(),
+        "--check did not detect drift in a hand-edited rust-worker flake"
+    );
+}
+
+#[test]
 fn generate_workflows_round_trips_without_a_domain_registry() {
     let repo = staged_repo();
     // First emit the deploy/cleanup workflows from the ci.deploy block...

--- a/tools/shaka/tests/fixtures/external-repo/buzzingo/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/external-repo/buzzingo/project.cue.fixture
@@ -7,12 +7,16 @@ package project
 // for its prod-only route (#869). Validating it must not require a
 // vendored domain registry (#863). As an external consumer it sets
 // `consumesShaka` so the generated flake PATH-prepends a FlakeHub
-// `shaka` ahead of the `workflowPackages` shim (#831).
+// `shaka` ahead of the `workflowPackages` shim (#831). It also declares
+// `extraRustTargets` so the generated toolchain cross-compiles the
+// `uniffi` FFI crate to native mobile targets alongside wasm32 (#932,
+// #936).
 #Project & {
 	name: "buzzingo"
 	kind: "rust-worker"
 	worker: {
 		consumesShaka: true
+		extraRustTargets: ["aarch64-apple-ios", "aarch64-linux-android"]
 	}
 	ci: {
 		deploy: {


### PR DESCRIPTION
The #937 report ("generate-flakes ignores rust-worker, extraRustTargets
inert") was a stale-FlakeHub-pin artifact, not a live bug: the
rust-worker dispatch arm has shipped since 762e4f23 and #936 added the
extraRustTargets rendering. Lock the live behavior so it can't silently
regress into the reported state.

Extend the external-repo harness: the buzzingo fixture now declares
extraRustTargets (its real buzzingo#91 need), and a new test asserts the
targets union onto wasm32 in the generated toolchain and that --check
flags a hand-edited rust-worker flake instead of treating it as
hand-authored.

The generate-flakes --help still claimed "rust-cli kind only; other
kinds keep their hand-authored flake", contradicting the actual
generator (which covers rust-cli, rust-lib, rust-worker, wasm-app,
document, and opt-in infra/nix-lib) and the "Generated by shaka" header
those flakes carry. That stale text was the one real defect behind #937:
it left consumers unable to tell whether a rust-worker flake is generated
and drift-gated (it is) or hand-authored. Describe the coverage
generically so the text stays accurate as new kinds gain templates.

Closes #937