### PR TITLE
feat(apps/notes-web): delete notes from the sidebar

### DIFF
--- a/apps/notes-web/dist/index.html
+++ b/apps/notes-web/dist/index.html
@@ -153,7 +153,20 @@
             a.href = "?note=" + encodeURIComponent(child.note);
             a.textContent = name;
             if (child.note === noteId) a.className = "active";
-            li.appendChild(a);
+            const del = document.createElement("button");
+            del.type = "button";
+            del.className = "note-del";
+            del.title = "Delete note";
+            del.textContent = "×";
+            del.addEventListener("click", (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              deleteNote(child.note);
+            });
+            const row = document.createElement("div");
+            row.className = "note-row";
+            row.append(a, del);
+            li.appendChild(row);
           } else {
             const span = document.createElement("span");
             span.className = "folder";
@@ -196,6 +209,31 @@
         renderNode(buildTree(notes), tree);
       }
       loadVault();
+
+      // Delete a note: confirm, ask the backend to purge it (storage + git
+      // file), then refresh. If we just deleted the note we're viewing, fall
+      // back to the default note.
+      async function deleteNote(note) {
+        if (!confirm(`Delete "${note}"? This removes it from git.`)) return;
+        try {
+          const res = await fetch(
+            `https://${backend}/delete?note=${encodeURIComponent(note)}`,
+            { method: "POST", credentials: "include" },
+          );
+          if (!res.ok) {
+            alert("Delete failed.");
+            return;
+          }
+        } catch (e) {
+          alert("Delete failed.");
+          return;
+        }
+        if (note === noteId) {
+          location.search = "?note=scratch";
+        } else {
+          loadVault();
+        }
+      }
 
       // New note: navigate to the empty note. It commits to git (and thus
       // joins the vault listing) on its first edit.

--- a/apps/notes-web/dist/style.css
+++ b/apps/notes-web/dist/style.css
@@ -121,16 +121,46 @@ main {
   margin: 0.1rem 0;
 }
 
+.note-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .vault-tree a {
+  flex: 1;
+  min-width: 0;
   color: var(--fg);
   text-decoration: none;
   display: block;
   padding: 0.1rem 0.3rem;
   border-radius: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .vault-tree a:hover {
   background: light-dark(#ececec, #242424);
+}
+
+.note-del {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+  visibility: hidden;
+}
+
+.note-row:hover .note-del {
+  visibility: visible;
+}
+
+.note-del:hover {
+  color: var(--fg);
 }
 
 .vault-tree a.active {

--- a/services/notes-sync/src/git.rs
+++ b/services/notes-sync/src/git.rs
@@ -322,6 +322,37 @@ mod worker_client {
                 ))),
             }
         }
+
+        /// Remove `target.path` from git. A note that was never committed
+        /// has no file — that's a no-op success, so a delete is idempotent.
+        pub async fn delete_note_file(
+            &self,
+            target: &GitTarget,
+            message: &str,
+        ) -> Result<(), CommitError> {
+            // The contents API needs the current blob sha to delete it.
+            let Some(sha) = self.current_sha(target).await? else {
+                return Ok(());
+            };
+            let body = serde_json::json!({
+                "message": message,
+                "sha": sha,
+                "branch": target.branch,
+            });
+            let mut init = RequestInit::new();
+            init.with_method(Method::Delete)
+                .with_headers(self.headers()?)
+                .with_body(Some(body.to_string().into()));
+            let req = Request::new_with_init(&Self::contents_url(target), &init)
+                .map_err(|e| CommitError::Transport(e.to_string()))?;
+            let mut resp = self.send(req).await?;
+            match resp.status_code() {
+                200 => Ok(()),
+                other => Err(CommitError::Transport(format!(
+                    "DELETE contents returned {other}"
+                ))),
+            }
+        }
     }
 
     impl GitHubClient for WorkerGitHubClient {

--- a/services/notes-sync/src/route.rs
+++ b/services/notes-sync/src/route.rs
@@ -15,10 +15,15 @@
 /// Returns `None` for any other shape or a segment that fails those rules.
 pub fn parse_ws_note_id(path: &str) -> Option<&str> {
     let id = path.strip_prefix("/note/")?.strip_suffix("/ws")?;
-    if id.is_empty() || !id.split('/').all(is_safe_segment) {
-        return None;
-    }
-    Some(id)
+    is_valid_note_id(id).then_some(id)
+}
+
+/// Whether `id` is a valid note path: non-empty, and every `/`-separated
+/// segment is safe as a path component (see `is_safe_segment`). The same
+/// rule gates the websocket route and the mutation endpoints, so a note id
+/// that reaches a Durable Object or a git path is always trusted.
+pub fn is_valid_note_id(id: &str) -> bool {
+    !id.is_empty() && id.split('/').all(is_safe_segment)
 }
 
 /// A single path segment is safe when it is non-empty, isn't a `.`/`..`
@@ -89,5 +94,17 @@ mod tests {
         assert_eq!(parse_ws_note_id("/note/foo bar/ws"), None);
         assert_eq!(parse_ws_note_id("/note/foo:bar/ws"), None);
         assert_eq!(parse_ws_note_id("/note/foo%2Fbar/ws"), None);
+    }
+
+    #[test]
+    fn is_valid_note_id_accepts_safe_paths_and_rejects_the_rest() {
+        assert!(is_valid_note_id("scratch"));
+        assert!(is_valid_note_id("projects/foo/idea"));
+        assert!(!is_valid_note_id(""));
+        assert!(!is_valid_note_id("/leading"));
+        assert!(!is_valid_note_id("trailing/"));
+        assert!(!is_valid_note_id("a//b"));
+        assert!(!is_valid_note_id("../escape"));
+        assert!(!is_valid_note_id("has space"));
     }
 }

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -14,14 +14,20 @@ use serde::{Deserialize, Serialize};
 // bare name (see the workers-rs `counter.rs` example).
 use worker::{
     console_log, durable_object, event, wasm_bindgen, Context, Date, DurableObject, Env, Error,
-    Headers, Request, Response, ResponseBuilder, Result, State, WebSocket,
+    Headers, Method, Request, RequestInit, Response, ResponseBuilder, Result, State, WebSocket,
     WebSocketIncomingMessage, WebSocketPair,
 };
 
 use crate::auth::{authorize_owner, authorized_did};
 use crate::git::{commit_with_retry, CommitError, GitTarget, WorkerGitHubClient};
-use crate::route::parse_ws_note_id;
+use crate::route::{is_valid_note_id, parse_ws_note_id};
 use crate::state::{is_stale, next_alarm};
+
+/// Internal DO control path: the top-level `/delete` handler forwards a
+/// `POST` here to the note's Durable Object so it purges its own storage
+/// and backing git file. Never routed from the public surface — only the
+/// orchestrator reaches it, with the note id in `X-Note-Id`.
+const PURGE_PATH: &str = "/__purge";
 
 /// Commit the note this long after the last edit — coalesces a burst of
 /// keystrokes into a single git commit once the typing settles. Durability
@@ -61,6 +67,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/oauth/callback" => return crate::oauth::handle_callback(req, env).await,
         "/me" => return handle_me(&req, &env),
         "/vault" => return handle_vault(&req, &env).await,
+        "/delete" => return handle_delete(&req, &env).await,
         _ => {}
     }
 
@@ -172,6 +179,47 @@ async fn handle_vault(req: &Request, env: &Env) -> Result<Response> {
         .fixed(body.into_bytes()))
 }
 
+/// `POST /delete?note=<id>` — delete a note for the owner's session.
+/// Forwards to the note's Durable Object, which purges its own storage and
+/// removes the backing git file (idempotent: deleting an uncommitted or
+/// already-gone note still succeeds). Returns `{"ok": true}`.
+async fn handle_delete(req: &Request, env: &Env) -> Result<Response> {
+    if !session_authorized(req, env) {
+        return Response::error("unauthorized", 401);
+    }
+    let note = req
+        .url()?
+        .query_pairs()
+        .find(|(k, _)| k == "note")
+        .map(|(_, v)| v.into_owned())
+        .unwrap_or_default();
+    if !is_valid_note_id(&note) {
+        return Response::error("invalid note id", 400);
+    }
+
+    // Hand off to the note's DO. The id rides a header so it needs no path
+    // encoding, and the DO uses it to resolve the git path it owns.
+    let headers = Headers::new();
+    headers.set("X-Note-Id", &note)?;
+    let mut init = RequestInit::new();
+    init.with_method(Method::Post).with_headers(headers);
+    let ctrl = Request::new_with_init(&format!("https://do{PURGE_PATH}"), &init)?;
+    let stub = env
+        .durable_object("NOTE")?
+        .id_from_name(&note)?
+        .get_stub()?;
+    let resp = stub.fetch_with_request(ctrl).await?;
+    if resp.status_code() != 200 {
+        return Response::error("delete failed", 502);
+    }
+
+    let headers = shell_cors_headers(env)?;
+    Ok(ResponseBuilder::new()
+        .with_status(200)
+        .with_headers(headers)
+        .fixed(b"{\"ok\":true}".to_vec()))
+}
+
 /// Per-connection state persisted across hibernation via the socket
 /// attachment. On wake the Durable Object is rebuilt from a lean
 /// constructor, so anything connection-scoped (here, the note id) has to
@@ -273,12 +321,35 @@ impl NoteDurableObject {
             .get("note_id")
             .await?
             .unwrap_or_default();
+        self.git_target_for(&note_id)
+    }
+
+    /// Resolve the GitHub target for an explicit (already-validated) note
+    /// id. The env config is shared across notes; only the path differs.
+    fn git_target_for(&self, note_id: &str) -> Result<GitTarget> {
         Ok(GitTarget {
             owner: self.env.var("GITHUB_OWNER")?.to_string(),
             repo: self.env.var("GITHUB_REPO")?.to_string(),
             branch: self.env.var("GITHUB_BRANCH")?.to_string(),
             path: format!("notes/{note_id}.md"),
         })
+    }
+
+    /// Delete this note: remove its backing git file, then wipe all durable
+    /// storage so a future open of the same id starts empty. Git is dropped
+    /// first — if that fails we return the error without touching storage,
+    /// keeping the DO and git consistent for a retry. Idempotent: an
+    /// uncommitted note has no file, and clearing clear storage is a no-op.
+    async fn purge(&self, note_id: &str) -> Result<Response> {
+        let target = self.git_target_for(note_id)?;
+        let token = self.env.secret("GITHUB_TOKEN")?.to_string();
+        WorkerGitHubClient::new(token)
+            .delete_note_file(&target, &format!("note: delete {}", target.path))
+            .await
+            .map_err(|e| Error::RustError(e.to_string()))?;
+        self.state.storage().delete_all().await?;
+        let _ = self.state.storage().delete_alarm().await;
+        Response::ok("purged")
     }
 
     /// Commit the current body to git with optimistic stale-ref retry.
@@ -317,6 +388,14 @@ impl DurableObject for NoteDurableObject {
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {
+        // Internal control op: the `/delete` orchestrator forwards a purge
+        // here with the note id in `X-Note-Id`. Handled before the websocket
+        // path so it never tries to upgrade.
+        if req.path() == PURGE_PATH {
+            let note_id = req.headers().get("X-Note-Id")?.unwrap_or_default();
+            return self.purge(&note_id).await;
+        }
+
         let note_id = parse_ws_note_id(&req.path())
             .map(str::to_owned)
             .unwrap_or_default();


### PR DESCRIPTION
Deleting a note has to clear the Durable Object's storage, not just the
git file — DO storage is the source of truth (git is never read back), so
removing only the file would leave the note fully intact on reopen.

`POST /delete?note=<id>` (owner-gated, id validated by the shared
`is_valid_note_id`) forwards to the note's DO over an internal control
path; the DO removes its backing git file and then wipes all durable
storage so a future open of the same id starts empty. Git is dropped
first, so a failed delete leaves DO and git consistent for a retry, and
the whole thing is idempotent (an uncommitted or already-gone note still
succeeds). Adds `WorkerGitHubClient::delete_note_file` for the git side.

Part of #981.

Each note in the sidebar tree gets a delete affordance (revealed on row
hover); clicking confirms, then POSTs to /delete and refreshes the vault.
Deleting the note you're currently viewing falls back to the default
`scratch` note. Long note names truncate with an ellipsis so the delete
button stays reachable.

Part of #981.