### PR TITLE
fix(shaka): close orphaned linked issues during workspace cleanup

### DIFF
--- a/tools/shaka/src/commit.rs
+++ b/tools/shaka/src/commit.rs
@@ -406,9 +406,16 @@ pub(crate) fn inject_autoclose(description: &str, tied: &[u64]) -> Option<String
     if tied.is_empty() {
         return None;
     }
-    let body = description.split_once('\n').map(|(_, rest)| rest).unwrap_or("");
+    let body = description
+        .split_once('\n')
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
     let present = issue_ref::extract_autoclose_refs(body);
-    let missing: Vec<u64> = tied.iter().copied().filter(|n| !present.contains(n)).collect();
+    let missing: Vec<u64> = tied
+        .iter()
+        .copied()
+        .filter(|n| !present.contains(n))
+        .collect();
     if missing.is_empty() {
         return None;
     }
@@ -921,7 +928,10 @@ mod tests {
     #[test]
     fn inject_autoclose_handles_multiple_missing() {
         let got = inject_autoclose("feat: x\n\nWhy.", &[7, 9]);
-        assert_eq!(got.as_deref(), Some("feat: x\n\nWhy.\n\nCloses #7\nCloses #9"));
+        assert_eq!(
+            got.as_deref(),
+            Some("feat: x\n\nWhy.\n\nCloses #7\nCloses #9")
+        );
     }
 
     #[test]

--- a/tools/shaka/src/commit.rs
+++ b/tools/shaka/src/commit.rs
@@ -390,6 +390,78 @@ fn check_issue_link(commit: &Commit, tied_issues: &[u64]) -> Option<Finding> {
     })
 }
 
+/// Pure: given a commit `description` (title line + body) and the issue
+/// numbers the branch is tied to, return an amended description that
+/// appends a `Closes #N` line for every tied issue whose autoclose
+/// reference is missing from the body. Returns `None` when nothing needs
+/// adding (no tied issues, or every one is already referenced).
+///
+/// New references are appended as a trailing block, separated from the
+/// existing message by a blank line, one `Closes #N` per line in the
+/// order given. The keyword has to live in the commit that lands on the
+/// default branch: shaka merges via rebase, and GitHub only runs its
+/// body-keyword autoclose on its own merge event — not on the rebased
+/// commits it records by detection (#946).
+pub(crate) fn inject_autoclose(description: &str, tied: &[u64]) -> Option<String> {
+    if tied.is_empty() {
+        return None;
+    }
+    let body = description.split_once('\n').map(|(_, rest)| rest).unwrap_or("");
+    let present = issue_ref::extract_autoclose_refs(body);
+    let missing: Vec<u64> = tied.iter().copied().filter(|n| !present.contains(n)).collect();
+    if missing.is_empty() {
+        return None;
+    }
+    let trailer = missing
+        .iter()
+        .map(|n| format!("Closes #{n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(format!("{}\n\n{trailer}", description.trim_end()))
+}
+
+/// Shared computation for the autoclose-injection helpers: read `@`'s
+/// description and the tied-issue numbers whose autoclose reference is
+/// missing from its body. Tied issues come from the same heuristics
+/// `commit lint` uses (`gather_tied_issues`).
+fn autoclose_gap(revset: &str) -> Result<(String, Vec<u64>), String> {
+    let description = jj::current_description().map_err(|e| e.to_string())?;
+    let tied = gather_tied_issues(revset);
+    if tied.is_empty() {
+        return Ok((description, Vec::new()));
+    }
+    let body = description
+        .split_once('\n')
+        .map(|(_, rest)| rest)
+        .unwrap_or("");
+    let present = issue_ref::extract_autoclose_refs(body);
+    let missing = tied.into_iter().filter(|n| !present.contains(n)).collect();
+    Ok((description, missing))
+}
+
+/// Read-only: the issue numbers `ensure_tip_autocloses` would inject for
+/// `revset`. Used by `--dry-run` callers to preview the amendment without
+/// mutating the commit.
+pub fn tip_autoclose_plan(revset: &str) -> Result<Vec<u64>, String> {
+    Ok(autoclose_gap(revset)?.1)
+}
+
+/// Ensure the working-copy commit (`@`, the tip that lands on `main`)
+/// carries a `Closes #N` reference for every issue the current branch is
+/// tied to, amending its description in place when one is missing.
+/// Idempotent: a no-op when the branch isn't issue-tied or the references
+/// are already present. Returns the issue numbers it injected (empty when
+/// nothing changed) so callers can report the amendment.
+pub fn ensure_tip_autocloses(revset: &str) -> Result<Vec<u64>, String> {
+    let (description, missing) = autoclose_gap(revset)?;
+    if missing.is_empty() {
+        return Ok(Vec::new());
+    }
+    let updated = inject_autoclose(&description, &missing).expect("missing non-empty yields Some");
+    jj::describe(&updated).map_err(|e| e.to_string())?;
+    Ok(missing)
+}
+
 fn lint_commit(commit: &Commit, ctx: &LintContext) -> Vec<Finding> {
     let mut findings = Vec::new();
     let desc = commit.description.trim_end();
@@ -818,6 +890,63 @@ mod tests {
         // plus workspace link to #99). Closing either satisfies the rule.
         let commit = commit_at_tip("feat: x\n\nCloses #99");
         assert!(check_issue_link(&commit, &[42, 99]).is_none());
+    }
+
+    // -- autoclose injection -------------------------------------------
+
+    #[test]
+    fn inject_autoclose_appends_when_missing() {
+        let got = inject_autoclose("feat(shaka): add thing\n\nWhy this matters.", &[42]);
+        assert_eq!(
+            got.as_deref(),
+            Some("feat(shaka): add thing\n\nWhy this matters.\n\nCloses #42")
+        );
+    }
+
+    #[test]
+    fn inject_autoclose_noop_when_already_present() {
+        // Any autoclose keyword for the tied issue satisfies the rule.
+        for body in ["Closes #42", "Fixes #42", "resolves #42"] {
+            let desc = format!("feat: x\n\n{body}");
+            assert_eq!(inject_autoclose(&desc, &[42]), None, "for body {body:?}");
+        }
+    }
+
+    #[test]
+    fn inject_autoclose_appends_only_missing_of_multiple() {
+        let got = inject_autoclose("feat: x\n\nCloses #42", &[42, 99]);
+        assert_eq!(got.as_deref(), Some("feat: x\n\nCloses #42\n\nCloses #99"));
+    }
+
+    #[test]
+    fn inject_autoclose_handles_multiple_missing() {
+        let got = inject_autoclose("feat: x\n\nWhy.", &[7, 9]);
+        assert_eq!(got.as_deref(), Some("feat: x\n\nWhy.\n\nCloses #7\nCloses #9"));
+    }
+
+    #[test]
+    fn inject_autoclose_title_only_commit() {
+        let got = inject_autoclose("feat: solo", &[42]);
+        assert_eq!(got.as_deref(), Some("feat: solo\n\nCloses #42"));
+    }
+
+    #[test]
+    fn inject_autoclose_none_when_no_tied_issues() {
+        assert_eq!(inject_autoclose("feat: x\n\nWhy.", &[]), None);
+    }
+
+    #[test]
+    fn inject_autoclose_refs_keyword_does_not_count() {
+        // `Refs #N` isn't an autoclose keyword, so the issue is still
+        // missing a real close and gets one appended.
+        let got = inject_autoclose("feat: x\n\nRefs #42", &[42]);
+        assert_eq!(got.as_deref(), Some("feat: x\n\nRefs #42\n\nCloses #42"));
+    }
+
+    #[test]
+    fn inject_autoclose_trims_trailing_whitespace_before_appending() {
+        let got = inject_autoclose("feat: x\n\nWhy.\n\n", &[42]);
+        assert_eq!(got.as_deref(), Some("feat: x\n\nWhy.\n\nCloses #42"));
     }
 
     #[test]

--- a/tools/shaka/src/gh.rs
+++ b/tools/shaka/src/gh.rs
@@ -258,26 +258,86 @@ pub fn pr_for_head(repo: &str, head: &str) -> Result<Option<PrInfo>, GhError> {
     Ok(Some(PrInfo { number, url, state }))
 }
 
-/// Find the merged PR that closed the given issue, if any.
+/// An issue's open/closed state together with the merged PR (if any) that
+/// GitHub links as closing it. Crucially this does *not* gate on the issue
+/// being closed — it surfaces the "PR merged but issue still open" case
+/// that shaka's rebase merge leaves behind (#946), so `workspace cleanup`
+/// can close the orphaned issue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueClosure {
+    /// True when the issue is still open on the remote.
+    pub issue_open: bool,
+    /// The first *merged* PR among the issue's closing references, if any.
+    pub merged_closing_pr: Option<PrInfo>,
+}
+
+/// Query an issue's state and its linked closing PRs in one GraphQL call.
 ///
-/// Uses `gh issue view N --json state,closedByPullRequestsReferences`. GitHub
-/// only populates `closedByPullRequestsReferences` for PRs that were merged
-/// with an autoclose keyword (`Closes #N`, `Fixes #N`, …) — exactly the
-/// signal we want for `shaka workspace cleanup` to identify a workspace whose
-/// work has landed, even after `repo sync` has deleted the local bookmark.
-///
-/// Returns `Ok(None)` if the issue is open, has no closing PR reference, or
-/// the issue does not exist. Returns the first referenced PR if multiple.
-pub fn merged_pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError> {
+/// `closedByPullRequestsReferences` lists the PRs GitHub has linked to the
+/// issue via an autoclose keyword, regardless of whether the issue itself
+/// closed — which is exactly the gap that the rebase-merge path opens.
+/// `repo` is `owner/name`.
+pub fn issue_closure(repo: &str, n: u64) -> Result<IssueClosure, GhError> {
+    let mut parts = repo.splitn(2, '/');
+    let owner = parts.next().unwrap_or("");
+    let name = parts.next().unwrap_or("");
+    const QUERY: &str = "query($owner:String!,$name:String!,$number:Int!){\
+        repository(owner:$owner,name:$name){\
+        issue(number:$number){state \
+        closedByPullRequestsReferences(first:10,includeClosedPrs:true){\
+        nodes{number url state}}}}}";
+    let result = api_graphql(
+        QUERY,
+        &[("owner", owner), ("name", name)],
+        &[("number", n as i64)],
+    )?;
+    parse_issue_closure(&result, n, repo)
+}
+
+/// Pure: extract an [`IssueClosure`] from the GraphQL response envelope.
+/// Errors if the issue node is absent (not found / no access).
+fn parse_issue_closure(result: &Value, n: u64, repo: &str) -> Result<IssueClosure, GhError> {
+    let issue = &result["data"]["repository"]["issue"];
+    if issue.is_null() {
+        return SchemaSnafu {
+            message: format!("issue #{n} not found in {repo}"),
+        }
+        .fail();
+    }
+
+    let issue_open = issue["state"].as_str() == Some("OPEN");
+    let merged_closing_pr = issue["closedByPullRequestsReferences"]["nodes"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|node| node["state"].as_str() == Some("MERGED"))
+        .and_then(|node| {
+            let number = node["number"].as_u64()?;
+            let url = node["url"].as_str()?.to_string();
+            Some(PrInfo {
+                number,
+                url,
+                state: PrState::Merged,
+            })
+        });
+
+    Ok(IssueClosure {
+        issue_open,
+        merged_closing_pr,
+    })
+}
+
+/// Close an issue, leaving an explanatory comment. Wraps `gh issue close`.
+pub fn close_issue(repo: &str, n: u64, comment: &str) -> Result<(), GhError> {
     let output = Command::new("gh")
         .args([
             "issue",
-            "view",
+            "close",
             &n.to_string(),
             "--repo",
             repo,
-            "--json",
-            "state,closedByPullRequestsReferences",
+            "--comment",
+            comment,
         ])
         .output()
         .context(SpawnSnafu)?;
@@ -285,54 +345,21 @@ pub fn merged_pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return GhCommandSnafu {
-            command: format!("gh issue view {n} --repo {repo}"),
+            command: format!("gh issue close {n} --repo {repo}"),
             stderr: stderr.trim().to_string(),
         }
         .fail();
     }
-
-    let body = String::from_utf8_lossy(&output.stdout);
-    if body.trim().is_empty() {
-        return Ok(None);
-    }
-    let parsed: Value = serde_json::from_str(&body).context(JsonParseSnafu {
-        context: format!("failed to parse JSON from gh issue view {n}"),
-    })?;
-
-    if parsed["state"].as_str() != Some("CLOSED") {
-        return Ok(None);
-    }
-
-    let Some(first) = parsed["closedByPullRequestsReferences"]
-        .as_array()
-        .and_then(|arr| arr.first())
-    else {
-        return Ok(None);
-    };
-
-    let number = first["number"].as_u64().with_context(|| SchemaSnafu {
-        message: format!("closing PR for issue #{n} missing 'number' field"),
-    })?;
-    let url = first["url"]
-        .as_str()
-        .with_context(|| SchemaSnafu {
-            message: format!("closing PR for issue #{n} missing 'url' field"),
-        })?
-        .to_string();
-    Ok(Some(PrInfo {
-        number,
-        url,
-        state: PrState::Merged,
-    }))
+    Ok(())
 }
 
 /// Find a PR (open, closed, or merged) whose body references `Closes #n`.
 /// Returns the first match (most recently updated by gh's default sort).
 ///
 /// Relies on the repo convention of `Closes #N` in PR bodies (CLAUDE.md);
-/// `Fixes`/`Resolves` aren't matched. For merged PRs that closed the issue
-/// you can also use [`merged_pr_for_issue`] — this helper additionally
-/// catches *open* PRs, which `closedByPullRequestsReferences` does not.
+/// `Fixes`/`Resolves` aren't matched. For the merged PR linked to an issue
+/// you can also use [`issue_closure`] — this helper additionally catches
+/// *open* PRs, which `closedByPullRequestsReferences` does not.
 pub fn pr_for_issue(repo: &str, n: u64) -> Result<Option<PrInfo>, GhError> {
     let query = format!("in:body Closes #{n}");
     let output = Command::new("gh")
@@ -1313,6 +1340,82 @@ mod tests {
     #[test]
     fn parse_open_prs_empty() {
         assert!(parse_open_prs("[]").unwrap().is_empty());
+    }
+
+    fn closure_envelope(state: &str, refs: Value) -> Value {
+        serde_json::json!({
+            "data": { "repository": { "issue": {
+                "state": state,
+                "closedByPullRequestsReferences": { "nodes": refs }
+            }}}
+        })
+    }
+
+    #[test]
+    fn parse_issue_closure_open_with_merged_pr() {
+        // The #946 case: issue still open, but its linked PR has merged.
+        let env = closure_envelope(
+            "OPEN",
+            serde_json::json!([{"number": 77, "url": "https://x/pull/77", "state": "MERGED"}]),
+        );
+        let c = parse_issue_closure(&env, 33, "o/r").unwrap();
+        assert!(c.issue_open);
+        let pr = c.merged_closing_pr.unwrap();
+        assert_eq!(pr.number, 77);
+        assert_eq!(pr.state, PrState::Merged);
+    }
+
+    #[test]
+    fn parse_issue_closure_ignores_open_linked_pr() {
+        // A linked-but-unmerged PR doesn't count — nothing has landed yet.
+        let env = closure_envelope(
+            "OPEN",
+            serde_json::json!([{"number": 5, "url": "https://x/pull/5", "state": "OPEN"}]),
+        );
+        let c = parse_issue_closure(&env, 1, "o/r").unwrap();
+        assert!(c.issue_open);
+        assert!(c.merged_closing_pr.is_none());
+    }
+
+    #[test]
+    fn parse_issue_closure_picks_merged_among_many() {
+        let env = closure_envelope(
+            "OPEN",
+            serde_json::json!([
+                {"number": 5, "url": "https://x/pull/5", "state": "CLOSED"},
+                {"number": 9, "url": "https://x/pull/9", "state": "MERGED"},
+            ]),
+        );
+        let pr = parse_issue_closure(&env, 1, "o/r")
+            .unwrap()
+            .merged_closing_pr
+            .unwrap();
+        assert_eq!(pr.number, 9);
+    }
+
+    #[test]
+    fn parse_issue_closure_closed_issue() {
+        let env = closure_envelope(
+            "CLOSED",
+            serde_json::json!([{"number": 77, "url": "https://x/pull/77", "state": "MERGED"}]),
+        );
+        let c = parse_issue_closure(&env, 1, "o/r").unwrap();
+        assert!(!c.issue_open);
+        assert!(c.merged_closing_pr.is_some());
+    }
+
+    #[test]
+    fn parse_issue_closure_no_refs() {
+        let c = parse_issue_closure(&closure_envelope("OPEN", serde_json::json!([])), 1, "o/r")
+            .unwrap();
+        assert!(c.issue_open);
+        assert!(c.merged_closing_pr.is_none());
+    }
+
+    #[test]
+    fn parse_issue_closure_missing_issue_errors() {
+        let env = serde_json::json!({"data": {"repository": {"issue": null}}});
+        assert!(parse_issue_closure(&env, 42, "o/r").is_err());
     }
 
     #[test]

--- a/tools/shaka/src/repo/send.rs
+++ b/tools/shaka/src/repo/send.rs
@@ -1,8 +1,13 @@
+use crate::commit;
 use crate::gh;
 use crate::jj;
 use crate::preflight;
 use crate::repo::describe;
 use crate::term::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
+
+/// Revset for the commits this branch lands on `main` — the tip (`@`) is
+/// the load-bearing commit that must carry the autoclose keyword.
+const BRANCH_REVSET: &str = "main@origin..@";
 
 pub fn run(bookmark_arg: Option<String>, no_pr: bool, no_auto_merge: bool, dry_run: bool) {
     let description = match jj::current_description() {
@@ -32,6 +37,12 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, no_auto_merge: bool, dry_r
         },
     };
 
+    // Land the autoclose keyword in the commit, not just the PR body: a
+    // rebase merge doesn't trigger GitHub's body-keyword autoclose (#946).
+    if !dry_run {
+        inject_autoclose();
+    }
+
     let synthesized = match describe::for_current_branch() {
         Ok(d) => d,
         Err(e) => {
@@ -45,6 +56,14 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, no_auto_merge: bool, dry_r
     if dry_run {
         println!("would run: jj git fetch");
         println!("would run: jj rebase -b @ -d main@origin");
+        match commit::tip_autoclose_plan(BRANCH_REVSET) {
+            Ok(missing) if !missing.is_empty() => {
+                let refs = format_refs(&missing);
+                println!("would run: jj describe @ {DIM}(inject {refs}){RESET}");
+            }
+            Ok(_) => {}
+            Err(e) => eprintln!("{YELLOW}{BOLD}warn:{RESET} could not plan autoclose: {e}"),
+        }
         println!(
             "would run: shaka preflight --since main@origin {DIM}(only if rebase moved @){RESET}"
         );
@@ -144,6 +163,29 @@ pub fn run(bookmark_arg: Option<String>, no_pr: bool, no_auto_merge: bool, dry_r
     if !no_auto_merge {
         queue_auto_merge(&pr_url);
     }
+}
+
+/// Inject `Closes #N` into the tip commit for any tied issue missing it,
+/// reporting what changed. Soft-fails: the keyword is a convenience, so a
+/// jj error here shouldn't abort the send — `commit lint` still gates the
+/// commit, and the user can add it by hand.
+fn inject_autoclose() {
+    match commit::ensure_tip_autocloses(BRANCH_REVSET) {
+        Ok(injected) if !injected.is_empty() => {
+            println!(
+                "{DIM}injected {} into tip commit{RESET}",
+                format_refs(&injected)
+            );
+        }
+        Ok(_) => {}
+        Err(e) => eprintln!("{YELLOW}{BOLD}warn:{RESET} could not inject autoclose keyword: {e}"),
+    }
+}
+
+/// Render issue numbers as a `Closes #a, #b` phrase for status output.
+fn format_refs(issues: &[u64]) -> String {
+    let refs: Vec<String> = issues.iter().map(|n| format!("#{n}")).collect();
+    format!("Closes {}", refs.join(", "))
 }
 
 /// Queue GitHub auto-merge (rebase strategy) on the PR. Soft-fails:

--- a/tools/shaka/src/repo/ship.rs
+++ b/tools/shaka/src/repo/ship.rs
@@ -37,6 +37,17 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
     if dry_run {
         println!("would run: jj git fetch");
         println!("would run: jj rebase -b @ -d main@origin");
+        match commit::tip_autoclose_plan(SHIP_REVSET) {
+            Ok(missing) if !missing.is_empty() => {
+                let refs: Vec<String> = missing.iter().map(|n| format!("#{n}")).collect();
+                println!(
+                    "would run: jj describe @ {DIM}(inject Closes {}){RESET}",
+                    refs.join(", ")
+                );
+            }
+            Ok(_) => {}
+            Err(e) => eprintln!("{YELLOW}{BOLD}warn:{RESET} could not plan autoclose: {e}"),
+        }
         println!("would run: shaka commit lint -r {SHIP_REVSET}");
         println!("would run: jj diff -r {SHIP_REVSET}");
         if skip_preflight {
@@ -72,6 +83,21 @@ pub fn run(bookmark_arg: Option<String>, skip_preflight: bool, dry_run: bool) {
             "{YELLOW}{BOLD}nothing to ship{RESET} (no non-empty commits ahead of main@origin)"
         );
         return;
+    }
+
+    // Inject `Closes #N` before linting so the issue-link rule passes on
+    // an issue-tied branch instead of failing — and so the keyword lands
+    // in the commit that hits `main`, surviving the rebase merge (#946).
+    match commit::ensure_tip_autocloses(SHIP_REVSET) {
+        Ok(injected) if !injected.is_empty() => {
+            let refs: Vec<String> = injected.iter().map(|n| format!("#{n}")).collect();
+            println!(
+                "{DIM}injected Closes {} into tip commit{RESET}",
+                refs.join(", ")
+            );
+        }
+        Ok(_) => {}
+        Err(e) => eprintln!("{YELLOW}{BOLD}warn:{RESET} could not inject autoclose keyword: {e}"),
     }
 
     println!("{BOLD}step 3/6: linting commits in {SHIP_REVSET}{RESET}");

--- a/tools/shaka/src/workspace/cleanup.rs
+++ b/tools/shaka/src/workspace/cleanup.rs
@@ -9,6 +9,10 @@ use std::path::Path;
 struct MergedWorkspace {
     name: String,
     pr_url: String,
+    /// A linked issue still open despite the merged PR — GitHub's
+    /// body-keyword autoclose doesn't fire on shaka's rebase merge (#946),
+    /// so cleanup closes it as a belt-and-suspenders.
+    open_issue: Option<u64>,
 }
 
 /// Walk all workspaces, find ones whose work has landed via a merged PR,
@@ -62,6 +66,7 @@ pub fn run(dry_run: bool) {
             candidates.push(MergedWorkspace {
                 name: ws.name.clone(),
                 pr_url,
+                open_issue: open_linked_issue(&repo_root, &repo, &ws.name),
             });
         }
     }
@@ -73,11 +78,19 @@ pub fn run(dry_run: bool) {
 
     for candidate in &candidates {
         if dry_run {
+            if let Some(issue) = candidate.open_issue {
+                println!(
+                    "{DIM}dry-run:{RESET} would close issue {BOLD}#{issue}{RESET} (merged: {})",
+                    candidate.pr_url
+                );
+            }
             println!(
                 "{DIM}dry-run:{RESET} would forget workspace {BOLD}{}{RESET} (merged: {})",
                 candidate.name, candidate.pr_url
             );
         } else {
+            close_open_issue(&repo, candidate);
+
             let path = workspace_path(&repo_root, &candidate.name);
 
             if let Err(e) = jj::workspace_forget(&candidate.name) {
@@ -129,4 +142,41 @@ fn resolve_merged_pr(repo_root: &Path, repo: &str, name: &str) -> Option<String>
     let bookmarks = jj::bookmarks_on(&revset).unwrap_or_default();
 
     staleness::resolve_merged_pr(repo, name, &bookmarks, issue_from_link)
+}
+
+/// If the workspace has a persisted issue link whose issue is still open
+/// despite a merged closing PR, return the issue number. This is the #946
+/// case: the rebase merge that landed the PR didn't trigger GitHub's
+/// body-keyword autoclose, so the issue lingers open.
+fn open_linked_issue(repo_root: &Path, repo: &str, name: &str) -> Option<u64> {
+    let issue = issue_link::read(repo_root, name).ok().flatten()?.issue;
+    match gh::issue_closure(repo, issue) {
+        Ok(c) if c.issue_open && c.merged_closing_pr.is_some() => Some(issue),
+        Ok(_) => None,
+        Err(e) => {
+            eprintln!("{DIM}warn:{RESET} could not check issue #{issue} state: {e}");
+            None
+        }
+    }
+}
+
+/// Close the candidate's still-open linked issue, leaving a comment that
+/// explains why shaka closed it. Soft-fails so a close error doesn't block
+/// forgetting the workspace.
+fn close_open_issue(repo: &str, candidate: &MergedWorkspace) {
+    let Some(issue) = candidate.open_issue else {
+        return;
+    };
+    let comment = format!(
+        "Closing automatically: {} merged via shaka's rebase flow, which doesn't \
+         trigger GitHub's PR-body autoclose. (shaka workspace cleanup, #946)",
+        candidate.pr_url
+    );
+    match gh::close_issue(repo, issue, &comment) {
+        Ok(()) => println!(
+            "{GREEN}{BOLD}closed{RESET} issue {BOLD}#{issue}{RESET} (merged: {})",
+            candidate.pr_url
+        ),
+        Err(e) => eprintln!("{RED}{BOLD}error:{RESET} failed to close issue #{issue}: {e}"),
+    }
 }

--- a/tools/shaka/src/workspace/staleness.rs
+++ b/tools/shaka/src/workspace/staleness.rs
@@ -104,9 +104,16 @@ pub(super) fn resolve_merged_pr(
         .filter(|_| issue_from_link.is_none());
 
     if let Some(issue) = issue_from_link.or(issue_from_name) {
-        match gh::merged_pr_for_issue(repo, issue) {
-            Ok(Some(pr)) => return Some(pr.url),
-            Ok(None) => {}
+        // A merged closing PR means the work landed — even if GitHub left
+        // the issue open because the rebase merge skipped the body-keyword
+        // autoclose (#946). `issue_closure` reports that case; the older
+        // `merged_pr_for_issue` missed it by gating on a closed issue.
+        match gh::issue_closure(repo, issue) {
+            Ok(c) => {
+                if let Some(pr) = c.merged_closing_pr {
+                    return Some(pr.url);
+                }
+            }
             Err(e) => {
                 eprintln!("{DIM}warn:{RESET} could not query PR for issue #{issue}: {e}");
             }


### PR DESCRIPTION
shaka merges PRs with a rebase strategy, so GitHub records the merge by
commit detection rather than its own merge event. In that path GitHub
never runs the body-keyword autoclose automation, leaving issues that
only carried `Closes #N` in the PR body open after merge. Closing
keywords in a commit message, by contrast, are honored on any push to
the default branch.

Inject `Closes #N` into the tip commit for every tied issue (resolved
from the workspace --issue link or an iN bookmark) that lacks it, in both
repo send and repo ship. ship injects before commit lint so the issue-link
rule passes automatically instead of demanding a manual edit.

Belt-and-suspenders for the rebase-merge autoclose gap: even with the
keyword now landing in the commit, a PR merged outside that path (manual
gh merge, a body-only keyword) can leave its linked issue open. When
workspace cleanup finds a merged workspace whose persisted --issue link
points at a still-open issue, close it with a comment naming the PR.

Add gh::issue_closure (GraphQL: issue state plus its merged closing PR,
without gating on the issue being closed) and gh::close_issue. Cleanup
detection now treats a merged closing PR as landed even when the issue is
open, which also lets such workspaces be forgotten instead of lingering.

Closes #946