### PR TITLE
feat(notes-web): show signed-in state in the shell

### DIFF
--- a/apps/notes-web/dist/index.html
+++ b/apps/notes-web/dist/index.html
@@ -25,6 +25,8 @@
         />
         <button type="submit">sign in</button>
       </form>
+      <!-- Shown instead of the login form once `/me` confirms a session. -->
+      <span id="account" class="account" hidden></span>
     </header>
     <main>
       <textarea
@@ -62,6 +64,44 @@
           location.href = `https://${backend}/oauth/login?handle=${encodeURIComponent(handle)}`;
         }
       });
+
+      // Auth probe: the session cookie is HttpOnly, so the shell can't read
+      // it. Ask the backend `/me` (which can) whether we're signed in, and
+      // as whom, then show a signed-in badge instead of the login form.
+      async function refreshAuth() {
+        const login = document.getElementById("login");
+        const account = document.getElementById("account");
+        let did;
+        try {
+          const res = await fetch(`https://${backend}/me`, {
+            credentials: "include",
+          });
+          if (res.ok) ({ did } = await res.json());
+        } catch (e) {
+          return; // network error — leave the login form as-is
+        }
+        if (!did) {
+          login.hidden = false;
+          account.hidden = true;
+          return;
+        }
+        login.hidden = true;
+        account.hidden = false;
+        account.textContent = "signed in";
+        // Best-effort: resolve the DID to a handle for a friendlier label.
+        try {
+          const doc = await fetch(`https://plc.directory/${did}`).then((r) =>
+            r.json(),
+          );
+          const aka = (doc.alsoKnownAs || []).find((a) =>
+            a.startsWith("at://"),
+          );
+          if (aka) account.textContent = `signed in as @${aka.slice(5)}`;
+        } catch (e) {
+          /* keep the plain "signed in" label */
+        }
+      }
+      refreshAuth();
 
       const status = document.getElementById("status");
       try {

--- a/apps/notes-web/dist/style.css
+++ b/apps/notes-web/dist/style.css
@@ -64,6 +64,13 @@ body {
   cursor: pointer;
 }
 
+/* Shown in place of the login form once `/me` confirms a session. */
+.account {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
 main {
   flex: 1;
   display: flex;

--- a/services/notes-sync/src/auth.rs
+++ b/services/notes-sync/src/auth.rs
@@ -152,30 +152,43 @@ pub fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
         .find_map(|kv| kv.strip_prefix(name)?.strip_prefix('='))
 }
 
-/// Authorize a note-socket upgrade for the single owner. Returns true only
-/// when the `Cookie:` header carries a `session` cookie that verifies
+/// The owner DID a request is authorized as, or `None`. Returns `Some`
+/// only when the `Cookie:` header carries a `session` cookie that verifies
 /// against `secret` *and* whose DID equals `owner_did`.
 ///
 /// Fails **closed**: a missing secret, missing/blank owner config, an
 /// absent/malformed/expired/tampered cookie, or a DID that isn't the
-/// owner's all deny. This is the single authorization gate for the app —
-/// authn-only OAuth proves *an* identity; this proves it's *yours*.
+/// owner's all yield `None`. This is the single authorization decision for
+/// the app — authn-only OAuth proves *an* identity; this proves it's
+/// *yours*. The socket gate ([`authorize_owner`]) is the boolean view; the
+/// `/me` endpoint uses the DID itself.
+pub fn authorized_did(
+    cookie_header: Option<&str>,
+    secret: Option<&[u8]>,
+    owner_did: Option<&str>,
+    now_unix: i64,
+) -> Option<String> {
+    let (Some(header), Some(secret), Some(owner)) = (cookie_header, secret, owner_did) else {
+        return None;
+    };
+    let owner = owner.trim();
+    if owner.is_empty() {
+        return None;
+    }
+    cookie_value(header, "session")
+        .and_then(|c| verify_session(c, secret, now_unix).ok())
+        .filter(|did| did == owner)
+}
+
+/// Boolean view of [`authorized_did`]: whether the request is the owner's
+/// authenticated session. The note-socket upgrade gate.
 pub fn authorize_owner(
     cookie_header: Option<&str>,
     secret: Option<&[u8]>,
     owner_did: Option<&str>,
     now_unix: i64,
 ) -> bool {
-    let (Some(header), Some(secret), Some(owner)) = (cookie_header, secret, owner_did) else {
-        return false;
-    };
-    let owner = owner.trim();
-    if owner.is_empty() {
-        return false;
-    }
-    cookie_value(header, "session")
-        .and_then(|c| verify_session(c, secret, now_unix).ok())
-        .is_some_and(|did| did == owner)
+    authorized_did(cookie_header, secret, owner_did, now_unix).is_some()
 }
 
 #[cfg(test)]
@@ -314,6 +327,24 @@ mod tests {
         // Bluesky account must not be authorized.
         let h = header_for("did:plc:someone-else", 1_000);
         assert!(!authorize_owner(Some(&h), Some(SECRET), Some(OWNER), 500));
+    }
+
+    #[test]
+    fn authorized_did_returns_the_owner_did_or_none() {
+        let owner = header_for(OWNER, 1_000);
+        assert_eq!(
+            authorized_did(Some(&owner), Some(SECRET), Some(OWNER), 500),
+            Some(OWNER.to_owned())
+        );
+        // A valid non-owner cookie yields None (the gate is owner-only).
+        let other = header_for("did:plc:someone-else", 1_000);
+        assert_eq!(
+            authorized_did(Some(&other), Some(SECRET), Some(OWNER), 500),
+            None
+        );
+        // Fails closed on missing config, exactly like the bool wrapper.
+        assert_eq!(authorized_did(Some(&owner), None, Some(OWNER), 500), None);
+        assert_eq!(authorized_did(Some(&owner), Some(SECRET), None, 500), None);
     }
 
     #[test]

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -14,11 +14,11 @@ use serde::{Deserialize, Serialize};
 // bare name (see the workers-rs `counter.rs` example).
 use worker::{
     console_log, durable_object, event, wasm_bindgen, Context, Date, DurableObject, Env, Error,
-    Request, Response, ResponseBuilder, Result, State, WebSocket, WebSocketIncomingMessage,
-    WebSocketPair,
+    Headers, Request, Response, ResponseBuilder, Result, State, WebSocket,
+    WebSocketIncomingMessage, WebSocketPair,
 };
 
-use crate::auth::authorize_owner;
+use crate::auth::{authorize_owner, authorized_did};
 use crate::git::{commit_with_retry, CommitError, GitTarget, WorkerGitHubClient};
 use crate::route::parse_ws_note_id;
 use crate::state::{is_stale, next_alarm};
@@ -55,6 +55,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         }
         "/oauth/login" => return crate::oauth::handle_login(req, env).await,
         "/oauth/callback" => return crate::oauth::handle_callback(req, env).await,
+        "/me" => return handle_me(&req, &env),
         _ => {}
     }
 
@@ -93,6 +94,44 @@ fn session_authorized(req: &Request, env: &Env) -> bool {
         owner.as_deref(),
         now,
     )
+}
+
+/// `GET /me` — the shell's auth probe. Returns `{"did": …}` with `200`
+/// when the request carries the owner's session cookie, else `401`. The
+/// session cookie is `HttpOnly`, so the front end can't read it directly;
+/// this lets it learn whether it's signed in (and as whom) without
+/// exposing the cookie. CORS allows the same-site cross-origin
+/// credentialed fetch from the shell origin (`OAUTH_APP_URL`).
+fn handle_me(req: &Request, env: &Env) -> Result<Response> {
+    let secret = env.secret("SESSION_SECRET").ok().map(|s| s.to_string());
+    let owner = env.var("OWNER_DID").ok().map(|v| v.to_string());
+    let header = req.headers().get("Cookie").ok().flatten();
+    let now = Date::now().as_millis() as i64 / 1000;
+    let did = authorized_did(
+        header.as_deref(),
+        secret.as_deref().map(str::as_bytes),
+        owner.as_deref(),
+        now,
+    );
+
+    let allow_origin = env
+        .var("OAUTH_APP_URL")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let headers = Headers::new();
+    // A specific origin (not `*`) is required for credentialed CORS.
+    headers.set("Access-Control-Allow-Origin", &allow_origin)?;
+    headers.set("Access-Control-Allow-Credentials", "true")?;
+    headers.set("Vary", "Origin")?;
+    headers.set("Content-Type", "application/json")?;
+    let (status, body) = match did {
+        Some(did) => (200, serde_json::json!({ "did": did }).to_string()),
+        None => (401, "{}".to_owned()),
+    };
+    Ok(ResponseBuilder::new()
+        .with_status(status)
+        .with_headers(headers)
+        .fixed(body.into_bytes()))
 }
 
 /// Per-connection state persisted across hibernation via the socket


### PR DESCRIPTION
The session cookie is HttpOnly, so the notes-web shell (a different
origin) can't read it to tell whether you're signed in. Add GET /me: it
returns {"did": ...} with 200 when the request carries the owner's
session cookie, else 401, with CORS for the shell origin (OAUTH_APP_URL)
so the same-site cross-origin credentialed fetch can read it.

Refactor the owner gate into authorized_did (returning the DID) with
authorize_owner as the boolean wrapper the socket upgrade still uses, so
/me can surface the identity without duplicating the fail-closed logic.

Part of #971

The login form was always shown and never reflected an established
session — you had to infer auth from whether the editor's socket
connected. On load the shell now fetches /me with credentials; when
signed in it hides the form and shows a 'signed in as @handle' badge
(resolving the handle from the DID document, falling back to the DID),
and shows the form otherwise.

Closes #971