### PR TITLE
feat(notes-web): add rename button to the sidebar tree

### DIFF
--- a/apps/notes-web/dist/index.html
+++ b/apps/notes-web/dist/index.html
@@ -153,9 +153,19 @@
             a.href = "?note=" + encodeURIComponent(child.note);
             a.textContent = name;
             if (child.note === noteId) a.className = "active";
+            const ren = document.createElement("button");
+            ren.type = "button";
+            ren.className = "note-act";
+            ren.title = "Rename or move note";
+            ren.textContent = "✎";
+            ren.addEventListener("click", (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              renameNote(child.note);
+            });
             const del = document.createElement("button");
             del.type = "button";
-            del.className = "note-del";
+            del.className = "note-act";
             del.title = "Delete note";
             del.textContent = "×";
             del.addEventListener("click", (e) => {
@@ -165,7 +175,7 @@
             });
             const row = document.createElement("div");
             row.className = "note-row";
-            row.append(a, del);
+            row.append(a, ren, del);
             li.appendChild(row);
           } else {
             const span = document.createElement("span");
@@ -230,6 +240,55 @@
         }
         if (note === noteId) {
           location.search = "?note=scratch";
+        } else {
+          loadVault();
+        }
+      }
+
+      // Rename/move a note: prompt for a new path, validate it, ask the
+      // backend to move the git file and migrate the Durable Object, then
+      // follow the note to its new path (or just refresh the listing).
+      async function renameNote(note) {
+        const to = (
+          prompt(`Rename "${note}" to (new path):`, note) || ""
+        ).trim();
+        if (!to || to === note) return;
+        if (!validNotePath(to)) {
+          alert("Use letters, digits, . _ - and / between segments.");
+          return;
+        }
+        // If we're renaming the note we're currently editing, freeze the
+        // surface before the move. The server reads the source note's body
+        // and then clears its Durable Object; a keystroke landing in that
+        // window would be committed to the old path and then erased. Making
+        // the textarea read-only stops new edits from being sent; on success
+        // we navigate (a full reload), which tears down the live socket.
+        const editor = document.getElementById("editor");
+        const editingThis = note === noteId;
+        if (editingThis) editor.readOnly = true;
+        try {
+          const res = await fetch(
+            `https://${backend}/rename?note=${encodeURIComponent(note)}&to=${encodeURIComponent(to)}`,
+            { method: "POST", credentials: "include" },
+          );
+          if (!res.ok) {
+            if (editingThis) editor.readOnly = false;
+            alert(
+              res.status === 409
+                ? "A note already exists at that path."
+                : res.status === 404
+                  ? "That note no longer exists."
+                  : "Rename failed.",
+            );
+            return;
+          }
+        } catch (e) {
+          if (editingThis) editor.readOnly = false;
+          alert("Rename failed.");
+          return;
+        }
+        if (editingThis) {
+          location.search = "?note=" + encodeURIComponent(to);
         } else {
           loadVault();
         }

--- a/apps/notes-web/dist/style.css
+++ b/apps/notes-web/dist/style.css
@@ -144,7 +144,7 @@ main {
   background: light-dark(#ececec, #242424);
 }
 
-.note-del {
+.note-act {
   border: 0;
   background: transparent;
   color: var(--muted);
@@ -155,11 +155,11 @@ main {
   visibility: hidden;
 }
 
-.note-row:hover .note-del {
+.note-row:hover .note-act {
   visibility: visible;
 }
 
-.note-del:hover {
+.note-act:hover {
   color: var(--fg);
 }
 

--- a/services/notes-sync/src/git.rs
+++ b/services/notes-sync/src/git.rs
@@ -68,6 +68,10 @@ pub trait GitHubClient {
         base_sha: Option<&str>,
         message: &str,
     ) -> Result<PutOutcome, CommitError>;
+
+    /// Remove `target.path` from git. A path with no committed file is a
+    /// no-op success, so a delete is idempotent.
+    async fn delete_file(&self, target: &GitTarget, message: &str) -> Result<(), CommitError>;
 }
 
 /// Commit `text` to `target`, re-reading the sha and retrying when the ref
@@ -93,6 +97,40 @@ pub async fn commit_with_retry<C: GitHubClient>(
         }
     }
     Err(CommitError::RetriesExhausted)
+}
+
+/// Move a note's backing file from `old` to `new`, carrying `content`.
+/// **Create-before-delete**: the destination file is committed first (so the
+/// body is durable at the new path before anything is removed), and only
+/// then is the source file dropped. A partial failure never *loses* data,
+/// but it is not automatically clean to retry:
+///
+/// - If the **create** fails, nothing changed — the source still holds the
+///   body and a retry is safe.
+/// - If the create succeeds but the **delete** (or any later orchestration
+///   step) fails, the *destination* now lingers alongside the source. A
+///   naive retry would be rejected as a destination collision; the caller
+///   must instead resume the move idempotently (see [`crate::route::plan_rename`]
+///   and [`crate::route::RenamePlan::Resume`]). Re-running this helper as
+///   part of that resume is safe: the create re-PUTs the same body and the
+///   delete then removes the source.
+///
+/// Returns the new file's commit sha. The caller is responsible for refusing
+/// an overwrite of a *different* note already at the destination; this helper
+/// carries `content` to `new` unconditionally.
+pub async fn move_note_file<C: GitHubClient>(
+    client: &C,
+    old: &GitTarget,
+    new: &GitTarget,
+    content: &str,
+    max_retries: u32,
+) -> Result<String, CommitError> {
+    let create_msg = format!("note: rename {} -> {}", old.path, new.path);
+    let sha = commit_with_retry(client, new, content, &create_msg, max_retries).await?;
+    // Destination is durable; now drop the source.
+    let delete_msg = format!("note: rename remove {}", old.path);
+    client.delete_file(old, &delete_msg).await?;
+    Ok(sha)
 }
 
 /// Parse a GitHub git-tree listing (the `git/trees/<ref>?recursive=1`
@@ -164,6 +202,67 @@ mod tests {
                 Ok(PutOutcome::Committed("new-commit-sha".into()))
             }
         }
+
+        async fn delete_file(
+            &self,
+            _target: &GitTarget,
+            _message: &str,
+        ) -> Result<(), CommitError> {
+            Ok(())
+        }
+    }
+
+    /// Fake that records every operation in order so a test can assert the
+    /// create-before-delete sequence and the path/content a move writes.
+    struct RecordingClient {
+        events: std::cell::RefCell<Vec<String>>,
+    }
+
+    impl RecordingClient {
+        fn new() -> Self {
+            Self {
+                events: std::cell::RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl GitHubClient for RecordingClient {
+        async fn current_sha(&self, target: &GitTarget) -> Result<Option<String>, CommitError> {
+            self.events
+                .borrow_mut()
+                .push(format!("read:{}", target.path));
+            // Destination is free (a fresh create); the move helper assumes so.
+            Ok(None)
+        }
+
+        async fn put_file(
+            &self,
+            target: &GitTarget,
+            content: &str,
+            _base_sha: Option<&str>,
+            _message: &str,
+        ) -> Result<PutOutcome, CommitError> {
+            self.events
+                .borrow_mut()
+                .push(format!("put:{}={}", target.path, content));
+            Ok(PutOutcome::Committed("dest-sha".into()))
+        }
+
+        async fn delete_file(&self, target: &GitTarget, _message: &str) -> Result<(), CommitError> {
+            self.events
+                .borrow_mut()
+                .push(format!("delete:{}", target.path));
+            Ok(())
+        }
+    }
+
+    fn note_target(path: &str) -> GitTarget {
+        GitTarget {
+            owner: "kolohelios".into(),
+            repo: "notes".into(),
+            branch: "main".into(),
+            path: path.into(),
+        }
     }
 
     fn target() -> GitTarget {
@@ -207,6 +306,113 @@ mod tests {
         assert_eq!(err, CommitError::RetriesExhausted);
         // max_retries=3 → 4 attempts (the initial try plus 3 retries).
         assert_eq!(c.puts.get(), 4);
+    }
+
+    #[tokio::test]
+    async fn move_creates_destination_before_deleting_source() {
+        let c = RecordingClient::new();
+        let sha = move_note_file(
+            &c,
+            &note_target("notes/old.md"),
+            &note_target("notes/projects/new.md"),
+            "hello body",
+            3,
+        )
+        .await
+        .unwrap();
+        assert_eq!(sha, "dest-sha");
+
+        let events = c.events.borrow();
+        // The destination is written (with the carried content) and only then
+        // is the source removed — create-before-delete, so no body is ever
+        // left unreferenced.
+        assert_eq!(
+            *events,
+            vec![
+                "read:notes/projects/new.md".to_string(),
+                "put:notes/projects/new.md=hello body".to_string(),
+                "delete:notes/old.md".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn move_propagates_a_destination_write_failure_without_deleting() {
+        // A client whose create fails must never reach the delete — the source
+        // file has to survive so the body isn't lost.
+        struct FailingPut;
+        impl GitHubClient for FailingPut {
+            async fn current_sha(&self, _t: &GitTarget) -> Result<Option<String>, CommitError> {
+                Ok(None)
+            }
+            async fn put_file(
+                &self,
+                _t: &GitTarget,
+                _c: &str,
+                _b: Option<&str>,
+                _m: &str,
+            ) -> Result<PutOutcome, CommitError> {
+                Err(CommitError::Transport("boom".into()))
+            }
+            async fn delete_file(&self, _t: &GitTarget, _m: &str) -> Result<(), CommitError> {
+                panic!("delete must not run when the destination write failed");
+            }
+        }
+        let err = move_note_file(
+            &FailingPut,
+            &note_target("notes/old.md"),
+            &note_target("notes/new.md"),
+            "body",
+            3,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CommitError::Transport("boom".into()));
+    }
+
+    #[tokio::test]
+    async fn move_propagates_a_delete_failure_after_the_create_landed() {
+        // The data-safety contract: when the destination create succeeds but
+        // the source delete fails, the error propagates *and* the create has
+        // already happened — the body is durable at the new path before the
+        // failure, so the caller can resume rather than lose data.
+        struct CreatesThenFailsDelete {
+            created: Cell<bool>,
+        }
+        impl GitHubClient for CreatesThenFailsDelete {
+            async fn current_sha(&self, _t: &GitTarget) -> Result<Option<String>, CommitError> {
+                Ok(None)
+            }
+            async fn put_file(
+                &self,
+                _t: &GitTarget,
+                _c: &str,
+                _b: Option<&str>,
+                _m: &str,
+            ) -> Result<PutOutcome, CommitError> {
+                self.created.set(true);
+                Ok(PutOutcome::Committed("dest-sha".into()))
+            }
+            async fn delete_file(&self, _t: &GitTarget, _m: &str) -> Result<(), CommitError> {
+                Err(CommitError::Transport("delete boom".into()))
+            }
+        }
+        let client = CreatesThenFailsDelete {
+            created: Cell::new(false),
+        };
+        let err = move_note_file(
+            &client,
+            &note_target("notes/old.md"),
+            &note_target("notes/new.md"),
+            "body",
+            3,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, CommitError::Transport("delete boom".into()));
+        // Destination-durable-before-error: the create ran before the delete
+        // failed, so the body is safe at the new path for a resume.
+        assert!(client.created.get());
     }
 
     #[test]
@@ -323,35 +529,64 @@ mod worker_client {
             }
         }
 
+        /// Read the decoded UTF-8 body committed at `target.path`, or `None`
+        /// if no file exists there. The rename orchestrator uses this to
+        /// recover the source body when the source Durable Object is cold
+        /// (its in-memory text is empty though git holds the note) and to
+        /// read the destination body when resuming a half-finished move.
+        /// Carrying `""` from a cold DO would erase the note on the move, so
+        /// this git fallback is what keeps a transient display gap from
+        /// becoming permanent data loss.
+        pub async fn get_file_content(
+            &self,
+            target: &GitTarget,
+        ) -> Result<Option<String>, CommitError> {
+            let url = format!("{}?ref={}", Self::contents_url(target), target.branch);
+            let mut init = RequestInit::new();
+            init.with_method(Method::Get).with_headers(self.headers()?);
+            let req = Request::new_with_init(&url, &init)
+                .map_err(|e| CommitError::Transport(e.to_string()))?;
+            let mut resp = self.send(req).await?;
+            match resp.status_code() {
+                200 => {
+                    let body = resp
+                        .text()
+                        .await
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    let v: serde_json::Value = serde_json::from_str(&body)
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    // GitHub returns base64 with embedded newlines; the
+                    // STANDARD engine rejects whitespace, so strip it first.
+                    let encoded: String = v
+                        .get("content")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or_default()
+                        .split_whitespace()
+                        .collect();
+                    let bytes = base64::engine::general_purpose::STANDARD
+                        .decode(encoded.as_bytes())
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    let text = String::from_utf8(bytes)
+                        .map_err(|e| CommitError::Transport(e.to_string()))?;
+                    Ok(Some(text))
+                }
+                404 => Ok(None),
+                other => Err(CommitError::Transport(format!(
+                    "GET contents returned {other}"
+                ))),
+            }
+        }
+
         /// Remove `target.path` from git. A note that was never committed
         /// has no file — that's a no-op success, so a delete is idempotent.
+        /// Thin alias over the [`GitHubClient::delete_file`] trait method so
+        /// existing callers (the `/delete` purge) read naturally.
         pub async fn delete_note_file(
             &self,
             target: &GitTarget,
             message: &str,
         ) -> Result<(), CommitError> {
-            // The contents API needs the current blob sha to delete it.
-            let Some(sha) = self.current_sha(target).await? else {
-                return Ok(());
-            };
-            let body = serde_json::json!({
-                "message": message,
-                "sha": sha,
-                "branch": target.branch,
-            });
-            let mut init = RequestInit::new();
-            init.with_method(Method::Delete)
-                .with_headers(self.headers()?)
-                .with_body(Some(body.to_string().into()));
-            let req = Request::new_with_init(&Self::contents_url(target), &init)
-                .map_err(|e| CommitError::Transport(e.to_string()))?;
-            let mut resp = self.send(req).await?;
-            match resp.status_code() {
-                200 => Ok(()),
-                other => Err(CommitError::Transport(format!(
-                    "DELETE contents returned {other}"
-                ))),
-            }
+            self.delete_file(target, message).await
         }
     }
 
@@ -426,6 +661,31 @@ mod worker_client {
                 409 => Ok(PutOutcome::StaleRef),
                 other => Err(CommitError::Transport(format!(
                     "PUT contents returned {other}"
+                ))),
+            }
+        }
+
+        async fn delete_file(&self, target: &GitTarget, message: &str) -> Result<(), CommitError> {
+            // The contents API needs the current blob sha to delete it.
+            let Some(sha) = self.current_sha(target).await? else {
+                return Ok(());
+            };
+            let body = serde_json::json!({
+                "message": message,
+                "sha": sha,
+                "branch": target.branch,
+            });
+            let mut init = RequestInit::new();
+            init.with_method(Method::Delete)
+                .with_headers(self.headers()?)
+                .with_body(Some(body.to_string().into()));
+            let req = Request::new_with_init(&Self::contents_url(target), &init)
+                .map_err(|e| CommitError::Transport(e.to_string()))?;
+            let resp = self.send(req).await?;
+            match resp.status_code() {
+                200 => Ok(()),
+                other => Err(CommitError::Transport(format!(
+                    "DELETE contents returned {other}"
                 ))),
             }
         }

--- a/services/notes-sync/src/route.rs
+++ b/services/notes-sync/src/route.rs
@@ -37,6 +37,81 @@ fn is_safe_segment(segment: &str) -> bool {
         .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
 }
 
+/// Why a rename request can't proceed. Returned by [`plan_rename`] so the
+/// wasm handler can map each case to an HTTP status without re-deriving the
+/// rules.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenameError {
+    /// Either the source or destination id is not a valid note path.
+    InvalidId,
+    /// Source and destination are the same note — nothing to move.
+    SameId,
+    /// No committed note exists at the source path. `/rename` is the trust
+    /// boundary (the front end only offers rename on listed notes, but a
+    /// raw request need not), and a rename of a missing source would
+    /// otherwise create a spurious empty note at the destination.
+    SourceMissing,
+}
+
+/// How a rename of `old` to `new` should be carried out, decided from the
+/// committed vault listing. Returned by [`plan_rename`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum RenamePlan {
+    /// Source present, destination free — a normal create-before-delete
+    /// move.
+    Fresh,
+    /// Source present *and* a file already sits at the destination. A prior
+    /// attempt created the destination but failed before removing the
+    /// source (the orchestration is not atomic), so the caller re-drives
+    /// the remaining steps idempotently — but only after confirming the
+    /// destination body is the one being carried; a destination holding a
+    /// *different* body is a genuine collision the caller rejects as a
+    /// conflict.
+    Resume,
+}
+
+/// Plan a `rename`/move of `old` to `new` against the current vault. Both
+/// ids must be valid note paths (the same rule the websocket route and
+/// `/delete` enforce), the move must actually change the path, and the
+/// source must exist. `existing` is the committed vault listing (see
+/// `list_note_paths`).
+///
+/// A destination that already exists is *not* a hard error: combined with a
+/// still-present source it signals a half-finished earlier attempt that the
+/// caller can resume (see [`RenamePlan::Resume`]). The caller disambiguates
+/// a true collision from a resumable in-progress rename by comparing the
+/// destination's committed body against the body being carried.
+pub fn plan_rename(old: &str, new: &str, existing: &[String]) -> Result<RenamePlan, RenameError> {
+    if !is_valid_note_id(old) || !is_valid_note_id(new) {
+        return Err(RenameError::InvalidId);
+    }
+    if old == new {
+        return Err(RenameError::SameId);
+    }
+    if !existing.iter().any(|n| n == old) {
+        return Err(RenameError::SourceMissing);
+    }
+    if existing.iter().any(|n| n == new) {
+        return Ok(RenamePlan::Resume);
+    }
+    Ok(RenamePlan::Fresh)
+}
+
+/// Pick the body to carry in a rename. The source Durable Object's
+/// materialized text is authoritative when present, but a cold or
+/// never-opened DO returns an empty body even though git holds the
+/// committed note (the DO does not hydrate from git on open). Falling back
+/// to the committed git blob keeps the move from carrying `""` and erasing
+/// the source when the body is dropped — turning a transient display gap
+/// into permanent data loss.
+pub fn choose_rename_body(do_text: &str, git_text: Option<&str>) -> String {
+    if do_text.is_empty() {
+        git_text.unwrap_or_default().to_owned()
+    } else {
+        do_text.to_owned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +181,80 @@ mod tests {
         assert!(!is_valid_note_id("a//b"));
         assert!(!is_valid_note_id("../escape"));
         assert!(!is_valid_note_id("has space"));
+    }
+
+    #[test]
+    fn plan_rename_accepts_a_move_to_a_free_path() {
+        let existing = vec!["scratch".to_string(), "projects/foo".to_string()];
+        assert_eq!(
+            plan_rename("scratch", "projects/bar", &existing),
+            Ok(RenamePlan::Fresh)
+        );
+    }
+
+    #[test]
+    fn plan_rename_rejects_an_invalid_id_on_either_side() {
+        let existing = vec!["ok".to_string()];
+        assert_eq!(
+            plan_rename("../escape", "ok2", &existing),
+            Err(RenameError::InvalidId)
+        );
+        assert_eq!(
+            plan_rename("ok", "has space", &existing),
+            Err(RenameError::InvalidId)
+        );
+        assert_eq!(
+            plan_rename("", "ok2", &existing),
+            Err(RenameError::InvalidId)
+        );
+    }
+
+    #[test]
+    fn plan_rename_rejects_a_no_op_move() {
+        let existing = vec!["scratch".to_string()];
+        assert_eq!(
+            plan_rename("scratch", "scratch", &existing),
+            Err(RenameError::SameId)
+        );
+    }
+
+    #[test]
+    fn plan_rename_rejects_a_missing_source() {
+        // A valid-id rename of a note that isn't in the vault must not
+        // silently create an empty note at the destination.
+        let existing = vec!["scratch".to_string()];
+        assert_eq!(
+            plan_rename("ghost", "projects/bar", &existing),
+            Err(RenameError::SourceMissing)
+        );
+    }
+
+    #[test]
+    fn plan_rename_resumes_when_both_paths_are_present() {
+        // Source still present *and* destination already committed → a prior
+        // attempt got past the create but not the source delete. The caller
+        // resumes (and disambiguates a true collision by body).
+        let existing = vec!["scratch".to_string(), "projects/foo".to_string()];
+        assert_eq!(
+            plan_rename("scratch", "projects/foo", &existing),
+            Ok(RenamePlan::Resume)
+        );
+    }
+
+    #[test]
+    fn choose_rename_body_prefers_a_non_empty_do_body() {
+        assert_eq!(choose_rename_body("live", Some("stale git")), "live");
+        assert_eq!(choose_rename_body("live", None), "live");
+    }
+
+    #[test]
+    fn choose_rename_body_falls_back_to_git_for_a_cold_do() {
+        // A cold/never-opened DO exports "" though git holds the note —
+        // carry the committed blob rather than erasing it on the move.
+        assert_eq!(
+            choose_rename_body("", Some("committed body")),
+            "committed body"
+        );
+        assert_eq!(choose_rename_body("", None), "");
     }
 }

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -19,8 +19,10 @@ use worker::{
 };
 
 use crate::auth::{authorize_owner, authorized_did};
-use crate::git::{commit_with_retry, CommitError, GitTarget, WorkerGitHubClient};
-use crate::route::{is_valid_note_id, parse_ws_note_id};
+use crate::git::{commit_with_retry, move_note_file, CommitError, GitTarget, WorkerGitHubClient};
+use crate::route::{
+    choose_rename_body, is_valid_note_id, parse_ws_note_id, plan_rename, RenameError, RenamePlan,
+};
 use crate::state::{is_stale, next_alarm};
 
 /// Internal DO control path: the top-level `/delete` handler forwards a
@@ -28,6 +30,19 @@ use crate::state::{is_stale, next_alarm};
 /// and backing git file. Never routed from the public surface — only the
 /// orchestrator reaches it, with the note id in `X-Note-Id`.
 const PURGE_PATH: &str = "/__purge";
+
+/// Internal DO control path: the `/rename` orchestrator forwards a `POST`
+/// here to the *source* note's Durable Object to read its materialized body
+/// (returned as `{"seq":…,"text":…}`) before the move. Read-only — it never
+/// mutates the source, so a later failure leaves the source recoverable.
+const EXPORT_PATH: &str = "/__export";
+
+/// Internal DO control path: the `/rename` orchestrator forwards a `POST`
+/// here to the *destination* note's Durable Object with the migrated body in
+/// the request JSON (`{"text":…}`) and the new id in `X-Note-Id`, so opening
+/// `?note=<new>` shows the content. The DO does not hydrate from git on open,
+/// so a fresh id is an empty object until it is seeded here.
+const SEED_PATH: &str = "/__seed";
 
 /// Commit the note this long after the last edit — coalesces a burst of
 /// keystrokes into a single git commit once the typing settles. Durability
@@ -68,6 +83,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/me" => return handle_me(&req, &env),
         "/vault" => return handle_vault(&req, &env).await,
         "/delete" => return handle_delete(&req, &env).await,
+        "/rename" => return handle_rename(&req, &env).await,
         _ => {}
     }
 
@@ -197,19 +213,7 @@ async fn handle_delete(req: &Request, env: &Env) -> Result<Response> {
         return Response::error("invalid note id", 400);
     }
 
-    // Hand off to the note's DO. The id rides a header so it needs no path
-    // encoding, and the DO uses it to resolve the git path it owns.
-    let headers = Headers::new();
-    headers.set("X-Note-Id", &note)?;
-    let mut init = RequestInit::new();
-    init.with_method(Method::Post).with_headers(headers);
-    let ctrl = Request::new_with_init(&format!("https://do{PURGE_PATH}"), &init)?;
-    let stub = env
-        .durable_object("NOTE")?
-        .id_from_name(&note)?
-        .get_stub()?;
-    let resp = stub.fetch_with_request(ctrl).await?;
-    if resp.status_code() != 200 {
+    if purge_note(env, &note).await.is_err() {
         return Response::error("delete failed", 502);
     }
 
@@ -218,6 +222,237 @@ async fn handle_delete(req: &Request, env: &Env) -> Result<Response> {
         .with_status(200)
         .with_headers(headers)
         .fixed(b"{\"ok\":true}".to_vec()))
+}
+
+/// How many times to re-attempt an idempotent Durable Object control op
+/// (seed/purge) before giving up. These run *after* the git move has already
+/// made the destination durable, so a transient failure here must not be
+/// allowed to leave the old path resurrectable or the new path blank.
+const CONTROL_OP_RETRIES: u32 = 3;
+
+/// `POST /rename?note=<old>&to=<new>` — move a note to a new path for the
+/// owner's session. The orchestration is ordered for data safety:
+///
+/// 1. Read the source body. The source DO's materialized text is preferred,
+///    but a cold DO (never opened since eviction/migration) reports `""`
+///    though git holds the note, so the committed git blob is the fallback —
+///    carrying `""` would erase the source on the move.
+/// 2. Refuse to clobber a live destination: a note typed into but not yet
+///    committed to git is invisible to the committed-listing guard, so probe
+///    the destination DO and reject (409) if it holds uncommitted content.
+/// 3. Git move: create the destination with the body, then drop the source
+///    (create-before-delete, so the body is durable at the new path first).
+/// 4. Seed the destination DO so opening `?note=<new>` shows the body
+///    (the DO does not hydrate from git on open), retried since the git move
+///    has already committed.
+/// 5. Clear the source DO so the old path can't be resurrected from a stale
+///    reopen, also retried.
+///
+/// A destination that already exists in git is not a hard error when the
+/// source is still present: it signals a half-finished earlier attempt
+/// (the create landed but a later step failed), which is *resumed*
+/// idempotently rather than wedged behind a 409 — provided the destination
+/// holds the body being carried (a different body there is a genuine
+/// collision). Returns `{"ok": true}`.
+async fn handle_rename(req: &Request, env: &Env) -> Result<Response> {
+    if !session_authorized(req, env) {
+        return Response::error("unauthorized", 401);
+    }
+    let url = req.url()?;
+    let param = |key: &str| {
+        url.query_pairs()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.into_owned())
+            .unwrap_or_default()
+    };
+    let old = param("note");
+    let new = param("to");
+
+    // The plan is decided against the committed vault listing; the same
+    // client then performs the git move.
+    let owner = env.var("GITHUB_OWNER")?.to_string();
+    let repo = env.var("GITHUB_REPO")?.to_string();
+    let branch = env.var("GITHUB_BRANCH")?.to_string();
+    let token = env.secret("GITHUB_TOKEN")?.to_string();
+    let client = WorkerGitHubClient::new(token);
+    let existing = client
+        .list_note_paths(&owner, &repo, &branch)
+        .await
+        .map_err(|e| Error::RustError(e.to_string()))?;
+
+    let plan = match plan_rename(&old, &new, &existing) {
+        Ok(plan) => plan,
+        Err(RenameError::InvalidId) => return Response::error("invalid note id", 400),
+        Err(RenameError::SameId) => {
+            return Response::error("source and destination are the same", 400)
+        }
+        Err(RenameError::SourceMissing) => return Response::error("note not found", 404),
+    };
+
+    let old_target = note_git_target(env, &old)?;
+    let new_target = note_git_target(env, &new)?;
+
+    // 1. Choose the body to carry: the source DO's live text when present,
+    //    else the committed git blob (a cold DO reports `""`).
+    let do_text = export_note_text(env, &old).await?;
+    let git_text = client
+        .get_file_content(&old_target)
+        .await
+        .map_err(|e| Error::RustError(e.to_string()))?;
+    let text = choose_rename_body(&do_text, git_text.as_deref());
+
+    // 2. Guard the destination against a silent overwrite.
+    match plan {
+        RenamePlan::Fresh => {
+            // The committed-listing guard already proved the destination is
+            // free in git, but a note edited-but-not-yet-committed lives only
+            // in its DO. Refuse rather than let `seed`'s `delete_all` wipe it.
+            if !export_note_text(env, &new).await?.is_empty() {
+                return Response::error("destination already exists", 409);
+            }
+        }
+        RenamePlan::Resume => {
+            // Destination is already committed. It's a resumable in-progress
+            // rename only if it holds the body we're carrying; a different
+            // body there is a real, distinct note — a genuine collision.
+            let dest = client
+                .get_file_content(&new_target)
+                .await
+                .map_err(|e| Error::RustError(e.to_string()))?;
+            if dest.as_deref() != Some(text.as_str()) {
+                return Response::error("destination already exists", 409);
+            }
+        }
+    }
+
+    // 3. Git move: create the destination with the body, then drop the source.
+    //    Idempotent on a resume — the create re-PUTs the same body.
+    move_note_file(&client, &old_target, &new_target, &text, MAX_COMMIT_RETRIES)
+        .await
+        .map_err(|e| Error::RustError(e.to_string()))?;
+
+    // 4. Seed the destination DO so opening `?note=<new>` shows the body. The
+    //    git file already exists, so a missed seed would otherwise show blank.
+    if seed_note_with_retry(env, &new, &text).await.is_err() {
+        return Response::error("rename seed failed", 502);
+    }
+
+    // 5. Clear the source DO (its git file is already gone) so a stale reopen
+    //    of the old path cannot resurrect it.
+    if purge_note_with_retry(env, &old).await.is_err() {
+        return Response::error("rename cleanup failed", 502);
+    }
+
+    let headers = shell_cors_headers(env)?;
+    Ok(ResponseBuilder::new()
+        .with_status(200)
+        .with_headers(headers)
+        .fixed(b"{\"ok\":true}".to_vec()))
+}
+
+/// Resolve a note's GitHub target from env config plus its (already
+/// validated) id. The env config is shared across notes; only the path
+/// differs, at `notes/<note_id>.md`.
+fn note_git_target(env: &Env, note_id: &str) -> Result<GitTarget> {
+    Ok(GitTarget {
+        owner: env.var("GITHUB_OWNER")?.to_string(),
+        repo: env.var("GITHUB_REPO")?.to_string(),
+        branch: env.var("GITHUB_BRANCH")?.to_string(),
+        path: format!("notes/{note_id}.md"),
+    })
+}
+
+/// Build a `POST` control request to a note's Durable Object, carrying the
+/// note id in `X-Note-Id` (so it needs no path encoding) and an optional
+/// JSON body.
+fn control_request(path: &str, note_id: &str, body: Option<String>) -> Result<Request> {
+    let headers = Headers::new();
+    headers.set("X-Note-Id", note_id)?;
+    let mut init = RequestInit::new();
+    init.with_method(Method::Post).with_headers(headers);
+    if let Some(body) = body {
+        init.with_body(Some(body.into()));
+    }
+    Request::new_with_init(&format!("https://do{path}"), &init)
+}
+
+/// Forward `ctrl` to the Durable Object for `note_id` and return its
+/// response. The id keys the DO (`idFromName`) and rides the request so the
+/// object can resolve the git path it owns.
+async fn forward_to_note(env: &Env, note_id: &str, ctrl: Request) -> Result<Response> {
+    let stub = env
+        .durable_object("NOTE")?
+        .id_from_name(note_id)?
+        .get_stub()?;
+    stub.fetch_with_request(ctrl).await
+}
+
+/// Read a note's current materialized body from its Durable Object.
+async fn export_note_text(env: &Env, note_id: &str) -> Result<String> {
+    let ctrl = control_request(EXPORT_PATH, note_id, None)?;
+    let mut resp = forward_to_note(env, note_id, ctrl).await?;
+    if resp.status_code() != 200 {
+        return Err(Error::RustError("export failed".into()));
+    }
+    let body = resp.text().await?;
+    let v: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| Error::RustError(e.to_string()))?;
+    Ok(v.get("text")
+        .and_then(|t| t.as_str())
+        .unwrap_or_default()
+        .to_owned())
+}
+
+/// Seed a note's Durable Object with `text` so opening it shows the body.
+async fn seed_note(env: &Env, note_id: &str, text: &str) -> Result<()> {
+    let body = serde_json::json!({ "text": text }).to_string();
+    let ctrl = control_request(SEED_PATH, note_id, Some(body))?;
+    let resp = forward_to_note(env, note_id, ctrl).await?;
+    if resp.status_code() != 200 {
+        return Err(Error::RustError("seed failed".into()));
+    }
+    Ok(())
+}
+
+/// Purge a note's Durable Object (its storage and backing git file).
+/// Idempotent: an uncommitted or already-gone note still succeeds.
+async fn purge_note(env: &Env, note_id: &str) -> Result<()> {
+    let ctrl = control_request(PURGE_PATH, note_id, None)?;
+    let resp = forward_to_note(env, note_id, ctrl).await?;
+    if resp.status_code() != 200 {
+        return Err(Error::RustError("purge failed".into()));
+    }
+    Ok(())
+}
+
+/// Seed the destination DO, retrying a transient failure. Both `seed` and
+/// the underlying control op are idempotent, so a retry just re-installs the
+/// same body. Called after the git move has committed, where a permanently
+/// missed seed would leave `?note=<new>` showing blank over real content.
+async fn seed_note_with_retry(env: &Env, note_id: &str, text: &str) -> Result<()> {
+    let mut last = Ok(());
+    for _ in 0..CONTROL_OP_RETRIES {
+        match seed_note(env, note_id, text).await {
+            Ok(()) => return Ok(()),
+            Err(e) => last = Err(e),
+        }
+    }
+    last
+}
+
+/// Purge the source DO, retrying a transient failure. `purge` is idempotent,
+/// so a retry that races a prior partial purge still converges. Called as the
+/// rename's final step, where a permanently missed purge would leave the old
+/// path resurrectable from a stale reopen.
+async fn purge_note_with_retry(env: &Env, note_id: &str) -> Result<()> {
+    let mut last = Ok(());
+    for _ in 0..CONTROL_OP_RETRIES {
+        match purge_note(env, note_id).await {
+            Ok(()) => return Ok(()),
+            Err(e) => last = Err(e),
+        }
+    }
+    last
 }
 
 /// Per-connection state persisted across hibernation via the socket
@@ -327,12 +562,7 @@ impl NoteDurableObject {
     /// Resolve the GitHub target for an explicit (already-validated) note
     /// id. The env config is shared across notes; only the path differs.
     fn git_target_for(&self, note_id: &str) -> Result<GitTarget> {
-        Ok(GitTarget {
-            owner: self.env.var("GITHUB_OWNER")?.to_string(),
-            repo: self.env.var("GITHUB_REPO")?.to_string(),
-            branch: self.env.var("GITHUB_BRANCH")?.to_string(),
-            path: format!("notes/{note_id}.md"),
-        })
+        note_git_target(&self.env, note_id)
     }
 
     /// Delete this note: remove its backing git file, then wipe all durable
@@ -350,6 +580,26 @@ impl NoteDurableObject {
         self.state.storage().delete_all().await?;
         let _ = self.state.storage().delete_alarm().await;
         Response::ok("purged")
+    }
+
+    /// Seed this (destination) Durable Object with a migrated body during a
+    /// rename. The object is reset to a clean single-entry log holding `text`
+    /// as the initial `Whole` delta, so a later eviction replays losslessly,
+    /// and the snapshot is marked already-committed — the rename's git move
+    /// wrote this exact body to the new path, so no redundant commit is due.
+    async fn seed(&self, note_id: &str, text: &str) -> Result<Response> {
+        self.state.storage().delete_all().await?;
+        let _ = self.state.storage().delete_alarm().await;
+        let seq: Seq = 1;
+        let delta = Delta::Whole {
+            text: text.to_owned(),
+        };
+        self.state.storage().put(&log_key(seq), &delta).await?;
+        self.state.storage().put("seq", seq).await?;
+        self.state.storage().put("text", text).await?;
+        self.state.storage().put("committed_seq", seq).await?;
+        self.state.storage().put("note_id", note_id).await?;
+        Response::ok("seeded")
     }
 
     /// Commit the current body to git with optimistic stale-ref retry.
@@ -387,13 +637,34 @@ impl DurableObject for NoteDurableObject {
         Self { state, env }
     }
 
-    async fn fetch(&self, req: Request) -> Result<Response> {
-        // Internal control op: the `/delete` orchestrator forwards a purge
-        // here with the note id in `X-Note-Id`. Handled before the websocket
-        // path so it never tries to upgrade.
+    async fn fetch(&self, mut req: Request) -> Result<Response> {
+        // Internal control ops forwarded by the top-level orchestrators carry
+        // the note id in `X-Note-Id`. Handled before the websocket path so they
+        // never try to upgrade.
         if req.path() == PURGE_PATH {
             let note_id = req.headers().get("X-Note-Id")?.unwrap_or_default();
             return self.purge(&note_id).await;
+        }
+        // Rename, source side: report the current body so the orchestrator can
+        // carry it to the new path. Read-only.
+        if req.path() == EXPORT_PATH {
+            let (seq, text) = self.load_state().await?;
+            let body = serde_json::json!({ "seq": seq, "text": text }).to_string();
+            return Response::ok(body);
+        }
+        // Rename, destination side: install the migrated body so opening the
+        // new id shows it. The body rides the request JSON.
+        if req.path() == SEED_PATH {
+            let note_id = req.headers().get("X-Note-Id")?.unwrap_or_default();
+            let body = req.text().await?;
+            let v: serde_json::Value =
+                serde_json::from_str(&body).map_err(|e| Error::RustError(e.to_string()))?;
+            let text = v
+                .get("text")
+                .and_then(|t| t.as_str())
+                .unwrap_or_default()
+                .to_owned();
+            return self.seed(&note_id, &text).await;
         }
 
         let note_id = parse_ws_note_id(&req.path())


### PR DESCRIPTION
Renaming a note must move its git file and migrate its per-note Durable
Object, since a DO is keyed by note id and a fresh id opens empty (it does
not hydrate from git). Add POST /rename?note=<old>&to=<new>, owner-gated
like /delete, that validates both ids, refuses a no-op or an overwrite of
an existing note, then orchestrates a data-safe move: read the source
body, create the destination git file before deleting the source
(create-before-delete so a partial failure never loses data), seed the
destination DO so the new path shows the body, and only then clear the
source DO so a stale reopen cannot resurrect it.

The vault sidebar could create, switch, and delete notes but not move
them. Mirror the delete control with a rename button that prompts for a
new path, validates it client-side, POSTs /rename, and follows the note
to its new path on success.

Closes #981