### PR TITLE
fix(blogctl): honor [defaults].model in draft/refine/final-edit/ping

### DIFF
--- a/apps/blogctl/src/cli.rs
+++ b/apps/blogctl/src/cli.rs
@@ -8,7 +8,6 @@ use clap_complete::Shell;
 use crate::commands;
 use crate::error::{Error, Result};
 use crate::kind::Kind;
-use crate::openrouter;
 use crate::sync::{Jj, RealJj};
 use crate::target::Target;
 
@@ -153,9 +152,11 @@ pub enum Command {
         /// title + existing body).
         #[arg(long)]
         prompt: String,
-        /// OpenRouter model identifier.
-        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
-        model: String,
+        /// OpenRouter model identifier. When omitted, falls back to
+        /// `[defaults].model` from `.blog-os.toml`, then the built-in
+        /// default.
+        #[arg(long)]
+        model: Option<String>,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -172,9 +173,11 @@ pub enum Command {
         /// post's title + current body).
         #[arg(long)]
         prompt: String,
-        /// OpenRouter model identifier.
-        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
-        model: String,
+        /// OpenRouter model identifier. When omitted, falls back to
+        /// `[defaults].model` from `.blog-os.toml`, then the built-in
+        /// default.
+        #[arg(long)]
+        model: Option<String>,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -193,9 +196,11 @@ pub enum Command {
         /// LinkedIn rules don't apply.
         #[arg(long)]
         prompt: Option<String>,
-        /// OpenRouter model identifier.
-        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
-        model: String,
+        /// OpenRouter model identifier. When omitted, falls back to
+        /// `[defaults].model` from `.blog-os.toml`, then the built-in
+        /// default.
+        #[arg(long)]
+        model: Option<String>,
         /// Skip the post-write `jj` commit + push for this invocation.
         #[arg(long)]
         no_sync: bool,
@@ -370,9 +375,17 @@ pub enum AiAction {
     Ping {
         /// Prompt text to send to the model.
         prompt: String,
-        /// OpenRouter model identifier.
-        #[arg(long, default_value = openrouter::DEFAULT_MODEL)]
-        model: String,
+        /// Workdir whose `[defaults].model` is consulted when `--model`
+        /// is omitted. Defaults to the current working directory; a
+        /// missing or unreadable `.blog-os.toml` is fine — `ping` then
+        /// falls back to the built-in default.
+        #[arg(long, value_name = "PATH")]
+        workdir: Option<PathBuf>,
+        /// OpenRouter model identifier. When omitted, falls back to
+        /// `[defaults].model` from `.blog-os.toml`, then the built-in
+        /// default.
+        #[arg(long)]
+        model: Option<String>,
     },
 }
 
@@ -584,7 +597,11 @@ pub fn dispatch_with_jj(cmd: Command, jj: &dyn Jj) -> Result<()> {
             commands::update::run(jj, workdir_or_pwd(workdir)?, no_sync)
         }
         Command::Ai { action } => match action {
-            AiAction::Ping { prompt, model } => commands::ai::ping(prompt, model),
+            AiAction::Ping {
+                prompt,
+                workdir,
+                model,
+            } => commands::ai::ping(prompt, model, workdir_or_pwd(workdir)?),
         },
         Command::Draft {
             slug,
@@ -957,6 +974,16 @@ mod tests {
                 "ai",
                 "ping",
                 "hello",
+                "--model",
+                "openai/gpt-4o-mini",
+            ],
+            vec![
+                "blogctl",
+                "ai",
+                "ping",
+                "hello",
+                "--workdir",
+                "/tmp/wd",
                 "--model",
                 "openai/gpt-4o-mini",
             ],

--- a/apps/blogctl/src/commands/ai.rs
+++ b/apps/blogctl/src/commands/ai.rs
@@ -1,7 +1,21 @@
+use std::path::PathBuf;
+
 use crate::error::Result;
 use crate::openrouter;
+use crate::storage::{ConfigStatus, Repository, Workdir};
 
-pub fn ping(prompt: String, model: String) -> Result<()> {
+/// One-shot OpenRouter prompt. Unlike `draft`/`refine`/`final-edit`,
+/// `ping` doesn't operate on a post and works outside an initialized
+/// workdir — so it reads `[defaults].model` best-effort: if `workdir`
+/// holds a readable `.blog-os.toml`, its `defaults.model` participates
+/// in resolution; a missing or unparsable config simply falls through
+/// to the built-in default. `--model` always wins when passed.
+pub fn ping(prompt: String, model: Option<String>, workdir: PathBuf) -> Result<()> {
+    let config_default = match Repository::unchecked(Workdir::new(&workdir)).audit_config() {
+        ConfigStatus::Ok(config) => config.defaults.model,
+        ConfigStatus::Missing | ConfigStatus::Unparsable(_) => None,
+    };
+    let model = openrouter::resolve_model(model.as_deref(), config_default.as_deref());
     let reply = openrouter::chat(&prompt, &model)?;
     println!("{reply}");
     Ok(())

--- a/apps/blogctl/src/commands/draft.rs
+++ b/apps/blogctl/src/commands/draft.rs
@@ -27,7 +27,7 @@ pub struct DraftArgs {
     pub slug: String,
     pub workdir: PathBuf,
     pub prompt: String,
-    pub model: String,
+    pub model: Option<String>,
     pub no_sync: bool,
 }
 
@@ -42,24 +42,25 @@ pub fn run(jj: &dyn Jj, args: DraftArgs) -> Result<()> {
         });
     }
 
+    let config = repo.read_config()?;
+    let model = openrouter::resolve_model(args.model.as_deref(), config.defaults.model.as_deref());
+
     let llm_prompt = build_prompt(&post.metadata.title, &post.body, &args.prompt);
-    let reply = openrouter::chat(&llm_prompt, &args.model)?;
+    let reply = openrouter::chat(&llm_prompt, &model)?;
 
     post.body = reply;
     post.metadata.ai = Some(merge_draft_record(
         post.metadata.ai.take(),
         AiDraftRecord {
             prompt: args.prompt.clone(),
-            model: args.model.clone(),
+            model: model.clone(),
             generated_at: OffsetDateTime::now_utc(),
         },
     ));
 
-    let config = repo.read_config()?;
     let opts = SyncOptions::from_config(&config.sync, args.no_sync);
-    let message = format!("post({}): draft via {}", args.slug, args.model);
+    let message = format!("post({}): draft via {}", args.slug, model);
     let path = handle.path.clone();
-    let model = args.model.clone();
     let slug = args.slug.clone();
 
     sync::commit_and_push(jj, &args.workdir, &opts, &message, || {

--- a/apps/blogctl/src/commands/final_edit.rs
+++ b/apps/blogctl/src/commands/final_edit.rs
@@ -40,7 +40,7 @@ pub struct FinalEditArgs {
     pub slug: String,
     pub workdir: PathBuf,
     pub prompt: Option<String>,
-    pub model: String,
+    pub model: Option<String>,
     pub no_sync: bool,
 }
 
@@ -55,28 +55,29 @@ pub fn run(jj: &dyn Jj, args: FinalEditArgs) -> Result<()> {
         });
     }
 
+    let config = repo.read_config()?;
+    let model = openrouter::resolve_model(args.model.as_deref(), config.defaults.model.as_deref());
+
     let instruction = args
         .prompt
         .clone()
         .unwrap_or_else(|| DEFAULT_POLISH_PROMPT.to_string());
     let llm_prompt = build_prompt(&post.metadata.title, &post.body, &instruction);
-    let reply = openrouter::chat(&llm_prompt, &args.model)?;
+    let reply = openrouter::chat(&llm_prompt, &model)?;
 
     post.body = reply;
     post.metadata.ai = Some(merge_final_edit_record(
         post.metadata.ai.take(),
         AiFinalEditRecord {
             prompt: instruction,
-            model: args.model.clone(),
+            model: model.clone(),
             generated_at: OffsetDateTime::now_utc(),
         },
     ));
 
-    let config = repo.read_config()?;
     let opts = SyncOptions::from_config(&config.sync, args.no_sync);
-    let message = format!("post({}): final-edit via {}", args.slug, args.model);
+    let message = format!("post({}): final-edit via {}", args.slug, model);
     let path = handle.path.clone();
-    let model = args.model.clone();
     let slug = args.slug.clone();
 
     sync::commit_and_push(jj, &args.workdir, &opts, &message, || {

--- a/apps/blogctl/src/commands/refine.rs
+++ b/apps/blogctl/src/commands/refine.rs
@@ -31,7 +31,7 @@ pub struct RefineArgs {
     pub slug: String,
     pub workdir: PathBuf,
     pub prompt: String,
-    pub model: String,
+    pub model: Option<String>,
     pub no_sync: bool,
 }
 
@@ -46,24 +46,25 @@ pub fn run(jj: &dyn Jj, args: RefineArgs) -> Result<()> {
         });
     }
 
+    let config = repo.read_config()?;
+    let model = openrouter::resolve_model(args.model.as_deref(), config.defaults.model.as_deref());
+
     let llm_prompt = build_prompt(&post.metadata.title, &post.body, &args.prompt);
-    let reply = openrouter::chat(&llm_prompt, &args.model)?;
+    let reply = openrouter::chat(&llm_prompt, &model)?;
 
     post.body = reply;
     post.metadata.ai = Some(merge_refine_record(
         post.metadata.ai.take(),
         AiRefineRecord {
             prompt: args.prompt.clone(),
-            model: args.model.clone(),
+            model: model.clone(),
             generated_at: OffsetDateTime::now_utc(),
         },
     ));
 
-    let config = repo.read_config()?;
     let opts = SyncOptions::from_config(&config.sync, args.no_sync);
-    let message = format!("post({}): refine via {}", args.slug, args.model);
+    let message = format!("post({}): refine via {}", args.slug, model);
     let path = handle.path.clone();
-    let model = args.model.clone();
     let slug = args.slug.clone();
 
     sync::commit_and_push(jj, &args.workdir, &opts, &message, || {

--- a/apps/blogctl/src/openrouter.rs
+++ b/apps/blogctl/src/openrouter.rs
@@ -23,6 +23,21 @@ fn endpoint() -> String {
 
 pub const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4-6";
 
+/// Resolve which OpenRouter model a command should use, applying the
+/// precedence `--model` flag > `[defaults].model` > the built-in
+/// [`DEFAULT_MODEL`].
+///
+/// `flag` is the command's `--model` argument (`None` when the user
+/// didn't pass it); `config_default` is `[defaults].model` from the
+/// workdir's `.blog-os.toml` (`None` when unset). The `--model` clap
+/// args deliberately carry no `default_value`, so an absent `flag`
+/// genuinely means "fall through" rather than "the user typed the
+/// default" — that conflation is what made `[defaults].model` inert
+/// (#956).
+pub fn resolve_model(flag: Option<&str>, config_default: Option<&str>) -> String {
+    flag.or(config_default).unwrap_or(DEFAULT_MODEL).to_string()
+}
+
 #[derive(Debug, Serialize)]
 struct ChatRequest<'a> {
     model: &'a str,
@@ -150,6 +165,24 @@ mod tests {
             Some(v) => env::set_var(API_BASE_VAR, v),
             None => env::remove_var(API_BASE_VAR),
         }
+    }
+
+    #[test]
+    fn resolve_model_prefers_flag_over_config_and_builtin() {
+        assert_eq!(
+            resolve_model(Some("flag/model"), Some("config/model")),
+            "flag/model"
+        );
+    }
+
+    #[test]
+    fn resolve_model_falls_back_to_config_default_when_flag_absent() {
+        assert_eq!(resolve_model(None, Some("config/model")), "config/model");
+    }
+
+    #[test]
+    fn resolve_model_falls_back_to_builtin_when_neither_set() {
+        assert_eq!(resolve_model(None, None), DEFAULT_MODEL);
     }
 
     #[test]

--- a/apps/blogctl/templates/workdir-readme.md
+++ b/apps/blogctl/templates/workdir-readme.md
@@ -24,8 +24,10 @@ split:
 - **`post`** — short-form feed content. The default for `blogctl new`.
 - **`article`** — long-form with its own permanent URL.
 
-Kind drives prompt selection, exit-criteria thresholds, and optional
-per-stage model overrides. Both kinds traverse the same stage pipeline.
+Kind gates exit-criteria thresholds today (evaluated at `blogctl
+promote` time). Once the run-stage pipeline lands (#233), kind will also
+drive prompt selection and optional per-stage model overrides. Both
+kinds traverse the same stage pipeline.
 
 ```sh
 blogctl new "Title" --workdir .                  # kind: post
@@ -47,8 +49,9 @@ blogctl new "Title" --workdir .                   # theme: standard (default)
 blogctl new "Title" --workdir . --theme parable   # theme: parable
 ```
 
-Theme drives prompt selection at `blogctl run-stage` time (model and
-exit criteria stay theme-agnostic for now).
+Theme will drive prompt selection once the `blogctl run-stage` pipeline
+lands (#233); model and exit criteria stay theme-agnostic. No shipped
+command selects prompts by theme yet.
 
 ## Layout
 
@@ -62,12 +65,13 @@ exit criteria stay theme-agnostic for now).
   abandoned/
   .blog-os.toml
   README.md
-  <prompt files>          # e.g. ideation-post-standard.md
+  <prompt files>          # planned (#233): e.g. ideation-post-standard.md
 ```
 
-Prompt files live at the workdir root next to `.blog-os.toml`. They are
-loaded by the OpenRouter integration; naming follows the pattern
-`<stage>-<kind>-<theme>.md`.
+Prompt files live at the workdir root next to `.blog-os.toml`. The
+file-based prompt pipeline that loads them (naming pattern
+`<stage>-<kind>-<theme>.md`) is planned (#233); no shipped command reads
+these files yet.
 
 ## Version control
 

--- a/apps/blogctl/tests/ai_endpoint.rs
+++ b/apps/blogctl/tests/ai_endpoint.rs
@@ -53,7 +53,10 @@ fn ping_hits_endpoint_via_env_override() {
     );
     env::set_var("OPENROUTER_API_KEY", "test-key");
 
-    let result = commands::ai::ping("hello".into(), "test-model".into());
+    // `ping` reads `[defaults].model` best-effort from the workdir; a
+    // temp dir with no `.blog-os.toml` exercises the "no config" path,
+    // and the explicit model flag wins regardless.
+    let result = commands::ai::ping("hello".into(), Some("test-model".into()), env::temp_dir());
 
     // Restore env before asserting so a panic doesn't poison subsequent
     // tests.
@@ -76,7 +79,7 @@ fn openrouter_api_key_missing_surfaces_clean_error() {
     let prev_key = env::var("OPENROUTER_API_KEY").ok();
     env::remove_var("OPENROUTER_API_KEY");
 
-    let result = commands::ai::ping("hello".into(), "test-model".into());
+    let result = commands::ai::ping("hello".into(), Some("test-model".into()), env::temp_dir());
 
     if let Some(v) = prev_key {
         env::set_var("OPENROUTER_API_KEY", v);

--- a/apps/blogctl/tests/workflow.rs
+++ b/apps/blogctl/tests/workflow.rs
@@ -264,7 +264,7 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
             slug: slug.into(),
             workdir: workdir.clone(),
             prompt: "go".into(),
-            model: "test-model".into(),
+            model: Some("test-model".into()),
             no_sync: true,
         },
     )
@@ -282,7 +282,7 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
             slug: slug.into(),
             workdir: workdir.clone(),
             prompt: "write me three paragraphs about mocking".into(),
-            model: "test-model".into(),
+            model: Some("test-model".into()),
             no_sync: true,
         },
     )?;
@@ -310,7 +310,7 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
             slug: slug.into(),
             workdir: workdir.clone(),
             prompt: "tighten".into(),
-            model: "test-model".into(),
+            model: Some("test-model".into()),
             no_sync: true,
         },
     )
@@ -328,7 +328,7 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
             slug: slug.into(),
             workdir: workdir.clone(),
             prompt: "tighten paragraphs".into(),
-            model: "test-model".into(),
+            model: Some("test-model".into()),
             no_sync: true,
         },
     )?;
@@ -359,7 +359,7 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
             slug: slug.into(),
             workdir: workdir.clone(),
             prompt: None,
-            model: "test-model".into(),
+            model: Some("test-model".into()),
             no_sync: true,
         },
     )
@@ -378,7 +378,7 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
             slug: slug.into(),
             workdir: workdir.clone(),
             prompt: None,
-            model: "test-model".into(),
+            model: Some("test-model".into()),
             no_sync: true,
         },
     )?;
@@ -417,5 +417,120 @@ fn run_ai_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
         fe.prompt
     );
     assert_eq!(fe.model, "test-model");
+    Ok(())
+}
+
+/// `[defaults].model` is honored by `draft` when `--model` is omitted,
+/// and an explicit `--model` overrides it (#956). The clap default that
+/// used to populate `--model` made the config knob inert; this guards
+/// the resolution precedence end to end via the recorded
+/// `ai.draft.model` audit field.
+#[test]
+fn draft_resolves_model_from_defaults_then_flag_override() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let mut server = mockito::Server::new();
+    // Two drafts run back to back; each consumes one canned reply.
+    let mock_default = mock_chat_completion(&mut server, DRAFT_REPLY);
+    let mock_override = mock_chat_completion(&mut server, DRAFT_REPLY);
+
+    let prev_base = env::var("OPENROUTER_API_BASE").ok();
+    let prev_key = env::var("OPENROUTER_API_KEY").ok();
+    env::set_var(
+        "OPENROUTER_API_BASE",
+        format!("{}/chat/completions", server.url()),
+    );
+    env::set_var("OPENROUTER_API_KEY", "test-key");
+
+    let result = run_draft_model_resolution();
+
+    match prev_base {
+        Some(v) => env::set_var("OPENROUTER_API_BASE", v),
+        None => env::remove_var("OPENROUTER_API_BASE"),
+    }
+    match prev_key {
+        Some(v) => env::set_var("OPENROUTER_API_KEY", v),
+        None => env::remove_var("OPENROUTER_API_KEY"),
+    }
+
+    result.expect("draft model resolution should succeed");
+    mock_default.assert();
+    mock_override.assert();
+}
+
+fn run_draft_model_resolution() -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp, workdir) = fresh_workdir();
+    commands::init::run(&FakeJj::new(), workdir.clone(), true)?;
+
+    // Set `[defaults].model` by round-tripping the freshly written config
+    // through the typed `Config` — no string-literal config fixture.
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let mut config = repo.read_config()?;
+    config.defaults.model = Some("config/default-model".into());
+    std::fs::write(
+        Workdir::new(&workdir).config_path(),
+        toml::to_string(&config)?,
+    )?;
+
+    commands::new::run(
+        &FakeJj::new(),
+        "Model resolution".into(),
+        workdir.clone(),
+        Some("model-resolution".into()),
+        Kind::Post,
+        None,
+        true,
+    )?;
+    let slug = "model-resolution";
+    commands::promote::run(&FakeJj::new(), slug.to_string(), workdir.clone(), true)?;
+
+    // No --model → resolves to [defaults].model.
+    commands::draft::run(
+        &FakeJj::new(),
+        DraftArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: "go".into(),
+            model: None,
+            no_sync: true,
+        },
+    )?;
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let (_, post) = repo.load(slug)?;
+    assert_eq!(
+        post.metadata
+            .ai
+            .as_ref()
+            .and_then(|ai| ai.draft.as_ref())
+            .expect("ai.draft set post-draft")
+            .model,
+        "config/default-model",
+        "omitted --model should fall back to [defaults].model"
+    );
+
+    // Explicit --model overrides [defaults].model. Draft doesn't promote,
+    // so the post is still in Ideation for a second pass.
+    commands::draft::run(
+        &FakeJj::new(),
+        DraftArgs {
+            slug: slug.into(),
+            workdir: workdir.clone(),
+            prompt: "go again".into(),
+            model: Some("flag/explicit-model".into()),
+            no_sync: true,
+        },
+    )?;
+    let repo = Repository::open(Workdir::new(&workdir))?;
+    let (_, post) = repo.load(slug)?;
+    assert_eq!(
+        post.metadata
+            .ai
+            .as_ref()
+            .and_then(|ai| ai.draft.as_ref())
+            .expect("ai.draft set post-second-draft")
+            .model,
+        "flag/explicit-model",
+        "explicit --model should override [defaults].model"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
The generated workdir README described `blogctl run-stage`, theme-driven
prompt selection, and the file-based prompt pipeline in the present
tense, but none of those ship yet (they are #233) — a user following the
README hits `unrecognized subcommand 'run-stage'`. Mark those sections as
planned (#233). Exit-criteria predicates stay described as live because
`promote` evaluates them today.

Refs #233

The AI commands declared a clap `default_value` for `--model`, so the
flag was always populated and `[defaults].model` from `.blog-os.toml`
never took effect — the documented knob was inert.

Make `--model` an `Option<String>` with no clap default and resolve the
precedence `--model` > `[defaults].model` > built-in fallback through a
shared `openrouter::resolve_model`, applied uniformly across draft,
refine, final-edit, and `ai ping`. `ai ping` gains an optional
`--workdir` (defaulting to PWD) and reads the config best-effort, so it
still works outside an initialized workdir.

Closes #956