### PR TITLE
chore(services/notes-sync): relax commit cadence to ~5 minutes

### DIFF
--- a/.shaka/labels.cue
+++ b/.shaka/labels.cue
@@ -15,6 +15,7 @@ package labels
 		{name: "nix", color:          "5277c3", description: "Nix flakes, kolohelios-nix shared lib", scope: true},
 		{name: "pollen-alert", color: "0e8a16", description: "Pollen alert worker", scope: true},
 		{name: "portfolio", color:    "1d76db", description: "Personal portfolio site at kolohelios.com", scope: true},
+		{name: "services/notes-sync", color: "1abc9c", description: "Git-backed live-synced note service (Durable Object)", scope: true},
 		{name: "shaka", color:        "5319e7", description: "shaka CLI / repo tooling", scope: true},
 		{name: "todoist", color:      "e60023", description: "Todoist CLI tool", scope: true},
 

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -24,11 +24,15 @@ use crate::route::parse_ws_note_id;
 use crate::state::{is_stale, next_alarm};
 
 /// Commit the note this long after the last edit — coalesces a burst of
-/// keystrokes into a single git commit once the typing settles.
-const COMMIT_DEBOUNCE: Duration = Duration::from_secs(5);
+/// keystrokes into a single git commit once the typing settles. Durability
+/// lives in DO storage (an edit is persisted before its `Ack`), so git is
+/// only backup/history/embedding-source; the cadence is sized for a legible
+/// history, not for minimizing data loss.
+const COMMIT_DEBOUNCE: Duration = Duration::from_secs(60);
 /// Commit at least this often under continuous editing, so a never-idle
-/// session still backs up.
-const COMMIT_BACKSTOP: Duration = Duration::from_secs(60);
+/// session still backs up. Bounds how far GitHub trails the DO; not a
+/// durability bound (DO storage already holds every accepted edit).
+const COMMIT_BACKSTOP: Duration = Duration::from_secs(300);
 /// After a failed commit, retry no sooner than this.
 const COMMIT_RETRY_BACKOFF: Duration = Duration::from_secs(30);
 /// Optimistic stale-ref retries within a single commit attempt.


### PR DESCRIPTION
Durability lives in Durable Object storage — every accepted edit is
persisted before its Ack, and a wake-from-eviction reloads from DO
storage, not git. So the GitHub commit is only backup, history, and an
eventual embedding source, none of which need sub-minute freshness. The
old 5s debounce / 60s backstop were sized as if git were the durability
boundary; widening to 60s / 300s de-noises the commit history without
risking data (alarms are durable; the seq-vs-committed_seq guard already
skips no-op commits).

Adds the services/notes-sync scope label so the issue and PR can carry a
canonical scope.

Closes #979