### PR TITLE
feat(apps/notes-web): vault sidebar with note tree and switching

### DIFF
--- a/apps/notes-web/dist/index.html
+++ b/apps/notes-web/dist/index.html
@@ -29,6 +29,14 @@
       <span id="account" class="account" hidden></span>
     </header>
     <main>
+      <nav id="sidebar" class="sidebar" aria-label="vault">
+        <div class="sidebar-head">
+          <span>vault</span>
+          <button id="new-note" type="button" title="New note">+</button>
+        </div>
+        <!-- Filled from GET /vault: a tree of the committed notes. -->
+        <div id="vault-tree" class="vault-tree">loading…</div>
+      </nav>
       <textarea
         id="editor"
         spellcheck="true"
@@ -52,7 +60,10 @@
       // separate Worker; its host is injected at deploy as
       // `window.NOTES_BACKEND`, defaulting to this origin for local dev.
       const backend = window.NOTES_BACKEND || location.host;
-      const wsUrl = `${wsProto}://${backend}/note/${encodeURIComponent(noteId)}/ws`;
+      // The id is a `/`-separated path; the server rejects a percent-encoded
+      // slash (`%2F`), so encode each segment but keep the separators raw.
+      const wsPath = noteId.split("/").map(encodeURIComponent).join("/");
+      const wsUrl = `${wsProto}://${backend}/note/${wsPath}/ws`;
 
       // Sign in: hand off to the backend's ATProto OAuth login. It
       // resolves the handle, runs the flow, mints the session cookie, and
@@ -102,6 +113,101 @@
         }
       }
       refreshAuth();
+
+      // A note path is `/`-separated unreserved segments — the same shape
+      // the backend validates, checked here for instant feedback.
+      function validNotePath(p) {
+        return (
+          p.length > 0 &&
+          p
+            .split("/")
+            .every(
+              (s) => /^[A-Za-z0-9._-]+$/.test(s) && s !== "." && s !== "..",
+            )
+        );
+      }
+
+      // Build a nested tree from the flat, sorted note paths so the sidebar
+      // can render folders and notes.
+      function buildTree(paths) {
+        const root = { children: {} };
+        for (const p of paths) {
+          const parts = p.split("/");
+          let node = root;
+          parts.forEach((part, i) => {
+            node.children[part] ??= { children: {} };
+            node = node.children[part];
+            if (i === parts.length - 1) node.note = p;
+          });
+        }
+        return root;
+      }
+
+      function renderNode(node, container) {
+        const ul = document.createElement("ul");
+        for (const name of Object.keys(node.children).sort()) {
+          const child = node.children[name];
+          const li = document.createElement("li");
+          if (child.note !== undefined) {
+            const a = document.createElement("a");
+            a.href = "?note=" + encodeURIComponent(child.note);
+            a.textContent = name;
+            if (child.note === noteId) a.className = "active";
+            li.appendChild(a);
+          } else {
+            const span = document.createElement("span");
+            span.className = "folder";
+            span.textContent = name + "/";
+            li.appendChild(span);
+          }
+          if (Object.keys(child.children).length) renderNode(child, li);
+          ul.appendChild(li);
+        }
+        container.appendChild(ul);
+      }
+
+      // Load the vault listing and render the sidebar tree. The endpoint is
+      // owner-gated, so an unauthenticated visitor sees a prompt to sign in.
+      async function loadVault() {
+        const tree = document.getElementById("vault-tree");
+        let notes;
+        try {
+          const res = await fetch(`https://${backend}/vault`, {
+            credentials: "include",
+          });
+          if (res.status === 401) {
+            tree.textContent = "sign in to see your vault";
+            return;
+          }
+          if (!res.ok) {
+            tree.textContent = "vault unavailable";
+            return;
+          }
+          ({ notes } = await res.json());
+        } catch (e) {
+          tree.textContent = "vault unavailable";
+          return;
+        }
+        tree.replaceChildren();
+        if (!notes.length) {
+          tree.textContent = "no notes yet";
+          return;
+        }
+        renderNode(buildTree(notes), tree);
+      }
+      loadVault();
+
+      // New note: navigate to the empty note. It commits to git (and thus
+      // joins the vault listing) on its first edit.
+      document.getElementById("new-note").addEventListener("click", () => {
+        const path = (prompt("New note path (e.g. projects/idea)") || "").trim();
+        if (!path) return;
+        if (!validNotePath(path)) {
+          alert("Use letters, digits, . _ - and / between segments.");
+          return;
+        }
+        location.search = "?note=" + encodeURIComponent(path);
+      });
 
       const status = document.getElementById("status");
       try {

--- a/apps/notes-web/dist/style.css
+++ b/apps/notes-web/dist/style.css
@@ -77,6 +77,72 @@ main {
   min-height: 0;
 }
 
+.sidebar {
+  width: 16rem;
+  flex-shrink: 0;
+  overflow-y: auto;
+  padding: 0.5rem;
+  border-right: 1px solid var(--muted);
+  font-size: 0.85rem;
+}
+
+.sidebar-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  color: var(--muted);
+  text-transform: lowercase;
+}
+
+#new-note {
+  border: 1px solid var(--muted);
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 1;
+  padding: 0 0.4rem;
+  cursor: pointer;
+}
+
+.vault-tree {
+  color: var(--muted);
+  padding: 0.25rem 0.5rem;
+}
+
+.vault-tree ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 0.75rem;
+}
+
+.vault-tree li {
+  margin: 0.1rem 0;
+}
+
+.vault-tree a {
+  color: var(--fg);
+  text-decoration: none;
+  display: block;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+}
+
+.vault-tree a:hover {
+  background: light-dark(#ececec, #242424);
+}
+
+.vault-tree a.active {
+  background: light-dark(#e0e0e0, #2c2c2c);
+  font-weight: 600;
+}
+
+.vault-tree .folder {
+  display: block;
+  padding: 0.1rem 0.3rem;
+}
+
 #editor {
   flex: 1;
   width: 100%;

--- a/services/notes-sync/src/git.rs
+++ b/services/notes-sync/src/git.rs
@@ -95,6 +95,31 @@ pub async fn commit_with_retry<C: GitHubClient>(
     Err(CommitError::RetriesExhausted)
 }
 
+/// Parse a GitHub git-tree listing (the `git/trees/<ref>?recursive=1`
+/// response) into the vault's note ids: every blob under `notes/` whose
+/// name ends in `.md`, with the `notes/` prefix and `.md` suffix removed,
+/// sorted for a stable listing. Directories, non-markdown files, and
+/// anything outside `notes/` are ignored. This is the pure half of the
+/// vault index — the wasm client just fetches the tree and hands it here.
+pub fn note_paths_from_tree(tree_json: &str) -> Result<Vec<String>, CommitError> {
+    let v: serde_json::Value =
+        serde_json::from_str(tree_json).map_err(|e| CommitError::Transport(e.to_string()))?;
+    let entries = v
+        .get("tree")
+        .and_then(|t| t.as_array())
+        .ok_or_else(|| CommitError::Transport("tree listing missing `tree` array".into()))?;
+    let mut ids: Vec<String> = entries
+        .iter()
+        .filter(|e| e.get("type").and_then(|t| t.as_str()) == Some("blob"))
+        .filter_map(|e| e.get("path").and_then(|p| p.as_str()))
+        .filter_map(|path| path.strip_prefix("notes/")?.strip_suffix(".md"))
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+        .collect();
+    ids.sort();
+    Ok(ids)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -183,6 +208,36 @@ mod tests {
         // max_retries=3 → 4 attempts (the initial try plus 3 retries).
         assert_eq!(c.puts.get(), 4);
     }
+
+    #[test]
+    fn note_paths_extracts_markdown_blobs_under_notes() {
+        // A recursive tree mixes nested blobs, directory entries, files
+        // outside `notes/`, and non-markdown files — only `notes/*.md`
+        // blobs are notes, prefix/suffix stripped, and the result sorted.
+        let json = r#"{"tree":[
+            {"path":"notes/scratch.md","type":"blob"},
+            {"path":"notes/projects","type":"tree"},
+            {"path":"notes/projects/foo.md","type":"blob"},
+            {"path":"notes/diagram.png","type":"blob"},
+            {"path":"README.md","type":"blob"}
+        ],"truncated":false}"#;
+        assert_eq!(
+            note_paths_from_tree(json).unwrap(),
+            vec!["projects/foo".to_string(), "scratch".to_string()]
+        );
+    }
+
+    #[test]
+    fn note_paths_is_empty_for_a_vault_with_no_notes() {
+        let json = r#"{"tree":[{"path":"README.md","type":"blob"}],"truncated":false}"#;
+        assert!(note_paths_from_tree(json).unwrap().is_empty());
+    }
+
+    #[test]
+    fn note_paths_errors_on_a_malformed_listing() {
+        assert!(note_paths_from_tree("not json").is_err());
+        assert!(note_paths_from_tree("{}").is_err());
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -233,6 +288,39 @@ mod worker_client {
                 .send()
                 .await
                 .map_err(|e| CommitError::Transport(e.to_string()))
+        }
+
+        /// List the vault's note ids by walking the repo's git tree under
+        /// `notes/` (recursive trees API). Returns an empty list when the
+        /// branch has no commits yet (a fresh repo) or holds no notes.
+        pub async fn list_note_paths(
+            &self,
+            owner: &str,
+            repo: &str,
+            branch: &str,
+        ) -> Result<Vec<String>, CommitError> {
+            let url = format!(
+                "https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1"
+            );
+            let mut init = RequestInit::new();
+            init.with_method(Method::Get).with_headers(self.headers()?);
+            let req = Request::new_with_init(&url, &init)
+                .map_err(|e| CommitError::Transport(e.to_string()))?;
+            let mut resp = self.send(req).await?;
+            match resp.status_code() {
+                200 => {
+                    let body = resp
+                        .text()
+                        .await
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    super::note_paths_from_tree(&body)
+                }
+                // No commits on the branch yet (empty repo) — an empty vault.
+                404 | 409 => Ok(Vec::new()),
+                other => Err(CommitError::Transport(format!(
+                    "GET trees returned {other}"
+                ))),
+            }
         }
     }
 

--- a/services/notes-sync/src/route.rs
+++ b/services/notes-sync/src/route.rs
@@ -5,15 +5,31 @@
 
 /// Extract the note id from a websocket path of the form `/note/<id>/ws`.
 ///
-/// Returns `None` for any other shape, an empty id, or an id containing a
-/// path separator — so a caller can treat `Some(id)` as a validated,
-/// single-segment note identifier.
+/// The id may be a `/`-separated path (`projects/foo/idea`) so a vault
+/// nests under `notes/<id>.md`. The returned value is validated to be safe
+/// as both a Durable Object key and a git path: it has no empty segments
+/// (so no leading, trailing, or doubled slashes), no `.`/`..` segment (so
+/// no traversal out of `notes/`), and every segment is made only of
+/// `[A-Za-z0-9._-]`. A caller can treat `Some(id)` as a trusted note path.
+///
+/// Returns `None` for any other shape or a segment that fails those rules.
 pub fn parse_ws_note_id(path: &str) -> Option<&str> {
     let id = path.strip_prefix("/note/")?.strip_suffix("/ws")?;
-    if id.is_empty() || id.contains('/') {
+    if id.is_empty() || !id.split('/').all(is_safe_segment) {
         return None;
     }
     Some(id)
+}
+
+/// A single path segment is safe when it is non-empty, isn't a `.`/`..`
+/// traversal token, and contains only unreserved path characters.
+fn is_safe_segment(segment: &str) -> bool {
+    if segment.is_empty() || segment == "." || segment == ".." {
+        return false;
+    }
+    segment
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
 }
 
 #[cfg(test)]
@@ -23,6 +39,22 @@ mod tests {
     #[test]
     fn parses_a_well_formed_ws_path() {
         assert_eq!(parse_ws_note_id("/note/abc123/ws"), Some("abc123"));
+    }
+
+    #[test]
+    fn accepts_a_nested_path_id() {
+        assert_eq!(
+            parse_ws_note_id("/note/projects/foo/idea/ws"),
+            Some("projects/foo/idea")
+        );
+    }
+
+    #[test]
+    fn accepts_unreserved_segment_characters() {
+        assert_eq!(
+            parse_ws_note_id("/note/daily/2026-06-25_draft.v2/ws"),
+            Some("daily/2026-06-25_draft.v2")
+        );
     }
 
     #[test]
@@ -38,7 +70,24 @@ mod tests {
     }
 
     #[test]
-    fn rejects_multi_segment_id() {
-        assert_eq!(parse_ws_note_id("/note/a/b/ws"), None);
+    fn rejects_empty_segments_from_stray_slashes() {
+        // Leading, trailing, and doubled slashes all yield an empty segment.
+        assert_eq!(parse_ws_note_id("/note//foo/ws"), None);
+        assert_eq!(parse_ws_note_id("/note/foo//ws"), None);
+        assert_eq!(parse_ws_note_id("/note/foo//bar/ws"), None);
+    }
+
+    #[test]
+    fn rejects_dot_traversal_segments() {
+        assert_eq!(parse_ws_note_id("/note/../secrets/ws"), None);
+        assert_eq!(parse_ws_note_id("/note/foo/../../etc/ws"), None);
+        assert_eq!(parse_ws_note_id("/note/./foo/ws"), None);
+    }
+
+    #[test]
+    fn rejects_unsafe_segment_characters() {
+        assert_eq!(parse_ws_note_id("/note/foo bar/ws"), None);
+        assert_eq!(parse_ws_note_id("/note/foo:bar/ws"), None);
+        assert_eq!(parse_ws_note_id("/note/foo%2Fbar/ws"), None);
     }
 }

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -60,6 +60,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/oauth/login" => return crate::oauth::handle_login(req, env).await,
         "/oauth/callback" => return crate::oauth::handle_callback(req, env).await,
         "/me" => return handle_me(&req, &env),
+        "/vault" => return handle_vault(&req, &env).await,
         _ => {}
     }
 
@@ -118,22 +119,55 @@ fn handle_me(req: &Request, env: &Env) -> Result<Response> {
         now,
     );
 
-    let allow_origin = env
-        .var("OAUTH_APP_URL")
-        .map(|v| v.to_string())
-        .unwrap_or_default();
-    let headers = Headers::new();
-    // A specific origin (not `*`) is required for credentialed CORS.
-    headers.set("Access-Control-Allow-Origin", &allow_origin)?;
-    headers.set("Access-Control-Allow-Credentials", "true")?;
-    headers.set("Vary", "Origin")?;
-    headers.set("Content-Type", "application/json")?;
+    let headers = shell_cors_headers(env)?;
     let (status, body) = match did {
         Some(did) => (200, serde_json::json!({ "did": did }).to_string()),
         None => (401, "{}".to_owned()),
     };
     Ok(ResponseBuilder::new()
         .with_status(status)
+        .with_headers(headers)
+        .fixed(body.into_bytes()))
+}
+
+/// JSON-response headers for the shell's credentialed cross-origin fetches
+/// (`/me`, `/vault`). A specific origin (`OAUTH_APP_URL`, not `*`) is
+/// required when `Access-Control-Allow-Credentials` is set.
+fn shell_cors_headers(env: &Env) -> Result<Headers> {
+    let allow_origin = env
+        .var("OAUTH_APP_URL")
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let headers = Headers::new();
+    headers.set("Access-Control-Allow-Origin", &allow_origin)?;
+    headers.set("Access-Control-Allow-Credentials", "true")?;
+    headers.set("Vary", "Origin")?;
+    headers.set("Content-Type", "application/json")?;
+    Ok(headers)
+}
+
+/// `GET /vault` — the sidebar's note listing. Returns
+/// `{"notes": ["projects/foo", "scratch", …]}` for the owner's session,
+/// else `401`. The index is a git-tree walk of `notes/`, so a note that's
+/// been edited but not yet committed (within the lazy debounce/backstop
+/// window) won't appear until its first commit lands.
+async fn handle_vault(req: &Request, env: &Env) -> Result<Response> {
+    if !session_authorized(req, env) {
+        return Response::error("unauthorized", 401);
+    }
+    let owner = env.var("GITHUB_OWNER")?.to_string();
+    let repo = env.var("GITHUB_REPO")?.to_string();
+    let branch = env.var("GITHUB_BRANCH")?.to_string();
+    let token = env.secret("GITHUB_TOKEN")?.to_string();
+    let notes = WorkerGitHubClient::new(token)
+        .list_note_paths(&owner, &repo, &branch)
+        .await
+        .map_err(|e| Error::RustError(e.to_string()))?;
+
+    let headers = shell_cors_headers(env)?;
+    let body = serde_json::json!({ "notes": notes }).to_string();
+    Ok(ResponseBuilder::new()
+        .with_status(200)
         .with_headers(headers)
         .fixed(body.into_bytes()))
 }


### PR DESCRIPTION
A vault organizes notes in a tree, so a note id needs to be a path
(`projects/foo/idea` -> `notes/projects/foo/idea.md`) rather than a flat
segment. The DO key (`idFromName`) and git path already nest cleanly; the
only blocker was the router rejecting any id with a slash.

Relax `parse_ws_note_id` to accept `/`-separated ids, validating each
segment so the result stays safe as both a DO key and a git path: no
empty segments (no leading/trailing/doubled slashes), no `.`/`..`
traversal out of `notes/`, and unreserved characters only.

Part of #981.

The sidebar needs the set of note paths to render. Per the "simpler
hypothesis" tenet, derive it from git rather than standing up a Vault
Durable Object: `GET /vault` walks the repo's recursive git tree and
returns `{"notes": [<path>, …]}` for the owner's session (same cookie
gate and CORS shape as `/me`).

The pure half — turning a git-tree listing into sorted note ids (blobs
under `notes/` ending in `.md`, prefix/suffix stripped) — is
`note_paths_from_tree`, native-tested; the wasm `list_note_paths` only
fetches the tree and hands it over. An empty/uncommitted repo lists
nothing. One known limit: a note edited but not yet committed (within the
lazy commit window) won't appear until its first commit lands.

Part of #981.

Turn the single-note shell into a vault: a sidebar fetches the owner's
note listing from `GET /vault`, builds a folder tree from the
`/`-separated paths, and highlights the current note. Switching a note
navigates (`?note=<path>`) rather than re-pointing the editor in place —
the WASM `start` has no teardown (it leaks its closures and auto-
reconnects), so a full reload is the robust v1; live in-place switching
is a follow-up that needs an editor stop handle.

A "new note" action prompts for a path and opens it empty; it joins the
listing once its first edit commits. Note paths are now `/`-separated, so
the socket URL encodes each segment but keeps the separators raw (the
server rejects a percent-encoded slash).

Part of #981.