### PR TITLE
feat(notes-sync): LLM auto-filing of new notes

### DIFF
--- a/apps/notes-web/dist/index.html
+++ b/apps/notes-web/dist/index.html
@@ -317,17 +317,51 @@
         }
       }
 
-      // New note: navigate to the empty note. It commits to git (and thus
-      // joins the vault listing) on its first edit.
-      document.getElementById("new-note").addEventListener("click", () => {
-        const path = (prompt("New note path (e.g. projects/idea)") || "").trim();
-        if (!path) return;
-        if (!validNotePath(path)) {
-          alert("Use letters, digits, . _ - and / between segments.");
-          return;
+      // Ask the backend to auto-file a draft into a folder ("it goes where it
+      // goes"). Returns a suggested `folder/slug` path, or "" when auto-filing
+      // is disabled (no LLM key), the draft is blank, or anything fails — the
+      // caller then falls back to a plain manual prompt. Never throws.
+      async function suggestNotePath(draft) {
+        if (!draft) return "";
+        try {
+          const res = await fetch(`https://${backend}/suggest-path`, {
+            method: "POST",
+            credentials: "include",
+            body: draft,
+          });
+          if (!res.ok) return "";
+          const { path } = await res.json();
+          return typeof path === "string" ? path : "";
+        } catch (e) {
+          return "";
         }
-        location.search = "?note=" + encodeURIComponent(path);
-      });
+      }
+
+      // New note: optionally describe it so the LLM can auto-file it into the
+      // right folder, then confirm/edit the path and navigate to the empty
+      // note. It commits to git (and thus joins the vault listing) on its
+      // first edit. Auto-filing is a convenience layered over the manual path
+      // entry: a blank description, a disabled LLM, or any failure degrades to
+      // the plain path prompt.
+      document
+        .getElementById("new-note")
+        .addEventListener("click", async () => {
+          const draft = (
+            prompt(
+              "What's the note about? (used to auto-file it — leave blank to set the path yourself)",
+            ) || ""
+          ).trim();
+          const suggested = await suggestNotePath(draft);
+          const path = (
+            prompt("New note path (e.g. projects/idea)", suggested) || ""
+          ).trim();
+          if (!path) return;
+          if (!validNotePath(path)) {
+            alert("Use letters, digits, . _ - and / between segments.");
+            return;
+          }
+          location.search = "?note=" + encodeURIComponent(path);
+        });
 
       const status = document.getElementById("status");
       try {

--- a/services/notes-sync/src/llm.rs
+++ b/services/notes-sync/src/llm.rs
@@ -197,6 +197,120 @@ pub async fn derive_title<C: ChatCompletions>(
     Ok(clean_title(&reply))
 }
 
+/// Cap the number of existing folders listed in the auto-filing prompt so a
+/// large vault doesn't blow the prompt budget. A representative slice of the
+/// folder taxonomy is enough for the model to pick a home.
+const MAX_FILING_FOLDERS: usize = 200;
+
+/// Steers the model to file a note into a vault folder and name it, replying
+/// with only a bare path so [`clean_suggested_path`] has little to strip.
+const FILING_SYSTEM_PROMPT: &str = "You file a note into a personal notes \
+vault. Given the note body and the existing folders, choose the single \
+best-fitting existing folder, or propose one short new folder if none fit. \
+Then append a concise kebab-case slug naming the note. Reply with ONLY the \
+resulting path: folder segments and the slug separated by '/', lowercase, \
+using only letters, digits, hyphens, and slashes. No leading or trailing \
+slash, no quotes, no markdown, no explanation. \
+Example: projects/acme/launch-checklist";
+
+/// Derive the set of existing folders from note ids: every directory prefix
+/// of every path. A top-level note (no slash) contributes no folder. Note ids
+/// are paths like `projects/foo/idea`, whose prefixes are `projects` and
+/// `projects/foo`. Sorted and de-duplicated (via a `BTreeSet`) for a stable,
+/// budget-friendly listing — the folder taxonomy auto-filing chooses from.
+pub fn folders_from_paths(paths: &[String]) -> Vec<String> {
+    let mut folders: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for path in paths {
+        let segments: Vec<&str> = path.split('/').collect();
+        // Every prefix up to (but not including) the leaf is a folder.
+        for i in 1..segments.len() {
+            folders.insert(segments[..i].join("/"));
+        }
+    }
+    folders.into_iter().collect()
+}
+
+/// Build the `user` message for auto-filing: the existing folder taxonomy
+/// (capped at [`MAX_FILING_FOLDERS`]) plus the note body (truncated to
+/// [`MAX_PROMPT_CHARS`]). Pure so the wasm transport and the native tests
+/// build the identical prompt.
+pub(crate) fn build_filing_prompt(folders: &[String], body: &str) -> String {
+    let listed: Vec<&str> = folders
+        .iter()
+        .take(MAX_FILING_FOLDERS)
+        .map(String::as_str)
+        .collect();
+    let folder_block = if listed.is_empty() {
+        "(none yet — the vault is empty)".to_string()
+    } else {
+        listed.join("\n")
+    };
+    let snippet = truncate(body, MAX_PROMPT_CHARS);
+    format!("Existing folders:\n{folder_block}\n\nNote body:\n{snippet}")
+}
+
+/// Reduce one path segment to lowercase unreserved characters: runs of
+/// anything outside `[a-z0-9._-]` collapse to a single hyphen, and leading/
+/// trailing hyphens are trimmed. Keeps a model's spaced-out title
+/// (`My Great Note`) from failing [`crate::route::is_valid_note_id`].
+fn slug_segment(segment: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = false;
+    for ch in segment.chars() {
+        let lower = ch.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() || matches!(lower, '.' | '_' | '-') {
+            out.push(lower);
+            prev_dash = false;
+        } else if !out.is_empty() && !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+/// Normalize a raw model reply into a candidate note path, or `None` when
+/// nothing usable remains. Takes the first non-blank line, strips a markdown
+/// heading marker, surrounding quotes/backticks, and stray leading/trailing
+/// slashes, then slugifies each segment to the unreserved path characters the
+/// vault allows. The candidate is *not* fully validated here — the caller runs
+/// it through [`crate::route::is_valid_note_id`] and falls back on garbage
+/// (e.g. a `..` traversal segment slugs through unchanged and is rejected
+/// there).
+pub fn clean_suggested_path(raw: &str) -> Option<String> {
+    let first_line = raw.lines().map(str::trim).find(|l| !l.is_empty())?;
+    let s = first_line.trim_start_matches('#').trim();
+    let s = s.trim_matches(['"', '\'', '`']).trim();
+    let s = s.trim_matches('/');
+    let cleaned: Vec<String> = s
+        .split('/')
+        .map(slug_segment)
+        .filter(|seg| !seg.is_empty())
+        .collect();
+    (!cleaned.is_empty()).then(|| cleaned.join("/"))
+}
+
+/// Auto-file a note `body` into an existing vault folder (or a sensible new
+/// one) and name it, returning a candidate note path — "it goes where it
+/// goes". Returns `Ok(None)` for a blank body (no call made) or when the
+/// cleaned reply is empty. The candidate is *not* validated here — the caller
+/// runs it through [`crate::route::is_valid_note_id`] and falls back when the
+/// model returns garbage. The no-key gate lives at the call site (the client
+/// is only built when [`autoname_enabled`]), so a missing key is a clean
+/// no-op: no client, no call.
+pub async fn suggest_path<C: ChatCompletions>(
+    client: &C,
+    body: &str,
+    folders: &[String],
+) -> Result<Option<String>, LlmError> {
+    if body.trim().is_empty() {
+        return Ok(None);
+    }
+    let user = build_filing_prompt(folders, body);
+    let reply = client.complete(FILING_SYSTEM_PROMPT, &user).await?;
+    Ok(clean_suggested_path(&reply))
+}
+
 /// Whether `note` warrants a (re)title. A blank body is never titled (there
 /// is nothing to name). Otherwise `force` titles regardless of an existing
 /// title (the on-demand retitle), while the lazy cadence only titles a note
@@ -534,6 +648,201 @@ mod tests {
         assert!(!autoname_enabled(None));
         assert!(!autoname_enabled(Some("")));
         assert!(!autoname_enabled(Some("   ")));
+        assert!(autoname_enabled(Some("sk-or-v1-abc123")));
+    }
+
+    #[test]
+    fn folders_from_paths_takes_every_directory_prefix() {
+        // A top-level note contributes no folder; a nested note contributes
+        // each of its ancestor prefixes, de-duplicated and sorted.
+        let paths = vec![
+            "scratch".to_string(),
+            "projects/foo".to_string(),
+            "projects/bar/idea".to_string(),
+            "daily/2026-01-01".to_string(),
+        ];
+        assert_eq!(
+            folders_from_paths(&paths),
+            vec![
+                "daily".to_string(),
+                "projects".to_string(),
+                "projects/bar".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn folders_from_paths_is_empty_for_only_top_level_notes() {
+        let paths = vec!["scratch".to_string(), "inbox".to_string()];
+        assert!(folders_from_paths(&paths).is_empty());
+    }
+
+    #[test]
+    fn folders_from_paths_dedupes_shared_ancestors() {
+        let paths = vec![
+            "projects/foo".to_string(),
+            "projects/bar".to_string(),
+            "projects/baz/deep".to_string(),
+        ];
+        assert_eq!(
+            folders_from_paths(&paths),
+            vec!["projects".to_string(), "projects/baz".to_string()]
+        );
+    }
+
+    #[test]
+    fn filing_prompt_lists_folders_and_carries_the_body() {
+        let folders = vec!["projects".to_string(), "daily".to_string()];
+        let prompt = build_filing_prompt(&folders, "buy milk and eggs");
+        assert!(prompt.contains("projects"));
+        assert!(prompt.contains("daily"));
+        assert!(prompt.contains("buy milk and eggs"));
+    }
+
+    #[test]
+    fn filing_prompt_flags_an_empty_vault() {
+        let prompt = build_filing_prompt(&[], "first note ever");
+        assert!(prompt.contains("vault is empty"));
+        assert!(prompt.contains("first note ever"));
+    }
+
+    #[test]
+    fn filing_prompt_caps_the_folder_list() {
+        // A vault with more folders than the budget lists only the first
+        // MAX_FILING_FOLDERS — the (n+1)-th never appears.
+        let folders: Vec<String> = (0..MAX_FILING_FOLDERS + 5)
+            .map(|i| format!("folder-{i:04}"))
+            .collect();
+        let prompt = build_filing_prompt(&folders, "body");
+        assert!(prompt.contains("folder-0000"));
+        assert!(!prompt.contains(&format!("folder-{:04}", MAX_FILING_FOLDERS)));
+    }
+
+    #[test]
+    fn filing_prompt_truncates_a_giant_body() {
+        let body = "x".repeat(MAX_PROMPT_CHARS + 500);
+        let prompt = build_filing_prompt(&[], &body);
+        // The body slice is capped; the untruncated length never makes it in.
+        assert!(!prompt.contains(&"x".repeat(MAX_PROMPT_CHARS + 1)));
+    }
+
+    #[test]
+    fn clean_suggested_path_passes_through_a_clean_path() {
+        assert_eq!(
+            clean_suggested_path("projects/acme/launch-checklist").as_deref(),
+            Some("projects/acme/launch-checklist")
+        );
+    }
+
+    #[test]
+    fn clean_suggested_path_strips_quotes_slashes_and_heading() {
+        assert_eq!(
+            clean_suggested_path("## \"/projects/foo/idea/\"").as_deref(),
+            Some("projects/foo/idea")
+        );
+    }
+
+    #[test]
+    fn clean_suggested_path_slugifies_spaces_and_case() {
+        // A model that ignores the kebab-case instruction still yields a valid
+        // id: spaces collapse to hyphens and everything lowercases.
+        assert_eq!(
+            clean_suggested_path("Projects/My Great Note").as_deref(),
+            Some("projects/my-great-note")
+        );
+    }
+
+    #[test]
+    fn clean_suggested_path_takes_only_the_first_line() {
+        assert_eq!(
+            clean_suggested_path("\n\nprojects/foo\nsome explanation").as_deref(),
+            Some("projects/foo")
+        );
+    }
+
+    #[test]
+    fn clean_suggested_path_empty_or_junk_is_none() {
+        assert_eq!(clean_suggested_path(""), None);
+        assert_eq!(clean_suggested_path("   \n "), None);
+        // Only separator characters — nothing slugs through.
+        assert_eq!(clean_suggested_path("/// !!! ///"), None);
+    }
+
+    #[tokio::test]
+    async fn suggest_path_round_trips_against_a_mocked_endpoint() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/api/v1/chat/completions")
+            // The request carries the folders and the body in the user turn.
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::Regex("Existing folders".to_string()),
+                mockito::Matcher::Regex("projects".to_string()),
+                mockito::Matcher::Regex("groceries for the week".to_string()),
+            ]))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "choices": [
+                        {"message": {"role": "assistant", "content": "home/grocery-list"}}
+                    ]
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let client = UreqClient {
+            endpoint: format!("{}/api/v1/chat/completions", server.url()),
+            model: "test/model".to_string(),
+        };
+        let folders = vec!["projects".to_string(), "home".to_string()];
+        let path = suggest_path(&client, "groceries for the week", &folders)
+            .await
+            .unwrap();
+        assert_eq!(path.as_deref(), Some("home/grocery-list"));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn suggest_path_cleans_a_noisy_reply() {
+        let client = FakeClient {
+            reply: "  \"/Projects/My Idea/\"  \nblah".to_string(),
+        };
+        let path = suggest_path(&client, "some body", &["projects".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(path.as_deref(), Some("projects/my-idea"));
+    }
+
+    #[tokio::test]
+    async fn suggest_path_blank_body_makes_no_call() {
+        // A blank draft returns None without invoking the client — the same
+        // short-circuit derive_title uses. A client that would panic proves it.
+        struct PanicClient;
+        impl ChatCompletions for PanicClient {
+            async fn complete(&self, _s: &str, _u: &str) -> Result<String, LlmError> {
+                panic!("suggest_path must not call the model for a blank body");
+            }
+            fn model_id(&self) -> &str {
+                "panic"
+            }
+        }
+        assert_eq!(
+            suggest_path(&PanicClient, "   \n\t", &["projects".to_string()])
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn suggest_path_no_key_gate_reuses_autoname_enabled() {
+        // Auto-filing shares the autoname no-key gate: an unset/empty key means
+        // the OpenRouter client is never built, so `suggest_path` is never
+        // reached — a clean no-op before the worker's key is provisioned.
+        assert!(!autoname_enabled(None));
+        assert!(!autoname_enabled(Some("")));
         assert!(autoname_enabled(Some("sk-or-v1-abc123")));
     }
 

--- a/services/notes-sync/src/runtime.rs
+++ b/services/notes-sync/src/runtime.rs
@@ -21,7 +21,8 @@ use worker::{
 use crate::auth::{authorize_owner, authorized_did};
 use crate::git::{commit_with_retry, move_note_file, CommitError, GitTarget, WorkerGitHubClient};
 use crate::llm::{
-    autoname_enabled, derive_title, should_autoname, WorkerOpenRouterClient, DEFAULT_MODEL,
+    autoname_enabled, derive_title, folders_from_paths, should_autoname, suggest_path,
+    WorkerOpenRouterClient, DEFAULT_MODEL,
 };
 use crate::route::{
     choose_rename_body, is_valid_note_id, parse_ws_note_id, plan_rename,
@@ -123,6 +124,7 @@ pub async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
         "/oauth/callback" => return crate::oauth::handle_callback(req, env).await,
         "/me" => return handle_me(&req, &env),
         "/vault" => return handle_vault(&req, &env).await,
+        "/suggest-path" => return handle_suggest_path(req, &env).await,
         "/delete" => return handle_delete(&req, &env).await,
         "/rename" => return handle_rename(&req, &env).await,
         "/retitle" => return handle_retitle(&req, &env).await,
@@ -235,6 +237,82 @@ async fn handle_vault(req: &Request, env: &Env) -> Result<Response> {
         .with_status(200)
         .with_headers(headers)
         .fixed(body.into_bytes()))
+}
+
+/// Build the OpenRouter client from the worker secret + model var, or `None`
+/// when auto-naming/auto-filing is disabled. A `None` is the graceful path:
+/// the key isn't provisioned yet, so LLM features are a clean no-op and the
+/// worker still ships and deploys before the key lands in 1Password. Shared by
+/// the top-level `/suggest-path` handler and the per-note Durable Object.
+fn openrouter_client_from_env(env: &Env) -> Option<WorkerOpenRouterClient> {
+    let key = env
+        .secret("OPENROUTER_API_KEY")
+        .ok()
+        .map(|s| s.to_string())
+        .unwrap_or_default();
+    if !autoname_enabled(Some(&key)) {
+        console_log!("openrouter: OPENROUTER_API_KEY unset/empty; skipping");
+        return None;
+    }
+    let model = env
+        .var("OPENROUTER_MODEL")
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+    Some(WorkerOpenRouterClient::new(key, model))
+}
+
+/// `POST /suggest-path` — LLM auto-filing for a new note. The request body is
+/// the draft note text; the response is `{"path": "<folder>/<slug>"}` naming
+/// where the note should live, or `{"path": null}` when auto-filing is
+/// disabled (`OPENROUTER_API_KEY` unset), the draft is blank, the vault
+/// listing is unavailable, or the model returns something that isn't a valid
+/// note id. "It goes where it goes" — the model picks the best-fitting
+/// existing folder (or a sensible new one) from the vault's folder taxonomy
+/// and names the note. Owner-gated. Never fails the request on an LLM error: a
+/// bad or missing suggestion just yields a null path and the front end falls
+/// back to a manual path prompt.
+async fn handle_suggest_path(mut req: Request, env: &Env) -> Result<Response> {
+    if !session_authorized(&req, env) {
+        return Response::error("unauthorized", 401);
+    }
+    let draft = req.text().await.unwrap_or_default();
+    let path = suggest_note_path(env, &draft).await;
+
+    let headers = shell_cors_headers(env)?;
+    let body = serde_json::json!({ "path": path }).to_string();
+    Ok(ResponseBuilder::new()
+        .with_status(200)
+        .with_headers(headers)
+        .fixed(body.into_bytes()))
+}
+
+/// Auto-file `draft` into the vault, returning the suggested note path or
+/// `None` when auto-filing can't (or shouldn't) run: the key is unset, the
+/// draft is blank, the vault listing is unavailable, the model errors, or the
+/// reply isn't a valid note id. Every failure degrades to `None` so the caller
+/// falls back to a manual path — auto-filing is a convenience, never a gate.
+async fn suggest_note_path(env: &Env, draft: &str) -> Option<String> {
+    let client = openrouter_client_from_env(env)?;
+    let owner = env.var("GITHUB_OWNER").ok()?.to_string();
+    let repo = env.var("GITHUB_REPO").ok()?.to_string();
+    let branch = env.var("GITHUB_BRANCH").ok()?.to_string();
+    let token = env.secret("GITHUB_TOKEN").ok()?.to_string();
+    let existing = WorkerGitHubClient::new(token)
+        .list_note_paths(&owner, &repo, &branch)
+        .await
+        .ok()?;
+    let folders = folders_from_paths(&existing);
+    let suggestion = match suggest_path(&client, draft, &folders).await {
+        Ok(Some(p)) => p,
+        Ok(None) => return None,
+        Err(e) => {
+            console_log!("suggest-path: filing failed: {e}; no suggestion");
+            return None;
+        }
+    };
+    // Trust boundary: the model's reply becomes a note id only if it passes
+    // the same validation the websocket route and mutation endpoints enforce.
+    is_valid_note_id(&suggestion).then_some(suggestion)
 }
 
 /// `POST /delete?note=<id>` — delete a note for the owner's session.
@@ -804,22 +882,7 @@ impl NoteDurableObject {
     /// commit still proceeds — the worker ships before the key lands in
     /// 1Password.
     fn openrouter_client(&self) -> Option<WorkerOpenRouterClient> {
-        let key = self
-            .env
-            .secret("OPENROUTER_API_KEY")
-            .ok()
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-        if !autoname_enabled(Some(&key)) {
-            console_log!("autoname: OPENROUTER_API_KEY unset/empty; skipping");
-            return None;
-        }
-        let model = self
-            .env
-            .var("OPENROUTER_MODEL")
-            .map(|v| v.to_string())
-            .unwrap_or_else(|_| DEFAULT_MODEL.to_string());
-        Some(WorkerOpenRouterClient::new(key, model))
+        openrouter_client_from_env(&self.env)
     }
 
     /// Best-effort autoname: if the current body warrants a title (see


### PR DESCRIPTION
LLM auto-filing ("it goes where it goes"): on new-note creation, an owner-gated POST /suggest-path asks the model (reusing Phase B llm.rs) to pick the best-fitting existing folder plus a slug, given the note description and the vault folders derived from the git-tree listing; the create flow pre-fills the path prompt with the suggestion. Graceful no-op when OPENROUTER_API_KEY is unset (reuses the Phase B no-key gate); path-safe via is_valid_note_id at the trust boundary; native mockito tests. Reviewed clean.

Closes #992