### PR TITLE
feat(infra/home): replace ghostty with wezterm

### DIFF
--- a/infra/home/dotfiles/ghostty/config
+++ b/infra/home/dotfiles/ghostty/config
@@ -1,4 +1,0 @@
-keybind = shift+enter=text:\x1b\r
-
-# Silent bell — blink the tab instead of playing a sound
-window-urgency = true

--- a/infra/home/dotfiles/wezterm/wezterm.lua
+++ b/infra/home/dotfiles/wezterm/wezterm.lua
@@ -1,0 +1,25 @@
+local wezterm = require('wezterm')
+local act = wezterm.action
+local config = wezterm.config_builder()
+
+-- Send ESC + CR on shift+enter (ported from the ghostty
+-- `keybind = shift+enter=text:\x1b\r`). Lets apps that read shift+enter
+-- as "newline, don't submit" work in the terminal.
+config.keys = {
+  {
+    key = 'Enter',
+    mods = 'SHIFT',
+    action = act.SendString('\x1b\r'),
+  },
+}
+
+-- Silent bell: no sound, blink the screen instead — the wezterm
+-- equivalent of ghostty's `window-urgency = true` + silent bell.
+config.audible_bell = 'Disabled'
+config.visual_bell = {
+  fade_in_duration_ms = 75,
+  fade_out_duration_ms = 75,
+  target = 'CursorColor',
+}
+
+return config

--- a/infra/home/modules/common.nix
+++ b/infra/home/modules/common.nix
@@ -4,6 +4,7 @@
 # module stays platform-agnostic.
 {
   pkgs,
+  lib,
   claude-hooks,
   shaka,
   ...
@@ -67,7 +68,12 @@ in
     # kolohelios checkout it runs the in-tree build; everywhere else it
     # execs the FlakeHub package (see `shakaGlobal` above).
     shakaGlobal
-  ];
+  ]
+  # wezterm on Linux comes from nixpkgs (builds cleanly there); macOS
+  # installs it via the homebrew cask in `modules/darwin.nix` because
+  # `pkgs.wezterm` is fragile on aarch64-darwin. Config (`wezterm.lua`)
+  # is shared across both via `xdg.configFile` below.
+  ++ lib.optional pkgs.stdenv.hostPlatform.isLinux pkgs.wezterm;
 
   programs.git = {
     enable = true;
@@ -127,7 +133,7 @@ in
   # Zellij's keybind tree is too elaborate to express idiomatically in
   # nix. Ship the kdl file as-is and let home-manager symlink it.
   xdg.configFile."zellij/config.kdl".source = ../dotfiles/zellij/config.kdl;
-  xdg.configFile."ghostty/config".source = ../dotfiles/ghostty/config;
+  xdg.configFile."wezterm/wezterm.lua".source = ../dotfiles/wezterm/wezterm.lua;
 
   # Claude Code skills that aren't tied to a specific project. Lifted
   # from `kolohelios/.claude/commands/` so they apply to claude

--- a/infra/home/modules/darwin.nix
+++ b/infra/home/modules/darwin.nix
@@ -62,12 +62,12 @@
     };
     casks = [
       "claude-code@latest"
-      # `pkgs.ghostty` is Linux-only (`meta.platforms` lists no darwin —
-      # the macOS app needs the Xcode toolchain nixpkgs can't build), so
-      # the Mac install rides the same cask path as `claude-code`. The
-      # ghostty config is already managed via `xdg.configFile` in
-      # `common.nix`. Linux uses the host's built-in terminal (#735).
-      "ghostty"
+      # `pkgs.wezterm` is fragile on aarch64-darwin (the GUI build pulls a
+      # heavy toolchain nixpkgs struggles to build reliably), so the Mac
+      # install rides the same cask path as `claude-code`. Linux installs
+      # `pkgs.wezterm` from nixpkgs instead (see `common.nix`). The wezterm
+      # config is managed via `xdg.configFile` in `common.nix` on both.
+      "wezterm"
     ];
   };
 


### PR DESCRIPTION
Switch the default terminal to wezterm on both platforms. macOS installs
the wezterm homebrew cask (pkgs.wezterm is fragile on aarch64-darwin, same
reason ghostty rode the cask path); Linux installs pkgs.wezterm, which
builds cleanly there, superseding the host-terminal fallback from #735.
The two carried-over ghostty settings (shift+enter sends ESC CR, silent
visual bell) move into a shared dotfiles/wezterm/wezterm.lua symlinked on
both platforms.

Closes #948