### PR TITLE
fix(blogctl): ignore transitive quick-xml DoS advisories

### DIFF
--- a/apps/blogctl/deny.toml
+++ b/apps/blogctl/deny.toml
@@ -1,6 +1,18 @@
 [advisories]
 unmaintained = "all"
 version      = 2
+# Two quick-xml DoS advisories reachable only transitively through
+# `calamine 0.35` (blogctl → calamine → quick-xml 0.39). Both are
+# denial-of-service via malicious XML, and both are fixed in quick-xml
+# >=0.41 — but calamine 0.35 pins `quick-xml ^0.39` (<0.40), so there is no
+# in-place bump (`cargo update -p quick-xml` moves nothing). blogctl only
+# parses trusted local blog spreadsheets, never untrusted/network input, so
+# the DoS doesn't apply. Drop these once calamine ships a release on
+# quick-xml >=0.41.
+ignore = [
+  "RUSTSEC-2026-0194", # quick-xml: quadratic time on duplicate attribute names
+  "RUSTSEC-2026-0195", # quick-xml: unbounded allocation in NsReader
+]
 
 [licenses]
 allow = [


### PR DESCRIPTION
Two newly-published quick-xml advisories (RUSTSEC-2026-0194 quadratic-time,
RUSTSEC-2026-0195 unbounded NsReader allocation) reach blogctl only through
calamine 0.35's pinned quick-xml 0.39, and cargo-deny fetches the RUSTSEC
DB fresh each run — so they broke every PR's preflight (and main), not just
blogctl.

Both are DoS-via-malicious-XML and are fixed in quick-xml >=0.41, but
calamine 0.35 pins quick-xml ^0.39 (<0.40), so there is no in-place bump.
blogctl parses only trusted local blog spreadsheets, never untrusted input,
so the DoS doesn't apply. Ignore both IDs (scoped, with rationale) until
calamine ships a release on quick-xml >=0.41.

Closes #1027