### PR TITLE
fix(notes-web): build and ship editor bundle on deploy

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -80,6 +80,11 @@ on:
         required: false
         type: string
         default: ""
+      pre_build_command:
+        description: "If non-empty, a shell command run (cwd = project_dir, with nix on PATH) before worker-build in every mode. Use to stage build artifacts produced by another project into this Worker's asset directory (the command picks its own devshell, e.g. `nix develop ../other`). Empty = skip."
+        required: false
+        type: string
+        default: ""
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN:
         description: "1Password Service Account token used by `op run` to resolve `.env` references"
@@ -138,6 +143,25 @@ jobs:
           out=$(nix build --no-link --print-out-paths \
             "https://flakehub.com/f/kolohelios/shaka/*.tar.gz")
           echo "CFDEPLOY_SHAKA=$out/bin" >> "$GITHUB_ENV"
+      - name: pre-build assets
+        # Stage build artifacts produced by *another* project into this
+        # Worker's asset directory before `worker-build`/`wrangler deploy`.
+        # E.g. notes-web builds the notes-editor WASM bundle into
+        # `dist/editor/` here so `[assets]` ships it. The command picks
+        # its own devshell (only `nix` is guaranteed on PATH) — typically
+        # `nix develop ../<other> --command ...` — because the artifact's
+        # toolchain lives in *its* flake, not this project's. Runs in
+        # every mode (verify/preview/deploy) so a broken cross-project
+        # build fails the PR verify, not just the production deploy.
+        #
+        # Passed via `env` and run through `bash -c "$VAR"` rather than
+        # interpolated into `run:` directly, so the command can't be a
+        # workflow-expression injection vector.
+        if: ${{ inputs.pre_build_command != '' }}
+        working-directory: ${{ inputs.project_dir }}
+        env:
+          PRE_BUILD_COMMAND: ${{ inputs.pre_build_command }}
+        run: bash -c "$PRE_BUILD_COMMAND"
       - name: worker-build
         working-directory: ${{ inputs.project_dir }}
         # Build the worker upstream of `wrangler deploy` so the wasm

--- a/.github/workflows/notes-web-deploy.yml
+++ b/.github/workflows/notes-web-deploy.yml
@@ -46,11 +46,13 @@ jobs:
             - 'apps/notes-web/**'
             - '.github/workflows/notes-web-deploy.yml'
             - '.github/workflows/cf-deploy.yml'
+            - 'apps/notes-editor/**'
   verify:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.portfolio == 'true' && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/cf-deploy.yml
     with:
+      pre_build_command: nix develop ../notes-editor --command bash -c 'cd ../notes-editor && just wasm-build' && mkdir -p dist/editor && cp ../notes-editor/dist/* dist/editor/
       project_dir: apps/notes-web
       verify_only: true
     secrets:
@@ -62,6 +64,7 @@ jobs:
     if: github.event_name == 'pull_request' && needs.changes.outputs.portfolio == 'true' && github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/cf-deploy.yml
     with:
+      pre_build_command: nix develop ../notes-editor --command bash -c 'cd ../notes-editor && just wasm-build' && mkdir -p dist/editor && cp ../notes-editor/dist/* dist/editor/
       project_dir: apps/notes-web
       script_name_override: notes-web-pr-${{ github.event.pull_request.number }}
     secrets:
@@ -100,6 +103,7 @@ jobs:
     if: (github.event_name == 'push' && needs.changes.outputs.portfolio == 'true') || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/cf-deploy.yml
     with:
+      pre_build_command: nix develop ../notes-editor --command bash -c 'cd ../notes-editor && just wasm-build' && mkdir -p dist/editor && cp ../notes-editor/dist/* dist/editor/
       project_dir: apps/notes-web
       verify_only: false
     secrets:

--- a/apps/notes-web/project.cue
+++ b/apps/notes-web/project.cue
@@ -27,6 +27,16 @@ package project
 		deploy: {
 			reusableWorkflow:    "./.github/workflows/cf-deploy.yml"
 			previewScriptPrefix: "notes-web"
+			// The editing surface is the Rust-WASM bundle built from
+			// apps/notes-editor; `dist/editor/` is a build artifact (not
+			// committed). Build it in the editor's own devshell and stage it
+			// into this Worker's `[assets]` dir before worker-build/wrangler,
+			// so the deployed shell can import `/editor/notes_editor.js`.
+			// Mirrors the manual steps in apps/notes-web/README.md.
+			preBuildCommand: "nix develop ../notes-editor --command bash -c 'cd ../notes-editor && just wasm-build' && mkdir -p dist/editor && cp ../notes-editor/dist/* dist/editor/"
+			// An editor source change must redeploy notes-web — the bundle it
+			// ships is rebuilt by preBuildCommand above.
+			extraWatchPaths: ["apps/notes-editor/**"]
 		}
 	}
 }

--- a/tools/shaka/schema/project-schema.cue
+++ b/tools/shaka/schema/project-schema.cue
@@ -262,6 +262,25 @@ import "kolohelios.com/infra/cloudflare-dns/domains:domain"
 	// Omit for a single-crate Worker (worker-build runs in `project_dir`).
 	workerBuildDir?: string & =~"^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$"
 
+	// Shell command run inside the deploy's checkout *before*
+	// `worker-build`, in every mode (verify/preview/deploy), with
+	// `project_dir` as the cwd. Threaded to `cf-deploy.yml`'s
+	// `pre_build_command` input. Use to stage build artifacts produced by
+	// *another* project into this Worker's asset directory — e.g.
+	// `notes-web` building the `notes-editor` WASM bundle into
+	// `dist/editor/`. The command picks its own devshell (the deploy only
+	// guarantees `nix` on PATH), so it can `nix develop ../<other>`. Omit
+	// when the Worker has no cross-project build dependency.
+	preBuildCommand?: string
+
+	// Extra `dorny/paths-filter` globs added to the generated deploy's
+	// change detection, beyond `<project_dir>/**` and the workflow files.
+	// Use when a deploy depends on sources *outside* `project_dir` — e.g.
+	// `notes-web` must redeploy when `apps/notes-editor/**` changes because
+	// `preBuildCommand` rebuilds that bundle. Omit for a self-contained
+	// project.
+	extraWatchPaths?: [...string]
+
 	// Worker runtime secret names to push at deploy via
 	// `shaka ci push-worker-secrets` (the reusable `cf-deploy.yml` runs
 	// it). Names only — values arrive from the resolved `op://`

--- a/tools/shaka/src/ci/worker_cleanup_workflow.rs
+++ b/tools/shaka/src/ci/worker_cleanup_workflow.rs
@@ -157,6 +157,8 @@ mod tests {
                 preview_script_prefix: "example-notes".to_string(),
                 environment: None,
                 worker_build_dir: None,
+                pre_build_command: None,
+                extra_watch_paths: None,
                 secrets: None,
             },
         }

--- a/tools/shaka/src/ci/worker_deploy_workflow.rs
+++ b/tools/shaka/src/ci/worker_deploy_workflow.rs
@@ -59,6 +59,19 @@ pub struct CiDeploy {
     /// `project_dir` (the single-crate default).
     #[serde(default)]
     pub worker_build_dir: Option<String>,
+    /// Shell command `cf-deploy.yml` runs (cwd = `project_dir`, `nix` on
+    /// PATH) before `worker-build`, in all three calls. Threaded to its
+    /// `pre_build_command` input. Stages another project's build artifacts
+    /// into this Worker's asset dir (e.g. notes-web building the
+    /// notes-editor WASM bundle into `dist/editor/`). Unset → omitted.
+    #[serde(default)]
+    pub pre_build_command: Option<String>,
+    /// Extra `dorny/paths-filter` globs added to the `changes` job, beyond
+    /// `<project_dir>/**` and the workflow files. For a deploy that depends
+    /// on sources outside `project_dir` (e.g. notes-web rebuilds when
+    /// `apps/notes-editor/**` changes). Unset/empty → only the defaults.
+    #[serde(default)]
+    pub extra_watch_paths: Option<Vec<String>>,
     /// Worker runtime secret names pushed at deploy by
     /// `push-worker-secrets`. Modelled here only so this
     /// `deny_unknown_fields` struct (which `generate-workflows`
@@ -143,8 +156,19 @@ fn changes_job(spec: &WorkerDeploySpec) -> InlineJob {
     } else {
         String::new()
     };
+    // Sources outside `project_dir` the deploy depends on — e.g. notes-web
+    // rebuilds the notes-editor bundle via `preBuildCommand`, so an editor
+    // change must trigger a notes-web redeploy.
+    let extra_watch = spec
+        .deploy
+        .extra_watch_paths
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|p| format!("\n  - '{p}'"))
+        .collect::<String>();
     let filter_body = format!(
-        "portfolio:\n  - '{project_dir_str}/**'\n  - '.github/workflows/{name}-deploy.yml'{reusable_watch}\n",
+        "portfolio:\n  - '{project_dir_str}/**'\n  - '.github/workflows/{name}-deploy.yml'{reusable_watch}{extra_watch}\n",
         name = spec.project_name,
     );
 
@@ -220,6 +244,17 @@ fn insert_worker_build_dir(with: &mut BTreeMap<String, Value>, spec: &WorkerDepl
     }
 }
 
+/// Add `pre_build_command` to a reusable-call `with:` block when the project
+/// set it — the cross-project asset-staging command cf-deploy runs before
+/// `worker-build`. Like `worker_build_dir`, threaded into all three calls
+/// (verify/preview/deploy): a preview Worker serves the same assets and a PR
+/// verify must catch a broken cross-project build before merge.
+fn insert_pre_build_command(with: &mut BTreeMap<String, Value>, spec: &WorkerDeploySpec) {
+    if let Some(cmd) = &spec.deploy.pre_build_command {
+        with.insert("pre_build_command".to_string(), Value::String(cmd.clone()));
+    }
+}
+
 fn verify_call(spec: &WorkerDeploySpec) -> ReusableCall {
     let mut with: BTreeMap<String, Value> = BTreeMap::new();
     with.insert(
@@ -228,6 +263,7 @@ fn verify_call(spec: &WorkerDeploySpec) -> ReusableCall {
     );
     with.insert("verify_only".to_string(), Value::Bool(true));
     insert_worker_build_dir(&mut with, spec);
+    insert_pre_build_command(&mut with, spec);
     ReusableCall {
         needs: Needs::Single("changes".to_string()),
         if_: Some(pr_gate()),
@@ -251,6 +287,7 @@ fn preview_call(spec: &WorkerDeploySpec) -> ReusableCall {
         )),
     );
     insert_worker_build_dir(&mut with, spec);
+    insert_pre_build_command(&mut with, spec);
     ReusableCall {
         needs: Needs::Multiple(vec!["changes".to_string(), "verify".to_string()]),
         if_: Some(pr_gate()),
@@ -278,6 +315,7 @@ fn deploy_call(spec: &WorkerDeploySpec) -> ReusableCall {
         );
     }
     insert_worker_build_dir(&mut with, spec);
+    insert_pre_build_command(&mut with, spec);
     // `workflow_dispatch` bypasses the changes filter so a manual
     // re-deploy isn't blocked by an unchanged push base. Real
     // `push: main` deploys still gate on the filter.
@@ -453,6 +491,8 @@ mod tests {
                 preview_script_prefix: "portfolio".to_string(),
                 environment: None,
                 worker_build_dir: None,
+                pre_build_command: None,
+                extra_watch_paths: None,
                 secrets: None,
             },
         }
@@ -650,6 +690,8 @@ mod tests {
                 preview_script_prefix: "buzzingo".to_string(),
                 environment: None,
                 worker_build_dir: Some("crates/buzzingo-server".to_string()),
+                pre_build_command: None,
+                extra_watch_paths: None,
                 secrets: None,
             },
         }
@@ -705,6 +747,8 @@ mod tests {
                 preview_script_prefix: "buzzingo".to_string(),
                 environment: Some("production".to_string()),
                 worker_build_dir: None,
+                pre_build_command: None,
+                extra_watch_paths: None,
                 secrets: None,
             },
         }
@@ -763,5 +807,91 @@ mod tests {
                 "{job} should omit worker_build_dir"
             );
         }
+    }
+
+    // ── pre-build command + extra watch paths (cross-project assets) ─────
+
+    /// A consumer (notes-web) whose deploy stages another project's build
+    /// artifacts (the notes-editor WASM bundle) before worker-build, and
+    /// must therefore also watch the other project's sources.
+    fn asset_build_spec() -> WorkerDeploySpec {
+        WorkerDeploySpec {
+            project_dir: PathBuf::from("apps/notes-web"),
+            project_name: "notes-web".to_string(),
+            deploy: CiDeploy {
+                reusable_workflow: "./.github/workflows/cf-deploy.yml".to_string(),
+                preview_script_prefix: "notes-web".to_string(),
+                environment: None,
+                worker_build_dir: None,
+                pre_build_command: Some(
+                    "nix develop ../notes-editor --command just wasm-build".to_string(),
+                ),
+                extra_watch_paths: Some(vec!["apps/notes-editor/**".to_string()]),
+                secrets: None,
+            },
+        }
+    }
+
+    fn emit_asset_build() -> serde_yaml_ng::Value {
+        let yaml = super::super::workflow::emit(&build(&asset_build_spec()));
+        serde_yaml_ng::from_str(&yaml).expect("valid YAML")
+    }
+
+    #[test]
+    fn pre_build_command_emitted_in_all_three_calls() {
+        // Like worker_build_dir, the pre-build command threads into every
+        // cf-deploy call: a preview Worker serves the same staged assets,
+        // and a PR verify must catch a broken cross-project build pre-merge.
+        let parsed = emit_asset_build();
+        for job in ["verify", "preview", "deploy"] {
+            assert_eq!(
+                parsed["jobs"][job]["with"]["pre_build_command"].as_str(),
+                Some("nix develop ../notes-editor --command just wasm-build"),
+                "{job} should pass pre_build_command"
+            );
+        }
+    }
+
+    #[test]
+    fn pre_build_command_omitted_when_unset() {
+        // The portfolio fixture has `pre_build_command: None`; no call carries it.
+        let parsed = emit_fixture();
+        for job in ["verify", "preview", "deploy"] {
+            assert!(
+                parsed["jobs"][job]["with"]["pre_build_command"].is_null(),
+                "{job} should omit pre_build_command"
+            );
+        }
+    }
+
+    #[test]
+    fn changes_filter_includes_extra_watch_paths() {
+        let parsed = emit_asset_build();
+        let filters = parsed["jobs"]["changes"]["steps"]
+            .as_sequence()
+            .expect("steps")
+            .iter()
+            .find_map(|s| s["with"].get("filters").and_then(|f| f.as_str()))
+            .expect("paths-filter step with a filters body");
+        // Defaults stay watched...
+        assert!(filters.contains("apps/notes-web/**"), "{filters}");
+        // ...plus the extra cross-project source.
+        assert!(filters.contains("apps/notes-editor/**"), "{filters}");
+    }
+
+    #[test]
+    fn changes_filter_omits_extra_watch_paths_when_unset() {
+        // The portfolio fixture sets none; the filter carries only the
+        // project dir, the deploy workflow, and the reusable workflow.
+        let parsed = emit_fixture();
+        let filters = parsed["jobs"]["changes"]["steps"]
+            .as_sequence()
+            .expect("steps")
+            .iter()
+            .find_map(|s| s["with"].get("filters").and_then(|f| f.as_str()))
+            .expect("paths-filter step with a filters body");
+        assert!(filters.contains("apps/portfolio/**"), "{filters}");
+        // No stray editor-style glob leaked in.
+        assert!(!filters.contains("notes-editor"), "{filters}");
     }
 }


### PR DESCRIPTION
A Cloudflare Worker that serves assets built by *another* project had no
way to stage them at deploy: the reusable cf-deploy.yml only ran
worker-build + wrangler deploy, and the generated deploy's paths-filter
only watched the project's own directory.

Add two optional ci.deploy fields, threaded through the deploy
generator. preBuildCommand runs in the deploy checkout before
worker-build, in every mode (verify/preview/deploy), so a broken
cross-project build fails the PR verify, not just production.
extraWatchPaths adds globs to the change filter so a dependency's source
change triggers a redeploy. cf-deploy.yml gains a pre_build_command
input, run via bash -c "$VAR" rather than expression interpolation to
avoid a workflow-injection vector.

Sign-in (and the editor) was dead in production: the deploy never built
the notes-editor WASM bundle into dist/editor/, so
/editor/notes_editor.js 404'd. The shell's module import threw before
the submit handler attached, so clicking sign in did nothing and the
editor never loaded.

Declare preBuildCommand to build the bundle in the editor's own
devshell and stage it into dist/editor/ before worker-build, and
extraWatchPaths so an editor source change redeploys notes-web. The
OAuth backend was already healthy; only the front-end bundle was
missing.

Closes #952