### PR TITLE
fix(notes-sync): wire GITHUB_TOKEN so notes back up to git

### DIFF
--- a/services/notes-sync/.env.example
+++ b/services/notes-sync/.env.example
@@ -25,3 +25,13 @@ CLOUDFLARE_ACCOUNT_ID="cc625b188f1219ec7ff2e9d19d1a1a7e"
 #     --title 'notes-sync SESSION_SECRET' \
 #     --vault vedq2v6cmtkglnonkenrjneepa --generate-password=64
 SESSION_SECRET="op://vedq2v6cmtkglnonkenrjneepa/notes-sync SESSION_SECRET/password"
+
+# Worker runtime secret: the GitHub token the Durable Object uses to commit
+# each note to `kolohelios/notes-store` via the Contents API. Needs
+# **Contents: write** on that one repo — a fine-grained PAT scoped to
+# `notes-store`, or a GitHub App installation token. Declared in
+# `project.cue` `ci.deploy.secrets`. Create the 1Password item once,
+# pasting the token as its password (do NOT commit the value):
+#   op item create --category password --title 'notes-sync GITHUB_TOKEN' \
+#     --vault vedq2v6cmtkglnonkenrjneepa password=<the-token>
+GITHUB_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/notes-sync GITHUB_TOKEN/password"

--- a/services/notes-sync/project.cue
+++ b/services/notes-sync/project.cue
@@ -20,12 +20,13 @@ package project
 			reusableWorkflow:    "./.github/workflows/cf-deploy.yml"
 			previewScriptPrefix: "notes-sync"
 			// Worker runtime secrets pushed at deploy from their `op://`
-			// refs in `.env.example` by `push-worker-secrets`. SESSION_SECRET
-			// signs the auth cookie minted by the OAuth callback; without it
-			// the callback throws ("SESSION_SECRET not set") on every
-			// sign-in. Declared here (not set out-of-band) so it's
-			// reproducible and survives redeploys.
-			secrets: ["SESSION_SECRET"]
+			// refs in `.env.example` by `push-worker-secrets`, so they're
+			// reproducible and survive redeploys rather than being set
+			// out-of-band. SESSION_SECRET signs the auth cookie the OAuth
+			// callback mints; GITHUB_TOKEN authenticates the cold-tier git
+			// commit (the DO PUTs each note to notes-store via the Contents
+			// API). Without either, the corresponding path throws.
+			secrets: ["SESSION_SECRET", "GITHUB_TOKEN"]
 		}
 	}
 }


### PR DESCRIPTION
The Durable Object commits each note to kolohelios/notes-store via the
GitHub Contents API (runtime.rs reads env.secret("GITHUB_TOKEN")), but
the token was never set on the Worker — so the cold-tier git backup
failed silently and notes lived only in the hot-tier DO. The backing
repo didn't exist either.

Declare GITHUB_TOKEN alongside SESSION_SECRET in ci.deploy.secrets and
add its op:// ref to .env.example, so push-worker-secrets sets it on
every deploy from 1Password. The notes-store repo and a Contents-scoped
token are the out-of-band prerequisites (a fine-grained PAT or App
token).

Closes #969