### PR TITLE
feat(scoretracker): track rotating dealer and per-round wild for tic

### DIFF
--- a/apps/scoretracker/games/schema.cue
+++ b/apps/scoretracker/games/schema.cue
@@ -21,6 +21,23 @@ package games
 	winner:      "lowest" | "highest"
 	scoring:     #Scoring
 	roundAward?: #RoundAward
+	// Optional rotating dealer: the engine tracks whose deal each round is,
+	// starting from a per-game round-1 dealer and rotating through `players`.
+	dealer?: #Dealer
+	// Optional per-round wild rank (e.g. Three Thirteen): round N's wild is
+	// `ranks[N-1]`, a held card of that rank scores `points`, and the game
+	// caps at `len(ranks)` rounds.
+	wildProgression?: #WildProgression
+}
+
+#Dealer: {rotates: bool}
+
+// Wild rank per round. Ranks are canonical/lowercase card tokens
+// (`"2".."10"`, `"j"`, `"q"`, `"k"`, `"a"`); a token matching the round's
+// rank (via its aliases, e.g. `jack`/`j`) scores `points`.
+#WildProgression: {
+	ranks: [string, ...string]
+	points: int
 }
 
 // How a single parsed token becomes points. Lookup order: a `named` token

--- a/apps/scoretracker/games/tic.cue
+++ b/apps/scoretracker/games/tic.cue
@@ -27,5 +27,17 @@ games: tic: {
 		// worth -5 (applied to the running total continuously, same final
 		// result).
 		roundAward: {label: "tic", pointsPerAward: -5}
+
+		// Dealer rotates each round from a chosen round-1 dealer.
+		dealer: {rotates: true}
+
+		// Three Thirteen: 11 rounds, the wild rank climbs 3→King. A held
+		// wild-rank card scores 50 (overriding its normal value — so a King
+		// in the Kings-wild round is 50, not 10). The game ends after round
+		// 11.
+		wildProgression: {
+			ranks: ["3", "4", "5", "6", "7", "8", "9", "10", "j", "q", "k"]
+			points: 50
+		}
 	}
 }

--- a/apps/scoretracker/public/index.html
+++ b/apps/scoretracker/public/index.html
@@ -72,6 +72,12 @@
         background: var(--accent-soft); color: var(--ink);
         border-radius: 12px; padding: 0.6rem 0.8rem; font-size: 0.95rem; margin-bottom: 0.9rem;
       }
+      .roundbar {
+        display: flex; justify-content: center; gap: 0.4rem;
+        background: var(--bg); color: var(--ink); border: 1px solid var(--accent);
+        border-radius: 12px; padding: 0.6rem 0.8rem; margin-bottom: 0.9rem;
+        font-size: 1rem; font-weight: 700; text-align: center;
+      }
       button.go {
         width: 100%; padding: 0.85rem; font-size: 1.05rem; font-weight: 700;
         background: var(--accent); color: #fff; border: none; border-radius: 12px; cursor: pointer;
@@ -215,15 +221,53 @@
       function renderEntry(def) {
         const el = $("entry");
         el.innerHTML = "";
-        if (def.model.kind === "roundPoints") {
-          el.appendChild(roundForm(def));
-        } else {
+        if (def.model.kind !== "roundPoints") {
           el.appendChild(matchForm(def));
+          return;
         }
+        if (data.complete) {
+          el.innerHTML =
+            `<h2>game complete</h2><div class="who">all rounds played — final standings above. undo to reopen the last round, or start a new game.</div>`;
+          return;
+        }
+        el.appendChild(roundForm(def));
       }
 
       function roundForm(def) {
         const frag = document.createElement("div");
+        const hasDealer = !!def.model.dealer;
+        const hasWild = !!def.model.wildProgression;
+
+        // Upcoming-round banner: whose deal and what's wild.
+        if (hasDealer || hasWild) {
+          const bits = [`round ${data.rounds.length + 1}`];
+          if (hasDealer && data.nextDealer) bits.push(`${data.nextDealer} deals`);
+          if (hasWild && data.nextWild) bits.push(`wild: ${prettyRank(data.nextWild)}`);
+          const banner = document.createElement("div");
+          banner.className = "roundbar";
+          banner.textContent = bits.join("  ·  ");
+          frag.appendChild(banner);
+        }
+
+        // Before round 1, let the table pick who deals first.
+        if (hasDealer && data.rounds.length === 0) {
+          const wrap = document.createElement("div");
+          wrap.className = "award";
+          wrap.innerHTML = `<label>who deals first?</label>`;
+          const chips = document.createElement("div");
+          chips.className = "chips";
+          for (const p of data.players) {
+            const c = document.createElement("button");
+            c.className = "chip";
+            c.textContent = p;
+            c.setAttribute("aria-pressed", data.nextDealer === p);
+            c.onclick = () => post("/reset", { firstDealer: p });
+            chips.appendChild(c);
+          }
+          wrap.appendChild(chips);
+          frag.appendChild(wrap);
+        }
+
         const h = document.createElement("h2");
         h.textContent = "add round";
         frag.appendChild(h);
@@ -237,7 +281,7 @@
           name.textContent = p;
           const inp = document.createElement("input");
           inp.type = "text";
-          inp.placeholder = "cards, e.g. 5, wild";
+          inp.placeholder = hasWild ? "cards, e.g. 5, 3, jack" : "cards, e.g. 5, wild";
           inp.autocapitalize = "off";
           inputs[p] = inp;
           row.append(name, inp);
@@ -325,9 +369,13 @@
               const tic = r.award === p ? " ·" + def.model.roundAward.label : "";
               return `${esc(p)} ${e ? e.points : 0}${tic}`;
             });
+            const meta = [];
+            if (r.wild) meta.push(`wild ${prettyRank(r.wild)}`);
+            if (r.dealer) meta.push(`${r.dealer} dealt`);
+            const label = meta.length ? `round ${r.n} · ${meta.join(" · ")}` : `round ${r.n}`;
             const div = document.createElement("div");
             div.className = "h";
-            div.innerHTML = `<span>round ${r.n}</span><span class="who">${esc(parts.join("  ·  "))}</span>`;
+            div.innerHTML = `<span>${esc(label)}</span><span class="who">${esc(parts.join("  ·  "))}</span>`;
             el.appendChild(div);
           }
         } else {
@@ -375,6 +423,9 @@
       function esc(s) {
         return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#x27;" }[c]));
       }
+
+      // Display a wild rank: face/number cards read naturally (j → J, 10 → 10).
+      function prettyRank(r) { return String(r).toUpperCase(); }
 
       boot();
     </script>

--- a/apps/scoretracker/src/engine/config.rs
+++ b/apps/scoretracker/src/engine/config.rs
@@ -44,6 +44,23 @@ pub struct RoundPoints {
     pub scoring: Scoring,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub round_award: Option<RoundAward>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dealer: Option<Dealer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wild_progression: Option<WildProgression>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Dealer {
+    pub rotates: bool,
+}
+
+/// Per-round wild rank. `ranks[i]` is the wild for round `i + 1` (canonical
+/// lowercase card tokens); a held card of that rank scores `points`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WildProgression {
+    pub ranks: Vec<String>,
+    pub points: i64,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/apps/scoretracker/src/engine/error.rs
+++ b/apps/scoretracker/src/engine/error.rs
@@ -21,6 +21,9 @@ pub enum EngineError {
     #[snafu(display("nothing to undo"))]
     NothingToUndo,
 
+    #[snafu(display("this game is complete — no more rounds"))]
+    GameComplete,
+
     #[snafu(display("that action doesn't match this game's scoring style"))]
     WrongModel,
 

--- a/apps/scoretracker/src/engine/score.rs
+++ b/apps/scoretracker/src/engine/score.rs
@@ -1,12 +1,41 @@
-//! Token → points, per a game's `Scoring`. Lookup order: a named token
-//! (e.g. `skip`, `wild`, `ace`) wins; otherwise parse as an integer and
-//! match `ranges` (first hit) then `faceValue` (value == points).
+//! Token → points, per a game's `Scoring`. Lookup order: the round's wild
+//! rank (if any) scores as wild and wins; then a named token (e.g. `skip`,
+//! `ace`); otherwise parse as an integer and match `ranges` (first hit)
+//! then `faceValue` (value == points).
 
 use crate::engine::config::Scoring;
 use crate::engine::error::EngineError;
 
-/// Points for a single already-lowercased token.
-pub fn token_points(token: &str, scoring: &Scoring) -> Result<i64, EngineError> {
+/// The round's wild: its canonical rank plus the points a matching card
+/// scores. `None` for games without a per-round wild.
+pub type Wild<'a> = Option<(&'a str, i64)>;
+
+/// Canonical rank key for wild-matching. Face cards and aces collapse to a
+/// single letter (so `jack`/`j` both match wild rank `j`); number cards are
+/// their own value. `None` for tokens that aren't a card rank (e.g. `skip`,
+/// `wild`) — those can never be the round's wild.
+pub fn canonical_rank(token: &str) -> Option<String> {
+    match token {
+        "a" | "ace" => Some("a".to_owned()),
+        "k" | "king" => Some("k".to_owned()),
+        "q" | "queen" => Some("q".to_owned()),
+        "j" | "jack" => Some("j".to_owned()),
+        _ => token
+            .parse::<i64>()
+            .ok()
+            .filter(|n| (2..=10).contains(n))
+            .map(|n| n.to_string()),
+    }
+}
+
+/// Points for a single already-lowercased token, given the round's wild.
+pub fn token_points(token: &str, scoring: &Scoring, wild: Wild) -> Result<i64, EngineError> {
+    // The round's wild rank overrides that rank's normal value.
+    if let Some((wild_rank, wild_points)) = wild {
+        if canonical_rank(token).as_deref() == Some(wild_rank) {
+            return Ok(wild_points);
+        }
+    }
     if let Some(points) = scoring.named.get(token) {
         return Ok(*points);
     }
@@ -28,10 +57,27 @@ pub fn token_points(token: &str, scoring: &Scoring) -> Result<i64, EngineError> 
 }
 
 /// Sum the points of one player's tokens. Empty (no cards) is zero.
-pub fn entry_points(tokens: &[String], scoring: &Scoring) -> Result<i64, EngineError> {
+pub fn entry_points(tokens: &[String], scoring: &Scoring, wild: Wild) -> Result<i64, EngineError> {
     let mut total = 0;
     for t in tokens {
-        total += token_points(t, scoring)?;
+        total += token_points(t, scoring, wild)?;
     }
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_rank;
+
+    #[test]
+    fn canonical_rank_collapses_aliases() {
+        assert_eq!(canonical_rank("jack").as_deref(), Some("j"));
+        assert_eq!(canonical_rank("j").as_deref(), Some("j"));
+        assert_eq!(canonical_rank("KING"), None); // caller lowercases first
+        assert_eq!(canonical_rank("king").as_deref(), Some("k"));
+        assert_eq!(canonical_rank("10").as_deref(), Some("10"));
+        assert_eq!(canonical_rank("5").as_deref(), Some("5"));
+        assert_eq!(canonical_rank("wild"), None);
+        assert_eq!(canonical_rank("skip"), None);
+    }
 }

--- a/apps/scoretracker/src/engine/state.rs
+++ b/apps/scoretracker/src/engine/state.rs
@@ -19,14 +19,19 @@ pub struct Entry {
     pub points: i64,
 }
 
-/// One `roundPoints` round: an entry per player, plus an optional award
-/// recipient (e.g. who "tic'd" by going out first).
+/// One `roundPoints` round: an entry per player, plus optional per-round
+/// context — the award recipient (who "tic'd"), the wild rank in effect, and
+/// who dealt.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Round {
     pub n: u32,
     pub entries: BTreeMap<String, Entry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub award: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wild: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dealer: Option<String>,
 }
 
 /// One finished `matchWins` game.
@@ -51,6 +56,20 @@ pub struct GameData {
     /// more than one entry means a tie.
     #[serde(default)]
     pub leaders: Vec<String>,
+    /// Index into `players` of the round-1 dealer (rotating-dealer games).
+    #[serde(default)]
+    pub dealer_start: usize,
+    /// Who deals the upcoming round (rotating-dealer games, when not
+    /// complete).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_dealer: Option<String>,
+    /// The wild rank for the upcoming round (wild-progression games, when not
+    /// complete).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_wild: Option<String>,
+    /// True once a wild-progression game has played all its rounds.
+    #[serde(default)]
+    pub complete: bool,
 }
 
 impl GameData {
@@ -83,11 +102,23 @@ pub fn apply_round(
         return Err(EngineError::WrongModel);
     };
 
+    // 0-based index of the round being added; its wild rank (if the game has
+    // a progression), which also caps the number of rounds.
+    let idx = data.rounds.len();
+    let wild = match &rp.wild_progression {
+        Some(wp) => match wp.ranks.get(idx) {
+            Some(rank) => Some((rank.clone(), wp.points)),
+            None => return Err(EngineError::GameComplete),
+        },
+        None => None,
+    };
+    let wild_ctx = wild.as_ref().map(|(rank, points)| (rank.as_str(), *points));
+
     let mut entries = BTreeMap::new();
     for player in &data.players {
         let raw = raws.get(player).cloned().unwrap_or_default();
         let tokens = parse::tokenize(&raw, &rp.scoring.empty_aliases);
-        let points = score::entry_points(&tokens, &rp.scoring)?;
+        let points = score::entry_points(&tokens, &rp.scoring, wild_ctx)?;
         entries.insert(
             player.clone(),
             Entry {
@@ -109,8 +140,14 @@ pub fn apply_round(
         }
     }
 
-    let n = data.rounds.len() as u32 + 1;
-    data.rounds.push(Round { n, entries, award });
+    let dealer = dealer_for_round(&data.players, rp, data.dealer_start, idx);
+    data.rounds.push(Round {
+        n: idx as u32 + 1,
+        entries,
+        award,
+        wild: wild.map(|(rank, _)| rank),
+        dealer,
+    });
     recompute(data, game);
     Ok(())
 }
@@ -147,12 +184,23 @@ pub fn undo(data: &mut GameData, game: &Game) -> Result<(), EngineError> {
     Ok(())
 }
 
-/// Start a fresh game, optionally with a new roster. An empty/omitted
-/// roster keeps the current players.
-pub fn reset(data: &mut GameData, game: &Game, players: Option<Vec<String>>) {
+/// Start a fresh game, optionally with a new roster and/or a round-1 dealer.
+/// An empty/omitted roster keeps the current players; a `first_dealer` that
+/// isn't a current player is ignored.
+pub fn reset(
+    data: &mut GameData,
+    game: &Game,
+    players: Option<Vec<String>>,
+    first_dealer: Option<String>,
+) {
     if let Some(roster) = players {
         if !roster.is_empty() {
             data.players = roster;
+        }
+    }
+    if let Some(dealer) = first_dealer {
+        if let Some(i) = data.players.iter().position(|p| *p == dealer) {
+            data.dealer_start = i;
         }
     }
     data.rounds.clear();
@@ -180,6 +228,25 @@ fn recompute(data: &mut GameData, game: &Game) {
             } else {
                 leaders_by(&totals, rp.winner)
             };
+
+            // Upcoming round (0-based index = rounds played so far).
+            let next = data.rounds.len();
+            data.complete = rp
+                .wild_progression
+                .as_ref()
+                .is_some_and(|wp| next >= wp.ranks.len());
+            data.next_wild = if data.complete {
+                None
+            } else {
+                rp.wild_progression
+                    .as_ref()
+                    .and_then(|wp| wp.ranks.get(next).cloned())
+            };
+            data.next_dealer = if data.complete {
+                None
+            } else {
+                dealer_for_round(&data.players, rp, data.dealer_start, next)
+            };
         }
         Model::MatchWins(_) => {
             for m in &data.matches {
@@ -190,10 +257,29 @@ fn recompute(data: &mut GameData, game: &Game) {
             } else {
                 leaders_by(&totals, Winner::Highest)
             };
+            data.complete = false;
+            data.next_wild = None;
+            data.next_dealer = None;
         }
     }
 
     data.totals = totals;
+}
+
+/// Who deals round `round_index` (0-based) for a rotating-dealer game:
+/// `players[(dealer_start + round_index) % n]`. `None` if the game has no
+/// rotating dealer or no players.
+fn dealer_for_round(
+    players: &[String],
+    rp: &RoundPoints,
+    dealer_start: usize,
+    round_index: usize,
+) -> Option<String> {
+    if !rp.dealer.as_ref().is_some_and(|d| d.rotates) || players.is_empty() {
+        return None;
+    }
+    let i = (dealer_start + round_index) % players.len();
+    Some(players[i].clone())
 }
 
 fn apply_award(totals: &mut BTreeMap<String, i64>, recipient: Option<&str>, rp: &RoundPoints) {

--- a/apps/scoretracker/src/runtime.rs
+++ b/apps/scoretracker/src/runtime.rs
@@ -33,11 +33,14 @@ struct RoundRequest {
     winner: Option<String>,
 }
 
-/// Body for `POST /reset` — an optional new roster.
+/// Body for `POST /reset` — an optional new roster and/or round-1 dealer.
 #[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct ResetRequest {
     #[serde(default)]
     players: Option<Vec<String>>,
+    #[serde(default)]
+    first_dealer: Option<String>,
 }
 
 #[event(fetch)]
@@ -147,7 +150,7 @@ impl DurableObject for GameState {
             (Method::Post, "reset") => {
                 mutated = true;
                 let body = req.json::<ResetRequest>().await.unwrap_or_default();
-                state::reset(&mut data, game, body.players);
+                state::reset(&mut data, game, body.players, body.first_dealer);
                 Ok(())
             }
             _ => return json_err(404, "not found", "no such action"),

--- a/apps/scoretracker/tests/scoring.rs
+++ b/apps/scoretracker/tests/scoring.rs
@@ -114,6 +114,7 @@ fn reset_clears_and_can_change_roster() {
         &mut d,
         game,
         Some(vec!["Ada".to_owned(), "Bo".to_owned(), "Cy".to_owned()]),
+        None,
     );
     assert_eq!(d.players, vec!["Ada", "Bo", "Cy"]);
     assert!(d.rounds.is_empty());
@@ -165,4 +166,87 @@ fn unknown_player_and_wrong_model_are_rejected() {
         state::apply_match(&mut d2, phase10, "Jon").unwrap_err(),
         EngineError::WrongModel
     );
+}
+
+#[test]
+fn tic_wild_rank_auto_scores_in_a_number_round() {
+    let game = config::game("tic").expect("tic exists");
+    let mut d = GameData::new(game);
+    assert_eq!(d.next_wild.as_deref(), Some("3")); // round 1 wild
+                                                   // Round 1: 3s are wild. Jon holds two 3s (wild, 50 each) + a 7.
+    state::apply_round(
+        &mut d,
+        game,
+        &entries(&[("Jon", "3, 3, 7"), ("Jessica", "no cards")]),
+        None,
+    )
+    .expect("round");
+    assert_eq!(d.totals["Jon"], 107); // 50 + 50 + 7
+    assert_eq!(d.rounds[0].wild.as_deref(), Some("3"));
+    assert_eq!(d.next_wild.as_deref(), Some("4")); // round 2 wild
+}
+
+#[test]
+fn tic_wild_overrides_face_card_in_a_face_round() {
+    let game = config::game("tic").expect("tic exists");
+    let mut d = GameData::new(game);
+    // Advance to round 9 (index 8), where Jacks are wild.
+    for _ in 0..8 {
+        state::apply_round(&mut d, game, &entries(&[]), None).expect("round");
+    }
+    assert_eq!(d.next_wild.as_deref(), Some("j"));
+    // Jack -> 50 (wild), Queen/King -> 10 (face, not wild), Ace -> 20.
+    state::apply_round(
+        &mut d,
+        game,
+        &entries(&[("Jon", "jack, queen, king, ace")]),
+        None,
+    )
+    .expect("round");
+    assert_eq!(d.totals["Jon"], 90); // 50 + 10 + 10 + 20
+}
+
+#[test]
+fn tic_dealer_rotates_from_chosen_first_dealer() {
+    let game = config::game("tic").expect("tic exists");
+    let mut d = GameData::new(game);
+    assert_eq!(d.next_dealer.as_deref(), Some("Jon")); // default: players[0]
+    state::reset(&mut d, game, None, Some("Jessica".to_owned()));
+    assert_eq!(d.next_dealer.as_deref(), Some("Jessica")); // round 1
+    state::apply_round(&mut d, game, &entries(&[]), None).expect("round");
+    assert_eq!(d.rounds[0].dealer.as_deref(), Some("Jessica"));
+    assert_eq!(d.next_dealer.as_deref(), Some("Jon")); // round 2 rotates
+    state::apply_round(&mut d, game, &entries(&[]), None).expect("round");
+    assert_eq!(d.next_dealer.as_deref(), Some("Jessica")); // round 3
+}
+
+#[test]
+fn tic_caps_at_eleven_rounds() {
+    let game = config::game("tic").expect("tic exists");
+    let mut d = GameData::new(game);
+    for _ in 0..11 {
+        state::apply_round(&mut d, game, &entries(&[]), None).expect("round");
+    }
+    assert!(d.complete);
+    assert!(d.next_wild.is_none());
+    assert!(d.next_dealer.is_none());
+    assert_eq!(
+        state::apply_round(&mut d, game, &entries(&[]), None).unwrap_err(),
+        EngineError::GameComplete
+    );
+    // Undo re-opens the final round.
+    state::undo(&mut d, game).expect("undo");
+    assert!(!d.complete);
+    assert_eq!(d.next_wild.as_deref(), Some("k")); // round 11 wild
+}
+
+#[test]
+fn games_without_dealer_or_wild_expose_neither() {
+    for id in ["phase10", "skipbo"] {
+        let game = config::game(id).expect("game exists");
+        let d = GameData::new(game);
+        assert!(d.next_dealer.is_none(), "{id} should have no dealer");
+        assert!(d.next_wild.is_none(), "{id} should have no wild");
+        assert!(!d.complete, "{id} should never be 'complete'");
+    }
 }


### PR DESCRIPTION
tic is played as Three Thirteen: 11 rounds, the wild rank climbs 3->King
each round, and the dealer rotates. The tracker now surfaces both.

The roundPoints model gains two optional, config-driven blocks (only tic
opts in, so Phase 10 / Skip-Bo are untouched): `dealer.rotates` and
`wildProgression{ranks, points}`. The engine computes each round's wild
from the progression, scores a held wild-rank card as 50 (overriding its
normal value — a King in the Kings-wild round is 50, not 10), rotates the
dealer from a user-chosen round-1 dealer, caps the game at 11 rounds, and
exposes the upcoming round's dealer/wild plus a completion flag. The UI
shows 'round N · X deals · wild: R', lets you pick the first dealer, and
records dealer/wild in history.

Closes #1023