### PR TITLE
feat(shaka): handle host-built native-app kind across tooling

### DIFF
--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -577,4 +577,43 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 		// `packages` knob.
 		description?: string & !=""
 	}
+} | {
+	// Native mobile app shell — a SwiftUI/iOS or Jetpack Compose/Android
+	// app that links the bindings and libraries a `uniffi` FFI crate
+	// produces. One kind covers both platforms because shaka's behavior is
+	// identical for each: it never builds the app. iOS needs macOS + Xcode
+	// (`xcodebuild`, an XCFramework, a Simulator); Android needs the
+	// Android SDK + Gradle (+ NDK for the `.so`s) — none of which the Linux
+	// `shaka preflight` lane carries.
+	//
+	// So `native-app` is a *host-built* kind: the `project.cue` validates
+	// (keeping the "every project declares a kind" invariant), but shaka
+	// generates no `flake.nix` and no `justfile` for it, and `preflight`
+	// skips it in the per-project `just validate` loop rather than failing
+	// on a build it can't run. Repo-level checks (whitespace, typos, vale,
+	// taplo) still scan its files. The developer assembles the
+	// XCFramework/AAR from the FFI crate (`just ffi-ios` / `ffi-android`
+	// in the consuming repo), links it, and builds in Xcode/Gradle on a
+	// host with the platform toolchain. shaka holds no opinion on project
+	// representation (`.xcodeproj` vs SPM vs XcodeGen/Tuist; Gradle
+	// layout) — that's the consumer's call until a second consumer wants a
+	// shared one.
+	kind: "native-app"
+	nativeApp: {
+		// Target platform. Selects the host toolchain the developer
+		// builds with (Xcode for `ios`, Gradle for `android`); shaka
+		// treats the two identically otherwise.
+		platform: "ios" | "android"
+
+		// The `uniffi` FFI crate (a sibling project elsewhere in the
+		// repo, or in a repo this one consumes) whose generated
+		// bindings/libraries this app links. Recorded so the app's
+		// provenance is declared even though shaka doesn't wire the build.
+		ffiCrate: string & =~"^[a-z][a-z0-9-]*$"
+
+		// Reverse-DNS application identifier — the iOS bundle identifier
+		// or the Android `applicationId` (same grammar). Lowercase
+		// dot-separated segments, e.g. `com.example.app`.
+		appId: string & =~"^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$"
+	}
 })

--- a/tools/shaka/src/preflight.rs
+++ b/tools/shaka/src/preflight.rs
@@ -318,11 +318,24 @@ pub fn run(keep_going: bool, since: Option<String>, json: bool) {
     repo_skipped.extend(repo_inapplicable);
 
     let projects: Vec<PathBuf> = crate::project::schema_check::discover(Path::new("."));
-    let (project_to_run, project_skipped): (Vec<PathBuf>, Vec<PathBuf>) =
+    let (candidates, mut project_skipped): (Vec<PathBuf>, Vec<PathBuf>) =
         projects.into_iter().partition(|p| match &changed {
             None => true,
             Some(paths) => paths.iter().any(|cp| under_project(cp, p)),
         });
+    // Among the path-selected candidates, `native-app` is a host-built
+    // kind (iOS/Android): it has no generated flake or justfile, so there
+    // is no `nix develop . --command just validate` to run on the Linux
+    // preflight lane. Move it to `skipped` rather than failing on a build
+    // this lane can't do — repo-level checks (whitespace, typos, vale,
+    // taplo) still cover its files. Reading the kind only for in-scope
+    // candidates keeps the common `--since` run from shelling `cue export`
+    // for every project. (#941)
+    let (project_to_run, host_built): (Vec<PathBuf>, Vec<PathBuf>) =
+        candidates.into_iter().partition(|p| {
+            crate::project::schema_check::project_kind(p).as_deref() != Some("native-app")
+        });
+    project_skipped.extend(host_built);
 
     let total = repo_to_run.len() + project_to_run.len();
     let total_skipped = repo_skipped.len() + project_skipped.len();

--- a/tools/shaka/src/project/audit.rs
+++ b/tools/shaka/src/project/audit.rs
@@ -52,6 +52,7 @@ pub enum ProjectKind {
     Infra,
     NixLib,
     Document,
+    NativeApp,
 }
 
 impl ProjectKind {
@@ -510,8 +511,11 @@ impl Rule for ValidateRecipeMeaningful {
     fn name(&self) -> &'static str {
         "validate-recipe-meaningful"
     }
-    fn applies(&self, _meta: &ProjectMeta) -> bool {
-        true
+    fn applies(&self, meta: &ProjectMeta) -> bool {
+        // native-app is host-built (iOS/Android): shaka generates no
+        // justfile and preflight skips its per-project `just validate`,
+        // so there's no recipe to hold meaningful. (#941)
+        meta.kind != ProjectKind::NativeApp
     }
     fn check(&self, project_dir: &Path, _meta: &ProjectMeta) -> RuleResult {
         let justfile = project_dir.join("justfile");
@@ -1227,6 +1231,36 @@ mod tests {
             },
             ..rust_meta()
         }
+    }
+
+    fn native_app_meta() -> ProjectMeta {
+        ProjectMeta {
+            name: "demo".into(),
+            kind: ProjectKind::NativeApp,
+            coverage: None,
+            audit: None,
+            cli: None,
+            ci: None,
+        }
+    }
+
+    #[test]
+    fn project_kind_deserializes_native_app() {
+        // audit reads every project's kind via `cue export` -> serde; an
+        // unknown variant would abort the whole `shaka project audit` run,
+        // so the enum must accept the kebab-case `native-app`. (#941)
+        let meta: ProjectMeta =
+            serde_json::from_str(r#"{"name":"buzzingo-ios","kind":"native-app"}"#).expect("parse");
+        assert_eq!(meta.kind, ProjectKind::NativeApp);
+    }
+
+    #[test]
+    fn validate_recipe_rule_skips_native_app() {
+        // native-app is host-built: no justfile, so the validate-recipe
+        // rule must not apply (its check hard-fails on a missing justfile).
+        // It still applies to a kind that carries one. (#941)
+        assert!(!ValidateRecipeMeaningful.applies(&native_app_meta()));
+        assert!(ValidateRecipeMeaningful.applies(&rust_meta()));
     }
 
     #[test]

--- a/tools/shaka/src/project/generate_flakes.rs
+++ b/tools/shaka/src/project/generate_flakes.rs
@@ -267,6 +267,11 @@ pub fn run(check: bool) {
                     render_worker_flake(&meta.name, worker),
                 ));
             }
+            // native-app is host-built (iOS/Android): it has no nix
+            // toolchain — the app builds in Xcode/Gradle — so shaka emits
+            // no flake.nix for it at all. Deliberately flake-less, not a
+            // hand-authored holdout awaiting a template. (#941)
+            "native-app" => continue,
             // Other kinds keep their hand-authored flake.nix until the
             // generator grows a template for them.
             _ => continue,

--- a/tools/shaka/src/project/generate_justfiles.rs
+++ b/tools/shaka/src/project/generate_justfiles.rs
@@ -695,6 +695,14 @@ pub fn run(check: bool) {
     for project in &projects {
         match read_meta(project) {
             Ok(meta) => {
+                // native-app is host-built (iOS/Android): the platform
+                // build runs in Xcode/Gradle, not `just validate`, so
+                // shaka emits no justfile for it. Skip rather than error
+                // like a genuinely unknown kind — this absence is by
+                // design. (#941)
+                if meta.kind == "native-app" {
+                    continue;
+                }
                 if let Some(reason) = waived_justfile(&meta) {
                     println!(
                         "  {YELLOW}{BOLD}WAIVED{RESET}   {} {DIM}({reason}){RESET}",

--- a/tools/shaka/tests/external_repo.rs
+++ b/tools/shaka/tests/external_repo.rs
@@ -47,6 +47,19 @@ fn staged_repo() -> tempfile::TempDir {
     root
 }
 
+/// Add a host-built `native-app` project to a staged repo. iOS/Android
+/// app shells consume the FFI crate but shaka generates nothing for them
+/// and preflight never builds them — see #941.
+fn add_native_app(root: &Path) {
+    let dst = root.join("apps/buzzingo-ios");
+    std::fs::create_dir_all(&dst).unwrap();
+    std::fs::copy(
+        fixtures_root().join("buzzingo-ios/project.cue.fixture"),
+        dst.join("project.cue"),
+    )
+    .unwrap();
+}
+
 fn run(root: &Path, args: &[&str]) -> std::process::Output {
     Command::new(SHAKA_BIN)
         .args(args)
@@ -162,4 +175,64 @@ fn generate_workflows_round_trips_without_a_domain_registry() {
         "--check drifted right after generate: {}",
         String::from_utf8_lossy(&check.stderr)
     );
+}
+
+#[test]
+fn native_app_validates_but_generates_no_flake_or_justfile() {
+    // #941: a host-built native-app (iOS/Android) keeps the "every project
+    // declares a kind" invariant — its project.cue validates — but shaka
+    // generates nothing for it (no nix toolchain, no `just validate`), and
+    // the generators must skip it rather than erroring on a missing
+    // template. Staged alongside the rust-worker so the generators see a
+    // mixed repo, exactly as the buzzingo monorepo will.
+    let repo = staged_repo();
+    add_native_app(repo.path());
+
+    // schema-check accepts both projects.
+    let schema = run(repo.path(), &["project", "schema-check"]);
+    assert!(
+        schema.status.success(),
+        "schema-check rejected a native-app project: {}",
+        String::from_utf8_lossy(&schema.stderr)
+    );
+
+    // generate-flakes succeeds and writes NO flake for the native-app
+    // (the rust-worker still gets one).
+    let flakes = run(repo.path(), &["project", "generate-flakes"]);
+    assert!(
+        flakes.status.success(),
+        "generate-flakes errored on a native-app project: {}",
+        String::from_utf8_lossy(&flakes.stderr)
+    );
+    assert!(
+        !repo.path().join("apps/buzzingo-ios/flake.nix").exists(),
+        "shaka generated a flake.nix for a host-built native-app"
+    );
+
+    // generate-justfiles succeeds and writes NO justfile for the
+    // native-app — skipped, not treated as an unknown kind (which exits 1).
+    let justfiles = run(repo.path(), &["project", "generate-justfiles"]);
+    assert!(
+        justfiles.status.success(),
+        "generate-justfiles errored on a native-app project: {}",
+        String::from_utf8_lossy(&justfiles.stderr)
+    );
+    assert!(
+        !repo.path().join("apps/buzzingo-ios/justfile").exists(),
+        "shaka generated a justfile for a host-built native-app"
+    );
+
+    // ...and both --check passes agree byte-for-byte (no drift introduced
+    // by the native-app project).
+    for cmd in [
+        ["project", "generate-flakes", "--check"],
+        ["project", "generate-justfiles", "--check"],
+    ] {
+        let check = run(repo.path(), &cmd);
+        assert!(
+            check.status.success(),
+            "{cmd:?} drifted with a native-app present: {}",
+            String::from_utf8_lossy(&check.stderr)
+        );
+    }
 }

--- a/tools/shaka/tests/fixtures/external-repo/buzzingo-ios/project.cue.fixture
+++ b/tools/shaka/tests/fixtures/external-repo/buzzingo-ios/project.cue.fixture
@@ -1,0 +1,16 @@
+package project
+
+// A host-built native-app (SwiftUI/iOS) in an external repo: it consumes
+// the buzzingo-ffi uniffi bindings but shaka generates no flake/justfile
+// for it and preflight never builds it (iOS needs macOS + Xcode). The
+// project.cue still validates so the "every project declares a kind"
+// invariant holds. (#941)
+#Project & {
+	name: "buzzingo-ios"
+	kind: "native-app"
+	nativeApp: {
+		platform: "ios"
+		ffiCrate: "buzzingo-ffi"
+		appId:    "com.buzzingo.app"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/native-app-bad-app-id.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/native-app-bad-app-id.cue
@@ -1,0 +1,14 @@
+package project
+
+// `appId` must be reverse-DNS (lowercase dot-separated segments). A
+// single-segment, capitalized, or space-bearing value isn't a valid
+// bundle id / applicationId, so the schema rejects it.
+#Project & {
+	name: "buzzingo-ios"
+	kind: "native-app"
+	nativeApp: {
+		platform: "ios"
+		ffiCrate: "buzzingo-ffi"
+		appId:    "Buzzingo"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/native-app-bad-platform.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/native-app-bad-platform.cue
@@ -1,0 +1,13 @@
+package project
+
+// `platform` is constrained to "ios" | "android"; a native-app for any
+// other platform has no defined host-build flow, so the schema rejects it.
+#Project & {
+	name: "buzzingo-watch"
+	kind: "native-app"
+	nativeApp: {
+		platform: "watchos"
+		ffiCrate: "buzzingo-ffi"
+		appId:    "com.buzzingo.app"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/invalid/native-app-missing-block.cue
+++ b/tools/shaka/tests/fixtures/schema/invalid/native-app-missing-block.cue
@@ -1,0 +1,9 @@
+package project
+
+// `native-app` requires a `nativeApp` block (platform, ffiCrate, appId);
+// declaring the kind without it leaves the app's platform and provenance
+// undefined, so the schema rejects it.
+#Project & {
+	name: "buzzingo-ios"
+	kind: "native-app"
+}

--- a/tools/shaka/tests/fixtures/schema/valid/native-app-android.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/native-app-android.cue
@@ -1,0 +1,14 @@
+package project
+
+// A Jetpack Compose/Android native app shell consuming the same uniffi
+// FFI crate. Host-built (Gradle + Android SDK); the one native-app kind
+// covers both platforms via the `platform` field.
+#Project & {
+	name: "buzzingo-android"
+	kind: "native-app"
+	nativeApp: {
+		platform: "android"
+		ffiCrate: "buzzingo-ffi"
+		appId:    "com.buzzingo.app"
+	}
+}

--- a/tools/shaka/tests/fixtures/schema/valid/native-app-ios.cue
+++ b/tools/shaka/tests/fixtures/schema/valid/native-app-ios.cue
@@ -1,0 +1,14 @@
+package project
+
+// A SwiftUI/iOS native app shell consuming a uniffi FFI crate's
+// bindings. Host-built (Xcode); shaka validates the project.cue but
+// generates no flake/justfile and never builds it.
+#Project & {
+	name: "buzzingo-ios"
+	kind: "native-app"
+	nativeApp: {
+		platform: "ios"
+		ffiCrate: "buzzingo-ffi"
+		appId:    "com.buzzingo.app"
+	}
+}


### PR DESCRIPTION
Native mobile app shells (SwiftUI/iOS, Jetpack Compose/Android) had no
legal kind to declare, yet the monorepo invariant is that every project
declares a project.cue with a schema-validated kind. That blocked
buzzingo#92/#93, the iOS and Android apps that consume the buzzingo-ffi
uniffi bindings.

Add one native-app kind with a platform field (ios|android) rather than
separate swift-app/kotlin-app kinds: shaka's behavior is identical for
both because it never builds either. The kind is host-built — the schema
doc-comment is the authoritative record of that posture (no generated
flake/justfile; preflight skips the build; the developer assembles the
XCFramework/AAR and builds in Xcode/Gradle). nativeApp carries the
platform, the FFI crate it links, and the reverse-DNS appId.

Teach the generators, audit, and preflight that native-app is host-built
so the kind added to the schema actually works end-to-end without a Linux
build gate it can't satisfy:

- generate-justfiles skips it (no justfile; the platform build runs in
  Xcode/Gradle, not `just validate`) rather than erroring on a missing
  template like an unknown kind.
- generate-flakes gets an explicit no-flake arm — deliberately flake-less,
  not a hand-authored holdout awaiting a template.
- audit gains the NativeApp kind variant (so `shaka project audit` doesn't
  abort deserializing it) and gates validate-recipe-meaningful off, since
  that rule hard-fails on a missing justfile.
- preflight moves native-app out of the per-project validate loop,
  reporting it skipped; the kind is read only for path-selected candidates
  so the common --since run doesn't shell cue export for every project.

An external-repo integration test stages a native-app beside the
rust-worker and asserts the generators skip it cleanly (no flake/justfile,
no drift, exit 0); audit unit tests lock the enum and the rule gate.

Closes #941