### PR TITLE
fix(scoretracker): use new_sqlite_classes for free-plan Durable Object

### DIFF
--- a/apps/scoretracker/wrangler.toml
+++ b/apps/scoretracker/wrangler.toml
@@ -16,8 +16,11 @@ name               = "scoretracker"
 [durable_objects]
 bindings = [{ name = "GAME", class_name = "GameState" }]
 
-# Classic key-value DO storage (the whole game is one small JSON blob — no
-# SQLite needed). Migrations are append-only by tag.
+# SQLite-backed DO storage. The whole game is one small JSON blob accessed
+# via the key-value `storage()` API, but the class must be registered with
+# `new_sqlite_classes` (not `new_classes`): Cloudflare requires SQLite-backed
+# Durable Objects on the free plan (API error 10097). Same as notes-sync.
+# Migrations are append-only by tag.
 [[migrations]]
-new_classes = ["GameState"]
-tag         = "v1"
+new_sqlite_classes = ["GameState"]
+tag                = "v1"


### PR DESCRIPTION
The initial deploy failed: Cloudflare requires SQLite-backed Durable
Objects on the free plan (`new_sqlite_classes`, API error 10097), but the
GameState class was registered with classic `new_classes`. The dry-run
`verify` doesn't create the namespace, so it passed while the real
preview/prod upload failed.

Storage access is the plain key-value `storage()` API, which is identical
on the SQLite backend, so this is a config-only change (matches
notes-sync). Since no deploy ever succeeded, amending the v1 migration in
place is safe — no namespace exists to migrate.