### PR TITLE
fix(notes-sync): restrict note access to the owner DID (fail closed)

### DIFF
--- a/services/notes-sync/src/auth.rs
+++ b/services/notes-sync/src/auth.rs
@@ -152,6 +152,32 @@ pub fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
         .find_map(|kv| kv.strip_prefix(name)?.strip_prefix('='))
 }
 
+/// Authorize a note-socket upgrade for the single owner. Returns true only
+/// when the `Cookie:` header carries a `session` cookie that verifies
+/// against `secret` *and* whose DID equals `owner_did`.
+///
+/// Fails **closed**: a missing secret, missing/blank owner config, an
+/// absent/malformed/expired/tampered cookie, or a DID that isn't the
+/// owner's all deny. This is the single authorization gate for the app —
+/// authn-only OAuth proves *an* identity; this proves it's *yours*.
+pub fn authorize_owner(
+    cookie_header: Option<&str>,
+    secret: Option<&[u8]>,
+    owner_did: Option<&str>,
+    now_unix: i64,
+) -> bool {
+    let (Some(header), Some(secret), Some(owner)) = (cookie_header, secret, owner_did) else {
+        return false;
+    };
+    let owner = owner.trim();
+    if owner.is_empty() {
+        return false;
+    }
+    cookie_value(header, "session")
+        .and_then(|c| verify_session(c, secret, now_unix).ok())
+        .is_some_and(|did| did == owner)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -266,5 +292,61 @@ mod tests {
         assert_eq!(cookie_value("other=1", "session"), None);
         // No false match on a longer name sharing the prefix.
         assert_eq!(cookie_value("sessionx=1", "session"), None);
+    }
+
+    // ── owner authorization ─────────────────────────────────────────────
+
+    const OWNER: &str = "did:plc:owner";
+
+    fn header_for(did: &str, exp: i64) -> String {
+        format!("session={}", mint_session(did, exp, SECRET))
+    }
+
+    #[test]
+    fn authorize_owner_accepts_the_owner() {
+        let h = header_for(OWNER, 1_000);
+        assert!(authorize_owner(Some(&h), Some(SECRET), Some(OWNER), 500));
+    }
+
+    #[test]
+    fn authorize_owner_rejects_a_non_owner() {
+        // The load-bearing case: a perfectly valid cookie for a *different*
+        // Bluesky account must not be authorized.
+        let h = header_for("did:plc:someone-else", 1_000);
+        assert!(!authorize_owner(Some(&h), Some(SECRET), Some(OWNER), 500));
+    }
+
+    #[test]
+    fn authorize_owner_fails_closed_on_missing_config_or_cookie() {
+        let h = header_for(OWNER, 1_000);
+        assert!(!authorize_owner(Some(&h), None, Some(OWNER), 500)); // no secret
+        assert!(!authorize_owner(Some(&h), Some(SECRET), None, 500)); // no owner
+        assert!(!authorize_owner(Some(&h), Some(SECRET), Some("  "), 500)); // blank owner
+        assert!(!authorize_owner(None, Some(SECRET), Some(OWNER), 500)); // no cookie header
+        assert!(!authorize_owner(
+            Some("other=1"),
+            Some(SECRET),
+            Some(OWNER),
+            500
+        )); // no session cookie
+    }
+
+    #[test]
+    fn authorize_owner_rejects_expired_tampered_or_wrong_secret() {
+        let h = header_for(OWNER, 1_000);
+        assert!(!authorize_owner(Some(&h), Some(SECRET), Some(OWNER), 2_000)); // expired
+        assert!(!authorize_owner(
+            Some(&h),
+            Some(b"other-secret"),
+            Some(OWNER),
+            500
+        )); // wrong secret
+        let tampered = format!("session={}xx", mint_session(OWNER, 1_000, SECRET));
+        assert!(!authorize_owner(
+            Some(&tampered),
+            Some(SECRET),
+            Some(OWNER),
+            500
+        )); // tampered sig
     }
 }

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -18,7 +18,7 @@ use worker::{
     WebSocketPair,
 };
 
-use crate::auth::{cookie_value, verify_session};
+use crate::auth::authorize_owner;
 use crate::git::{commit_with_retry, CommitError, GitTarget, WorkerGitHubClient};
 use crate::route::parse_ws_note_id;
 use crate::state::{is_stale, next_alarm};
@@ -75,25 +75,24 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
     Response::ok("notes-sync: ok")
 }
 
-/// Whether the request carries a valid session cookie. When
-/// `SESSION_SECRET` isn't configured yet, the gate is open — the OAuth
-/// login flow that issues cookies (and the secret) lands with auth; until
-/// then the WS stays reachable for the earlier phases' runtime checks.
+/// Whether the request is the owner's authenticated session. Authn-only
+/// OAuth proves *an* identity; this proves it's *ours* — the signed
+/// cookie must verify against `SESSION_SECRET` and carry the `OWNER_DID`.
+/// Fails closed: a missing secret or owner var, or any non-owner/invalid
+/// cookie, denies. (Earlier phases ran with the gate open while the OAuth
+/// flow was being built; that fail-open default is gone now that the
+/// secret and owner are configured.)
 fn session_authorized(req: &Request, env: &Env) -> bool {
-    let secret = match env.secret("SESSION_SECRET") {
-        Ok(s) => s.to_string(),
-        Err(_) => return true,
-    };
-    let header = req
-        .headers()
-        .get("Cookie")
-        .ok()
-        .flatten()
-        .unwrap_or_default();
+    let secret = env.secret("SESSION_SECRET").ok().map(|s| s.to_string());
+    let owner = env.var("OWNER_DID").ok().map(|v| v.to_string());
+    let header = req.headers().get("Cookie").ok().flatten();
     let now = Date::now().as_millis() as i64 / 1000;
-    cookie_value(&header, "session")
-        .and_then(|v| verify_session(v, secret.as_bytes(), now).ok())
-        .is_some()
+    authorize_owner(
+        header.as_deref(),
+        secret.as_deref().map(str::as_bytes),
+        owner.as_deref(),
+        now,
+    )
 }
 
 /// Per-connection state persisted across hibernation via the socket

--- a/services/notes-sync/wrangler.toml
+++ b/services/notes-sync/wrangler.toml
@@ -51,6 +51,12 @@ tag                = "v2"
 # (optional) is the appview used to resolve a handle to a DID. The
 # cookie-signing key is a secret:
 #   wrangler secret put SESSION_SECRET
+#
+# `OWNER_DID` is the single account allowed to reach a note socket: the WS
+# gate authorizes only a session cookie carrying this DID, so authn-only
+# OAuth (any Bluesky account) can't read or write the notes. A DID is a
+# public identifier, not a secret. `did:plc:ujhuvzz7wulwh7kkxcshwwrf` is
+# `kolohelios.bsky.social`.
 [vars]
 GITHUB_BRANCH         = "main"
 GITHUB_OWNER          = "kolohelios"
@@ -58,3 +64,4 @@ GITHUB_REPO           = "notes-store"
 OAUTH_APP_URL         = "https://notes.kolohelios.com"
 OAUTH_BASE_URL        = "https://notes-sync.kolohelios.com"
 OAUTH_HANDLE_RESOLVER = "https://bsky.social"
+OWNER_DID             = "did:plc:ujhuvzz7wulwh7kkxcshwwrf"


### PR DESCRIPTION
The note-socket gate authorized any valid session cookie regardless of
which Bluesky account it belonged to, and the note Durable Object is a
global namespace — so any user who signed in at notes.kolohelios.com
reached the same notes. Worse, the gate failed open: with SESSION_SECRET
unset it returned true, leaving the socket reachable with no auth at all
(the live state until the secret was set).

Add an OWNER_DID var and a pure, fail-closed authorize_owner: the cookie
must verify against SESSION_SECRET and carry OWNER_DID. A missing secret
or owner var, a non-owner DID, or any invalid/expired/tampered cookie all
deny. Authn-only OAuth proves an identity; this proves it's the owner's.

Closes #960