### PR TITLE
feat(notes-sync): OpenRouter LLM client + note autonaming

### DIFF
--- a/services/notes-sync/.env.example
+++ b/services/notes-sync/.env.example
@@ -35,3 +35,15 @@ SESSION_SECRET="op://vedq2v6cmtkglnonkenrjneepa/notes-sync SESSION_SECRET/passwo
 #   op item create --category password --title 'notes-sync GITHUB_TOKEN' \
 #     --vault vedq2v6cmtkglnonkenrjneepa password=<the-token>
 GITHUB_TOKEN="op://vedq2v6cmtkglnonkenrjneepa/notes-sync GITHUB_TOKEN/password"
+
+# Worker runtime secret: the OpenRouter API key the Durable Object uses to
+# autoname untitled notes (chat-completions over the body, on the lazy
+# commit cadence). Declared in `project.cue` `ci.deploy.secrets`. Autonaming
+# degrades gracefully when this is unset — the worker logs and skips, so it
+# deploys before the key is provisioned. Create the 1Password item once,
+# pasting the key (from openrouter.ai/keys) as its password (do NOT commit
+# the value):
+#   op item create --category password \
+#     --title 'notes-sync OPENROUTER_API_KEY' \
+#     --vault vedq2v6cmtkglnonkenrjneepa password=<the-key>
+OPENROUTER_API_KEY="op://vedq2v6cmtkglnonkenrjneepa/notes-sync OPENROUTER_API_KEY/password"

--- a/services/notes-sync/Cargo.lock
+++ b/services/notes-sync/Cargo.lock
@@ -3,6 +3,25 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,6 +31,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -36,6 +61,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -76,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -174,7 +214,7 @@ dependencies = [
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -192,9 +232,15 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -290,14 +336,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -339,6 +416,66 @@ checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -484,6 +621,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +646,42 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
 
 [[package]]
 name = "notes-protocol"
@@ -510,16 +698,19 @@ name = "notes-sync"
 version = "0.1.0"
 dependencies = [
  "base64",
- "getrandom",
+ "getrandom 0.2.17",
  "hmac",
+ "mockito",
  "notes-protocol",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sha2",
+ "snafu",
  "tokio",
+ "ureq",
  "worker",
 ]
 
@@ -548,6 +739,29 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -611,6 +825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,13 +861,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
@@ -667,6 +963,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -779,8 +1081,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -813,6 +1121,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -896,8 +1214,14 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys",
 ]
 
 [[package]]
@@ -909,6 +1233,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -928,6 +1284,20 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "url",
+]
 
 [[package]]
 name = "url"
@@ -958,6 +1328,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1036,6 +1415,27 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "worker"
@@ -1124,6 +1524,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/services/notes-sync/Cargo.toml
+++ b/services/notes-sync/Cargo.toml
@@ -38,13 +38,25 @@ serde_json = "1"
 serde_urlencoded = "0.7"
 # SHA-256 for the PKCE S256 challenge and the session-cookie HMAC.
 sha2 = "0.10"
+# Typed per-module error enums for the LLM client — the repo error
+# standard, same as notes-protocol. Pure-rust, folds into the wasm build.
+snafu = "0.9"
 # workers-rs runtime: Durable Objects + the WebSocket Hibernation API.
 worker = "0.8"
 
 [dev-dependencies]
-# Drives the async `commit_with_retry` tests on the host. The Worker
-# runtime has its own executor; this is native-test-only.
+# Mock the OpenRouter chat-completions endpoint over a real socket so the
+# request/response wire shapes are exercised natively (the wasm
+# `worker::Fetch` path can't be unit-tested off-target). Plain HTTP, so no
+# TLS dependency is pulled. Native-test-only.
+mockito = "1"
+# Drives the async `commit_with_retry` and `derive_title` tests on the
+# host. The Worker runtime has its own executor; this is native-test-only.
 tokio = { version = "1", features = ["macros", "rt"] }
+# Native HTTP client used only by the `mockito` round-trip test. Plain
+# HTTP (`default-features = false` drops the TLS/`webpki-roots` tree); the
+# production transport is the wasm `worker::Fetch` client, not this.
+ureq = { version = "2", default-features = false, features = ["json"] }
 
 [profile.release]
 codegen-units = 1

--- a/services/notes-sync/project.cue
+++ b/services/notes-sync/project.cue
@@ -26,7 +26,10 @@ package project
 			// callback mints; GITHUB_TOKEN authenticates the cold-tier git
 			// commit (the DO PUTs each note to notes-store via the Contents
 			// API). Without either, the corresponding path throws.
-			secrets: ["SESSION_SECRET", "GITHUB_TOKEN"]
+			// OPENROUTER_API_KEY authenticates note autonaming; unlike the
+			// others it degrades gracefully (logs + skips) when unset, so
+			// the worker can deploy before it's provisioned.
+			secrets: ["SESSION_SECRET", "GITHUB_TOKEN", "OPENROUTER_API_KEY"]
 		}
 	}
 }

--- a/services/notes-sync/src/lib.rs
+++ b/services/notes-sync/src/lib.rs
@@ -36,6 +36,7 @@
 pub mod auth;
 pub mod dpop;
 pub mod git;
+pub mod llm;
 pub mod oauth;
 pub mod route;
 pub mod state;

--- a/services/notes-sync/src/llm.rs
+++ b/services/notes-sync/src/llm.rs
@@ -1,0 +1,563 @@
+//! OpenRouter (OpenAI-compatible) chat-completions client and the note
+//! autonaming it feeds.
+//!
+//! Mirrors the shape of [`crate::git`]: a pure, native-testable core
+//! (request/response serde, the title-derivation and cleanup helpers, the
+//! autoname gate) behind a [`ChatCompletions`] trait, with the real
+//! `worker::Fetch` transport (`WorkerOpenRouterClient`) gated to
+//! `wasm32`. Native `cargo test` exercises the wire shapes against a
+//! `mockito` server and drives the title helpers directly; the wasm path
+//! is build-checked.
+//!
+//! The request/response serde is ported from `apps/blogctl/src/openrouter.rs`
+//! — the same OpenAI chat-completions shape — but the transport is the
+//! worker `Fetch` client rather than blocking `ureq`, which does not
+//! compile on `wasm32`.
+
+use serde::Deserialize;
+#[cfg(any(target_arch = "wasm32", test))]
+use serde::Serialize;
+use snafu::{ResultExt, Snafu};
+
+/// Production chat-completions endpoint.
+pub const DEFAULT_ENDPOINT: &str = "https://openrouter.ai/api/v1/chat/completions";
+
+/// Default model used for autonaming when none is configured (override via
+/// the `OPENROUTER_MODEL` worker var). Matches `blogctl`'s default so the
+/// repo speaks to one model family.
+pub const DEFAULT_MODEL: &str = "anthropic/claude-sonnet-4-6";
+
+/// Cap the body slice sent for titling — a title only needs the opening of
+/// a note, and a giant note would otherwise blow the prompt budget.
+const MAX_PROMPT_CHARS: usize = 4000;
+
+/// A derived title is clamped to this many words so it stays a label, not a
+/// sentence.
+const MAX_TITLE_WORDS: usize = 6;
+
+/// Instruction steering the model to emit a bare title and nothing else, so
+/// [`clean_title`] has little to strip.
+const TITLE_SYSTEM_PROMPT: &str = "You generate a concise title for a note. \
+Reply with ONLY the title: at most 6 words, no surrounding quotes, no trailing \
+punctuation, no markdown, plain text on a single line.";
+
+/// Why a chat-completions call (or its parse) failed.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum LlmError {
+    /// Transport or request-construction failure (no usable HTTP response).
+    #[snafu(display("OpenRouter transport error: {message}"))]
+    Transport { message: String },
+    /// The endpoint returned a non-2xx status.
+    #[snafu(display("OpenRouter returned status {status}"))]
+    Status { status: u16 },
+    /// The response body was not the expected chat-completions JSON.
+    #[snafu(display("could not parse OpenRouter response: {source}"))]
+    Parse { source: serde_json::Error },
+    /// A 2xx response that carried no choices to read a reply from.
+    #[snafu(display("OpenRouter returned no choices"))]
+    EmptyResponse,
+}
+
+/// One chat message in an OpenAI-compatible request.
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Debug, Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+/// An OpenAI-compatible chat-completions request body.
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Debug, Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<Message<'a>>,
+}
+
+/// The slice of a chat-completions response we read: the assistant text of
+/// the first choice.
+#[derive(Debug, Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Choice {
+    message: ReceivedMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReceivedMessage {
+    content: String,
+}
+
+/// Build the chat-completions request body for a `system` + `user` message
+/// pair. Pure so the wasm transport and the native test client serialize
+/// the identical wire shape. Serialization cannot fail — every field is a
+/// plain string.
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn build_request_body(model: &str, system: &str, user: &str) -> serde_json::Value {
+    let request = ChatRequest {
+        model,
+        messages: vec![
+            Message {
+                role: "system",
+                content: system,
+            },
+            Message {
+                role: "user",
+                content: user,
+            },
+        ],
+    };
+    serde_json::to_value(&request).expect("ChatRequest is serializable")
+}
+
+/// Extract the first choice's assistant text from a chat-completions
+/// response body. Pure, shared by the wasm transport and the native tests.
+pub fn parse_response(json: &str) -> Result<String, LlmError> {
+    let parsed: ChatResponse = serde_json::from_str(json).context(ParseSnafu)?;
+    parsed
+        .choices
+        .into_iter()
+        .next()
+        .map(|c| c.message.content)
+        .ok_or(LlmError::EmptyResponse)
+}
+
+/// The chat-completions transport. Implemented by the wasm
+/// `WorkerOpenRouterClient` and by a `ureq`/`mockito`-backed client in
+/// native tests.
+//
+// `async fn` in a trait is fine here: the only consumers are the generic
+// `derive_title` (static dispatch) and the wasm runtime, and we deliberately
+// want no `Send` bound — the `worker::Fetch` futures are `!Send`.
+#[allow(async_fn_in_trait)]
+pub trait ChatCompletions {
+    /// Send a `system` + `user` message pair and return the assistant's
+    /// reply text.
+    async fn complete(&self, system: &str, user: &str) -> Result<String, LlmError>;
+
+    /// The model id this client calls — exposed so a caller can stamp a
+    /// derived artifact (e.g. a title cache key) with the model that
+    /// produced it.
+    fn model_id(&self) -> &str;
+}
+
+/// Whether autonaming should run at all, given the configured API key. An
+/// unset, empty, or whitespace-only key means OpenRouter is not provisioned
+/// yet — a clean no-op so the worker ships and deploys *before* the key
+/// lands in 1Password.
+pub fn autoname_enabled(api_key: Option<&str>) -> bool {
+    api_key.is_some_and(|k| !k.trim().is_empty())
+}
+
+/// Truncate `s` to at most `max` chars on a char boundary.
+fn truncate(s: &str, max: usize) -> &str {
+    match s.char_indices().nth(max) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+/// Normalize a raw model reply into a usable title, or `None` when nothing
+/// usable remains. Defends against the model ignoring the instruction:
+/// takes the first non-blank line, strips a leading markdown heading
+/// marker, drops surrounding quotes/backticks and trailing punctuation, and
+/// clamps to `MAX_TITLE_WORDS` words.
+pub fn clean_title(raw: &str) -> Option<String> {
+    let first_line = raw.lines().map(str::trim).find(|l| !l.is_empty())?;
+    // A model that emits "# Heading" or "## Heading" — drop the markers.
+    let s = first_line.trim_start_matches('#').trim();
+    // Surrounding quotes/backticks the model may wrap the title in.
+    let s = s.trim_matches(['"', '\'', '`']).trim();
+    // Trailing sentence punctuation a title shouldn't carry.
+    let s = s.trim_end_matches(['.', ',', ';', ':', '!', '?']).trim();
+    let title: String = s
+        .split_whitespace()
+        .take(MAX_TITLE_WORDS)
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!title.is_empty()).then_some(title)
+}
+
+/// Derive a concise title from a note `body` by asking the model, then
+/// cleaning the reply. Returns `Ok(None)` for a blank body (no call made)
+/// or when the cleaned reply is empty.
+pub async fn derive_title<C: ChatCompletions>(
+    client: &C,
+    body: &str,
+) -> Result<Option<String>, LlmError> {
+    if body.trim().is_empty() {
+        return Ok(None);
+    }
+    let snippet = truncate(body, MAX_PROMPT_CHARS);
+    let reply = client.complete(TITLE_SYSTEM_PROMPT, snippet).await?;
+    Ok(clean_title(&reply))
+}
+
+/// Whether `note` warrants a (re)title. A blank body is never titled (there
+/// is nothing to name). Otherwise `force` titles regardless of an existing
+/// title (the on-demand retitle), while the lazy cadence only titles a note
+/// that has none.
+pub fn should_autoname(note: &str, force: bool) -> bool {
+    let body = notes_protocol::frontmatter::body_without_frontmatter(note);
+    if body.trim().is_empty() {
+        return false;
+    }
+    if force {
+        return true;
+    }
+    // A malformed front-matter block parses as an error; treat that as
+    // "no usable title" so a note still gets named rather than wedging.
+    match notes_protocol::frontmatter::parse(note) {
+        Ok((fm, _)) => fm.title.is_none(),
+        Err(_) => true,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use worker_client::WorkerOpenRouterClient;
+
+/// Real OpenRouter client, wasm-only because it depends on `worker::Fetch`.
+/// `derive_title` drives it through the [`ChatCompletions`] trait.
+#[cfg(target_arch = "wasm32")]
+mod worker_client {
+    use super::{build_request_body, parse_response, ChatCompletions, LlmError, DEFAULT_ENDPOINT};
+    use worker::{Fetch, Headers, Method, Request, RequestInit};
+
+    /// Chat-completions client authenticated with a static API key held as
+    /// a Wrangler secret (`OPENROUTER_API_KEY`).
+    pub struct WorkerOpenRouterClient {
+        api_key: String,
+        model: String,
+        endpoint: String,
+    }
+
+    impl WorkerOpenRouterClient {
+        /// New client for `model`, hitting the production endpoint.
+        pub fn new(api_key: String, model: String) -> Self {
+            Self {
+                api_key,
+                model,
+                endpoint: DEFAULT_ENDPOINT.to_string(),
+            }
+        }
+    }
+
+    fn transport(e: impl std::fmt::Display) -> LlmError {
+        LlmError::Transport {
+            message: e.to_string(),
+        }
+    }
+
+    impl ChatCompletions for WorkerOpenRouterClient {
+        async fn complete(&self, system: &str, user: &str) -> Result<String, LlmError> {
+            let body = build_request_body(&self.model, system, user);
+
+            let headers = Headers::new();
+            headers
+                .set("Authorization", &format!("Bearer {}", self.api_key))
+                .map_err(transport)?;
+            headers
+                .set("Content-Type", "application/json")
+                .map_err(transport)?;
+            // OpenRouter asks for these for attribution; harmless if ignored.
+            headers
+                .set("HTTP-Referer", "https://notes-sync.kolohelios.com")
+                .map_err(transport)?;
+            headers
+                .set("X-Title", "kolohelios-notes")
+                .map_err(transport)?;
+
+            let mut init = RequestInit::new();
+            init.with_method(Method::Post)
+                .with_headers(headers)
+                .with_body(Some(body.to_string().into()));
+            let req = Request::new_with_init(&self.endpoint, &init).map_err(transport)?;
+            let mut resp = Fetch::Request(req).send().await.map_err(transport)?;
+
+            let status = resp.status_code();
+            if !(200..300).contains(&status) {
+                return Err(LlmError::Status { status });
+            }
+            let text = resp.text().await.map_err(transport)?;
+            parse_response(&text)
+        }
+
+        fn model_id(&self) -> &str {
+            &self.model
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A native [`ChatCompletions`] client over `ureq`, used to exercise the
+    /// real request/response wire shapes against a `mockito` server (the
+    /// wasm `worker::Fetch` client can't run off-target).
+    struct UreqClient {
+        endpoint: String,
+        model: String,
+    }
+
+    impl ChatCompletions for UreqClient {
+        async fn complete(&self, system: &str, user: &str) -> Result<String, LlmError> {
+            let body = build_request_body(&self.model, system, user);
+            let resp = ureq::post(&self.endpoint)
+                .set("Authorization", "Bearer test-key")
+                .set("Content-Type", "application/json")
+                .send_json(body)
+                .map_err(|e| LlmError::Transport {
+                    message: e.to_string(),
+                })?;
+            let text = resp.into_string().map_err(|e| LlmError::Transport {
+                message: e.to_string(),
+            })?;
+            parse_response(&text)
+        }
+
+        fn model_id(&self) -> &str {
+            &self.model
+        }
+    }
+
+    /// A canned client that returns a fixed reply without any network — for
+    /// driving `derive_title`'s cleanup without a server.
+    struct FakeClient {
+        reply: String,
+    }
+
+    impl ChatCompletions for FakeClient {
+        async fn complete(&self, _system: &str, _user: &str) -> Result<String, LlmError> {
+            Ok(self.reply.clone())
+        }
+        fn model_id(&self) -> &str {
+            "fake/model"
+        }
+    }
+
+    #[test]
+    fn request_body_serializes_to_openrouter_shape() {
+        let body = build_request_body("anthropic/claude-sonnet-4-6", "sys", "the note body");
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "the note body"},
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn parse_response_extracts_first_choice_content() {
+        let raw = serde_json::json!({
+            "choices": [
+                {"message": {"role": "assistant", "content": "Project Roadmap"}},
+                {"message": {"role": "assistant", "content": "ignored"}},
+            ]
+        })
+        .to_string();
+        assert_eq!(parse_response(&raw).unwrap(), "Project Roadmap");
+    }
+
+    #[test]
+    fn parse_response_empty_choices_is_empty_response_error() {
+        let raw = serde_json::json!({ "choices": [] }).to_string();
+        assert!(matches!(
+            parse_response(&raw).unwrap_err(),
+            LlmError::EmptyResponse
+        ));
+    }
+
+    #[test]
+    fn parse_response_malformed_json_is_parse_error() {
+        assert!(matches!(
+            parse_response("not json").unwrap_err(),
+            LlmError::Parse { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn chat_round_trips_against_a_mocked_endpoint() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/chat/completions")
+            // Assert the request carries our model and the note body.
+            .match_body(mockito::Matcher::PartialJsonString(
+                serde_json::json!({
+                    "model": "test/model",
+                    "messages": [
+                        {"role": "system"},
+                        {"role": "user", "content": "name this note please"},
+                    ],
+                })
+                .to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "choices": [
+                        {"message": {"role": "assistant", "content": "Grocery List"}}
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = UreqClient {
+            endpoint: format!("{}/api/v1/chat/completions", server.url()),
+            model: "test/model".to_string(),
+        };
+        let title = derive_title(&client, "name this note please")
+            .await
+            .unwrap();
+        assert_eq!(title.as_deref(), Some("Grocery List"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn chat_non_2xx_status_is_an_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/api/v1/chat/completions")
+            .with_status(500)
+            .with_body("upstream boom")
+            .create_async()
+            .await;
+        let client = UreqClient {
+            endpoint: format!("{}/api/v1/chat/completions", server.url()),
+            model: "test/model".to_string(),
+        };
+        assert!(derive_title(&client, "body").await.is_err());
+    }
+
+    #[test]
+    fn model_id_is_exposed_for_cache_keys() {
+        let client = UreqClient {
+            endpoint: "http://example.invalid".to_string(),
+            model: "anthropic/claude-sonnet-4-6".to_string(),
+        };
+        assert_eq!(client.model_id(), "anthropic/claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn clean_title_passes_through_a_clean_title() {
+        assert_eq!(
+            clean_title("Project Roadmap").as_deref(),
+            Some("Project Roadmap")
+        );
+    }
+
+    #[test]
+    fn clean_title_strips_surrounding_quotes_and_trailing_period() {
+        assert_eq!(
+            clean_title("\"Weekly Standup Notes.\"").as_deref(),
+            Some("Weekly Standup Notes")
+        );
+    }
+
+    #[test]
+    fn clean_title_strips_a_markdown_heading_marker() {
+        assert_eq!(
+            clean_title("## Meeting Agenda").as_deref(),
+            Some("Meeting Agenda")
+        );
+    }
+
+    #[test]
+    fn clean_title_takes_only_the_first_nonblank_line() {
+        assert_eq!(
+            clean_title("\n\nFirst Line Title\nsome explanation follows").as_deref(),
+            Some("First Line Title")
+        );
+    }
+
+    #[test]
+    fn clean_title_clamps_to_six_words() {
+        assert_eq!(
+            clean_title("one two three four five six seven eight").as_deref(),
+            Some("one two three four five six")
+        );
+    }
+
+    #[test]
+    fn clean_title_empty_or_punctuation_only_is_none() {
+        assert_eq!(clean_title(""), None);
+        assert_eq!(clean_title("   \n  "), None);
+        assert_eq!(clean_title("\"\""), None);
+    }
+
+    #[tokio::test]
+    async fn derive_title_cleans_a_noisy_reply() {
+        let client = FakeClient {
+            reply: "  \"My Great Note.\"  \nblah".to_string(),
+        };
+        let title = derive_title(&client, "some body text").await.unwrap();
+        assert_eq!(title.as_deref(), Some("My Great Note"));
+    }
+
+    #[tokio::test]
+    async fn derive_title_blank_body_makes_no_call() {
+        // A blank body returns None without invoking the client at all — a
+        // fake that would panic if called proves the short-circuit.
+        struct PanicClient;
+        impl ChatCompletions for PanicClient {
+            async fn complete(&self, _s: &str, _u: &str) -> Result<String, LlmError> {
+                panic!("derive_title must not call the model for a blank body");
+            }
+            fn model_id(&self) -> &str {
+                "panic"
+            }
+        }
+        assert_eq!(derive_title(&PanicClient, "   \n\t").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn derive_title_blank_reply_is_none() {
+        let client = FakeClient {
+            reply: "   \n  ".to_string(),
+        };
+        assert_eq!(derive_title(&client, "body").await.unwrap(), None);
+    }
+
+    #[test]
+    fn autoname_enabled_only_with_a_real_key() {
+        assert!(!autoname_enabled(None));
+        assert!(!autoname_enabled(Some("")));
+        assert!(!autoname_enabled(Some("   ")));
+        assert!(autoname_enabled(Some("sk-or-v1-abc123")));
+    }
+
+    #[test]
+    fn should_autoname_untitled_note_with_body() {
+        assert!(should_autoname("a note with content\n", false));
+    }
+
+    #[test]
+    fn should_autoname_skips_an_already_titled_note() {
+        let note = "---\ntitle: Already Named\n---\nbody\n";
+        assert!(!should_autoname(note, false));
+    }
+
+    #[test]
+    fn should_autoname_force_retitles_even_when_titled() {
+        let note = "---\ntitle: Already Named\n---\nbody\n";
+        assert!(should_autoname(note, true));
+    }
+
+    #[test]
+    fn should_autoname_never_titles_an_empty_body_even_forced() {
+        // A title needs a body to name; force does not conjure one.
+        assert!(!should_autoname("", true));
+        assert!(!should_autoname("---\ntitle: X\n---\n\n   \n", true));
+    }
+}

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use notes_protocol::{ClientMsg, Delta, Seq, ServerMsg};
+use notes_protocol::{frontmatter, ClientMsg, Delta, Seq, ServerMsg};
 use serde::{Deserialize, Serialize};
 // `wasm_bindgen` is re-exported from `worker` and must be in scope: the
 // `#[durable_object]` macro expands to JS-glue code that references it by
@@ -20,6 +20,9 @@ use worker::{
 
 use crate::auth::{authorize_owner, authorized_did};
 use crate::git::{commit_with_retry, move_note_file, CommitError, GitTarget, WorkerGitHubClient};
+use crate::llm::{
+    autoname_enabled, derive_title, should_autoname, WorkerOpenRouterClient, DEFAULT_MODEL,
+};
 use crate::route::{
     choose_rename_body, is_valid_note_id, parse_ws_note_id, plan_rename,
     rename_blocked_by_live_socket, rename_lease_active, RenameError, RenamePlan,
@@ -75,6 +78,13 @@ const RENAME_LEASE_KEY: &str = "rename_lease_until";
 /// this bound only bites on a crash.
 const RENAME_LEASE_TTL: Duration = Duration::from_secs(30);
 
+/// Internal DO control path: the top-level `/retitle` handler forwards a
+/// `POST` here so the note's Durable Object regenerates its title from the
+/// body via the LLM (forced — even an already-titled note) through the
+/// single-writer delta path, then commits. Carries the note id in
+/// `X-Note-Id`.
+const RETITLE_PATH: &str = "/__retitle";
+
 /// Commit the note this long after the last edit — coalesces a burst of
 /// keystrokes into a single git commit once the typing settles. Durability
 /// lives in DO storage (an edit is persisted before its `Ack`), so git is
@@ -115,6 +125,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/vault" => return handle_vault(&req, &env).await,
         "/delete" => return handle_delete(&req, &env).await,
         "/rename" => return handle_rename(&req, &env).await,
+        "/retitle" => return handle_retitle(&req, &env).await,
         _ => {}
     }
 
@@ -253,6 +264,40 @@ async fn handle_delete(req: &Request, env: &Env) -> Result<Response> {
         .with_status(200)
         .with_headers(headers)
         .fixed(b"{\"ok\":true}".to_vec()))
+}
+
+/// `POST /retitle?note=<id>` — regenerate a note's title from its body via
+/// the LLM for the owner's session, on demand. Forwards to the note's
+/// Durable Object, which derives a title (forced — even an already-titled
+/// note is renamed), writes it through the single-writer delta path, and
+/// commits so the new title reaches git immediately. A clean no-op when the
+/// note has no body or `OPENROUTER_API_KEY` is unset. Returns
+/// `{"ok":true,"title":<title|null>}` (a `null` title means nothing was
+/// written).
+async fn handle_retitle(req: &Request, env: &Env) -> Result<Response> {
+    if !session_authorized(req, env) {
+        return Response::error("unauthorized", 401);
+    }
+    let note = req
+        .url()?
+        .query_pairs()
+        .find(|(k, _)| k == "note")
+        .map(|(_, v)| v.into_owned())
+        .unwrap_or_default();
+    if !is_valid_note_id(&note) {
+        return Response::error("invalid note id", 400);
+    }
+
+    let ctrl = control_request(RETITLE_PATH, &note, None)?;
+    let mut resp = forward_to_note(env, &note, ctrl).await?;
+    let status = resp.status_code();
+    let body = resp.text().await?;
+
+    let headers = shell_cors_headers(env)?;
+    Ok(ResponseBuilder::new()
+        .with_status(status)
+        .with_headers(headers)
+        .fixed(body.into_bytes()))
 }
 
 /// How many times to re-attempt an idempotent Durable Object control op
@@ -752,6 +797,117 @@ impl NoteDurableObject {
             let _ = send(&ws, msg);
         }
     }
+
+    /// Build the OpenRouter client from the worker secret + model var, or
+    /// `None` when autonaming is disabled. A `None` is the graceful path:
+    /// the key isn't provisioned yet, so callers skip titling and the git
+    /// commit still proceeds — the worker ships before the key lands in
+    /// 1Password.
+    fn openrouter_client(&self) -> Option<WorkerOpenRouterClient> {
+        let key = self
+            .env
+            .secret("OPENROUTER_API_KEY")
+            .ok()
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        if !autoname_enabled(Some(&key)) {
+            console_log!("autoname: OPENROUTER_API_KEY unset/empty; skipping");
+            return None;
+        }
+        let model = self
+            .env
+            .var("OPENROUTER_MODEL")
+            .map(|v| v.to_string())
+            .unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+        Some(WorkerOpenRouterClient::new(key, model))
+    }
+
+    /// Best-effort autoname: if the current body warrants a title (see
+    /// [`should_autoname`]), ask the model and write the title through the
+    /// single-writer delta path. Returns the applied title, or `None` when
+    /// nothing was written (already titled, blank body, key unset, or a
+    /// model error). **Never panics or propagates an LLM/transport error** —
+    /// the caller's git commit must proceed regardless, so autonaming can
+    /// ship before the key is provisioned.
+    ///
+    /// The model call awaits the network, during which a concurrent editor
+    /// edit could advance the log; the current `(seq, text)` is re-read
+    /// after the call and the title applied to *that* text (body preserved
+    /// verbatim via `set_title`), so a concurrent edit is never clobbered.
+    async fn maybe_autoname(&self, force: bool) -> Option<String> {
+        let (_, text) = self.load_state().await.ok()?;
+        if !should_autoname(&text, force) {
+            return None;
+        }
+        let client = self.openrouter_client()?;
+        let body = frontmatter::body_without_frontmatter(&text).to_owned();
+        let title = match derive_title(&client, &body).await {
+            Ok(Some(t)) => t,
+            Ok(None) => return None,
+            Err(e) => {
+                console_log!("autoname: title derivation failed: {e}; skipping");
+                return None;
+            }
+        };
+
+        // Re-read: the model call awaited, so the snapshot may be stale. Bail
+        // if the current text no longer warrants the title — a concurrent
+        // edit may have emptied the body or (unless forced) added a title.
+        let (cur_seq, cur_text) = self.load_state().await.ok()?;
+        if !should_autoname(&cur_text, force) {
+            return None;
+        }
+        let new_text = match frontmatter::set_title(&cur_text, &title) {
+            Ok(t) => t,
+            Err(e) => {
+                console_log!("autoname: could not write title: {e}; skipping");
+                return None;
+            }
+        };
+        let new_seq = cur_seq + 1;
+        let delta = Delta::Whole {
+            text: new_text.clone(),
+        };
+        if let Err(e) = self.commit_edit(new_seq, &delta, &new_text).await {
+            console_log!("autoname: could not persist title delta: {e}; skipping");
+            return None;
+        }
+        // Surface the new title to any connected editor.
+        self.broadcast(&ServerMsg::Sync {
+            seq: new_seq,
+            text: new_text,
+        });
+        Some(title)
+    }
+
+    /// On-demand retitle: store the note id (so the git path resolves even
+    /// on a cold object), force a title regeneration through the
+    /// single-writer delta path, then commit so the new title reaches git
+    /// immediately rather than waiting for the lazy cadence. Returns
+    /// `{"ok":true,"title":<title|null>}`.
+    async fn retitle(&self, note_id: &str) -> Result<Response> {
+        self.state.storage().put("note_id", note_id).await?;
+        let title = self.maybe_autoname(true).await;
+
+        let (seq, text) = self.load_state().await?;
+        let committed: Seq = self
+            .state
+            .storage()
+            .get("committed_seq")
+            .await?
+            .unwrap_or(0);
+        if seq > committed {
+            if let Ok(commit_sha) = self.commit_now(seq, &text).await {
+                self.state.storage().put("committed_seq", seq).await?;
+                self.broadcast(&ServerMsg::BackedUp {
+                    commit_sha: Some(commit_sha),
+                });
+            }
+        }
+
+        let body = serde_json::json!({ "ok": true, "title": title }).to_string();
+        Response::ok(body)
+    }
 }
 
 impl DurableObject for NoteDurableObject {
@@ -812,6 +968,12 @@ impl DurableObject for NoteDurableObject {
                 .unwrap_or_default()
                 .to_owned();
             return self.seed(&note_id, &text).await;
+        }
+        // On-demand retitle: regenerate the title from the body via the LLM
+        // and commit. Forced, so an already-titled note is renamed too.
+        if req.path() == RETITLE_PATH {
+            let note_id = req.headers().get("X-Note-Id")?.unwrap_or_default();
+            return self.retitle(&note_id).await;
         }
 
         // Refuse a new editor socket while a rename holds a lease on this note:
@@ -918,7 +1080,9 @@ impl DurableObject for NoteDurableObject {
     }
 
     async fn alarm(&self) -> Result<Response> {
-        let (seq, text) = self.load_state().await?;
+        // Only `seq` is needed to decide there's work; the body to commit is
+        // re-read below, after autoname may append a title delta.
+        let (seq, _) = self.load_state().await?;
         let committed: Seq = self
             .state
             .storage()
@@ -931,6 +1095,14 @@ impl DurableObject for NoteDurableObject {
         if seq <= committed {
             return Response::ok("nothing to commit");
         }
+
+        // Autoname on the lazy cadence — best-effort, before the commit, so
+        // an untitled note acquires a title on the same beat it backs up.
+        // Errors are swallowed inside `maybe_autoname`; the commit proceeds
+        // regardless.
+        let _ = self.maybe_autoname(false).await;
+        // Re-read: autoname may have appended a title delta.
+        let (seq, text) = self.load_state().await?;
 
         match self.commit_now(seq, &text).await {
             Ok(commit_sha) => {
@@ -965,7 +1137,9 @@ impl DurableObject for NoteDurableObject {
         // waiting for the alarm. `get_websockets()` still includes the
         // socket being closed, so `<= 1` means "this was the last one".
         if self.state.get_websockets().len() <= 1 {
-            let (seq, text) = self.load_state().await?;
+            // Only `seq` is needed to decide there's work; the body to commit
+            // is re-read below, after autoname may append a title delta.
+            let (seq, _) = self.load_state().await?;
             let committed: Seq = self
                 .state
                 .storage()
@@ -973,6 +1147,11 @@ impl DurableObject for NoteDurableObject {
                 .await?
                 .unwrap_or(0);
             if seq > committed {
+                // Autoname on the last disconnect too — best-effort, before
+                // the flush, so a note typed-and-closed without ever idling
+                // still gets named. Re-read in case a title delta was added.
+                let _ = self.maybe_autoname(false).await;
+                let (seq, text) = self.load_state().await?;
                 match self.commit_now(seq, &text).await {
                     Ok(_) => {
                         self.state.storage().put("committed_seq", seq).await?;


### PR DESCRIPTION
OpenRouter chat client (services/notes-sync/src/llm.rs — OpenAI-compatible over worker::Fetch, configurable base URL + model) plus note autonaming: an untitled note gets an LLM-derived title written into its front-matter THROUGH the Durable Object on the existing lazy commit cadence (single-writer preserved; no per-keystroke path). Graceful no-op when OPENROUTER_API_KEY is unset, so it ships dormant until the key is provisioned at the op:// item "notes-sync OPENROUTER_API_KEY". Held for review — worker commit path + secret.

Closes #991