### PR TITLE
ci(buzzingo): auto-bump buzzingo's shaka lock from kolohelios

### DIFF
--- a/.github/workflows/bump-buzzingo-shaka.yaml
+++ b/.github/workflows/bump-buzzingo-shaka.yaml
@@ -1,0 +1,71 @@
+name: Bump buzzingo shaka lock
+
+# Daily (+ on-demand) bump of the external buzzingo repo's `shaka` flake input.
+# buzzingo lives in its own repo and pins shaka via the canonical FlakeHub URL
+# (`apps/buzzingo/flake.nix`), so it can't ride the in-monorepo `bump-locks`
+# pass. `bump-locks --repo` clones buzzingo, discovers the consuming project
+# (`apps/buzzingo`), bumps its `flake.lock`, and opens or updates a single
+# `bot/bump-shaka` PR; buzzingo's own CI gates the merge.
+#
+# Authenticates as the `kolohelios-bot` GitHub App, scoped to the buzzingo repo
+# (the App must be installed there). A push made with the default `GITHUB_TOKEN`
+# would not re-trigger buzzingo's PR CI; the App identity does.
+on:
+  schedule:
+    # 06:00 UTC daily — offset from the kolohelios-nix / nixpkgs bumps.
+    # Idempotent: a no-op when buzzingo is already on the latest shaka.
+    - cron: "0 6 * * *"
+  # Ad-hoc bumps and post-credential-rotation verification.
+  workflow_dispatch:
+
+# A second run landing mid-bump would race on the bot branch. Cancel any
+# in-flight run; the new one sees the latest state.
+concurrency:
+  group: bump-buzzingo-shaka
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # `id-token: write` mints the OIDC token nix-installer uses for FlakeHub
+    # (resolving buzzingo's `shaka.url = ".../*"` to the latest release).
+    # `contents: read` is only for checking out *this* repo's `tools/shaka`;
+    # every write lands on buzzingo via the App-scoped token below.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.KOLOHELIOS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.KOLOHELIOS_BOT_APP_PRIVATE_KEY }}
+          # Scope the token to the external buzzingo repo (App installed there).
+          owner: kolohelios
+          repositories: buzzingo
+      # Check out kolohelios (default GITHUB_TOKEN) only to `nix run ./tools/shaka`.
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+          flakehub: true
+      - uses: DeterminateSystems/flakehub-cache-action@v3
+      - name: Configure git identity + buzzingo credential helper
+        # `bump-locks --repo` clones buzzingo, commits, force-pushes the bot
+        # branch, and opens/updates the PR via `gh`/`git`, which need the App
+        # token as GH_TOKEN and `gh auth setup-git` for the push.
+        run: |
+          git config --global user.name 'kolohelios-bot[bot]'
+          git config --global user.email '3591292+kolohelios-bot[bot]@users.noreply.github.com'
+          gh auth setup-git
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Bump buzzingo's shaka lock and open or update PR
+        run: |
+          nix run ./tools/shaka -- repo bump-locks \
+            --repo kolohelios/buzzingo \
+            --input shaka \
+            --pr-branch bot/bump-shaka \
+            --auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/tools/shaka/src/ci/audit_workflows.rs
+++ b/tools/shaka/src/ci/audit_workflows.rs
@@ -27,6 +27,10 @@ const HAND_AUTHORED: &[&str] = &[
     "auto-rebase-prs.yaml",
     "bump-kolohelios-nix.yaml",
     "bump-nixpkgs.yaml",
+    // Cross-repo: bumps the external buzzingo repo's `shaka` flake input via
+    // `bump-locks --repo` (buzzingo has no in-monorepo project.cue to generate
+    // from). Schedule + manual-dispatch driven.
+    "bump-buzzingo-shaka.yaml",
     "codeql.yml",
     // Repo-wide backstop: deletes any preview Worker whose PR has
     // closed. Runs on `push: main` + a daily cron + manual dispatch

--- a/tools/shaka/src/repo/bump_locks.rs
+++ b/tools/shaka/src/repo/bump_locks.rs
@@ -109,28 +109,48 @@ fn run_remote(input: &str, branch: &str, slug: &str, auto_merge: bool) -> Result
         return Err(format!("gh repo clone {slug}: {}", stderr.trim()));
     }
 
-    match bump_one(&work, input) {
-        BumpResult::Updated => {
-            println!("  {GREEN}{BOLD}updated{RESET}   {slug}");
+    // A consumer's flake may live at the repo root (single-flake repos) or in a
+    // project subdir (e.g. buzzingo's `apps/buzzingo`), so discover every
+    // consuming project rather than assuming a root flake.
+    let targets = consuming_projects(&work, input);
+    if targets.is_empty() {
+        return Err(format!(
+            "remote {slug} does not declare `{input}` as a flake input \
+             (checked the root flake and project subdirs)"
+        ));
+    }
+    let mut updated = false;
+    for project in &targets {
+        let label = project
+            .strip_prefix(&work)
+            .ok()
+            .filter(|rel| !rel.as_os_str().is_empty())
+            .map_or_else(|| ".".to_string(), |rel| rel.display().to_string());
+        match bump_one(project, input) {
+            BumpResult::Updated => {
+                println!("  {GREEN}{BOLD}updated{RESET}   {slug} ({label})");
+                updated = true;
+            }
+            BumpResult::Unchanged => {
+                println!("  {DIM}unchanged{RESET} {slug} ({label})");
+            }
+            // `consuming_projects` already filtered to flakes that declare the
+            // input, so a non-consumer can't reach here; ignore for safety.
+            BumpResult::Skipped => {}
+            BumpResult::Failed(msg) => {
+                return Err(format!("nix flake update failed in {label}: {msg}"));
+            }
         }
-        BumpResult::Unchanged => {
-            println!("  {DIM}unchanged{RESET} {slug}");
-            println!("{DIM}no changes to publish{RESET}");
-            return Ok(());
-        }
-        BumpResult::Skipped => {
-            return Err(format!(
-                "remote {slug} does not declare `{input}` as a flake input \
-                 (checked root flake.nix)"
-            ));
-        }
-        BumpResult::Failed(msg) => {
-            return Err(format!("nix flake update failed: {msg}"));
-        }
+    }
+    if !updated {
+        println!("{DIM}no changes to publish{RESET}");
+        return Ok(());
     }
 
     git_in(&work, &["checkout", "-B", branch])?;
-    git_in(&work, &["add", "flake.lock"])?;
+    // `-A` so a subdir consumer's `<project>/flake.lock` is staged, not just a
+    // root-level `flake.lock`.
+    git_in(&work, &["add", "-A"])?;
     let title = format!("chore(deps): bump {input} flake input");
     git_in(&work, &["commit", "-m", &title])?;
     // Re-anchor on live `main`: previous bump's PR may have merged since the clone (#563).
@@ -225,6 +245,22 @@ pub(crate) fn bump_one(project: &Path, input: &str) -> BumpResult {
     } else {
         BumpResult::Updated
     }
+}
+
+/// Projects within `root` whose `flake.nix` declares `input` as a flake input —
+/// the repo root flake (single-flake repos) plus every discovered project slot,
+/// so a consumer whose flake lives in a subdir (e.g. buzzingo's `apps/buzzingo`)
+/// is found, not only a root flake. Pure: reads `flake.nix` and string-matches,
+/// no `nix` invocation.
+fn consuming_projects(root: &Path, input: &str) -> Vec<PathBuf> {
+    let mut candidates = vec![root.to_path_buf()];
+    candidates.extend(schema_check::discover(root));
+    candidates.retain(|project| {
+        std::fs::read_to_string(project.join("flake.nix"))
+            .map(|contents| references_flake_input(&contents, input))
+            .unwrap_or(false)
+    });
+    candidates
 }
 
 /// The wasm-bindgen crates a `rust-worker` pins in lockstep — their
@@ -436,5 +472,59 @@ mod tests {
         let body = format_pr_body("kolohelios-nix", &[PathBuf::from("./apps/blogctl")], true);
         assert!(body.contains("Auto-merge queued"));
         assert!(!body.contains("No auto-merge"));
+    }
+
+    #[test]
+    fn consuming_projects_finds_subdir_flake_not_just_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        // buzzingo-shaped: the flake lives in a project subdir, no root flake.
+        let consumer = root.join("apps/buzzingo");
+        std::fs::create_dir_all(&consumer).unwrap();
+        std::fs::write(
+            consumer.join("flake.nix"),
+            "{\n  inputs.shaka.url = \"https://flakehub.com/f/kolohelios/shaka/*.tar.gz\";\n}\n",
+        )
+        .unwrap();
+        // Sibling project that doesn't pin the input.
+        let other = root.join("apps/other");
+        std::fs::create_dir_all(&other).unwrap();
+        std::fs::write(
+            other.join("flake.nix"),
+            "{\n  inputs.nixpkgs.url = \"x\";\n}\n",
+        )
+        .unwrap();
+
+        assert_eq!(consuming_projects(root, "shaka"), vec![consumer]);
+    }
+
+    #[test]
+    fn consuming_projects_includes_a_root_flake() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path();
+        std::fs::write(
+            root.join("flake.nix"),
+            "{\n  inputs.blogctl.url = \"https://flakehub.com/f/kolohelios/blogctl/*.tar.gz\";\n}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            consuming_projects(root, "blogctl"),
+            vec![root.to_path_buf()]
+        );
+    }
+
+    #[test]
+    fn consuming_projects_empty_when_input_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let proj = tmp.path().join("apps/thing");
+        std::fs::create_dir_all(&proj).unwrap();
+        std::fs::write(
+            proj.join("flake.nix"),
+            "{\n  inputs.nixpkgs.url = \"x\";\n}\n",
+        )
+        .unwrap();
+
+        assert!(consuming_projects(tmp.path(), "shaka").is_empty());
     }
 }


### PR DESCRIPTION
bump-locks --repo bumped only the clone's root flake.nix, so it couldn't bump
a repo whose flake lives in a project subdir — e.g. buzzingo, whose flake is
apps/buzzingo/flake.nix with no root flake (--repo errored "does not declare …
(checked root flake.nix)").

Generalize run_remote to discover the consuming project(s) in the clone via
schema_check::discover (the repo root plus every project slot), bump each
consuming project's lock, and git add -A so a subdir flake.lock is staged.
New pure consuming_projects helper + unit tests.

Toward #939.

Add bump-buzzingo-shaka.yaml: a daily + on-demand scheduler that mints a
buzzingo-scoped kolohelios-bot token and runs bump-locks --repo
kolohelios/buzzingo --input shaka --pr-branch bot/bump-shaka --auto-merge, so
buzzingo no longer needs a manual nix flake update shaka to pick up new shaka
releases. Account for the workflow in the audit-workflows hand-authored
allowlist.

Requires the kolohelios-bot App installed on the buzzingo repo.

Closes #939