### PR TITLE
build(deps): bump actions/cache from 5 to 6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
         determinate: true
         flakehub: true
     - uses: DeterminateSystems/flakehub-cache-action@v3
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       with:
         key: cargo-${{ runner.os }}-${{ hashFiles('tools/shaka/Cargo.lock') }}
         path: |

--- a/tools/shaka/src/ci/main_workflow.rs
+++ b/tools/shaka/src/ci/main_workflow.rs
@@ -295,7 +295,7 @@ fn preflight_job() -> InlineJob {
                 env: BTreeMap::new(),
             }),
             Step::Action(ActionStep {
-                uses: "actions/cache@v5".to_string(),
+                uses: "actions/cache@v6".to_string(),
                 id: None,
                 name: None,
                 if_: None,


### PR DESCRIPTION
actions/cache is pinned in the shaka main-workflow generator, so the
bump has to flow through the generator and a regenerate rather than a
hand-edit of the generated main.yaml. Dependabot edited the generated
file directly in #984, which drifts against the generator and fails
preflight. Supersedes #984.